### PR TITLE
nonmarkov added to list of packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 REQUIRES = ['numpy (>=1.6)', 'scipy (>=0.11)', 'cython (>=0.15)',
             'matplotlib (>=1.1)']
 PACKAGES = ['qutip', 'qutip/ui', 'qutip/cy', 'qutip/qip', 'qutip/qip/models',
-            'qutip/qip/algorithms', 'qutip/control', 'qutip/tests']
+            'qutip/qip/algorithms', 'qutip/control', 'qutip/nonmarkov', 
+            'qutip/tests']
 PACKAGE_DATA = {
     'qutip': ['configspec.ini'],
     'qutip/tests': ['bucky.npy', 'bucky_perm.npy'],


### PR DESCRIPTION
This is to fix issue #413 that caused new installations to be non-functional.
Anyone got any ideas as to why this was not picked up by the travis tests?