### PR TITLE
__mul__ and __add__ leave isherm lazily-evaluated.

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -315,7 +315,9 @@ class Qobj(object):
             if isinstance(dat, (int, float)):
                 out._isherm = self._isherm
             else:
-                out._isherm = out.isherm
+                # We use _isherm here to prevent recalculating on self and
+                # other, relying on that bool(None) == False.
+                out._isherm = True if self._isherm and other._isherm else out.isherm
 
             out.superrep = self.superrep
 
@@ -425,7 +427,7 @@ class Qobj(object):
                 else:
                     out.dims = dims
 
-                out._isherm = out.isherm
+                out._isherm = None
 
                 if self.superrep and other.superrep:
                     if self.superrep != other.superrep:

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -40,13 +40,20 @@ from qutip.qobj import Qobj
 from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
                                   rand_super)
 from qutip.states import basis, fock_dm, ket2dm
-from qutip.operators import create, destroy, num, sigmax
+from qutip.operators import create, destroy, num, sigmax, sigmay
 from qutip.superoperator import spre, spost, operator_to_vector
 from qutip.superop_reps import to_super
 from qutip.tensor import tensor, super_tensor, composite
 
 from operator import add, mul, truediv, sub
 
+def assert_hermicity(oper, hermicity, msg=""):
+    # Check the cached isherm, if any exists.
+    assert_(oper.isherm == hermicity, msg)
+    # Force a reset of the cached value for isherm.
+    oper._isherm = None
+    # Force a recalculation of isherm.
+    assert_(oper.isherm == hermicity, msg)
 
 def test_QobjData():
     "Qobj data"
@@ -131,21 +138,27 @@ def test_QobjHerm():
 
     # test addition of two nonhermitian operators adding up to a hermitian one
     q_x = q_a + q_ad
-    assert_(q_x.isherm)  # isherm use the _isherm cache from q_a + q_ad
-    q_x._isherm = None   # reset _isherm cache
-    assert_(q_x.isherm)  # recalculate _isherm
+    assert_hermicity(q_x, True)
 
     # test addition of one hermitan and one nonhermitian operator
     q = q_x + q_a
-    assert_(not q.isherm)
-    q._isherm = None
-    assert_(not q.isherm)
+    assert_hermicity(q, False)
 
     # test addition of two hermitan operators
     q = q_x + q_x
-    assert_(q.isherm)
-    q._isherm = None
-    assert_(q.isherm)
+    assert_hermicity(q, True)
+
+    # Test multiplication of two Hermitian operators.
+    # This results in a skew-Hermitian operator, so
+    # we're checking here that __mul__ doesn't set wrong
+    # metadata.
+    q = sigmax() * sigmay()
+    assert_hermicity(q, False, "Expected iZ = X * Y to be skew-Hermitian.")
+    # Similarly, we need to check that -Z = X * iY is correctly
+    # identified as Hermitian.
+    q = sigmax() * (1j * sigmay())
+    assert_hermicity(q, True, "Expected -Z = X * iY to be Hermitian.")
+
 
 
 def test_QobjDimsShape():


### PR DESCRIPTION
This PR changes ``Qobj.__mul__`` and ``Qobj.__add__`` to leave ``isherm`` lazily-evaluated (that is, ``_isherm = None``) unless the Hermicity of the result is already known from closure under addition. This change was prompted by noticing that ``isherm`` alone took up over half of the runtime of a computation I was attempting, despite that nothing actually ever looked at the Hermicity of a product of two ``Qobj`` instances. I also added additional tests to ensure that ``__mul__`` doesn't result in incorrect values of ``isherm``, something that was not previously covered by ``qutip.tests.test_qobj.test_QobjHerm``. The new tests pass locally on Python 2.7 and 3.4 (Ubuntu 14.10) as well as on Windows with Python 2.7.