### PR TITLE
Fixed ket generation from a list with Qobj

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -221,7 +221,7 @@ class Qobj():
                 # case where input is not array or sparse, i.e. a list
                 if len(np.array(inpt).shape) == 1:
                     # if list has only one dimension (i.e [5,4])
-                    inpt = np.array([inpt])
+                    inpt = np.array([inpt]).transpose()
                 else:  # if list has two dimensions (i.e [[5,4]])
                     inpt = np.array(inpt)
 


### PR DESCRIPTION
I used to be that `Qobj([1,2])` and `Qobj([[1,2]])` gives the same result, a `type=bra` state.

Now the former produces `type=ket` state.

And now it is consistent with generation `Qobj(np.array([1,2]))` and `Qobj(np.array([[1,2]]))`, respectively.
