### PR TITLE
Undo wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ Operating System :: Microsoft :: Windows
 import os
 import sys
 import numpy as np
-import setuptools
 from numpy.distutils.core import setup
 
 # all information about QuTiP goes here
@@ -157,6 +156,5 @@ setup(
     platforms=PLATFORMS,
     requires=REQUIRES,
     package_data=PACKAGE_DATA,
-    configuration=configuration,
-    zip_safe=False
+    configuration=configuration
 )


### PR DESCRIPTION
removed import of setuptools as this breaks fresh installations (i.e
under macports) on some systems by not registering the qutip module
properly. Added it just to try wheels builds so not important