### PR TITLE
ENH: Remove CXVPY logger warning in metrics

### DIFF
--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -57,7 +57,6 @@ try:
     import cvxpy
 except:
     cvxpy = None
-    logger.warning("CVXPY not found, semidefinite solving is disabled.")
 
 
 def fidelity(A, B):


### PR DESCRIPTION
Having a warning that appears every time qutip is imported should be avoided.  That is unless we want a ton of questions on the google help group.