### PR TITLE
BUG: Anaconda 2.5 does not like -march=native

### DIFF
--- a/qutip/control/setup.py
+++ b/qutip/control/setup.py
@@ -8,7 +8,7 @@ import os
 
 exts = ['cy_grape']
 
-_compiler_flags = ['-w', '-ffast-math', '-O3', '-march=native']
+_compiler_flags = ['-w', '-ffast-math', '-O3', '-mtune=native']
 
 def configuration(parent_package='', top_path=None):
     # compiles files during installation

--- a/qutip/cy/setup.py
+++ b/qutip/cy/setup.py
@@ -8,7 +8,7 @@ import os
 
 exts = ['spmatfuncs', 'stochastic', 'sparse_utils', 'graph_utils']
 
-_compiler_flags = ['-w', '-ffast-math', '-O3', '-march=native']
+_compiler_flags = ['-w', '-ffast-math', '-O3', '-mtune=native']
 
 def configuration(parent_package='', top_path=None):
     # compiles files during installation


### PR DESCRIPTION
- Switched to -mtune=native

The latest version of Anaconda does not play well with the -march flag.  I am not sure if this is due to the use of MKL on all platforms, or if it is something else.  -mtune works fine though.