### PR TITLE
Truncation of negative eigenvalues

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -170,6 +170,9 @@ class Qobj(object):
         Transpose of quantum object.
     transform(inpt, inverse=False)
         Performs a basis transformation defined by `inpt` matrix.
+    trunc_neg(method='clip')
+        Removes negative eigenvalues and returns a new Qobj that is
+        a valid density operator.
     unit(norm='tr', sparse=False, tol=0, maxiter=100000)
         Returns normalized quantum object.
     """
@@ -1179,6 +1182,25 @@ class Qobj(object):
         out.data = sp.csr_matrix(out.data, dtype=complex)
 
         return out
+
+
+    def trunc_neg(self, method="clip"):
+        if method not in ('clip', 'sgs'):
+            raise ValueError("Method {} not recognized.".format(method))
+
+        eigvals, eigstates = self.eigenstates()
+
+        if method == 'clip':
+            eigvals[eigvals < 0] = 0
+        elif method == 'sgs':
+            raise NotImplementedError("Not yet implemented.")
+
+        return sum([
+                val * ket2dm(state)
+                for val, state in zip(eigvals, eigstates)
+            ], Qobj(np.zeros(self.shape, dims=self.dims)))
+        ).unit()
+
 
     def matrix_element(self, bra, ket):
         """Calculates a matrix element.

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1196,9 +1196,9 @@ class Qobj(object):
             raise NotImplementedError("Not yet implemented.")
 
         return sum([
-                val * ket2dm(state)
+                val * qutip.states.ket2dm(state)
                 for val, state in zip(eigvals, eigstates)
-            ], Qobj(np.zeros(self.shape, dims=self.dims)))
+            ], Qobj(np.zeros(self.shape), dims=self.dims)
         ).unit()
 
 
@@ -2006,3 +2006,4 @@ def isherm(Q):
 from qutip.eseries import eseries
 import qutip.superop_reps as sr
 import qutip.operators as ops
+import qutip.states

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1215,6 +1215,9 @@ class Qobj(object):
         if all([eigval >= 0 for eigval in eigvals]):
             # All positive, so just renormalize.
             return self.unit()
+        idx_nonzero = eigvals != 0
+        eigvals = eigvals[idx_nonzero]
+        eigstates = eigstates[idx_nonzero]
 
         if method == 'clip':
             eigvals[eigvals < 0] = 0

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -34,7 +34,7 @@
 import scipy.sparse as sp
 import scipy.linalg as la
 import numpy as np
-from numpy.testing import assert_equal, assert_, run_module_suite
+from numpy.testing import assert_equal, assert_, assert_almost_equal, run_module_suite
 
 from qutip.qobj import Qobj
 from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
@@ -788,6 +788,32 @@ def test_composite_vec():
     assert_(composite(r3, r4) == super_tensor(r3, r4))
     assert_(composite(k1, r4) == super_tensor(r1, r4))
     assert_(composite(r3, k2) == super_tensor(r3, r2))
+
+
+def test_trunc_neg():
+    def case(qobj, method, expected=None):
+        pos_qobj = qobj.trunc_neg(method=method)
+        assert(all([energy > -1e-8 for energy in pos_qobj.eigenenergies()]))
+        assert_almost_equal(pos_qobj.tr(), 1)
+
+        if expected is not None:
+            assert_almost_equal(pos_qobj.data.todense(), expected.data.todense())
+
+    for method in ('clip', 'sgs'):
+        # Make sure that it works for operators that are already positive.
+        yield case, rand_dm(5), method
+        # Make sure that it works for a diagonal matrix.
+        yield case, Qobj(np.diag([1.1, -0.1])), method, Qobj(np.diag([1.0, 0.0]))
+        # Make sure that it works for a non-diagonal matrix.
+        U = rand_unitary(3)
+        yield case, \
+            U * Qobj(np.diag([1.1, 0, -0.1])) * U.dag(), \
+            method, \
+            U * Qobj(np.diag([1.0, 0.0, 0.0])) * U.dag()
+
+    # Check the test case in SGS.
+    yield case, Qobj(np.diag([3. / 5, 1. / 2, 7. / 20, 1. / 10, -11. / 20])), 'sgs', \
+        Qobj(np.diag([9. / 20, 7. / 20, 1. / 5, 0, 0]))
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -46,6 +46,7 @@ from qutip.superop_reps import to_super, to_choi, to_chi
 from qutip.tensor import tensor, super_tensor, composite
 
 from operator import add, mul, truediv, sub
+from functools import partial
 
 def assert_hermicity(oper, hermicity, msg=""):
     # Check the cached isherm, if any exists.
@@ -789,8 +790,28 @@ def test_composite_vec():
     assert_(composite(k1, r4) == super_tensor(r1, r4))
     assert_(composite(r3, k2) == super_tensor(r3, r2))
 
+# TODO: move out to a more appropriate module.
+
+def has_description(case):
+    """
+    Decorates a test case such that it takes an argument describing
+    that case, such that failure logs are usefully formatted.
+    """
+    # See https://code.google.com/archive/p/python-nose/issues/244#c1
+    # for why this works.
+
+    def make_case(description):
+        partial_case = partial(case)
+        partial_case.description = description
+        return partial_case
+    return make_case
 
 def test_trunc_neg():
+    """
+    Test Qobj: Checks trunc_neg in several different cases.
+    """
+
+    @has_description
     def case(qobj, method, expected=None):
         pos_qobj = qobj.trunc_neg(method=method)
         assert(all([energy > -1e-8 for energy in pos_qobj.eigenenergies()]))
@@ -801,19 +822,24 @@ def test_trunc_neg():
 
     for method in ('clip', 'sgs'):
         # Make sure that it works for operators that are already positive.
-        yield case, rand_dm(5), method
+        yield case("Test Qobj: trunc_neg works for positive opers."), \
+            rand_dm(5), method
         # Make sure that it works for a diagonal matrix.
-        yield case, Qobj(np.diag([1.1, -0.1])), method, Qobj(np.diag([1.0, 0.0]))
+        yield case("Test Qobj: trunc_neg works for diagonal opers."), \
+            Qobj(np.diag([1.1, -0.1])), method, Qobj(np.diag([1.0, 0.0]))
         # Make sure that it works for a non-diagonal matrix.
         U = rand_unitary(3)
-        yield case, \
+        yield case("Test Qobj: trunc_neg works for non-diagonal opers."), \
             U * Qobj(np.diag([1.1, 0, -0.1])) * U.dag(), \
             method, \
             U * Qobj(np.diag([1.0, 0.0, 0.0])) * U.dag()
 
     # Check the test case in SGS.
-    yield case, Qobj(np.diag([3. / 5, 1. / 2, 7. / 20, 1. / 10, -11. / 20])), 'sgs', \
+    yield (
+        case("Test Qobj: trunc_neg works for SGS known-good test case."),
+        Qobj(np.diag([3. / 5, 1. / 2, 7. / 20, 1. / 10, -11. / 20])), 'sgs',
         Qobj(np.diag([9. / 20, 7. / 20, 1. / 5, 0, 0]))
+    )
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This PR introduces a new method on``Qobj`` that forces an instance to be a valid density operator. This is useful when dealing with tomographic estimators that do not constrain to the space of density operators, such as least-squares fits. In particular, this PR allows for two different truncation algorithms: ``clip``, which is fast and straightforward, and the [SGS algorithm](https://dx.doi.org/10/bb76).