### PR TITLE
Fix #386 by changing axis for np.sum().

### DIFF
--- a/qutip/tensor.py
+++ b/qutip/tensor.py
@@ -359,7 +359,9 @@ def _tensor_contract_single(arr, i, j):
     idxs = np.arange(arr.shape[i])
     sl = tuple(slice(None, None, None)
                if idx not in (i, j) else idxs for idx in range(arr.ndim))
-    return np.sum(arr[sl], axis=0)
+    contract_at = i if j == i + 1 else 0
+    print contract_at
+    return np.sum(arr[sl], axis=contract_at)
 
 
 def _tensor_contract_dense(arr, *pairs):

--- a/qutip/tensor.py
+++ b/qutip/tensor.py
@@ -360,7 +360,6 @@ def _tensor_contract_single(arr, i, j):
     sl = tuple(slice(None, None, None)
                if idx not in (i, j) else idxs for idx in range(arr.ndim))
     contract_at = i if j == i + 1 else 0
-    print contract_at
     return np.sum(arr[sl], axis=contract_at)
 
 


### PR DESCRIPTION
This PR fixes #386 by changing checking if ``j == i + 1``, in which case NumPy doesn't automatically move fancy indices to the left. In particular, for adjacent indices, we should sum over index ``i``, not over index ``0`` as was assumed before. To catch regressions, this PR also adds more robust unit tests that check more unusual tensor contractions. Thanks to @arnelg for pointing this out!