### PR TITLE
Ial time dependent drift

### DIFF
--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -145,7 +145,7 @@ class Dynamics:
 
     drift_dyn_gen : Qobj
         Drift or system dynamics generator
-        Matrix defining the underlying dynamics of the system
+        List of matricies defining the underlying dynamics of the system
 
     ctrl_dyn_gen : List of Qobj
         Control dynamics generator: ctrl_dyn_gen ()
@@ -258,6 +258,7 @@ class Dynamics:
         self.initial = None
         self.target = None
         self.ctrl_amps = None
+        self.drift_amps = None
         self.initial_ctrl_scaling = 1.0
         self.initial_ctrl_offset = 0.0
         self.drift_dyn_gen = None
@@ -369,7 +370,7 @@ class Dynamics:
         """
 
         # Create containers for control Hamiltonian etc
-        shp = self.drift_dyn_gen.shape
+        shp = self.drift_dyn_gen[0].shape
         # set H to be just empty float arrays with the shape of H
         self.dyn_gen = [np.empty(shp, dtype=complex)
                         for x in range(self.num_tslots)]
@@ -402,7 +403,7 @@ class Dynamics:
         used in calculating propagators and gradients
         Note: used with PropCompDiag propagator calcs
         """
-        shp = self.drift_dyn_gen.shape
+        shp = self.drift_dyn_gen[0].shape
         n_ts = self.num_tslots
         self.decomp_curr = [False for x in range(n_ts)]
         self.prop_eigen = \
@@ -421,7 +422,7 @@ class Dynamics:
                                 " attribute is not set.")
                     cfg.clear_test_out_flags()
 
-    def initialize_controls(self, amps, init_tslots=True):
+    def initialize_controls(self, ctrl_amps, drift_amps=None, init_tslots=True):
         """
         Set the initial control amplitudes and time slices
         Note this must be called after the configuration is complete
@@ -448,6 +449,15 @@ class Dynamics:
         # Note this call is made just to initialise the num_ctrls attrib
         self.get_num_ctrls()
 
+        if drift_amps is None:
+            if self.get_num_drifts() > 1:
+                raise errors.UsageError("Multiple drifts were provdied, "
+                    "with no amplitudes.")
+            # Backwards compatibilty constant drift
+            self.drift_amps = np.ones(self.num_tslots)
+        else:
+            self.drift_amps = drift_amps
+
         if not self._timeslots_initialized:
             init_tslots = True
         if init_tslots:
@@ -456,7 +466,8 @@ class Dynamics:
         self.tslot_computer.init_comp()
         self.fid_computer.init_comp()
         self._ctrls_initialized = True
-        self.update_ctrl_amps(amps)
+        self.update_ctrl_amps(ctrl_amps)
+
 
     def check_ctrls_initialized(self):
         if not self._ctrls_initialized:
@@ -564,10 +575,10 @@ class Dynamics:
         Returns the size of the matrix that defines the drift dynamics
         that is assuming the drift is NxN, then this returns N
         """
-        if not isinstance(self.drift_dyn_gen, np.ndarray):
+        if not isinstance(self.drift_dyn_gen[0], np.ndarray):
             raise TypeError("Cannot get drift dimension, "
                             "as drift not set (correctly).")
-        return self.drift_dyn_gen.shape[0]
+        return self.drift_dyn_gen[0].shape[0]
 
     def get_num_ctrls(self):
         """
@@ -576,7 +587,19 @@ class Dynamics:
         subsequently
         """
         self.num_ctrls = len(self.ctrl_dyn_gen)
+
         return self.num_ctrls
+
+    def get_num_drifts(self):
+        """
+        calculate the of drifts from the length of the drift list
+        sets the num_drifts property, which can be used alternatively
+        subsequently
+        """
+
+        self.num_drifts = len(self.drift_dyn_gen)
+
+        return self.num_drifts
 
     def get_owd_evo_target(self):
         """
@@ -590,10 +613,14 @@ class Dynamics:
         Computes the dynamics generator for a given timeslot
         The is the combined Hamiltion for unitary systems
         """
