### PR TITLE
Stinespring dilations of type="super" Qobj

### DIFF
--- a/qutip/superop_reps.py
+++ b/qutip/superop_reps.py
@@ -245,7 +245,7 @@ def _svd_u_to_kraus(U, S, d, dK, indims, outdims):
     Ks = map(Qobj, array(U * S).reshape((d, d, dK), order='F').transpose((2, 0, 1)))
     for K in Ks:
         K.dims = [outdims, indims]
-    return Ks
+    return list(Ks)
 
 
 def _generalized_kraus(q_oper, thresh=1e-10):
@@ -305,7 +305,6 @@ def choi_to_stinespring(q_oper, thresh=1e-10):
     B = Qobj(zeros((dK * dR, dR)), dims=[in_left + [dK], in_right + [1]])
 
     for idx_kraus, (KL, KR) in enumerate(zip(kU, kV)):
-        print A.dims, tensor(KL, basis(dK, idx_kraus)).dims
         A += tensor(KL, basis(dK, idx_kraus))
         B += tensor(KR, basis(dK, idx_kraus))
         

--- a/qutip/superop_reps.py
+++ b/qutip/superop_reps.py
@@ -242,10 +242,10 @@ def _svd_u_to_kraus(U, S, d, dK, indims, outdims):
     """
     # We use U * S since S is 1-index, such that this is equivalent to
     # U . diag(S), but easier to write down.
-    Ks = map(Qobj, array(U * S).reshape((d, d, dK), order='F').transpose((2, 0, 1)))
+    Ks = list(map(Qobj, array(U * S).reshape((d, d, dK), order='F').transpose((2, 0, 1))))
     for K in Ks:
         K.dims = [outdims, indims]
-    return list(Ks)
+    return Ks
 
 
 def _generalized_kraus(q_oper, thresh=1e-10):

--- a/qutip/superop_reps.py
+++ b/qutip/superop_reps.py
@@ -242,7 +242,7 @@ def _svd_u_to_kraus(U, S, d, dK):
     """
     # We use U * S since S is 1-index, such that this is equivalent to
     # U . diag(S), but easier to write down.
-    return map(Qobj, array(U * S).reshape((d, d, dK)).transpose((2, 0, 1)))
+    return map(Qobj, array(U * S).reshape((d, d, dK), order='F').transpose((2, 0, 1)))
 
 
 def _generalized_kraus(q_oper, thresh=1e-10):

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -41,11 +41,11 @@ from __future__ import division
 
 from numpy import abs
 from numpy.linalg import norm
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_, run_module_suite, assert_equal
 
 from qutip.qobj import Qobj
 from qutip.states import basis
-from qutip.operators import identity, sigmax
+from qutip.operators import identity, sigmax, qeye
 from qutip.qip.gates import swap
 from qutip.random_objects import rand_super, rand_super_bcsz, rand_dm_ginibre
 from qutip.tensor import super_tensor
@@ -199,5 +199,17 @@ class TestSuperopReps(object):
 
         for idx in xrange(4):
             yield case, rand_super_bcsz(2), rand_dm_ginibre(2)
+
+    def test_stinespring_dims(self):
+        """
+        Stinespring: Check that dims of channels are preserved.
+        """
+        # FIXME: not the most general test, since this assumes a map
+        #        from square matrices to square matrices on the same space.
+        chan = super_tensor(to_super(sigmax()), to_super(qeye(3)))
+        A, B = to_stinespring(chan)
+        assert_equal(A.dims, [[2, 3, 1], [2, 3]])
+        assert_equal(B.dims, [[2, 3, 1], [2, 3]])
+
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -175,7 +175,7 @@ class TestSuperopReps(object):
             A, B = to_stinespring(map)
             assert_(norm((A - B).data.todense()) < thresh)
 
-        for idx in xrange(4):
+        for idx in range(4):
             yield case, rand_super_bcsz(7)
 
     def test_stinespring_agrees(self, thresh=1e-10):
@@ -193,11 +193,9 @@ class TestSuperopReps(object):
             #        ptraced!
             q2 = (A * state * B.dag()).ptrace((0,))
 
-            print q1, q2
-
             assert_((q1 - q2).norm('tr') <= thresh)
 
-        for idx in xrange(4):
+        for idx in range(4):
             yield case, rand_super_bcsz(2), rand_dm_ginibre(2)
 
     def test_stinespring_dims(self):

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -40,16 +40,18 @@ Created on Wed May 29 11:23:46 2013
 from __future__ import division
 
 from numpy import abs
+from numpy.linalg import norm
 from numpy.testing import assert_, run_module_suite
 
 from qutip.qobj import Qobj
 from qutip.states import basis
 from qutip.operators import identity, sigmax
 from qutip.qip.gates import swap
-from qutip.random_objects import rand_super
+from qutip.random_objects import rand_super, rand_super_bcsz, rand_dm_ginibre
 from qutip.tensor import super_tensor
 from qutip.superop_reps import (kraus_to_choi, to_super, to_choi, to_kraus,
-                                to_chi)
+                                to_chi, to_stinespring)
+from qutip.superoperator import operator_to_vector, vector_to_operator
 
 tol = 1e-10
 
@@ -165,5 +167,37 @@ class TestSuperopReps(object):
         for dims in range(2, 5):
             assert_(abs(to_choi(identity(dims)).tr() - dims) <= tol)
 
+    def test_stinespring_cp(self, thresh=1e-10):
+        """
+        Stinespring: A and B match for CP maps.
+        """
+        def case(map):
+            A, B = to_stinespring(map)
+            assert_(norm((A - B).data.todense()) < thresh)
+
+        for idx in xrange(4):
+            yield case, rand_super_bcsz(7)
+
+    def test_stinespring_agrees(self, thresh=1e-10):
+        """
+        Stinespring: Partial Tr over pair agrees w/ supermatrix.
+        """
+        def case(map, state):
+            S = to_super(map)
+            A, B = to_stinespring(map)
+
+            q1 = vector_to_operator(
+                S * operator_to_vector(state)
+            )
+            # FIXME: problem if Kraus index is implicitly
+            #        ptraced!
+            q2 = (A * state * B.dag()).ptrace((0,))
+
+            print q1, q2
+
+            assert_((q1 - q2).norm('tr') <= thresh)
+
+        for idx in xrange(4):
+            yield case, rand_super_bcsz(2), rand_dm_ginibre(2)
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This feature starts work towards implementing diamond norms between quantum channels by providing Stinespring dilations of ``type="super"`` Qobjs. This requires generalizing the current ``to_kraus`` feature, since the left and right Kraus operators are the same only for CP maps, whereas the arguments to diamond norms are very often not CP (in particular, will often be a difference, || \Lambda_1 - \Lambda_2 ||_\diamond).

The pull request is currently in an incomplete state, so as to solicit feedback before solidifying the design. The docstrings are missing or are incomplete, Python 3 compatibility has not yet been tested, and I still need to make unit tests. Most importantly, the ``dims`` attribute of the input Qobj is not yet preserved, in lieu of solving #331.