### PR TITLE
Hermitian eigenvalue solver used for spectral_decomp

### DIFF
--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -1196,7 +1196,7 @@ class DynamicsUnitary(Dynamics):
         elif self.oper_dtype == np.ndarray:
             H = self._dyn_gen[k]
             # returns row vector of eigenvals, columns with the eigenvecs
-            eig_val, eig_vec = np.linalg.eig(H)
+            eig_val, eig_vec = np.linalg.eigh(H)
         else:
             if sparse:
                 H = self._dyn_gen[k].toarray()


### PR DESCRIPTION
eigh now used in place eig for all oper_dtype
This resolved loss of unitary evolution that had be observed in some cases.