### PR TITLE
Adds target kwarg to average_gate_fidelity; unit tests.

### DIFF
--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -108,7 +108,7 @@ def process_fidelity(U1, U2, normalize=True):
         return (U1 * U2).tr()
 
 
-def average_gate_fidelity(oper):
+def average_gate_fidelity(oper, target=None):
     """
     Given a Qobj representing the supermatrix form of a map, returns the
     average gate fidelity (pseudo-metric) of that map.
@@ -117,20 +117,28 @@ def average_gate_fidelity(oper):
     ----------
     A : Qobj
         Quantum object representing a superoperator.
+    target : Qobj
+        Quantum object representing the target unitary; the inverse
+        is applied before evaluating the fidelity.
 
     Returns
     -------
     fid : float
-        Fidelity pseudo-metric between A and the identity superoperator.
+        Fidelity pseudo-metric between A and the identity superoperator,
+        or between A and the target superunitary.
     """
     kraus_form = to_kraus(oper)
     d = kraus_form[0].shape[0]
 
     if kraus_form[0].shape[1] != d:
-        return TypeError("Average gate fielity only implemented for square "
+        return TypeError("Average gate fidelity only implemented for square "
                          "superoperators.")
 
-    return (d + np.sum([np.abs(A_k.tr())**2
+    if target is None:
+        return (d + np.sum([np.abs(A_k.tr())**2
+                        for A_k in kraus_form])) / (d**2 + d)
+    else:
+        return (d + np.sum([np.abs((A_k * target.dag()).tr())**2
                         for A_k in kraus_form])) / (d**2 + d)
 
 

--- a/qutip/tests/test_metrics.py
+++ b/qutip/tests/test_metrics.py
@@ -50,7 +50,7 @@ from qutip.states import fock_dm, basis
 from qutip.propagator import propagator
 from qutip.random_objects import (
     rand_herm, rand_dm, rand_unitary, rand_ket, rand_super_bcsz,
-    rand_ket_haar, rand_dm_ginibre
+    rand_ket_haar, rand_dm_ginibre, rand_unitary_haar
 )
 from qutip.qobj import Qobj
 from qutip.superop_reps import to_super
@@ -231,6 +231,14 @@ def test_average_gate_fidelity():
         assert_(abs(average_gate_fidelity(identity(dims)) - 1) <= 1e-12)
     assert_(0 <= average_gate_fidelity(rand_super()) <= 1)
 
+def test_average_gate_fidelity_target():
+    """
+    Metrics: Tests that for random unitaries U, AGF(U, U) = 1.
+    """
+    for _ in range(10):
+        U = rand_unitary_haar(13)
+        SU = to_super(U)
+        assert_almost_equal(average_gate_fidelity(SU, target=U), 1)
 
 def test_hilbert_dist():
     """


### PR DESCRIPTION
The target kwarg for average_gate_fidelity makes it easier to compare
channels to a particular desired unitary without needing to apply the
target unitary on superoperator space. This is especially important to
open quantum systems control.