### PR TITLE
change version_table in ipynbtools to use deterministic output order

### DIFF
--- a/qutip/ipynbtools.py
+++ b/qutip/ipynbtools.py
@@ -79,18 +79,18 @@ def version_table(verbose=False):
     html = "<table>"
     html += "<tr><th>Software</th><th>Version</th></tr>"
 
-    packages = {"QuTiP": qutip.__version__,
-                "Numpy": numpy.__version__,
-                "SciPy": scipy.__version__,
-                "matplotlib": matplotlib.__version__,
-                "Cython": Cython.__version__,
-                "Python": sys.version,
-                "IPython": IPython.__version__,
-                "OS": "%s [%s]" % (os.name, sys.platform)
-                }
+    packages = [("QuTiP", qutip.__version__),
+                ("Numpy", numpy.__version__),
+                ("SciPy", scipy.__version__),
+                ("matplotlib", matplotlib.__version__),
+                ("Cython", Cython.__version__),
+                ("IPython", IPython.__version__),
+                ("Python", sys.version),
+                ("OS", "%s [%s]" % (os.name, sys.platform))
+                ]
 
-    for name in packages:
-        html += "<tr><td>%s</td><td>%s</td></tr>" % (name, packages[name])
+    for name, version in packages:
+        html += "<tr><td>%s</td><td>%s</td></tr>" % (name, version)
 
     if verbose:
         html += "<tr><th colspan='2'>Additional information</th></tr>"


### PR DESCRIPTION
I've been annoyed from time to time that the output of the very useful version_table is ordered randomly. This fixes that by using a list of tuples instead of a dictionary (an OrderedDict would work equally well, of course).