### PR TITLE
Add copy=True to csr_matrix() in Qobj constructor

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -185,14 +185,14 @@ class Qobj(object):
 
         if fast == 'mc':
             # fast Qobj construction for use in mcsolve with ket output
-            self.data = sp.csr_matrix(inpt, dtype=complex)
+            self.data = sp.csr_matrix(inpt, dtype=complex, copy=True)
             self.dims = dims
             self._isherm = False
             return
 
         if fast == 'mc-dm':
             # fast Qobj construction for use in mcsolve with dm output
-            self.data = sp.csr_matrix(inpt, dtype=complex)
+            self.data = sp.csr_matrix(inpt, dtype=complex, copy=True)
             self.dims = dims
             self._isherm = True
             return
@@ -201,7 +201,7 @@ class Qobj(object):
             # if input is already Qobj then return identical copy
 
             # make sure matrix is sparse (safety check)
-            self.data = sp.csr_matrix(inpt.data, dtype=complex)
+            self.data = sp.csr_matrix(inpt.data, dtype=complex, copy=True)
 
             if not np.any(dims):
                 # Dimensions of quantum object used for keeping track of tensor
@@ -248,7 +248,7 @@ class Qobj(object):
             if inpt.ndim == 1:
                 inpt = inpt[:, np.newaxis]
 
-            self.data = sp.csr_matrix(inpt, dtype=complex)
+            self.data = sp.csr_matrix(inpt, dtype=complex, copy=True)
 
             if not np.any(dims):
                 self.dims = [[int(inpt.shape[0])], [int(inpt.shape[1])]]
@@ -269,7 +269,7 @@ class Qobj(object):
             warnings.warn("Initializing Qobj from unsupported type: %s" %
                           builtins.type(inpt))
             inpt = np.array([[0]])
-            self.data = sp.csr_matrix(inpt, dtype=complex)
+            self.data = sp.csr_matrix(inpt, dtype=complex, copy=True)
             self.dims = [[int(inpt.shape[0])], [int(inpt.shape[1])]]
 
         if type == 'super':


### PR DESCRIPTION
When csr_matrix(spmat) is called with a sparse matrix spmat, the
default argument is copy=False, which then returns a reference to
spmat rather than a copy.

This behavior is the cause of at least one other bug (involving Qobj
multiplication) I have found, which I will fix separately if this
behavior is the intended result.

This probably hasn't been identified before because in many places
qobj.data is replaced with new matrices following computations. Also
copying can happen implicitly if the sparsity is changed as discussed 
here:
http://stackoverflow.com/questions/16722316/scipy-sparse-matrices-copy-argument