### PR TITLE
Feature unitarity

### DIFF
--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -267,4 +267,6 @@ def unitarity(oper):
     u : float
         Unitarity of ``oper``.
     """
-    return np.linalg.norm(_super_to_superpauli(oper).full()[1:, 1:], 2)
+    Eu = _super_to_superpauli(oper).full()[1:, 1:]
+    #return np.real(np.trace(np.dot(Eu, Eu.conj().T))) / len(Eu)
+    return np.linalg.norm(Eu, 'fro')**2 / len(Eu)

--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -36,12 +36,13 @@ This module contains a collection of functions for calculating metrics
 """
 
 __all__ = ['fidelity', 'tracedist', 'bures_dist', 'bures_angle',
-           'hilbert_dist', 'average_gate_fidelity', 'process_fidelity']
+           'hilbert_dist', 'average_gate_fidelity', 'process_fidelity',
+           'unitarity']
 
 import numpy as np
 from qutip.sparse import sp_eigs
 from qutip.states import ket2dm
-from qutip.superop_reps import to_kraus
+from qutip.superop_reps import to_kraus, _super_to_superpauli
 
 
 def fidelity(A, B):
@@ -250,3 +251,20 @@ def bures_angle(A, B):
         raise TypeError('A and B do not have same dimensions.')
 
     return np.arccos(fidelity(A, B))
+
+def unitarity(oper):
+    """
+    Returns the unitarity of a quantum map, defined as the Frobenius norm
+    of the unital block of that map's superoperator representation.
+
+    Parameters
+    ----------
+    oper : Qobj
+        Quantum map under consideration.
+
+    Returns
+    -------
+    u : float
+        Unitarity of ``oper``.
+    """
+    return np.linalg.norm(_super_to_superpauli(oper).full()[1:, 1:], 2)

--- a/qutip/superop_reps.py
+++ b/qutip/superop_reps.py
@@ -50,13 +50,13 @@ from itertools import starmap, product
 from numpy.core.multiarray import array, zeros
 from numpy.core.shape_base import hstack
 from numpy.matrixlib.defmatrix import matrix
-from numpy import sqrt
+from numpy import sqrt, floor, log2
 from scipy.linalg import eig
 
 # Other QuTiP functions and classes
 from qutip.superoperator import vec2mat, spre, spost, operator_to_vector
 from qutip.operators import identity, sigmax, sigmay, sigmaz
-from qutip.tensor import tensor
+from qutip.tensor import tensor, flatten
 from qutip.qobj import Qobj
 
 
@@ -137,6 +137,48 @@ def _super_tofrom_choi(q_oper):
     return Qobj(dims=q_oper.dims,
                 inpt=data.reshape([sqrt_shape] * 4).
                 transpose(3, 1, 2, 0).reshape(q_oper.data.shape))
+
+def _isqubitdims(dims):
+    """Checks whether all entries in a dims list are integer powers of 2.
+
+    Parameters
+    ----------
+    dims : nested list of ints
+        Dimensions to be checked.
+
+    Returns
+    -------
+    isqubitdims : bool
+        True if and only if every member of the flattened dims
+        list is an integer power of 2.
+    """
+    return all([
+        2**floor(log2(dim)) == dim
+        for dim in flatten(dims)
+    ])
+
+
+def _super_to_superpauli(q_oper):
+    """
+    Converts a superoperator in the column-stacking basis to
+    the Pauli basis (assuming qubit dimensions).
+
+    This is an internal function, as QuTiP does not currently have
+    a way to mark that superoperators are represented in the Pauli
+    basis as opposed to the column-stacking basis; a Pauli-basis
+    ``type='super'`` would thus break other conversion functions.
+    """
+    # Ensure we start with a column-stacking-basis superoperator.
+    sqobj = to_super(q_oper)
+    if not _isqubitdims(sqobj.dims):
+        raise ValueError("Pauli basis is only defined for qubits.")
+    nq = int(log2(sqobj.shape[0]) / 2)
+    B = _pauli_basis(nq) / sqrt(2**nq)
+    # To do this, we have to hack a bit and force the dims to match,
+    # since the _pauli_basis function makes different assumptions
+    # about indices than we need here.
+    B.dims = sqobj.dims
+    return B.dag() * sqobj * B
 
 
 def super_to_choi(q_oper):

