### PR TITLE
Qobj.__call__

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -674,10 +674,12 @@ class Qobj(object):
         
         if self.type == "super":
             if other.type == "ket":
-                other = ket2dm(other)
+                other = qutip.states.ket2dm(other)
                 
             if other.type == "oper":
-                return vector_to_operator(self * operator_to_vector(other))
+                return qutip.superoperator.vector_to_operator(
+                    self * qutip.superoperator.operator_to_vector(other)
+                )
             else:
                 raise TypeError("Can only act super on oper or ket.")
             
@@ -2202,3 +2204,4 @@ import qutip.tensor as tensor
 import qutip.operators as ops
 import qutip.metrics as mts
 import qutip.states
+import qutip.superoperator

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -663,6 +663,30 @@ class Qobj(object):
         # so we simply return the informal __str__ representation instead.)
         return self.__str__()
 
+    def __call__(self, other):
+        """
+        Acts this Qobj on another Qobj either by left-multiplication,
+        or by vectorization and devectorization, as
+        appropriate.
+        """
+        if not isinstance(other, Qobj):
+            raise TypeError("Only defined for quantum objects.")
+        
+        if self.type == "super":
+            if other.type == "ket":
+                other = ket2dm(other)
+                
+            if other.type == "oper":
+                return vector_to_operator(self * operator_to_vector(other))
+            else:
+                raise TypeError("Can only act super on oper or ket.")
+            
+        elif self.type == "oper":
+            if other.type == "ket":
+                return self * other
+            else:
+                raise TypeError("Can only act oper on ket.")
+
     def __getstate__(self):
         # defines what happens when Qobj object gets pickled
         self.__dict__.update({'qutip_version': __version__[:5]})

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -41,12 +41,42 @@ from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
                                   rand_super, rand_super_bcsz, rand_dm_ginibre)
 from qutip.states import basis, fock_dm, ket2dm
 from qutip.operators import create, destroy, num, sigmax, sigmay
-from qutip.superoperator import spre, spost, operator_to_vector
+from qutip.superoperator import spre, spost, operator_to_vector, vector_to_operator
 from qutip.superop_reps import to_super, to_choi, to_chi
 from qutip.tensor import tensor, super_tensor, composite
 
 from operator import add, mul, truediv, sub
 from functools import partial
+from contextlib import contextmanager
+
+@contextmanager
+def expect_exception(ex_class):
+    """
+    Context manager that raises an AssertionError if its body
+    does not raise a particular class of exception.
+    """
+    ex_name = getattr(ex_class, '__name__', str(ex_class))
+
+    try:
+        yield
+    except ex_class:
+        pass
+    except Exception as other_ex:
+        raise AssertionError(
+            "Expected {}, but {} was raised.".format(
+                ex_name, getattr(type(other_ex), '__name__', str(type(other_ex)))
+            )
+        )
+    else:
+        raise AssertionError("Expected {}, but nothing was raised.".format(ex_name))
+
+def test_expect_exception():
+    with expect_exception(ValueError):
+        raise ValueError
+
+    with expect_exception(AssertionError):
+        with expect_exception(ValueError):
+            pass
 
 def assert_hermicity(oper, hermicity, msg=""):
     # Check the cached isherm, if any exists.
@@ -905,6 +935,31 @@ def test_dual_channel():
         S = rand_super_bcsz(dim)
         S.dims = [[subdims, subdims], [subdims, subdims]]
         yield case, S
+
+
+def test_call():
+    # Make test objects.
+    psi = rand_ket(3)
+    rho = rand_dm_ginibre(3)
+    U = rand_unitary(3)
+    S = rand_super_bcsz(3)
+
+    # Case 0: oper(ket).
+    assert U(psi) == U * psi
+
+    # Case 1: oper(oper). Should raise TypeError.
+    with expect_exception(TypeError):
+        U(rho)
+
+    # Case 2: super(ket).
+    assert S(psi) == vector_to_operator(S * operator_to_vector(ket2dm(psi)))
+
+    # Case 3: super(oper).
+    assert S(rho) == vector_to_operator(S * operator_to_vector(rho))
+
+    # Case 4: super(super). Should raise TypeError.
+    with expect_exception(TypeError):
+        S(S)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes ``Qobj`` a callable, in keeping with the proposed semantics discussed in #475. Hopefully, this should make it easier for newcomers and experienced users alike to use the superoperator functionality by removing the need to use ``operator_to_vector`` and ``vector_to_operator`` in simple cases.