### PR TITLE
restore 'iterative-bicg' and 'iterative-bicgstab' as possible iterative solvers

### DIFF
--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -88,7 +88,7 @@ def steadystate(A, c_op_list=[], **kwargs):
     c_op_list : list
         A list of collapse operators.
 
-    method : str {'direct', 'eigen', 'iterative-bicg',
+    method : str {'direct', 'eigen', 'iterative-bicg', 'iterative-bicgstab',
                   'iterative-gmres', 'iterative-lgmres', 'svd', 'power'}
         Method for solving the underlying linear equation. Direct LU solver
         'direct' (default), sparse eigenvalue problem 'eigen',


### PR DESCRIPTION
They are still included in the docstrings, so they must either be restored or removed from the docstrings if there is no reason to support them.
