### PR TITLE
Import ket2dm into metrics.py

### DIFF
--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -26,6 +26,7 @@ from qutip.qobj import *
 import scipy.linalg as la
 import numpy as np
 from qutip.sparse import sp_eigs
+from qutip.states import ket2dm
 
 
 def fidelity(A, B):


### PR DESCRIPTION
In metrics.py, ket2dm was used without being imported into the namespace.
