### PR TITLE
Suppress superrep warnings when we know what we're doing.

### DIFF
--- a/qutip/superop_reps.py
+++ b/qutip/superop_reps.py
@@ -285,6 +285,12 @@ def chi_to_choi(q_oper):
     # the input.
     B.dims = q_oper.dims
 
+    # We normally should not multiply objects of different
+    # superreps, so Qobj warns about that. Here, however, we're actively
+    # converting between, so the superrep of B is irrelevant.
+    # To suppress warnings, we pretend that B is also a chi.
+    B.superrep = 'chi'
+
     # The Chi matrix has tr(chi) == d², so we need to divide out
     # by that to get back to the Choi form.
     return Qobj((B * q_oper * B.dag()) / q_oper.shape[0], superrep='choi')


### PR DESCRIPTION
This PR addresses #433 by manually setting ``Qobj.superrep`` to suppress warnings in ``chi_to_choi``. The change of basis for chi → choi is currently represented as a ``superrep='super'``, as that makes sense in several other contextx, such that spurious warnings were raised when performing this conversion.