### PR TITLE
Fix for #425

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1227,8 +1227,9 @@ class Qobj(object):
             
             acc = 0.0
             dim = self.shape[0]
+            n_eigs = len(eigvals)
             
-            for idx in reversed(range(dim)):
+            for idx in reversed(range(n_eigs)):
                 if eigvals[idx] + acc / (idx + 1) >= 0:
                     break
                 else:


### PR DESCRIPTION
This PR fixes how ``Qobj.trunc_neg_eigs(method='sgs')`` handles eigenvalues equal to 0, which should resolve #425.