### PR TITLE
Python3 compatibility fix in control classes apply_params

### DIFF
--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -293,8 +293,8 @@ class Dynamics:
         
         if isinstance(params, dict):
             self.params = params
-            for key, val in params.iteritems():
-                setattr(self, key, val)
+            for key in params:
+                setattr(self, key, params[key])
                 
     def set_log_level(self, lvl):
         """

--- a/qutip/control/fidcomp.py
+++ b/qutip/control/fidcomp.py
@@ -177,8 +177,8 @@ class FidelityComputer:
         
         if isinstance(params, dict):
             self.params = params
-            for key, val in params.iteritems():
-                setattr(self, key, val)
+            for key in params:
+                setattr(self, key, params[key])
                 
     def set_log_level(self, lvl):
         """

--- a/qutip/control/loadparams.py
+++ b/qutip/control/loadparams.py
@@ -48,7 +48,14 @@ defined for that object
 """
 
 import numpy as np
-from ConfigParser import SafeConfigParser
+
+try:
+    # Python 3
+    from configparser import SafeConfigParser
+except:
+    # Python 2
+    from ConfigParser import SafeConfigParser
+    
 # QuTiP logging
 from qutip import Qobj
 

--- a/qutip/control/optimizer.py
+++ b/qutip/control/optimizer.py
@@ -383,9 +383,13 @@ class Optimizer:
             self.method_options = {}
         mo = self.method_options
         
-        if hasattr(self, 'max_metric_corr') and not 'maxcor' in mo:
+        if 'max_metric_corr' in mo and not 'maxcor' in mo:
+            mo['maxcor'] = mo['max_metric_corr']
+        elif hasattr(self, 'max_metric_corr') and not 'maxcor' in mo:
             mo['maxcor'] = self.max_metric_corr
-        if hasattr(tc, 'accuracy_factor') and not 'ftol' in mo:
+        if 'accuracy_factor' in mo  and not 'ftol' in mo:
+            mo['ftol'] = mo['accuracy_factor']
+        elif hasattr(tc, 'accuracy_factor') and not 'ftol' in mo:
             mo['ftol'] = tc.accuracy_factor
         if tc.max_iterations > 0 and not 'maxiter' in mo:
             mo['maxiter'] = tc.max_iterations
@@ -413,7 +417,8 @@ class Optimizer:
         if isinstance(params, dict):
             self.method_params = params
             unused_params = {}
-            for key, val in params.iteritems():
+            for key in params:
+                val = params[key]
                 if hasattr(self, key):
                     setattr(self, key, val)
                 if hasattr(self.termination_conditions, key):
@@ -476,7 +481,7 @@ class Optimizer:
         parameter is not None
 
         The result is returned in an OptimResult object, which includes
-        the final fidelity, time evolution, reason for termination etc
+        the final fidelity, time evolution, reason forphase_option termination etc
         """
         self.init_optim(term_conds)
         term_conds = self.termination_conditions
@@ -906,19 +911,20 @@ class OptimizerLBFGSB(Optimizer):
         else:
             fprime = self.fid_err_grad_wrapper
             
-        if 'ftol' in self.method_options:
-            factr = self.method_options['ftol']
-        elif 'accuracy_factor' in self.method_options:
+
+        if 'accuracy_factor' in self.method_options:
             factr = self.method_options['accuracy_factor']
+        elif 'ftol' in self.method_options:
+            factr = self.method_options['ftol']
         elif hasattr(term_conds, 'accuracy_factor'):
             factr = term_conds.accuracy_factor
         else:
             factr = 1e7
             
-        if 'maxcor' in self.method_options:
-            m = self.method_options['maxcor']
-        elif 'max_metric_corr' in self.method_options:
+        if 'max_metric_corr' in self.method_options:
             m = self.method_options['max_metric_corr']
+        elif 'maxcor' in self.method_options:
+            m = self.method_options['maxcor']
         elif hasattr(self, 'max_metric_corr'):
             m = self.max_metric_corr
         else:

--- a/qutip/control/optimizer.py
+++ b/qutip/control/optimizer.py
@@ -481,7 +481,7 @@ class Optimizer:
         parameter is not None
 
         The result is returned in an OptimResult object, which includes
-        the final fidelity, time evolution, reason forphase_option termination etc
+        the final fidelity, time evolution, reason for termination etc
         """
         self.init_optim(term_conds)
         term_conds = self.termination_conditions

--- a/qutip/control/propcomp.py
+++ b/qutip/control/propcomp.py
@@ -113,8 +113,8 @@ class PropagatorComputer:
         
         if isinstance(params, dict):
             self.params = params
-            for key, val in params.iteritems():
-                setattr(self, key, val)
+            for key in params:
+                setattr(self, key, params[key])
 
     def set_log_level(self, lvl):
         """

--- a/qutip/control/termcond.py
+++ b/qutip/control/termcond.py
@@ -81,6 +81,7 @@ class TerminationConditions:
         scipy.optimize.fmin_l_bfgs_b factr argument.
         Only set for specific methods (fmin_l_bfgs_b) that uses this
         Otherwise the same thing is passed as method_option ftol
+        (although the scale is different)
         Hence it is not defined here, but may be set by the user
     """
     def __init__(self):

--- a/qutip/control/tslotcomp.py
+++ b/qutip/control/tslotcomp.py
@@ -121,8 +121,8 @@ class TimeslotComputer:
         
         if isinstance(params, dict):
             self.params = params
-            for key, val in params.iteritems():
-                setattr(self, key, val)
+            for key in params:
+                setattr(self, key, params[key])
 
     def flag_all_calc_now(self):
         pass


### PR DESCRIPTION
Use of iteritems removed in apply_params to make compatible with Python3
fixes #367 
Also some changes to the way max_metric_corr and accuracy_factor method_params are applied in the optimizer
