### PR TITLE
Fix a complicated list-cast-map-list antipattern

### DIFF
--- a/qutip/superop_reps.py
+++ b/qutip/superop_reps.py
@@ -217,10 +217,8 @@ def choi_to_kraus(q_oper):
     strict sub-class of Qobj.
     """
     vals, vecs = eig(q_oper.data.todense())
-    vecs = list(map(array, zip(*vecs)))
-    return list(map(lambda x: Qobj(inpt=x),
-                    [sqrt(vals[j]) * vec2mat(vecs[j])
-                     for j in range(len(vals))]))
+    vecs = [array(_) for _ in zip(*vecs)]
+    return [Qobj(inpt=sqrt(val)*vec2mat(vec)) for val, vec in zip(vals, vecs)]
 
 
 def kraus_to_choi(kraus_list):


### PR DESCRIPTION
The previous version contained multiple antipatterns:

- casting to list
- map when comprehension can be used
- map over a comprehension
- len(range(list)) looping

I also suspect that the `zip(*vecs)` call is just a  strange way to reimplement the transpose method, but I am not familiar with the code and did not want to change it.