### PR TITLE
Fix for num_waves and freq pulse parameters being ignored

### DIFF
--- a/qutip/control/pulsegen.py
+++ b/qutip/control/pulsegen.py
@@ -860,7 +860,7 @@ class PulseGenTriangle(PulseGenPeriodic):
         pulse = np.empty(self.num_tslots)
         t = 0.0
         for k in range(self.num_tslots):
-            phase = 2*np.pi*self.freq*t + self.start_phase
+            phase = 2*np.pi*self.freq*t + self.start_phase + np.pi/2.0
             x = phase/(2*np.pi)
             y = 2*np.abs(2*(x - np.floor(0.5 + x))) - 1
             pulse[k] = self.scaling*y

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -1933,13 +1933,7 @@ def create_pulse_optimizer(
         pgen.offset = pulse_offset
         pgen.lbound = amp_lbound
         pgen.ubound = amp_ubound
-        if ramping_pgen:
-            crab_pgen.ramping_pulse = ramping_pgen.gen_pulse()
 
-        # If the pulse is a periodic type, then set the pulse to be one complete
-        # wave
-        if isinstance(pgen, pulsegen.PulseGenPeriodic):
-            pgen.num_waves = 1.0
         optim.pulse_generator = pgen
 
     if log_level <= logging.DEBUG:


### PR DESCRIPTION
Removed hardcoded pulse generator num_waves from create_pulse_optimizer
Changed TRIANGLE pulse type to start from zero (to match the other periodic types)
Added test that checks freq and num_waves pulse parameters are applied correctly in create_pulse_optimizer

resolves issue #412 