### PR TITLE
New random pulse generators added to control/pulsegen

### DIFF
--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -856,6 +856,9 @@ def create_pulse_optimizer(
     p_gen = pulsegen.create_pulse_gen(pulse_type=init_pulse_type, dyn=dyn)
     p_gen.scaling = pulse_scaling
     p_gen.offset = pulse_offset
+    p_gen.lbound = amp_lbound
+    p_gen.ubound = amp_ubound
+    
     # If the pulse is a periodic type, then set the pulse to be one complete
     # wave
     if isinstance(p_gen, pulsegen.PulseGenPeriodic):


### PR DESCRIPTION
In attempt to have a method of producing initial pulses that are random but less noisy,
so that final (optimised pulses) are also less noisy
Was also hoping that this would improve convergence rate
Two of the pulsegen are based on summing waves
Two are based on random walks
Bounds also added to the pulsegens, as the scaling / offset parameters could not be relied upon to effectively enforce bounds on all the new pulsegens.
