### PR TITLE
Fix setup.py for use from external requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ MICRO = 0
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 REQUIRES = ['numpy (>=1.6)', 'scipy (>=0.11)', 'cython (>=0.15)',
-            'matplotlib (>=1.1)']
+            'matplotlib (>=1.1)'],
+INSTALL_REQUIRES = ['numpy>=1.6', 'scipy>=0.11', 'cython>=0.15', 'matplotlib>=1.1']
 PACKAGES = ['qutip', 'qutip/ui', 'qutip/cy', 'qutip/qip', 'qutip/qip/models',
             'qutip/qip/algorithms', 'qutip/control', 'qutip/nonmarkov', 
             'qutip/tests']
@@ -188,6 +189,6 @@ setup(
     package_data = PACKAGE_DATA,
     configuration = configuration,
     zip_safe = False,
-    install_requires=REQUIRES,
+    install_requires=INSTALL_REQUIRES,
     **TESTING_KWARGS
 )

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,16 @@ except ImportError:
     # for the best.
     # This is essential for downloading QuTiP from within another
     # project's requirements.txt.
+
+    # As per scipy/scipy#453, we should only do this fallback
+    # when called with the commands '--help' and 'egg_info':
+    if not (
+        '--help' in sys.argv[1:] or
+        sys.argv[1] in ('--help-commands', 'egg_info', '--version')
+    ):
+        # Reraise.
+        raise
+
     np = None
     try:
         from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ MICRO = 0
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 REQUIRES = ['numpy (>=1.6)', 'scipy (>=0.11)', 'cython (>=0.15)',
-            'matplotlib (>=1.1)'],
+            'matplotlib (>=1.1)']
 INSTALL_REQUIRES = ['numpy>=1.6', 'scipy>=0.11', 'cython>=0.15', 'matplotlib>=1.1']
 PACKAGES = ['qutip', 'qutip/ui', 'qutip/cy', 'qutip/qip', 'qutip/qip/models',
             'qutip/qip/algorithms', 'qutip/control', 'qutip/nonmarkov', 


### PR DESCRIPTION
As raised in #426, QuTiP currently does not install correctly if listed in the requirements.txt for an external project unless the target environment already has numpy installed. This is due to the use of ``numpy.distutils`` in the current ``setup.py``, such that this PR attempts to solve the issue by falling back to setuptools and then distutils when numpy is missing.