### PR TITLE
Fixed deprecationwarning with sqrt_shape.

### DIFF
--- a/qutip/superop_reps.py
+++ b/qutip/superop_reps.py
@@ -133,7 +133,7 @@ def _super_tofrom_choi(q_oper):
     type should be called externally.
     """
     data = q_oper.data.toarray()
-    sqrt_shape = sqrt(data.shape[0])
+    sqrt_shape = int(sqrt(data.shape[0]))
     return Qobj(dims=q_oper.dims,
                 inpt=data.reshape([sqrt_shape] * 4).
                 transpose(3, 1, 2, 0).reshape(q_oper.data.shape))


### PR DESCRIPTION
This one is very minor, but fixes a bug that cased a DeprecationWarning to be raised under recent versions of NumPy (I encountered with 1.9.1).
