### PR TITLE
Fix bug in _correlation_me_2op_2t

### DIFF
--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -666,15 +666,15 @@ def _correlation_me_2op_2t(H, rho0, tlist, taulist, c_ops, a_op, b_op,
     rho_t_list = mesolve(H, rho0, tlist, c_ops, [], args=args, options=options).states
 
     if reverse:
-        # <A(t+tau)B(t)>
-        for t_idx, rho_t in enumerate(rho_t_list):
-            C_mat[t_idx, :] = mesolve(H, b_op * rho_t, taulist,
-                                      c_ops, [a_op], args=args, options=options).expect[0]
-    else:
         # <A(t)B(t+tau)>
         for t_idx, rho_t in enumerate(rho_t_list):
             C_mat[t_idx, :] = mesolve(H, rho_t * a_op, taulist,
                                       c_ops, [b_op], args=args, options=options).expect[0]
+    else:
+        # <A(t+tau)B(t)>
+        for t_idx, rho_t in enumerate(rho_t_list):
+            C_mat[t_idx, :] = mesolve(H, b_op * rho_t, taulist,
+                                      c_ops, [a_op], args=args, options=options).expect[0]
 
     return C_mat
 


### PR DESCRIPTION
Currently, _correlation_me_2op_2t calculates <A(t+tau)B(t)> when reverse=True, and <A(t)B(t+tau)>. This is the opposite of what it should be, and causes qutip.correlation.correlation and qutip.correlation.correlation_2op_2t to give incorrect results when using the "me" solver.

This patch fixes the problem, making the behaviour of _correlation_me_2op_2t consistent with the other qutip.correlation functions and with the documentation.
