### PR TITLE
Fixed a bug in gradient computations in control module

### DIFF
--- a/qutip/control/cy_grape.pyx
+++ b/qutip/control/cy_grape.pyx
@@ -3,11 +3,11 @@
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +18,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 import numpy as np
@@ -50,12 +50,12 @@ ctypedef np.int64_t LTYPE_t
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef CTYPE_t cy_overlap(object op1, object op2):
-    
+
     cdef Py_ssize_t row
     cdef CTYPE_t tr = 0.0
-	
+
     op1 = op1.T.tocsr()
-	
+
     cdef int col1, row1_idx_start, row1_idx_end
     cdef np.ndarray[CTYPE_t, ndim=1, mode="c"] data1 = op1.data.conj()
     cdef np.ndarray[ITYPE_t, ndim=1, mode="c"] idx1 = op1.indices
@@ -82,7 +82,7 @@ cpdef CTYPE_t cy_overlap(object op1, object op2):
 
                 if col2 == row:
                     tr += data1[row1_idx] * data2[row2_idx]
- 
+
     return tr / op1.shape[0]
 
 
@@ -93,9 +93,9 @@ cpdef cy_grape_inner(U, np.ndarray[DTYPE_t, ndim=3, mode="c"] u,
                      float dt, float eps, float alpha, float beta,
                      int phase_sensitive,
                      int use_u_limits, float u_min, float u_max):
-	
-    cdef int j, k 
- 
+
+    cdef int j, k
+
     for m in range(M-1):
         P = U_b_list[m] * U
         for j in range(J):
@@ -104,7 +104,7 @@ cpdef cy_grape_inner(U, np.ndarray[DTYPE_t, ndim=3, mode="c"] u,
             if phase_sensitive:
                 du = - cy_overlap(P, Q)
             else:
-                du = - 2 * cy_overlap(P, Q) * cy_overlap(U_f_list[m], P) 
+                du = - 2 * cy_overlap(P, Q) * cy_overlap(U_f_list[m], P)
 
             if alpha > 0.0:
                 # penalty term for high power control signals u

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -319,7 +319,7 @@ class Dynamics:
         else:
             self.num_tslots = len(self.tau)
             self.evo_time = np.sum(self.tau)
-            
+
         self.time = np.zeros(self.num_tslots+1, dtype=float)
         # set the cumulative time by summing the time intervals
         for t in range(self.num_tslots):

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -403,7 +403,7 @@ class Dynamics:
                 "No tslot_computer (Timeslot computer)"
                 " set. A default should be assigned by the Dynamics class")
 
-        if not isinstance(self.fid_computer, fidcomp.FideliyComputer):
+        if not isinstance(self.fid_computer, fidcomp.FidelityComputer):
             raise errors.UsageError(
                 "No fid_computer (Fidelity computer)"
                 " set. A default should be assigned by the Dynamics subclass")

--- a/qutip/control/fidcomp.py
+++ b/qutip/control/fidcomp.py
@@ -327,8 +327,8 @@ class FidCompUnitary(FidelityComputer):
         This PSU version is independent of global phase
         """
         fid_pn = self.get_fidelity_prenorm()
-        grad_normalized = \
-            2*np.real(grad*np.conj(fid_pn)) / self.dimensional_norm
+        grad_normalized = np.real(grad * np.exp(-1j * np.angle(fid_pn)) /
+                                  self.dimensional_norm)
         return grad_normalized
 
     def get_fid_err(self):

--- a/qutip/control/fidcomp.py
+++ b/qutip/control/fidcomp.py
@@ -69,7 +69,7 @@ logger = logging.get_logger()
 import qutip.control.errors as errors
 
 
-class FideliyComputer:
+class FidelityComputer:
     """
     Base class for all Fidelity Computers.
     This cannot be used directly. See subclass descriptions and choose
@@ -204,7 +204,7 @@ class FideliyComputer:
         self.fid_err_grad_current = False
 
 
-class FidCompUnitary(FideliyComputer):
+class FidCompUnitary(FidelityComputer):
     """
     Computes fidelity error and gradient assuming unitary dynamics, e.g.
     closed qubit systems
@@ -223,12 +223,12 @@ class FidCompUnitary(FideliyComputer):
     """
 
     def reset(self):
-        FideliyComputer.reset(self)
+        FidelityComputer.reset(self)
         self.id_text = 'UNIT'
         self.uses_evo_t2targ = True
 
     def clear(self):
-        FideliyComputer.clear(self)
+        FidelityComputer.clear(self)
         self.fidelity_prenorm = None
         self.fidelity_prenorm_current = False
 
@@ -265,7 +265,7 @@ class FidCompUnitary(FideliyComputer):
         """
         Flag fidelity and gradients as needing recalculation
         """
-        FideliyComputer.flag_system_changed(self)
+        FidelityComputer.flag_system_changed(self)
         # Flag the fidelity (prenormalisation) value as needing calculation
         self.fidelity_prenorm_current = False
 
@@ -439,7 +439,7 @@ class FidCompUnitary(FideliyComputer):
         return grad
 
 
-class FidCompTraceDiff(FideliyComputer):
+class FidCompTraceDiff(FidelityComputer):
     """
     Computes fidelity error and gradient for general system dynamics
     by calculating the the fidelity error as the trace of the overlap
@@ -460,13 +460,13 @@ class FidCompTraceDiff(FideliyComputer):
     """
 
     def reset(self):
