### PR TITLE
Qtrl load params list, Qobj and ndarrays

### DIFF
--- a/qutip/control/loadparams.py
+++ b/qutip/control/loadparams.py
@@ -50,6 +50,8 @@ defined for that object
 import numpy as np
 from ConfigParser import SafeConfigParser
 # QuTiP logging
+from qutip import Qobj
+
 import qutip.logging as logging
 logger = logging.get_logger()
 
@@ -131,8 +133,32 @@ def set_param(parser, section, option, obj, attrib_name):
     if hasattr(obj, attrib_name):
         a = getattr(obj, attrib_name)
         dtype = type(a)
-
-    if dtype == float:
+        
+    if isinstance(a, Qobj):
+        try:
+            q = Qobj(eval(val))
+        except:
+            raise ValueError("Value '{}' cannot be used to generate a Qobj"
+                             " in parameter file [{}].{}".format(
+                                 val, section, option))
+        setattr(obj, attrib_name, q)
+    elif isinstance(a, np.ndarray):
+        try:
+            arr = np.array(eval(val), dtype=a.dtype)
+        except:
+            raise ValueError("Value '{}' cannot be used to generate an ndarray"
+                             " in parameter file [{}].{}".format(
+                                 val, section, option))
+        setattr(obj, attrib_name, arr)
+    elif isinstance(a, list):
+        try:
+            l = list(eval(val))
+        except:
+            raise ValueError("Value '{}' cannot be used to generate a list"
+                             " in parameter file [{}].{}".format(
+                                 val, section, option))
+        setattr(obj, attrib_name, l)
+    elif dtype == float:
         try:
             f = parser.getfloat(section, attrib_name)
         except:


### PR DESCRIPTION
This small change allows parameter values of data type list, Qobj and ndarray to be given in parameter files.
As with the other data types supported, the set_param function looks at the existing data type for the object property to determine how to parse the value in the parameter (ini) file.
Lists are expected to appear in the file in a format that can be pass to list() as 
setattr(obj, attrib_name, list(eval(val)))
is the call made, e.g.
[Dynamics]
evo_times=[1,2,5,10]

Similarly with arrays the call is 
setattr(obj, attrib_name, np.array(eval(val), dtype=a.dtype)) 
e.g.
target = [[1, 1], [1, 1]]
The same goes for Qobj

