### PR TITLE
Travis migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 
 python:
@@ -8,10 +9,16 @@ matrix:
         - python: 3.4
           env: CC=clang CXX=clang++
 
+addons:
+    apt:
+        packages:
+            - libatlas-dev
+            - libatlas-base-dev
+            - liblapack-dev
+            - gfortran
+
 before_install:
     - uname -a
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
     - ./miniconda.sh -b


### PR DESCRIPTION
Pursuant to discussions over the build failures observed in #359, this PR migrates Travis CI support to their new container-based configuration. I've observed that the builds with this configuration are more reliable, but they are slower for some reason. In the [instructions](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade#Faster-builds) they provide, Travis say that this configuration should be faster, and to let them know if our build is slower; that might be worth doing.