### PR TITLE
fix bug that was introduced with recent addition of array based td formats

### DIFF
--- a/qutip/odechecks.py
+++ b/qutip/odechecks.py
@@ -212,6 +212,12 @@ def _td_wrap_array_str(H, c_ops, args, times):
                 c_ops_new.append(ck)
 
     if args:
-        args_new.update(args)
+        if isinstance(args, dict):
+            args_new.update(args)
+        elif not args_new:
+            args_new = args
+        else:
+            raise ValueError("Time-dependent array format requires args to " +
+                             "be a dictionary")
 
     return H_new, c_ops_new, args_new


### PR DESCRIPTION
that only with that new which only works for args of type dict, while for backwards compatibility we need to also support args in e.g. type list.