-        FideliyComputer.reset(self)
+        FidelityComputer.reset(self)
         self.id_text = 'TRACEDIFF'
         self.scale_factor = None
         self.uses_evo_t2end = True
         if not self.parent.prop_computer.grad_exact:
             raise errors.UsageError(
-                "This FideliyComputer can only be"
+                "This FidelityComputer can only be"
                 " used with an exact gradient PropagatorComputer.")
 
     def init_comp(self):
@@ -597,7 +597,7 @@ class FidCompTraceDiffApprox(FidCompTraceDiff):
         a timeslot control amplitude
     """
     def reset(self):
-        FideliyComputer.reset(self)
+        FidelityComputer.reset(self)
         self.id_text = 'TDAPPROX'
         self.uses_evo_t2end = True
         self.scale_factor = None

--- a/qutip/control/optimconfig.py
+++ b/qutip/control/optimconfig.py
@@ -85,7 +85,7 @@ class OptimConfig:
         Fidelity error (and fidelity error gradient) computation method
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX
         DEF will use the default for the specific dyn_type
-        (See FideliyComputer classes for details)
+        (See FidelityComputer classes for details)
 
     phase_option : string
         determines how global phase is treated in fidelity

--- a/qutip/control/optimconfig.py
+++ b/qutip/control/optimconfig.py
@@ -185,8 +185,8 @@ class OptimConfig:
         # Test output file flags
         self.test_out_dir = None
         self.test_out_f_ext = ".txt"
-        self.clear_test_out_flags()        
-        
+        self.clear_test_out_flags()
+
     def clear_test_out_flags(self):
         self.test_out_iter = False
         self.test_out_fid_err = False
@@ -231,14 +231,14 @@ class OptimConfig:
 
         dir_ok, self.test_out_dir, msg = self.check_create_output_dir(
                     self.test_out_dir, desc='test_out')
-                                         
+
         if not dir_ok:
             self.reset_test_out_files()
             msg += "\ntest_out files will be suppressed."
             logger.error(msg)
-        
+
         return dir_ok
-            
+
     def check_create_output_dir(self, output_dir, desc='output'):
         """
         Checks if the given directory exists, if not it is created
@@ -247,24 +247,24 @@ class OptimConfig:
         dir_ok : boolean
             True if directory exists (previously or created)
             False if failed to create the directory
-        
+
         output_dir : string
             Path to the directory, which may be been made absolute
-        
+
         msg : string
             Error msg if directory creation failed
         """
-        
+
         dir_ok = True
         if '~' in output_dir:
             output_dir = os.path.expanduser(output_dir)
         elif not os.path.abspath(output_dir):
             # Assume relative path from cwd given
             output_dir = os.path.join(os.getcwd(), output_dir)
-    
-        errmsg = "Failed to create {} directory:\n{}\n".format(desc, 
+
+        errmsg = "Failed to create {} directory:\n{}\n".format(desc,
                                                             output_dir)
-         
+
         if os.path.exists(output_dir):
             if os.path.isfile(output_dir):
                 dir_ok = False
@@ -282,7 +282,7 @@ class OptimConfig:
                     dir_ok = False
                     errmsg += "Underling error (makedirs) :({}) {}".format(
                         type(e).__name__, e)
-        
+
         if dir_ok:
             return dir_ok, output_dir, "{} directory is ready".format(desc)
         else:

--- a/qutip/control/propcomp.py
+++ b/qutip/control/propcomp.py
@@ -227,7 +227,8 @@ class PropCompDiag(PropagatorComputer):
 
         # compute ctrl dyn gen in diagonalised basis
         # i.e. the basis of the full dyn gen for this timeslot
-        dg_diag = eig_vec_adj.dot(dyn.get_ctrl_dyn_gen(j)).dot(eig_vec)
+        dg_diag = \
+            dyn.tau[k]*eig_vec_adj.dot(dyn.get_ctrl_dyn_gen(j)).dot(eig_vec)
 
         # multiply by factor matrix
         factors = dyn.dyn_gen_factormatrix[k]

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -181,7 +181,7 @@ def optimize_pulse(
         Fidelity error (and fidelity error gradient) computation method
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX
         DEF will use the default for the specific dyn_type
-        (See FideliyComputer classes for details)
+        (See FidelityComputer classes for details)
 
     phase_option : string
         determines how global phase is treated in fidelity
@@ -627,7 +627,7 @@ def create_pulse_optimizer(
         Fidelity error (and fidelity error gradient) computation method
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX
         DEF will use the default for the specific dyn_type
-        (See FideliyComputer classes for details)
+        (See FidelityComputer classes for details)
 
     phase_option : string
         determines how global phase is treated in fidelity
@@ -769,7 +769,7 @@ def create_pulse_optimizer(
     else:
         raise errors.UsageError("No option for prop_type: " + prop_type)
 
-    # Create the FideliyComputer instance
+    # Create the FidelityComputer instance
     # The default will be typically be the best option
     # Note: the FidCompTraceDiffApprox is a subclass of FidCompTraceDiff
     # so need to check this type first


### PR DESCRIPTION
hi,
i think there was a bug in the computation of gradients for unitary problems. im not sure if i tracked them down correctly, but the gradients seem to be more consistent now. this can be checked with the following code after initialization of an Optimizer object `optim`.
```python
from scipy.optimize import check_grad
func = optim.fid_err_func_wrapper
grad = optim.fid_err_grad_wrapper
x0 = optim.dynamics.ctrl_amps.flatten()
check_grad(func, grad, x0)
```

also, im new to github and im not sure if im doing this correctly.