### PR TITLE
Improved Random Quantum Objects

### DIFF
--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -42,16 +42,21 @@ The sparsity of the ouput Qobj's is controlled by varing the
 __all__ = [
     'rand_herm', 'rand_unitary', 'rand_ket', 'rand_dm',
     'rand_unitary_haar', 'rand_ket_haar', 'rand_dm_ginibre',
-    'rand_super_bcsz'
+    'rand_dm_hs', 'rand_super_bcsz'
 ]
 
 from scipy import arcsin, sqrt, pi
+from scipy.linalg import sqrtm
 import numpy as np
+import numpy.linalg as la
 import scipy.sparse as sp
 from qutip.qobj import Qobj
 from qutip.operators import create, destroy, jmat
 from qutip.states import basis
-from qutip.superoperator import to_super
+import qutip.superop_reps as sr
+
+
+UNITS = np.array([1, 1j])
 
 def randnz(shape, norm=1 / np.sqrt(2)):
     # This function is intended for internal use.
@@ -312,7 +317,7 @@ def rand_dm_ginibre(dim=2, rank=None):
 
     return Qobj(rho)
 
-def rand_ds_hs(dim=2):
+def rand_dm_hs(dim=2):
     """
     Returns a Hilbert-Schmidt random density operator of dimension
     ``dim`` and rank ``rank`` by using the algorithm of
@@ -411,7 +416,7 @@ def rand_super_bcsz(dims=2, enforce_tp=True, rank=None):
         # marking the dimensions as that of a type=super (that is,
         # with left and right compound indices, each representing
         # left and right indices on the underlying Hilbert space).
-        D = Qobj(reduce(np.dot, (Z, XXdag, Z)))
+        D = Qobj(np.dot(Z, np.dot(XXdag, Z)))
     else:
         D = dim * Qobj(XXdag / np.trace(XXdag))
 
@@ -436,7 +441,7 @@ def rand_super_bcsz(dims=2, enforce_tp=True, rank=None):
     # Mark that we've made a Choi matrix.
     D.superrep = 'choi'
 
-    return to_super(D)
+    return sr.to_super(D)
 
 def _check_dims(dims, N1, N2):
     if len(dims) != 2:

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -1,0 +1,71 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+import scipy.sparse as sp
+import scipy.linalg as la
+import numpy as np
+from numpy.testing import assert_equal, assert_, run_module_suite
+
+from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
+                                  rand_super, rand_unitary_haar, rand_dm_ginibre,
+                                  rand_super_bcsz)
+from qutip.operators import qeye
+
+def test_rand_unitary_haar_unitarity():
+    """
+    Random Qobjs: Tests that unitaries are actually unitary.
+    """
+    U = rand_unitary_haar(5)
+    I = qeye(5)
+
+    assert_(U * U.dag() == I)
+
+def test_rand_dm_ginibre_rank():
+    """
+    Random Qobjs: Tests that Ginibre-random density operators have correct rank.
+    """
+    rho = rand_dm_ginibre(5, rank=3)
+
+    rank = sum([abs(E) >= 1e-10 for E in rho.eigenenergies()])
+    assert_(rank == 3)
+
+def test_rand_super_bcsz_cptp():
+    """
+    Random Qobjs: Tests that BCSZ-random superoperators are CPTP.
+    """
+    S = rand_super_bcsz(5)
+    assert_(S.iscptp)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -37,6 +37,7 @@ import numpy as np
 from numpy.testing import assert_equal, assert_, run_module_suite
 
 from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
+                                  rand_ket_haar, rand_dm_hs,
                                   rand_super, rand_unitary_haar, rand_dm_ginibre,
                                   rand_super_bcsz)
 from qutip.operators import qeye
@@ -66,6 +67,29 @@ def test_rand_super_bcsz_cptp():
     S = rand_super_bcsz(5)
     assert_(S.iscptp)
 
+def check_func_dims(func, args, kwargs, dims):
+    # TODO: promote this out of test_random, as it's generically useful
+    #       in writing tests.
+    resdims = func(*args, **kwargs).dims
+    assert_(resdims == dims, "Checking {}; epected dimensions of {}, got {}.".format(func.__name__, dims, resdims))
+
+def test_rand_vector_dims():
+    FUNCS = [rand_ket, rand_ket_haar]
+    for func in FUNCS:
+        yield check_func_dims, func, (7, ), {}, [[7], [1]]
+        yield check_func_dims, func, (6, ), {'dims': [2, 3]}, [[2, 3], [1]]
+
+def test_rand_oper_dims():
+    FUNCS = [rand_unitary, rand_herm, rand_dm, rand_unitary_haar, rand_dm_ginibre, rand_dm_hs]
+    for func in FUNCS:
+        yield check_func_dims, func, (7, ), {}, [[7], [7]]
+        yield check_func_dims, func, (6, ), {'dims': [[2, 3], [2, 3]]}, [[2, 3], [2, 3]]
+
+def test_rand_super_dims():
+    FUNCS = [rand_super, rand_super_bcsz]
+    for func in FUNCS:
+        yield check_func_dims, func, (7, ), {}, [[[7], [7]]] * 2
+        yield check_func_dims, func, (6, ), {'dims': [[[2, 3], [2, 3]], [[2, 3], [2, 3]]]}, [[[2, 3], [2, 3]], [[2, 3], [2, 3]]]
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This PR addresses #315 by providing sampling for Haar (unitary), Hilbert-Schmidt (DMs), Ginibre (DMs) and BCSZ (superoperators) distributions. Some more documentation is needed still, but the tests pass locally on Python 2.7 and 3.4.