### PR TITLE
do not feed long indices when sparse code expects int32

### DIFF
--- a/qutip/cy/graph_utils.pyx
+++ b/qutip/cy/graph_utils.pyx
@@ -37,9 +37,6 @@ cimport cython
 ###############################################################################
 # see scipy/sparse/csgraph/parameters.pxi
 
-ctypedef np.complex128_t CTYPE_t
-CTYPE = np.complex128
-
 ctypedef np.float64_t DTYPE_t
 DTYPE = np.float64
 

--- a/qutip/cy/sparse_utils.pyx
+++ b/qutip/cy/sparse_utils.pyx
@@ -37,24 +37,8 @@ cimport cython
 ###############################################################################
 # see scipy/sparse/csgraph/parameters.pxi
 
-ctypedef np.complex128_t CTYPE_t
-CTYPE = np.complex128
-
-ctypedef np.float64_t DTYPE_t
-DTYPE = np.float64
-
 ctypedef np.int32_t ITYPE_t
 ITYPE = np.int32
-
-ctypedef fused DATA_t:
-    np.int32_t
-    np.int64_t
-    np.uint32_t
-    np.uint64_t
-    np.float32_t
-    np.float64_t
-    np.complex64_t
-    np.complex128_t
 
 
 @cython.boundscheck(False)
@@ -82,7 +66,7 @@ def _sparse_bandwidth(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def _sparse_permute(
-        np.ndarray[DATA_t, ndim=1] data,
+        np.ndarray[cython.numeric, ndim=1] data,
         np.ndarray[ITYPE_t, ndim=1] idx,
         np.ndarray[ITYPE_t, ndim=1] ptr,
         int nrows,
@@ -98,7 +82,7 @@ def _sparse_permute(
 
     """
     cdef int ii, jj, kk, k0, nnz
-    cdef np.ndarray[DATA_t] new_data = np.zeros_like(data)
+    cdef np.ndarray[cython.numeric] new_data = np.zeros_like(data)
     cdef np.ndarray[ITYPE_t] new_idx = np.zeros_like(idx)
     cdef np.ndarray[ITYPE_t] new_ptr = np.zeros_like(ptr)
     cdef np.ndarray[ITYPE_t] perm_r
@@ -160,7 +144,7 @@ def _sparse_permute(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def _sparse_reverse_permute(
-        np.ndarray[DATA_t, ndim=1] data,
+        np.ndarray[cython.numeric, ndim=1] data,
         np.ndarray[ITYPE_t, ndim=1] idx, 
         np.ndarray[ITYPE_t, ndim=1] ptr,
         int nrows,
@@ -174,7 +158,7 @@ def _sparse_reverse_permute(
 
     """
     cdef int ii, jj, kk, k0, nnz
-    cdef np.ndarray[DATA_t, ndim=1] new_data = np.zeros_like(data)
+    cdef np.ndarray[cython.numeric, ndim=1] new_data = np.zeros_like(data)
     cdef np.ndarray[ITYPE_t, ndim=1] new_idx = np.zeros_like(idx)
     cdef np.ndarray[ITYPE_t, ndim=1] new_ptr = np.zeros_like(ptr)
     if flag==0: #CSR matrix

--- a/qutip/graph.py
+++ b/qutip/graph.py
@@ -146,7 +146,6 @@ def symrcm(A, sym=False):
     else:
         if not sym:
             A=A+A.transpose()
-        #raise Exception((A.indices.dtype, A.indptr.dtype))
         return _rcm(A.indices, A.indptr, nrows)
 
 

--- a/qutip/sparse.py
+++ b/qutip/sparse.py
@@ -41,18 +41,11 @@ import scipy.linalg as la
 from scipy.linalg.blas import get_blas_funcs
 _dznrm2 = get_blas_funcs("znrm2")
 from qutip.cy.sparse_utils import (
-        #_sparse_permute_int, _sparse_permute_float, _sparse_permute_complex,
-        #_sparse_reverse_permute_int, _sparse_reverse_permute_float,
-        #_sparse_reverse_permute_complex, 
         _sparse_permute, _sparse_reverse_permute, _sparse_bandwidth)
 from qutip.settings import debug
 
 if debug:
     import inspect
-
-
-ITYPE = np.int32
-
 
 
 def _sp_fro_norm(op):

--- a/qutip/tests/test_Sparse.py
+++ b/qutip/tests/test_Sparse.py
@@ -83,8 +83,8 @@ def test_sparse_nonsymmetric_reverse_permute():
     "Sparse: Nonsymmetric Reverse Permute"
     #CSR square array check
     A=rand_dm(25,0.5)
-    rperm=np.random.permutation(25).astype(np.float32)
-    cperm=np.random.permutation(25).astype(np.float32)
+    rperm=np.random.permutation(25)
+    cperm=np.random.permutation(25)
     x=sparse_permute(A,rperm,cperm)
     B=sparse_reverse_permute(x,rperm,cperm)
     assert_equal((A.full() - B.toarray()).all(), 0)


### PR DESCRIPTION
This tries to address https://github.com/qutip/qutip/issues/73 using some type conversion and some fused types.  I see a unit test error due to some fortran thing, and a couple of unit test failures, but I don't know if they are related.
