### PR TITLE
casting fix for correlation_2op_2t 

### DIFF
--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -1294,9 +1294,11 @@ def _correlation_mc_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
                 ]
 
                 # final correlation vector computed by combining the averages
-                corr_mat[t_idx, :] += \
-                    1/(4*options.ntraj[0]) * (c_tau[0] - c_tau[2] -
-                                              1j*c_tau[1] + 1j*c_tau[3])
+                corr_mat_add = np.asarray(1/(4*options.ntraj[0]) * 
+                        (c_tau[0] - c_tau[2] - 1j*c_tau[1] + 1j*c_tau[3]),
+                         dtype=corr_mat.dtype)
+                corr_mat[t_idx, :] += corr_mat_add
+                    
         if t_idx == 1:
             options.rhs_reuse = True
 


### PR DESCRIPTION
corr_mat casting made explicit
A cast from object to complex that was acceptable in numpy 1.9
was failing in numpy 1.10
This was causing an error in #379 Travis tests