### PR TITLE
add support for version strings ending in 'aX'

### DIFF
--- a/qutip/utilities.py
+++ b/qutip/utilities.py
@@ -389,6 +389,6 @@ def view_methods(Q):
 
 def _version2int(version_string):
     str_list = version_string.split(
-        "-dev")[0].split("rc")[0].split("b")[0].split("post")[0].split('.')
+        "-dev")[0].split("rc")[0].split("a")[0].split("b")[0].split("post")[0].split('.')
     return sum([int(d if len(d) > 0 else 0) * (100 ** (3 - n))
                 for n, d in enumerate(str_list[:3])])


### PR DESCRIPTION
Attempt to fix #207
