### PR TITLE
fix use of hardware_info in __init__.py

### DIFF
--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -162,8 +162,8 @@ else:
 
 if qutip.settings.num_cpus == 0:
     # if num_cpu is 0 set it to the available number of cores
-    from qutip.hardware_info import hardware_info
-    info = hardware_info()
+    import qutip.hardware_info
+    info =  qutip.hardware_info.hardware_info()
     if 'cpus' in info:
         qutip.settings.num_cpus = info['cpus']
     else:


### PR DESCRIPTION
When `qutip.settings.num_cpus==0` in `__init__.py`, the `qutip.hardware_info` module was replaced with the `hardware_info` function through `from qutip.hardware_info import hardware_info`. This caused problems in `ipynbtools.version_table`, which tries to call `qutip.hardware_info.hardware_info()`.