### PR TITLE
Fix for Liouville test

### DIFF
--- a/qutip/tests/test_superoper.py
+++ b/qutip/tests/test_superoper.py
@@ -181,7 +181,7 @@ class TestMatVec:
         L1 = liouvillian(H, c_ops)
         L2 = liouvillian_ref(H, c_ops)
 
-        assert_((L1 - L2).norm() < 1e-8)
+        assert_((L1 - L2).norm('max') < 1e-8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR changes the norm used in ``qutip.tests.test_superoper.testLiouvilleImplem`` to the max-norm. Previously, this test used the tr-norm, which scaled badly with the dimension of the Liouvillian under test, such that spurious failures were generated (see #419).