### PR TITLE
restore distinction between release/non-release in cython file handing

### DIFF
--- a/qutip/cy/setup.py
+++ b/qutip/cy/setup.py
@@ -13,15 +13,23 @@ def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration('cy', parent_package, top_path)
 
-    for ext in exts:
-        config.add_extension(
-            ext,
-            sources=[ext + ".pyx"],
-            include_dirs=[np.get_include()],
-            extra_compile_args=['-w -ffast-math -O3 -march=native -mfpmath=sse'],
-            extra_link_args=[])
+    if os.environ['QUTIP_RELEASE'] == 'TRUE':
+        for ext in exts:
+            config.add_extension(
+                ext, sources=[ext + ".c"],
+                include_dirs=[np.get_include()],
+                extra_compile_args=['-w -ffast-math -O3 -march=native -mfpmath=sse'],
+                extra_link_args=[])
 
-    config.ext_modules = cythonize(config.ext_modules)
+    else:
+        for ext in exts:
+            config.add_extension(
+                ext, sources=[ext + ".pyx"],
+                include_dirs=[np.get_include()],
+                extra_compile_args=['-w -ffast-math -O3 -march=native -mfpmath=sse'],
+                extra_link_args=[])
+
+        config.ext_modules = cythonize(config.ext_modules)
 
     return config
 

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ FULLVERSION = VERSION
 if not ISRELEASED:
     FULLVERSION += '.dev' + git_short_hash()
 
+os.environ['QUTIP_RELEASE'] = 'TRUE' if ISRELEASED else 'FALSE'
 
 def write_version_py(filename='qutip/version.py'):
     cnt = """\


### PR DESCRIPTION
in setup.py (could not find a good config that included the pyx files in the source distribion file produced by setup.py)
