### PR TITLE
fix Qobj division unit test

### DIFF
--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -265,7 +265,7 @@ def test_QobjDivision():
     q = Qobj(data)
     randN = 10 * np.random.random()
     q = q / randN
-    assert_(np.all(q.data.todense() - np.matrix(data) / randN == 0))
+    assert_(np.allclose(q.data.todense(), np.matrix(data) / randN))
 
 
 def test_QobjPower():


### PR DESCRIPTION
Attempt to solve issue with false errors in Qobj division tests on 32 bit system by using comparison that is more robust to floating-point errors.