### PR TITLE
BUG: Qobj*vec crashes computer

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -458,7 +458,15 @@ class Qobj(object):
             else:
                 raise TypeError("Incompatible Qobj shapes")
 
-        elif isinstance(other, (list, np.ndarray)):
+        elif isinstance(other, np.ndarray):
+            if other.dtype=='object':
+                return np.array([self * item for item in other],
+                                dtype=object)
+            else:
+                return self.data * other
+            
+        
+        elif isinstance(other, list):
             # if other is a list, do element-wise multiplication
             return np.array([self * item for item in other],
                             dtype=object)
@@ -486,16 +494,22 @@ class Qobj(object):
         """
         MULTIPLICATION with Qobj on RIGHT [ ex. 4*Qobj ]
         """
-
-        if isinstance(other, (list, np.ndarray)):
+        if isinstance(other, np.ndarray):
+            if other.dtype=='object':
+                return np.array([item * self for item in other],
+                                            dtype=object)
+            else:
+                return other * self.data
+        
+        elif isinstance(other, list):
             # if other is a list, do element-wise multiplication
             return np.array([item * self for item in other],
                             dtype=object)
 
-        if isinstance(other, eseries):
+        elif isinstance(other, eseries):
             return other.__mul__(self)
 
-        if isinstance(other, (int, float, complex,
+        elif isinstance(other, (int, float, complex,
                               np.integer, np.floating, np.complexfloating)):
             out = Qobj()
             out.data = other * self.data

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -421,6 +421,14 @@ def test_CheckMulType():
 
     assert_(opbra2.dag() == opket2)
 
+def test_Qobj_Spmv():
+    "Qobj mult ndarray right"
+    A = rand_herm(5)
+    b = rand_ket(5).full()
+    C = A*b
+    D = A.full().dot(b)
+    assert_(np.all((C-D)<1e-14))
+
 
 def test_QobjConjugate():
     "Qobj conjugate"


### PR DESCRIPTION
- A Qobj times a dense vector would result in a recursive loop and
crash the computer.

- Made the multi array check better about handling dtypes and added
test.

The output is a dense array.  However if we do create a dense Qobj class (as described in #437) then that should be the returned object.