--- a/qutip/tests/test_metrics.py
+++ b/qutip/tests/test_metrics.py
@@ -38,7 +38,7 @@ the qutip.metrics module.
 ###############################################################################
 import numpy as np
 from numpy import abs, sqrt
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_, assert_almost_equal, run_module_suite
 import scipy
 
 from qutip.operators import (
@@ -165,12 +165,15 @@ def test_unitarity_known():
     Metrics: Unitarity for known cases.
     """
     def case(q_oper, known_unitarity):
-        assert_(unitarity(q_oper) - known_unitarity <= 1e-6)
+        assert_almost_equal(unitarity(q_oper), known_unitarity)
 
     yield case, to_super(sigmax()), 1.0
     yield case, sum(map(
         to_super, [qeye(2), sigmax(), sigmay(), sigmaz()]
     )) / 4, 0.0
+    yield case, sum(map(
+        to_super, [qeye(2), sigmax()]
+    )) / 2, 1 / 3.0
 
 def test_unitarity_bounded(nq=3, n_cases=10):
     """

--- a/qutip/tests/test_metrics.py
+++ b/qutip/tests/test_metrics.py
@@ -41,10 +41,16 @@ from numpy import abs, sqrt
 from numpy.testing import assert_, run_module_suite
 import scipy
 
-from qutip.operators import create, destroy, jmat, identity, qdiags
+from qutip.operators import (
+    create, destroy, jmat, identity, qdiags, sigmax, sigmay, sigmaz, qeye
+)
 from qutip.states import fock_dm
 from qutip.propagator import propagator
-from qutip.random_objects import rand_herm, rand_dm, rand_unitary, rand_ket
+from qutip.random_objects import (
+    rand_herm, rand_dm, rand_unitary, rand_ket, rand_super_bcsz
+)
+from qutip.qobj import Qobj
+from qutip.superop_reps import to_super
 from qutip.metrics import *
 
 """
@@ -153,6 +159,29 @@ def test_hilbert_dist():
     r1 = qdiags(diag1, 0)
     r2 = qdiags(diag2, 0)
     assert_(abs(hilbert_dist(r1, r2)-1) <= 1e-6)
+
+def test_unitarity_known():
+    """
+    Metrics: Unitarity for known cases.
+    """
+    def case(q_oper, known_unitarity):
+        assert_(unitarity(q_oper) - known_unitarity <= 1e-6)
+
+    yield case, to_super(sigmax()), 1.0
+    yield case, sum(map(
+        to_super, [qeye(2), sigmax(), sigmay(), sigmaz()]
+    )) / 4, 0.0
+
+def test_unitarity_bounded(nq=3, n_cases=10):
+    """
+    Metrics: Unitarity in [0, 1].
+    """
+    def case(q_oper):
+        assert_(0.0 <= unitarity(q_oper) <= 1.0)
+
+    for _ in range(n_cases):
+        yield case, rand_super_bcsz(2**nq)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -47,7 +47,7 @@ __all__ = ['hinton', 'sphereplot', 'energy_level_diagram',
 import warnings
 import itertools as it
 import numpy as np
-from numpy import pi, array, sin, cos, angle
+from numpy import pi, array, sin, cos, angle, log2, sqrt
 
 try:
     import matplotlib.pyplot as plt
@@ -63,8 +63,7 @@ from qutip.wigner import wigner
 from qutip.tensor import tensor
 from qutip.matplotlib_utilities import complex_phase_cmap
 from qutip.superoperator import vector_to_operator
-from qutip.superop_reps import _pauli_basis, to_super
-from qutip.tensor import flatten
+from qutip.superop_reps import to_super, _super_to_superpauli, _isqubitdims
 
 from qutip import settings
 
@@ -82,25 +81,6 @@ def _blob(x, y, w, w_max, area, cmap=None):
     plt.fill(xcorners, ycorners,
              color=cmap(int((w + w_max) * 256 / (2 * w_max))))
 
-
-def _isqubitdims(dims):
-    """Checks whether all entries in a dims list are integer powers of 2.
-
-    Parameters
-    ----------
-    dims : nested list of ints
-        Dimensions to be checked.
-
-    Returns
-    -------
-    isqubitdims : bool
-        True if and only if every member of the flattened dims
-        list is an integer power of 2.
-    """
-    return all([
-        2**np.floor(np.log2(dim)) == dim
-        for dim in flatten(dims)
-    ])
 
 
 def _cb_labels(left_dims):
@@ -203,14 +183,8 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
                                  "currently only supported for qubits.")
             # Convert to a superoperator in the Pauli basis,
             # so that all the elements are real.
-            sqobj = to_super(rho)
-            nq = int(np.log2(sqobj.shape[0]) / 2)
-            B = _pauli_basis(nq) / np.sqrt(2**nq)
-            # To do this, we have to hack a bit and force the dims to match,
-            # since the _pauli_basis function makes different assumptions
-            # about indices than we need here.
-            B.dims = sqobj.dims
-            sqobj = B.dag() * sqobj * B
+            sqobj = _super_to_superpauli(rho)
+            nq = int(log2(sqobj.shape[0]) / 2)
             W = sqobj.full()
             # Create default labels, too.
             if (xlabels is None) or (ylabels is None):


### PR DESCRIPTION
This PR introduces a new metric, unitarity, based on [work with Wallman, Harper and Flammia](https://scirate.com/arxiv/1503.07865). In that work, we show that this metric is useful for discriminating between coherent and incoherence noise. As such, I hope that contributing an implementation of our new metric to QuTiP will be of use, especially for comparison to experimental data from randomized benchmarking. While it still needs some more documentation and test cases, I wanted to open the PR now to get some initial feedback.