### PR TITLE
Fixed basis transform in to_chi, added unit tests for regression.

### DIFF
--- a/qutip/superop_reps.py
+++ b/qutip/superop_reps.py
@@ -210,7 +210,7 @@ def choi_to_chi(q_oper):
     nq = len(q_oper.dims[0][0])
     B = _pauli_basis(nq)
     B.superrep = 'choi'
-    return Qobj(B * q_oper * B.dag(), superrep='chi')
+    return Qobj(B.dag() * q_oper * B, superrep='chi')
 
 
 def chi_to_choi(q_oper):
@@ -225,7 +225,7 @@ def chi_to_choi(q_oper):
 
     # The Chi matrix has tr(chi) == d², so we need to divide out
     # by that to get back to the Choi form.
-    return Qobj((B.dag() * q_oper * B) / q_oper.shape[0], superrep='choi')
+    return Qobj((B * q_oper * B.dag()) / q_oper.shape[0], superrep='choi')
 
 
 # PUBLIC CONVERSION FUNCTIONS -------------------------------------------------
@@ -308,7 +308,7 @@ def to_chi(q_oper):
         else:
             raise TypeError(q_oper.superrep)
     elif q_oper.type == 'oper':
-        return super_to_choi(spre(q_oper) * spost(q_oper.dag()))
+        return to_chi(spre(q_oper) * spost(q_oper.dag()))
     else:
         raise TypeError(
             "Conversion of Qobj with type = {0.type} "

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -39,8 +39,14 @@ Created on Wed May 29 11:23:46 2013
 ###############################################################################
 from __future__ import division
 
+<<<<<<< Updated upstream
 from numpy import abs
 from numpy.testing import assert_, run_module_suite
+=======
+from numpy import abs, pi
+from numpy.linalg import norm
+from numpy.testing import assert_, run_module_suite, assert_equal, assert_almost_equal
+>>>>>>> Stashed changes
 
 from qutip.qobj import Qobj
 from qutip.states import basis
@@ -165,5 +171,43 @@ class TestSuperopReps(object):
         for dims in range(2, 5):
             assert_(abs(to_choi(identity(dims)).tr() - dims) <= tol)
 
+
+    def test_chi_known(self):
+        """
+        Superoperator: Chi-matrix for known cases is correct.
+        """
+        def case(S, chi_expecte, silent=True):
+            chi_actual = to_chi(S)
+            chiq = Qobj(chi_expected, dims=[[[2], [2]], [[2], [2]]], superrep='chi')
+            if not silent:
+                print(chi_actual)
+                print(chi_expected)
+            assert_almost_equal((chi_actual - chiq).norm('tr'), 0)
+
+        yield case, sigmax(), [
+            [0, 0, 0, 0],
+            [0, 4, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ]
+        yield case, to_super(sigmax()), [
+            [0, 0, 0, 0],
+            [0, 4, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ]
+        yield case, qeye(2), [
+            [4, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ]
+        yield case, (-1j * sigmax() * pi / 4).expm(), [
+            [2, 2j, 0, 0],
+            [-2j, 2, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ]
+        
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -39,18 +39,13 @@ Created on Wed May 29 11:23:46 2013
 ###############################################################################
 from __future__ import division
 
-<<<<<<< Updated upstream
-from numpy import abs
-from numpy.testing import assert_, run_module_suite
-=======
 from numpy import abs, pi
 from numpy.linalg import norm
-from numpy.testing import assert_, run_module_suite, assert_equal, assert_almost_equal
->>>>>>> Stashed changes
+from numpy.testing import assert_, assert_almost_equal, run_module_suite
 
 from qutip.qobj import Qobj
 from qutip.states import basis
-from qutip.operators import identity, sigmax
+from qutip.operators import identity, sigmax, qeye
 from qutip.qip.gates import swap
 from qutip.random_objects import rand_super
 from qutip.tensor import super_tensor
@@ -176,7 +171,7 @@ class TestSuperopReps(object):
         """
         Superoperator: Chi-matrix for known cases is correct.
         """
-        def case(S, chi_expecte, silent=True):
+        def case(S, chi_expected, silent=True):
             chi_actual = to_chi(S)
             chiq = Qobj(chi_expected, dims=[[[2], [2]], [[2], [2]]], superrep='chi')
             if not silent:


### PR DESCRIPTION
In writing the documentation for #332, I noticed that the chi-matrix produced for several test channels was incorrect due to my placing the dagger in the wrong place. I apologize for that mistake--- this PR should fix it, and add unit tests that ensure that the chi matrix produced by to_chi agrees with that for some known Pauli channels and a unitary rotation.