### PR TITLE
Amplitude bounds now applied (again)

### DIFF
--- a/qutip/control/optimizer.py
+++ b/qutip/control/optimizer.py
@@ -936,7 +936,7 @@ class OptimizerLBFGSB(Optimizer):
                 fprime=fprime,
                 approx_grad=self.approx_grad,
                 callback=self.iter_step_callback_func,
-                bounds=bounds, m=m, factr=factr,
+                bounds=self.bounds, m=m, factr=factr,
                 pgtol=term_conds.min_gradient_norm,
                 disp=self.msg_level,
                 maxfun=term_conds.max_fid_func_calls,

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -1771,6 +1771,8 @@ def create_pulse_optimizer(
     
     optim.alg = alg
     optim.method = optim_method
+    optim.amp_lbound = amp_lbound
+    optim.amp_ubound = amp_ubound
     
     # Create the TerminationConditions instance
     tc = termcond.TerminationConditions()


### PR DESCRIPTION
Recent changes to the Optimiser class had left the bounds only being applied for the CRAB algorithm
Bounds now applied for GRAPE using l-bgfs-b and fmin_l_bfgs_b

fixes issue #353 