### PR TITLE
remove py 3.2 from travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - 2.7
-    - 3.2
     - 3.4
 
 before_install:


### PR DESCRIPTION
 to reduce load on travis system and shorten test times ?
