### PR TITLE
Fix for istp of composite systems

### DIFF
--- a/qutip/dimensions.py
+++ b/qutip/dimensions.py
@@ -177,6 +177,73 @@ def _enumerate_flat(l, idx=0):
             acc.append(labels)
         return acc, idx
 
+def _collapse_composite_index(dims):
+    """
+    Given the dimensions specification for a composite index
+    (e.g.: [2, 3] for the right index of a ket with dims [[1], [2, 3]]),
+    returns a dimensions specification for an index of the same shape,
+    but collapsed to a single "leg." In the previous example, [2, 3]
+    would collapse to [6].
+    """
+    return [np.prod(dims)]
+
+def _collapse_dims_to_level(dims, level=1):
+    """
+    Recursively collapses all indices in a dimensions specification
+    appearing at a given level, such that the returned dimensions
+    specification does not represent any composite systems.
+    """
+    if level == 0:
+        return _collapse_composite_index(dims)
+    else:
+        return [_collapse_dims_to_level(index, level=level - 1) for index in dims]
+    
+def collapse_dims_oper(dims):
+    """
+    Given the dimensions specifications for a ket-, bra- or oper-type
+    Qobj, returns a dimensions specification describing the same shape
+    by collapsing all composite systems. For instance, the bra-type
+    dimensions specification ``[[2, 3], [1]]`` collapses to
+    ``[[6], [1]]``.
+
+    Parameters
+    ----------
+
+    dims : list of lists of ints
+        Dimensions specifications to be collapsed.
+
+    Returns
+    -------
+
+    collapsed_dims : list of lists of ints
+        Collapsed dimensions specification describing the same shape
+        such that ``len(collapsed_dims[0]) == len(collapsed_dims[1]) == 1``.
+    """
+    return _collapse_dims_to_level(dims, 1)
+
+def collapse_dims_super(dims):
+    """
+    Given the dimensions specifications for an operator-ket-, operator-bra- or
+    super-type Qobj, returns a dimensions specification describing the same shape
+    by collapsing all composite systems. For instance, the super-type
+    dimensions specification ``[[[2, 3], [2, 3]], [[2, 3], [2, 3]]]`` collapses to
+    ``[[[6], [6]], [[6], [6]]]``.
+
+    Parameters
+    ----------
+
+    dims : list of lists of ints
+        Dimensions specifications to be collapsed.
+
+    Returns
+    -------
+
+    collapsed_dims : list of lists of ints
+        Collapsed dimensions specification describing the same shape
+        such that ``len(collapsed_dims[i][j]) == 1`` for ``i`` and ``j``
+        in ``range(2)``.
+    """
+    return _collapse_dims_to_level(dims, 2)
 
 def enumerate_flat(l):
     """Labels the indices at which scalars occur in a flattened list.

--- a/qutip/tests/test_dimensions.py
+++ b/qutip/tests/test_dimensions.py
@@ -39,7 +39,8 @@ from numpy.testing import assert_equal, assert_, run_module_suite
 from qutip.dimensions import (
     type_from_dims,
     flatten, enumerate_flat, deep_remove, unflatten,
-    dims_idxs_to_tensor_idxs, dims_to_tensor_shape
+    dims_idxs_to_tensor_idxs, dims_to_tensor_shape,
+    collapse_dims_oper, collapse_dims_super
 )
 from qutip.qobj import Qobj
 
@@ -155,3 +156,20 @@ def test_type_from_dims():
     super_data = np.random.random((N, N))
     super_qobj = Qobj(super_data, dims=[[[3]], [[3]]])
     qobj_case(super_qobj)
+
+def test_collapse():
+    # ket-type
+    # assert_equal(collapse_dims_oper([[1], [3]]), [[1], [3]], err_msg='ket-type, trivial')
+    # assert_equal(collapse_dims_oper([[1], [2, 3]]), [[1], [6]], err_msg='ket-type, bipartite')
+    # # bra-type
+    # assert_equal(collapse_dims_oper([[2], [1]]), [[2], [1]], err_msg='bra-type, trivial')
+    # assert_equal(collapse_dims_oper([[2, 3], [1]]), [[6], [1]], err_msg='bra-type, bipartite')
+    # # oper-type
+    # assert_equal(collapse_dims_oper([[2, 3], [2, 3]]), [[6], [6]], err_msg='oper-type, trivial')
+    # assert_equal(collapse_dims_oper([[2, 3], [4, 5]]), [[6], [20]], err_msg='oper-type, bipartite')
+    # # operator-ket-type
+    # assert_equal(collapse_dims_super([[[1]], [[2, 3], [2, 3]]]), [[[1]], [[6], [6]]])
+    # operator-bra-type
+    assert_equal(collapse_dims_super([[[2, 3], [2, 3]], [[1]]]), [[[6], [6]], [[1]]])
+    # super-type
+    assert_equal(collapse_dims_super([[[2, 3], [2, 3]], [[2, 3], [2, 3]]]), [[[6], [6]], [[6], [6]]])

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -47,10 +47,10 @@ from unittest import expectedFailure
 
 from qutip.qobj import Qobj
 from qutip.states import basis
-from qutip.operators import identity, sigmax, qeye, create
+from qutip.operators import identity, sigmax, sigmay, qeye, create
 from qutip.qip.gates import swap
 from qutip.random_objects import rand_super, rand_super_bcsz, rand_dm_ginibre
-from qutip.tensor import super_tensor
+from qutip.tensor import tensor, super_tensor
 from qutip.superop_reps import (kraus_to_choi, to_super, to_choi, to_kraus,
                                 to_chi, to_stinespring)
 from qutip.superoperator import operator_to_vector, vector_to_operator, sprepost
@@ -187,6 +187,15 @@ class TestSuperopReps(object):
         case(identity(2), True, True, True)
         case(sigmax(), True, True, True)
 
+        # Check that unitaries on bipartite systems are CPTP and HP.
+        case(tensor(sigmax(), identity(2)), True, True, True)
+
+        # Check that a linear combination of bipartitie unitaries is CPTP and HP.
+        S = (
+            to_super(tensor(sigmax(), identity(2))) + to_super(tensor(identity(2), sigmay()))
+        ) / 2
+        case(S, True, True, True)
+
         # The partial transpose map, whose Choi matrix is SWAP, is TP
         # and HP but not CP (one negative eigenvalue).
         W = Qobj(swap(), type='super', superrep='choi')
@@ -301,3 +310,4 @@ class TestSuperopReps(object):
 
 if __name__ == "__main__":
     run_module_suite()
+


### PR DESCRIPTION
This PR addresses #498 by collapsing composite (multipartite) dimensions before taking the partial trace. This is backed by new functions to collapse dimensions specifications of multipartite systems, and both these new functions and the originally erroneous behavior of ``Qobj.istp`` are now covered by new test cases.