### PR TITLE
Generalized superop reps to more robustly handle multiqubit dims.

### DIFF
--- a/qutip/superop_reps.py
+++ b/qutip/superop_reps.py
@@ -52,8 +52,10 @@ from numpy.core.multiarray import array, zeros
 from numpy.core.shape_base import hstack
 from numpy.matrixlib.defmatrix import matrix
 from numpy import sqrt, floor, log2
-from numpy import sqrt, dot
+from numpy import dot
 from scipy.linalg import eig, svd
+# Needed to avoid conflict with itertools.product.
+import numpy as np
 
 # Other QuTiP functions and classes
 from qutip.superoperator import vec2mat, spre, spost, operator_to_vector
@@ -245,6 +247,14 @@ def kraus_to_super(kraus_list):
     return choi_to_super(kraus_to_choi(kraus_list))
 
 
+def _nq(dims):
+    dim = np.product(dims[0][0])
+    nq = int(log2(dim))
+    if 2 ** nq != dim:
+        raise ValueError("{} is not an integer power of 2.".format(dim))
+    return nq
+
+
 def choi_to_chi(q_oper):
     """
     Converts a Choi matrix to a Chi matrix in the Pauli basis.
@@ -252,9 +262,13 @@ def choi_to_chi(q_oper):
     NOTE: this is only supported for qubits right now. Need to extend to
     Heisenberg-Weyl for other subsystem dimensions.
     """
-    nq = len(q_oper.dims[0][0])
+    nq = _nq(q_oper.dims)
     B = _pauli_basis(nq)
+    # Force the basis change to match the dimensions of
+    # the input.
+    B.dims = q_oper.dims
     B.superrep = 'choi'
+
     return Qobj(B.dag() * q_oper * B, superrep='chi')
 
 
@@ -265,8 +279,11 @@ def chi_to_choi(q_oper):
     NOTE: this is only supported for qubits right now. Need to extend to
     Heisenberg-Weyl for other subsystem dimensions.
     """
-    nq = len(q_oper.dims[0][0])
+    nq = _nq(q_oper.dims)
     B = _pauli_basis(nq)
+    # Force the basis change to match the dimensions of
+    # the input.
+    B.dims = q_oper.dims
 
     # The Chi matrix has tr(chi) == d², so we need to divide out
     # by that to get back to the Choi form.

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -209,6 +209,18 @@ class TestSuperopReps(object):
         assert_equal(A.dims, [[2, 3, 1], [2, 3]])
         assert_equal(B.dims, [[2, 3, 1], [2, 3]])
 
+    def test_chi_choi_roundtrip(self):
+        def case(qobj):
+            qobj = to_chi(qobj)
+            rt_qobj = to_chi(to_choi(qobj))
+
+            assert_almost_equal(rt_qobj.data.toarray(), qobj.data.toarray())
+            assert_equal(rt_qobj.type, qobj.type)
+            assert_equal(rt_qobj.dims, qobj.dims)
+
+        for N in (2, 4, 8):
+            yield case, rand_super_bcsz(N)
+
     def test_chi_known(self):
         """
         Superoperator: Chi-matrix for known cases is correct.


### PR DESCRIPTION
The previous implementation of ``choi_to_chi`` and ``chi_to_choi`` required that ``dims`` be specified explicitly as qubits; for example, ``[[[2, 2, 2], [2, 2, 2]], [[2, 2, 2], [2, 2, 2]]]`` for a three-qubit system. This PR generalizes to allow for ``dims`` built from powers of 2 instead, as in ``[[[8], [8]], [[8], [8]]]``. In addition, this PR adds new test cases to check that ``to_choi`` and ``to_chi`` properly roundtrip for multiqubit dimensions.