### PR TITLE
Clean up test namespace

### DIFF
--- a/qutip/tests/test_qpt.py
+++ b/qutip/tests/test_qpt.py
@@ -33,7 +33,7 @@
 
 import numpy as np
 from numpy.testing import assert_, run_module_suite
-from numpy.linalg import norm
+import scipy.linalg as la
 
 from qutip import (spre, spost, qeye, sigmax, sigmay, sigmaz, qpt)
 from qutip.qip.gates import snot, cnot
@@ -52,7 +52,7 @@ def test_qpt_snot():
     chi2 = np.zeros((2 ** (2 * N), 2 ** (2 * N)), dtype=complex)
     chi2[1, 1] = chi2[1, 3] = chi2[3, 1] = chi2[3, 3] = 0.5
 
-    assert_(norm(chi2 - chi1) < 1e-8)
+    assert_(la.norm(chi2 - chi1) < 1e-8)
 
 
 def test_qpt_cnot():
@@ -77,7 +77,7 @@ def test_qpt_cnot():
     chi2[12, 12] = chi2[13, 13] = 0.25
     chi2[13, 12] = chi2[12, 13] = -0.25
 
-    assert_(norm(chi2 - chi1) < 1e-8)
+    assert_(la.norm(chi2 - chi1) < 1e-8)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_superoper.py
+++ b/qutip/tests/test_superoper.py
@@ -32,7 +32,7 @@
 ###############################################################################
 
 import numpy as np
-from numpy.linalg import norm
+import scipy.linalg as la
 from numpy.testing import assert_, assert_equal, run_module_suite
 import scipy
 
@@ -107,7 +107,7 @@ class TestMatVec:
         M = scipy.rand(10, 10)
         V = mat2vec(M)
         M2 = vec2mat(V)
-        assert_(norm(M - M2) == 0.0)
+        assert_(la.norm(M - M2) == 0.0)
 
     def testVecMatVec(self):
         """
@@ -116,7 +116,7 @@ class TestMatVec:
         V = scipy.rand(100)     # a row vector
         M = vec2mat(V)
         V2 = mat2vec(M).T  # mat2vec returns a column vector
-        assert_(norm(V - V2) == 0.0)
+        assert_(la.norm(V - V2) == 0.0)
 
     def testVecMatIndexConversion(self):
         """


### PR DESCRIPTION
Some of the super operator and QPT tests may have name space issues as reported in the google group: 

https://groups.google.com/d/msg/qutip/Z-5o4HHYRv4/yRX7dvjiEgAJ

I can not reproduce the errors, but here is a clean up that will likely fix this possible issue.