### PR TITLE
Make Qobj().iscp compare to -settings.atol rather than zero

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1476,7 +1476,7 @@ class Qobj(object):
                     if self.superrep in ('choi', 'chi')
                     else sr.to_choi(self)
                 ).eigenenergies()
-                return all(eigs >= 0)
+                return all(eigs >= -settings.atol)
             except:
                 return False
         else:


### PR DESCRIPTION
This commit makes `Qobj().iscp` compare the choi matrix eigenvalues to `-settings.atol` rather than `0`. Otherwise it returns `False` for cases where some eigenvalues are negative due to numerical noise but should really be zero.