### PR TITLE
Make spmv compatible with non square matrices

### DIFF
--- a/qutip/cyQ/spmatfuncs.pyx
+++ b/qutip/cyQ/spmatfuncs.pyx
@@ -54,7 +54,7 @@ cpdef np.ndarray[CTYPE_t, ndim=1] spmv(np.ndarray[CTYPE_t, ndim=1] data,
     """
     cdef Py_ssize_t row
     cdef int jj,row_start,row_end
-    cdef int num_rows = vec.size
+    cdef int num_rows = ptr.size-1
     cdef CTYPE_t dot
     cdef np.ndarray[CTYPE_t, ndim=1] out = np.zeros((num_rows), dtype=np.complex)
     for row in range(num_rows):


### PR DESCRIPTION
I don't know how to generate .c file from the .pyx so I didn't use spmv in my recent stochastic speed improvement pull request.
I don't really understand why do we have the spmv. I see just a negligible speed improvement compared to the scipy.sparse matrix vector product.
