### PR TITLE
Possible fix for cython codegen errors

### DIFF
--- a/cython_fail_test.py
+++ b/cython_fail_test.py
@@ -1,0 +1,5 @@
+import qutip as q
+H = [[q.sigmax(), '1j * ( asdf + 0.0 )']] # Always works
+#H = [[q.sigmax(), '1j * ( 0.0 + asdf )']] # Doesn't work
+args = {'asdf':1.0}
+q.mesolve(H, q.basis(2,0), [0,1], [], [], args=args)

--- a/cython_fail_test.py
+++ b/cython_fail_test.py
@@ -1,5 +1,0 @@
-import qutip as q
-H = [[q.sigmax(), '1j * ( asdf + 0.0 )']] # Always works
-#H = [[q.sigmax(), '1j * ( 0.0 + asdf )']] # Doesn't work
-args = {'asdf':1.0}
-q.mesolve(H, q.basis(2,0), [0,1], [], [], args=args)

--- a/qutip/cy/codegen.py
+++ b/qutip/cy/codegen.py
@@ -139,7 +139,7 @@ class Codegen():
                     (value.dtype.name, name)
             else:
                 kind = type(value).__name__
-                ret += ",\n        np." + kind + "_t " + name
+                ret += ",\n        " + kind + " " + name
         return ret
 
     def ODE_func_header(self):

--- a/qutip/cy/codegen.py
+++ b/qutip/cy/codegen.py
@@ -138,11 +138,11 @@ class Codegen():
                 ret += ",\n        np.ndarray[np.%s_t, ndim=1] %s" % \
                     (value.dtype.name, name)
             else:
-                if isinstance(value, int):
+                if isinstance(value, (int, np.int32, np.int64)):
                     kind = 'int'
-                elif isinstance(value, float):
+                elif isinstance(value, (float, np.float32, np.float64)):
                     kind = 'float'
-                elif isinstance(value, complex):
+                elif isinstance(value, (complex, np.complex128)):
                     kind = 'complex'
                 #kind = type(value).__name__
                 ret += ",\n        " + kind + " " + name

--- a/qutip/cy/codegen.py
+++ b/qutip/cy/codegen.py
@@ -138,7 +138,13 @@ class Codegen():
                 ret += ",\n        np.ndarray[np.%s_t, ndim=1] %s" % \
                     (value.dtype.name, name)
             else:
-                kind = type(value).__name__
+                if instance(value, int):
+                    kind = 'int'
+                elif instance(value, float):
+                    kind = 'float'
+                elif instance(value, complex):
+                    kind = 'complex'
+                #kind = type(value).__name__
                 ret += ",\n        " + kind + " " + name
         return ret
 

--- a/qutip/cy/codegen.py
+++ b/qutip/cy/codegen.py
@@ -138,11 +138,11 @@ class Codegen():
                 ret += ",\n        np.ndarray[np.%s_t, ndim=1] %s" % \
                     (value.dtype.name, name)
             else:
-                if instance(value, int):
+                if isinstance(value, int):
                     kind = 'int'
-                elif instance(value, float):
+                elif isinstance(value, float):
                     kind = 'float'
-                elif instance(value, complex):
+                elif isinstance(value, complex):
                     kind = 'complex'
                 #kind = type(value).__name__
                 ret += ",\n        " + kind + " " + name


### PR DESCRIPTION
This seems to fix the issue reported by Vlad on the Google group.

This fixes the errors when using complex cmath header and typedef variables.  Variables must be of float, int, or complex, not np.kind_t