-        dg = np.asarray(self.drift_dyn_gen)
-        for j in range(self.get_num_ctrls()):
-            dg = dg + self.ctrl_amps[k, j]*np.asarray(self.ctrl_dyn_gen[j])
-        return dg
+
+        dg = np.sum(self.drift_amps[k, j]*np.asarray(self.drift_dyn_gen[j])
+            for j in range(self.get_num_drifts()))
+
+        cg = np.sum(self.ctrl_amps[k, j] * np.asarray(self.ctrl_dyn_gen[j])
+            for j in range(self.get_num_ctrls()))
+
+        return dg+cg
 
     def get_dyn_gen(self, k):
         """
@@ -693,7 +720,7 @@ class DynamicsUnitary(Dynamics):
     Attributes
     ----------
     drift_ham : Qobj
-        This is the drift Hamiltonian for unitary dynamics
+        These are the drift Hamiltonians for unitary dynamics
         It is mapped to drift_dyn_gen during initialize_controls
 
     ctrl_ham : List of Qobj
@@ -731,12 +758,12 @@ class DynamicsUnitary(Dynamics):
         # set the default propagator computer
         self.prop_computer = propcomp.PropCompDiag(self)
 
-    def initialize_controls(self, amplitudes, init_tslots=True):
+    def initialize_controls(self, amplitudes, drift_amps=None, init_tslots=True):
         # Either the _dyn_gen or _ham names can be used
         # This assumes that one or other has been set in the configuration
 
         self._map_dyn_gen_to_ham()
-        Dynamics.initialize_controls(self, amplitudes, init_tslots=init_tslots)
+        Dynamics.initialize_controls(self, amplitudes, drift_amps=drift_amps, init_tslots=init_tslots)
         self.H = self.dyn_gen
 
     def _map_dyn_gen_to_ham(self):
@@ -770,6 +797,11 @@ class DynamicsUnitary(Dynamics):
         if not self._dyn_gen_mapped:
             self._map_dyn_gen_to_ham()
         return Dynamics.get_num_ctrls(self)
+
+    def get_num_drifts(self):
+        if not self._dyn_gen_mapped:
+            self._map_dyn_gen_to_ham()
+        return Dynamics.get_num_drifts(self)
 
     def get_owd_evo_target(self):
         return self.target.conj().T

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -451,10 +451,11 @@ class Dynamics:
 
         if drift_amps is None:
             if self.get_num_drifts() > 1:
-                raise errors.UsageError("Multiple drifts were provdied, "
-                    "with no amplitudes.")
+                print(self.drift_dyn_gen)
+                raise errors.UsageError("No drift amplitudes were"
+                "provided. There are {} drifts".format(self.get_num_drifts()))
             # Backwards compatibilty constant drift
-            self.drift_amps = np.ones(self.num_tslots)
+            self.drift_amps = np.ones([self.num_tslots, self.get_num_drifts()])
         else:
             self.drift_amps = drift_amps
 
@@ -891,7 +892,7 @@ class DynamicsSymplectic(Dynamics):
 
     def get_omega(self):
         if self.omega is None:
-            n = self.drift_dyn_gen.shape[0] // 2
+            n = self.drift_dyn_gen[0].shape[0] // 2
             self.omega = sympl.calc_omega(n)
 
         return self.omega

--- a/qutip/control/optimizer.py
+++ b/qutip/control/optimizer.py
@@ -268,6 +268,7 @@ class Optimizer:
         result = optimresult.OptimResult()
         result.initial_fid_err = self.dynamics.fid_computer.get_fid_err()
         result.initial_amps = self.dynamics.ctrl_amps.copy()
+        result.drift_amps = self.dynamics.drift_amps.copy()
         result.time = self.dynamics.time
         result.optimizer = self
         return result

--- a/qutip/control/optimizer.py
+++ b/qutip/control/optimizer.py
@@ -284,6 +284,7 @@ class Optimizer:
 
         if term_conds is not None:
             self.termination_conditions = term_conds
+            logger.info("TERM CONDS")
         term_conds = self.termination_conditions
         
         if not isinstance(term_conds, termcond.TerminationConditions):

--- a/qutip/control/optimresult.py
+++ b/qutip/control/optimresult.py
@@ -126,6 +126,7 @@ class OptimResult:
         self.wall_time_limit_exceeded = False
         self.termination_reason = "not started yet"
         self.time = None
+        self.drift_amps = None
         self.initial_amps = None
         self.final_amps = None
         self.evo_full_final = None

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -456,8 +456,9 @@ def optimize_pulse(
         dg_name = "dynamics generator"
         if dyn_type == 'UNIT':
             dg_name = "Hamiltonian"
-        msg += "Drift {}:\n".format(dg_name)
-        msg += str(dyn.drift_dyn_gen)
+        for j in range(dyn.num_drifts):
+            msg += "Drift {} {}:\n".format(j+1, dg_name)
+            msg += str(dyn.drift_dyn_gen[j])
         for j in range(dyn.num_ctrls):
             msg += "\nControl {} {}:\n".format(j+1, dg_name)
             msg += str(dyn.ctrl_dyn_gen[j])
@@ -718,7 +719,6 @@ def optimize_pulse_unitary(
 
     # check parameters here, as names are different than in
     # create_pulse_optimizer, so TypeErrors would be confusing
-    print("working")
     if not isinstance(H_d, (list, tuple)):
         raise TypeError("H_d should be a list of Qobj")
 
@@ -1827,6 +1827,7 @@ def create_pulse_optimizer(
 
     # this function is called, so that the num_ctrls attribute will be set
     n_ctrls = dyn.get_num_ctrls()
+    n_drifts = dyn.get_num_drifts()
 
     ramping_pgen = None
     if ramping_pulse_type:

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -157,7 +157,7 @@ def optimize_pulse(
     Parameters
     ----------
 
-    drift : Qobj
+    drifts : Qobj
         the underlying dynamics generator of the system
 
     ctrls : List of Qobj
@@ -720,7 +720,12 @@ def optimize_pulse_unitary(
     # check parameters here, as names are different than in
     # create_pulse_optimizer, so TypeErrors would be confusing
     if not isinstance(H_d, (list, tuple)):
-        raise TypeError("H_d should be a list of Qobj")
+        if not isinstance(H_d, Qobj):
+            raise TypeError("drifts should be a Qobj or list of Qobj")
+    else:
+        for drift in H_d:
+            if not isinstance(drift, Qobj):
+                raise TypeError("drifts should be a Qobj or list of Qobj")
 
     if not isinstance(H_c, (list, tuple)):
         raise TypeError("H_c should be a list of Qobj")
@@ -780,7 +785,7 @@ def optimize_pulse_unitary(
         fid_params = {'phase_option':phase_option}
             
     return optimize_pulse(
-            drift=H_d, ctrls=H_c, initial=U_0, target=U_targ,
+            drifts=H_d, ctrls=H_c, initial=U_0, target=U_targ,
             num_tslots=num_tslots, evo_time=evo_time, tau=tau,
             amp_lbound=amp_lbound, amp_ubound=amp_ubound,
             fid_err_targ=fid_err_targ, min_grad=min_grad,
@@ -1572,12 +1577,14 @@ def create_pulse_optimizer(
 
     # check parameters
     if not isinstance(drifts, (list, tuple)):
-        raise TypeError("drifts should be a list of Qobj")
+        if not isinstance(drifts, Qobj):
+            raise TypeError("drifts should be a Qobj or list of Qobj")
+        drifts = list([drifts.full()])
     else:
         j = 0
         for drift in drifts:
             if not isinstance(drift, Qobj):
-                raise TypeError("drifts should be a list of Qobj")
+                raise TypeError("drifts should be a Qobj or a list of Qobj")
             else:
                 drifts[j] = drift.full()
                 j += 1

--- a/qutip/tests/test_control_pulseoptim.py
+++ b/qutip/tests/test_control_pulseoptim.py
@@ -367,7 +367,7 @@ class TestPulseOptim:
         dyn = dynamics.DynamicsUnitary(cfg)
         dyn.target = U_targ.full()
         dyn.initial = U_0.full()
-        dyn.drift_dyn_gen = H_d.full()
+        dyn.drift_dyn_gen = list([H_d.full()])
         dyn.ctrl_dyn_gen = list([H_c.full()])
         loadparams.load_parameters(cfg.param_fpath, dynamics=dyn)
         dyn.init_timeslots()      


### PR DESCRIPTION
@ajgpitch,

Could you take a look at these patches, with this set I've tried to keep this backwards compatible.

With this set, the helper function `create_pulse_optimizer` has been updated to accept the new drifts.
`optimize_pulse` currently creates an array of constant drift amplitudes, adding yet a another `PulseGen` parameter to an already excessive amount seemed counter productive.

There are no examples in this patch, that's something I'll look at if wanted.

Thanks
Ian