### PR TITLE
Minor homebrew script update

### DIFF
--- a/mac/install_qutip_py2.sh
+++ b/mac/install_qutip_py2.sh
@@ -50,11 +50,11 @@ brew install freetype
 # Matplotlib
 /usr/local/bin/pip install -U matplotlib
 # QuTiP
-/usr/local/bin/pip install -U https://github.com/qutip/qutip/archive/qutip-3.0.1.tar.gz --install-option=--with-f90mc
+/usr/local/bin/pip install -U qutip --install-option=--with-f90mc
 
-#run QuTiP tests from shell
+# run QuTiP tests from shell
 echo "Running QuTiP unit tests"
 /usr/local/bin/python -c "import qutip.testing as qt; qt.run()"
 
-#check brew installation
+# check brew installation
 brew doctor

--- a/mac/install_qutip_py3.sh
+++ b/mac/install_qutip_py3.sh
@@ -50,11 +50,11 @@ brew install freetype
 # Matplotlib
 /usr/local/bin/pip3 install -U matplotlib
 # QuTiP
-/usr/local/bin/pip3 install -U https://github.com/qutip/qutip/archive/qutip-3.0.1.tar.gz --install-option=--with-f90mc
+/usr/local/bin/pip3 install -U qutip --install-option=--with-f90mc
 
-#run QuTiP tests from shell
+# run QuTiP tests from shell
 echo "Running QuTiP unit tests"
 /usr/local/bin/python3 -c "import qutip.testing as qt; qt.run()"
 
-#check brew installation
+# check brew installation
 brew doctor


### PR DESCRIPTION
Install qutip from pypi instead of github, which makes it always point to the most current release.
