### PR TITLE
Bloch sphere - annotations, styles, different background 

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -290,6 +290,7 @@ class Bloch():
         self.points = []
         self.vectors = []
         self.point_style = []
+        self.annotations = []
 
     def add_points(self, points, meth='s'):
         """Add a list of data points to bloch sphere.


### PR DESCRIPTION
I made some changes for Bloch sphere, to match my needs.
- added annotations (`b.add_annotation`), so it is easy to put labels to states (the single thing I needed the most)
- added styles for labels (`b.set_label_convention`), including:
  - sx sy sz 
  - polarization with both [Jones](http://en.wikipedia.org/wiki/Jones_calculus) and [Stokes conventions](http://en.wikipedia.org/wiki/Stokes_parameters)

Also, I made some style changes:
- centered axes labels (before they were misaligned)
- removed box, which still can be turned on as an option `b.background = True` (frankly speaking, for publications it consumes way to much space, and when cropped - it does not look the best, at least for my taste)
- changed default figure size and vector width (related to the above, as more space is consumed by the sphere)

I am curious what do you think about the changes.

And an example:

```
import qutip as q
states = [q.ket("0"), (q.ket("0") - 2j * q.ket("1")).unit(),
          (q.ket("0") + 2j * q.ket("1")).unit()]
b = q.Bloch()
b.add_states(states)
b.add_annotation(1.1 * states[1], r"$\langle \vec{\sigma_5} \rangle$", fontsize=15)
b.add_annotation(1.1 * states[2], "See ref. [3]", fontsize=12, color="r")
b.set_label_convention("polarization jones")
b.show()
```

![bloch2](https://f.cloud.github.com/assets/1001610/2044353/1d8b2808-89ea-11e3-9eaf-b6edc19fe2f3.png)
