### PR TITLE
Fix gcc44 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
     - 2.7
     - 3.4
+matrix:
+    include:
+        - python: 3.4
+          env: CC=clang CXX=clang++
 
 before_install:
     - uname -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
     - nosetests --with-coverage --cover-package=qutip qutip
 
 after_success:
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]] && [[ $CC == 'gcc' ]]; then
           coveralls;
       fi
 

--- a/qutip/control/setup.py
+++ b/qutip/control/setup.py
@@ -8,7 +8,7 @@ import os
 
 exts = ['cy_grape']
 
-_compiler_flags = ['-w', '-ffast-math', '-O3', '-march=native', '-flto']
+_compiler_flags = ['-w', '-ffast-math', '-O3', '-march=native']
 
 def configuration(parent_package='', top_path=None):
     # compiles files during installation

--- a/qutip/cy/setup.py
+++ b/qutip/cy/setup.py
@@ -8,7 +8,7 @@ import os
 
 exts = ['spmatfuncs', 'stochastic', 'sparse_utils', 'graph_utils']
 
-_compiler_flags = ['-w', '-ffast-math', '-O3', '-march=native', '-flto']
+_compiler_flags = ['-w', '-ffast-math', '-O3', '-march=native']
 
 def configuration(parent_package='', top_path=None):
     # compiles files during installation


### PR DESCRIPTION
gcc 4.4 does not support the `-flto` option for link time optimization. This is still a common compiler because it is the system gcc in centos 6 and redhat enterprise 6.

In this pull request I've removed that option. Users who need this could set the CCFLAGS environment variable to customize the compiler flags. Alternatively, we could add options to `setup.py` to enable or disable link time optimization.

I've also added additional rows to the travis build matrix to test building with gcc 4.4 and clang. In its current form this adds 4 additional rows to the build matrix (2 additional compilers, each tested with python 2.7 and 3.4). Let me know if you think this is excessive. It's possible to add just one python version for gcc 4.4 and clang.