### PR TITLE
Ability to calculate two-time correlations with time-dependent c_ops and bug fixes related to the correlator module

### DIFF
--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -1340,9 +1340,11 @@ def _correlation_mc_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
                 ]
 
                 # final correlation vector computed by combining the averages
-                corr_mat_add = np.asarray(1/(4*options.ntraj[0]) * 
-                        (c_tau[0] - c_tau[2] - 1j*c_tau[1] + 1j*c_tau[3]),
-                         dtype=corr_mat.dtype)
+                corr_mat_add = np.asarray(
+                    1.0 / (4*options.ntraj[0]) *
+                    (c_tau[0] - c_tau[2] - 1j*c_tau[1] + 1j*c_tau[3]),
+                    dtype=corr_mat.dtype
+                )
                 corr_mat[t_idx, :] += corr_mat_add
                     
         if t_idx == 1:

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -51,7 +51,7 @@ from qutip.mesolve import mesolve
 from qutip.mcsolve import mcsolve
 from qutip.operators import qeye
 from qutip.qobj import Qobj, isket, issuper
-from qutip.rhs_generate import rhs_clear
+from qutip.rhs_generate import rhs_clear, _td_wrap_array_str
 from qutip.settings import debug
 from qutip.solver import Options
 from qutip.steadystate import steadystate
@@ -1080,6 +1080,9 @@ def _correlation_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
         raise TypeError("tlist must be positive and contain the element 0.")
     if min(taulist) != 0:
         raise TypeError("taulist must be positive and contain the element 0.")
+
+    rhs_clear()
+    H, c_ops, args = _td_wrap_array_str(H, c_ops, args, tlist)
 
     if solver == "me":
         return _correlation_me_2t(H, state0, tlist, taulist,

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -1366,11 +1366,24 @@ def _transform_L_t_shift(H, c_ops, args={}):
     # time-dependence to be the same for the hamiltonian as for the collapse
     # operators.
 
-    c_ops_shifted = c_ops
 
     if isinstance(H, Qobj):
         # constant hamiltonian
         H_shifted = H  # not shifted!
+
+    c_ops_is_td = False
+    if isinstance(c_ops, list):
+        for i in range(len(c_ops)):
+            # test is collapse operators are time-dependent
+            if isinstance(c_ops[i], list):
+                c_ops_is_td = True
+
+    if not c_ops_is_td:
+        # constant collapse operators
+        c_ops_shifted = c_ops  # not shifted!
+
+    if isinstance(H, Qobj) and not c_ops_is_td:
+        # constant hamiltonian and collapse operators
         _args = args  # not shifted!
 
     if isinstance(H, types.FunctionType):

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -74,7 +74,7 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
                        options=Options(ntraj=[20, 100])):
     """
     Calculate the two-operator two-time correlation function:
-    :math: `\left<A(t+\\tau)B(t)\\right>`
+    :math:`\left<A(t+\\tau)B(t)\\right>`
     along one time axis using the quantum regression theorem and the evolution
     solver indicated by the `solver` parameter.
 
@@ -82,7 +82,8 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
     ----------
 
     H : :class:`qutip.qobj.Qobj`
-        system Hamiltonian.
+        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        `mc`.
 
     state0 : :class:`qutip.qobj.Qobj`
         Initial state density matrix :math:`\\rho(t_0)` or state vector
@@ -94,8 +95,9 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
-    c_ops : list of :class:`qutip.qobj.Qobj`
-        list of collapse operators.
+    c_ops : *list* of :class:`qutip.qobj.Qobj`
+        list of collapse operators, may be time-dependent for solver choice of
+        `me` or `mc`.
 
     a_op : :class:`qutip.qobj.Qobj`
         operator A.
@@ -103,11 +105,11 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
     b_op : :class:`qutip.qobj.Qobj`
         operator B.
 
-    reverse : bool
+    reverse : *bool*
         If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
 
-    solver : str
+    solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series)
 
@@ -120,7 +122,7 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
     Returns
     -------
 
-    corr_vec: *array*
+    corr_vec : *array*
         An *array* of correlation values for the times specified by `tlist`.
 
     References
@@ -171,14 +173,14 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
     tlist : *list* / *array*
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. :math:`t \rightarrow \infty`; here tlist is
+        value is necessary, i.e. :math:`t \\rightarrow \\infty`; here tlist is
         automatically set, ignoring user input.
 
     taulist : *list* / *array*
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
-    c_ops : list of :class:`qutip.qobj.Qobj`
+    c_ops : *list* of :class:`qutip.qobj.Qobj`
         list of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
 
@@ -188,11 +190,11 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
     b_op : :class:`qutip.qobj.Qobj`
         operator B.
 
-    reverse : bool
+    reverse : *bool*
         If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
 
-    solver : str
+    solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series)
 
@@ -205,7 +207,7 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
     Returns
     -------
 
-    corr_mat: *array*
+    corr_mat : *array*
         An 2-dimensional *array* (matrix) of correlation values for the times
         specified by `tlist` (first index) and `taulist` (second index). If
         `tlist` is `None`, then a 1-dimensional *array* of correlation values
@@ -250,13 +252,14 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
     evolution solver indicated by the `solver` parameter.
 
     Note: it is not possibly to calculate a physically meaningful correlation
-    of this form where :math: `\\tau<0`.
+    of this form where :math:`\\tau<0`.
 
     Parameters
     ----------
 
     H : :class:`qutip.qobj.Qobj`
-        system Hamiltonian.
+        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        `mc`.
 
     rho0 : :class:`qutip.qobj.Qobj`
         Initial state density matrix :math:`\\rho(t_0)` or state vector
@@ -268,8 +271,9 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
-    c_ops : list of :class:`qutip.qobj.Qobj`
-        list of collapse operators.
+    c_ops : *list* of :class:`qutip.qobj.Qobj`
+        list of collapse operators, may be time-dependent for solver choice of
+        `me` or `mc`.
 
     a_op : :class:`qutip.qobj.Qobj`
         operator A.
@@ -280,7 +284,7 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
     c_op : :class:`qutip.qobj.Qobj`
         operator C.
 
-    solver : str
+    solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series)
 
@@ -293,7 +297,7 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
     Returns
     -------
 
-    corr_vec: *array*
+    corr_vec : *array*
         An *array* of correlation values for the times specified by `taulist`
 
     References
@@ -320,7 +324,7 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     evolution solver indicated by the `solver` parameter.
 
     Note: it is not possibly to calculate a physically meaningful correlation
-    of this form where :math: `\\tau<0`.
+    of this form where :math:`\\tau<0`.
 
     Parameters
     ----------
@@ -338,14 +342,14 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     tlist : *list* / *array*
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. :math:`t \rightarrow \infty`; here tlist is
+        value is necessary, i.e. :math:`t \\rightarrow \\infty`; here tlist is
         automatically set, ignoring user input.
 
     taulist : *list* / *array*
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
-    c_ops : list of :class:`qutip.qobj.Qobj`
+    c_ops : *list* of :class:`qutip.qobj.Qobj`
         list of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
 
@@ -358,7 +362,7 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     c_op : :class:`qutip.qobj.Qobj`
         operator C.
 
-    solver : str
+    solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series)
 
@@ -371,7 +375,7 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     Returns
     -------
 
-    corr_mat: *array*
+    corr_mat : *array*
         An 2-dimensional *array* (matrix) of correlation values for the times
         specified by `tlist` (first index) and `taulist` (second index). If
         `tlist` is `None`, then a 1-dimensional *array* of correlation values
@@ -405,7 +409,7 @@ def coherence_function_g1(H, taulist, c_ops, a_op, solver="me", args={},
 
     .. math::
 
-        g^{(1)}(\\tau) = \lim_{t \to \infty}
+        g^{(1)}(\\tau) = \lim_{t \\to \\infty}
         \\frac{\\langle a^\\dagger(t+\\tau)a(t)\\rangle}
         {\\langle a^\\dagger(t)a(t)\\rangle}
 
@@ -423,13 +427,13 @@ def coherence_function_g1(H, taulist, c_ops, a_op, solver="me", args={},
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
-    c_ops : list of :class:`qutip.qobj.Qobj`
+    c_ops : *list* of :class:`qutip.qobj.Qobj`
         list of collapse operators.
 
     a_op : :class:`qutip.qobj.Qobj`
         The annihilation operator of the mode.
 
-    solver : str
+    solver : *str*
         choice of solver (`me` for master-equation and
         `es` for exponential series)
 
@@ -442,7 +446,7 @@ def coherence_function_g1(H, taulist, c_ops, a_op, solver="me", args={},
     Returns
     -------
 
-    g1: *array*
+    g1 : *array*
         The normalized first-order coherence function.
 
     """
@@ -466,7 +470,7 @@ def coherence_function_g2(H, taulist, c_ops, a_op, solver="me", args={},
 
     .. math::
 
-        g^{(2)}(\\tau) = \lim_{t \to \infty}
+        g^{(2)}(\\tau) = \lim_{t \\to \\infty}
         \\frac{\\langle a^\\dagger(t)a^\\dagger(t+\\tau)
         a(t+\\tau)a(t)\\rangle}
         {\\langle a^\\dagger(t)a(t)\\rangle^2}
@@ -485,13 +489,13 @@ def coherence_function_g2(H, taulist, c_ops, a_op, solver="me", args={},
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
-    c_ops : list of :class:`qutip.qobj.Qobj`
+    c_ops : *list* of :class:`qutip.qobj.Qobj`
         list of collapse operators.
 
     a_op : :class:`qutip.qobj.Qobj`
         The annihilation operator of the mode.
 
-    solver : str
+    solver : *str*
         choice of solver (`me` for master-equation and
         `es` for exponential series)
 
@@ -504,7 +508,7 @@ def coherence_function_g2(H, taulist, c_ops, a_op, solver="me", args={},
     Returns
     -------
 
-    g2: *array*
+    g2 : *array*
         The normalized second-order coherence function.
 
     """
@@ -527,13 +531,13 @@ def coherence_function_g2(H, taulist, c_ops, a_op, solver="me", args={},
 def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
     """
     Calculate the spectrum of the correlation function
-    :math:`\lim_{t \to \infty} \left<A(t+\\tau)B(t)\\right>`,
+    :math:`\lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>`,
     i.e., the Fourier transform of the correlation function:
 
     .. math::
 
         S(\omega) = \int_{-\infty}^{\infty}
-        \lim_{t \to \infty} \left<A(t+\\tau)B(t)\\right>
+        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
         e^{-i\omega\\tau} d\\tau.
 
     using the solver indicated by the `solver` parameter. Note: this spectrum
@@ -548,7 +552,7 @@ def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
     wlist : *list* / *array*
         list of frequencies for :math:`\\omega`.
 
-    c_ops : list of :class:`qutip.qobj`
+    c_ops : *list* of :class:`qutip.qobj`
         list of collapse operators.
 
     a_op : :class:`qutip.qobj`
@@ -557,18 +561,18 @@ def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
     b_op : :class:`qutip.qobj`
         operator B.
 
-    solver : str
+    solver : *str*
         choice of solver (`es` for exponential series and
         `pi` for psuedo-inverse)
 
-    use_pinv : bool
+    use_pinv : *bool*
         For use with the `pi` solver: if `True` use numpy's pinv method,
         otherwise use a generic solver
 
     Returns
     -------
 
-    spectrum: *array*
+    spectrum : *array*
         An *array* with spectrum :math:`S(\omega)` for the frequencies
         specified in `wlist`.
 
@@ -641,7 +645,7 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
 
     .. math::
 
-        \lim_{t \to \infty} \left<A(t+\\tau)B(t)\\right>
+        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
 
     along one time axis (given steady-state initial conditions) using the
     quantum regression theorem and the evolution solver indicated by the
@@ -657,7 +661,7 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
-    c_ops : list of :class:`qutip.qobj.Qobj`
+    c_ops : *list* of :class:`qutip.qobj.Qobj`
         list of collapse operators.
 
     a_op : :class:`qutip.qobj.Qobj`
@@ -666,12 +670,12 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
     b_op : :class:`qutip.qobj.Qobj`
         operator B.
 
-    reverse : bool
+    reverse : *bool*
         If `True`, calculate
-        :math:`\lim_{t \to \infty} \left<A(t)B(t+\\tau)\\right>` instead of
-        :math:`\lim_{t \to \infty} \left<A(t+\\tau)B(t)\\right>`.
+        :math:`\lim_{t \\to \\infty} \left<A(t)B(t+\\tau)\\right>` instead of
+        :math:`\lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>`.
 
-    solver : str
+    solver : *str*
         choice of solver (`me` for master-equation and
         `es` for exponential series)
 
@@ -684,7 +688,7 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
     Returns
     -------
 
-    corr_vec: *array*
+    corr_vec : *array*
         An *array* of correlation values for the times specified by `tlist`.
 
     References
@@ -730,14 +734,14 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
     tlist : *list* / *array*
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. :math:`t \rightarrow \infty`; here tlist is
+        value is necessary, i.e. :math:`t \\rightarrow \\infty`; here tlist is
         automatically set, ignoring user input.
 
     taulist : *list* / *array*
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
-    c_ops : list of :class:`qutip.qobj.Qobj`
+    c_ops : *list* of :class:`qutip.qobj.Qobj`
         list of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
 
@@ -747,11 +751,11 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
     b_op : :class:`qutip.qobj.Qobj`
         operator B.
 
-    reverse : bool
+    reverse : *bool*
         If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
 
-    solver : str
+    solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series)
 
@@ -764,7 +768,7 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
     Returns
     -------
 
-    corr_mat: *array*
+    corr_mat : *array*
         An 2-dimensional *array* (matrix) of correlation values for the times
         specified by `tlist` (first index) and `taulist` (second index). If
         `tlist` is `None`, then a 1-dimensional *array* of correlation values
@@ -804,7 +808,8 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
     ----------
 
     H : :class:`qutip.qobj.Qobj`
-        system Hamiltonian.
+        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        `mc`.
 
     rho0 : :class:`qutip.qobj.Qobj`
         Initial state density matrix :math:`\\rho(t_0)` or state vector
@@ -816,8 +821,9 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
-    c_ops : list of :class:`qutip.qobj.Qobj`
-        list of collapse operators.
+    c_ops : *list* of :class:`qutip.qobj.Qobj`
+        list of collapse operators, may be time-dependent for solver choice of
+        `me` or `mc`.
 
     a_op : :class:`qutip.qobj.Qobj`
         operator A.
@@ -831,7 +837,7 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
     d_op : :class:`qutip.qobj.Qobj`
         operator D.
 
-    solver : str
+    solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series)
 
@@ -844,7 +850,7 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
     Returns
     -------
 
-    corr_vec: *array*
+    corr_vec : *array*
         An *array* of correlation values for the times specified by `taulist`
 
     References
@@ -895,14 +901,14 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
     tlist : *list* / *array*
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. :math:`t \rightarrow \infty`; here tlist is
+        value is necessary, i.e. :math:`t \\rightarrow \\infty`; here tlist is
         automatically set, ignoring user input.
 
     taulist : *list* / *array*
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
-    c_ops : list of :class:`qutip.qobj.Qobj`
+    c_ops : *list* of :class:`qutip.qobj.Qobj`
         list of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
 
@@ -918,7 +924,7 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
     d_op : :class:`qutip.qobj.Qobj`
         operator D.
 
-    solver : str
+    solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series)
 
@@ -931,7 +937,7 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
     Returns
     -------
 
-    corr_mat: *array*
+    corr_mat : *array*
         An 2-dimensional *array* (matrix) of correlation values for the times
         specified by `tlist` (first index) and `taulist` (second index). If
         `tlist` is `None`, then a 1-dimensional *array* of correlation values
@@ -962,13 +968,13 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
 def spectrum_ss(H, wlist, c_ops, a_op, b_op):
     """
     Calculate the spectrum of the correlation function
-    :math:`\lim_{t \to \infty} \left<A(t+\\tau)B(t)\\right>`,
+    :math:`\lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>`,
     i.e., the Fourier transform of the correlation function:
 
     .. math::
 
         S(\omega) = \int_{-\infty}^{\infty}
-        \lim_{t \to \infty} \left<A(t+\\tau)B(t)\\right>
+        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
         e^{-i\omega\\tau} d\\tau.
 
     using an eseries based solver Note: this spectrum is only defined for
@@ -983,7 +989,7 @@ def spectrum_ss(H, wlist, c_ops, a_op, b_op):
     wlist : *list* / *array*
         list of frequencies for :math:`\\omega`.
 
-    c_ops : list of :class:`qutip.qobj`
+    c_ops : *list* of :class:`qutip.qobj`
         list of collapse operators.
 
     a_op : :class:`qutip.qobj`
@@ -992,13 +998,13 @@ def spectrum_ss(H, wlist, c_ops, a_op, b_op):
     b_op : :class:`qutip.qobj`
         operator B.
 
-    use_pinv : bool
+    use_pinv : *bool*
         If `True` use numpy's `pinv` method, otherwise use a generic solver
 
     Returns
     -------
 
-    spectrum: *array*
+    spectrum : *array*
         An *array* with spectrum :math:`S(\omega)` for the frequencies
         specified in `wlist`.
 
@@ -1012,13 +1018,13 @@ def spectrum_ss(H, wlist, c_ops, a_op, b_op):
 def spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
     """
     Calculate the spectrum of the correlation function
-    :math:`\lim_{t \to \infty} \left<A(t+\\tau)B(t)\\right>`,
+    :math:`\lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>`,
     i.e., the Fourier transform of the correlation function:
 
     .. math::
 
         S(\omega) = \int_{-\infty}^{\infty}
-        \lim_{t \to \infty} \left<A(t+\\tau)B(t)\\right>
+        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
         e^{-i\omega\\tau} d\\tau.
 
     using a psuedo-inverse method. Note: this spectrum is only defined for
@@ -1033,7 +1039,7 @@ def spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
     wlist : *list* / *array*
         list of frequencies for :math:`\\omega`.
 
-    c_ops : list of :class:`qutip.qobj`
+    c_ops : *list* of :class:`qutip.qobj`
         list of collapse operators.
 
     a_op : :class:`qutip.qobj`
@@ -1042,13 +1048,13 @@ def spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
     b_op : :class:`qutip.qobj`
         operator B.
 
-    use_pinv : bool
+    use_pinv : *bool*
         If `True` use numpy's pinv method, otherwise use a generic solver
 
     Returns
     -------
 
-    spectrum: *array*
+    spectrum : *array*
         An *array* with spectrum :math:`S(\omega)` for the frequencies
         specified in `wlist`.
 

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -159,7 +159,8 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
     ----------
 
     H : :class:`qutip.qobj.Qobj`
-        system Hamiltonian.
+        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        `mc`.
 
     state0 : :class:`qutip.qobj.Qobj`
         Initial state density matrix :math:`\\rho_0` or state vector
@@ -178,7 +179,8 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
         the element `0`.
 
     c_ops : list of :class:`qutip.qobj.Qobj`
-        list of collapse operators.
+        list of collapse operators, may be time-dependent for solver choice of
+        `me` or `mc`.
 
     a_op : :class:`qutip.qobj.Qobj`
         operator A.
@@ -324,8 +326,8 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     ----------
 
     H : :class:`qutip.qobj.Qobj`
-        system Hamiltonian, or a callback function for time-dependent
-        Hamiltonians.
+        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        `mc`.
 
     rho0 : :class:`qutip.qobj.Qobj`
         Initial state density matrix :math:`\\rho_0` or state vector
@@ -344,7 +346,8 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
         the element `0`.
 
     c_ops : list of :class:`qutip.qobj.Qobj`
-        list of collapse operators. (does not accept time dependence)
+        list of collapse operators, may be time-dependent for solver choice of
+        `me` or `mc`.
 
     a_op : :class:`qutip.qobj.Qobj`
         operator A.
@@ -715,7 +718,8 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
     ----------
 
     H : :class:`qutip.qobj.Qobj`
-        system Hamiltonian.
+        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        `mc`.
 
     state0 : :class:`qutip.qobj.Qobj`
         Initial state density matrix :math:`\\rho(t_0)` or state vector
@@ -734,7 +738,8 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
         the element `0`.
 
     c_ops : list of :class:`qutip.qobj.Qobj`
-        list of collapse operators.
+        list of collapse operators, may be time-dependent for solver choice of
+        `me` or `mc`.
 
     a_op : :class:`qutip.qobj.Qobj`
         operator A.
@@ -878,8 +883,8 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
     ----------
 
     H : :class:`qutip.qobj.Qobj`
-        system Hamiltonian, or a callback function for time-dependent
-        Hamiltonians.
+        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        `mc`.
 
     rho0 : :class:`qutip.qobj.Qobj`
         Initial state density matrix :math:`\\rho_0` or state vector
@@ -898,7 +903,8 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
         the element `0`.
 
     c_ops : list of :class:`qutip.qobj.Qobj`
-        list of collapse operators. (does not accept time dependence)
+        list of collapse operators, may be time-dependent for solver choice of
+        `me` or `mc`.
 
     a_op : :class:`qutip.qobj.Qobj`
         operator A.

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -1139,6 +1139,8 @@ def _correlation_me_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
         if t_idx == 1:
             options.rhs_reuse = True
 
+    rhs_clear()
+
     return corr_mat
 
 
@@ -1244,6 +1246,7 @@ def _correlation_mc_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
 
     corr_mat = np.zeros([np.size(tlist), np.size(taulist)], dtype=complex)
     H_shifted, _args = _transform_H_t_shift(H, args)
+    rhs_clear()
 
     # calculation of <A(t)B(t+tau)C(t)> from only knowledge of psi0 requires
     # averaging over both t and tau
@@ -1301,6 +1304,8 @@ def _correlation_mc_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
                     
         if t_idx == 1:
             options.rhs_reuse = True
+
+    rhs_clear()
 
     return corr_mat
 

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -111,7 +111,7 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
 
     solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
-        `es` for exponential series)
+        `es` for exponential series).
 
     options : :class:`qutip.solver.Options`
         solver options class. `ntraj` is taken as a two-element list because
@@ -173,8 +173,8 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
     tlist : *list* / *array*
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. :math:`t \\rightarrow \\infty`; here tlist is
-        automatically set, ignoring user input.
+        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
+        tlist is automatically set, ignoring user input.
 
     taulist : *list* / *array*
         list of times for :math:`\\tau`. taulist must be positive and contain
@@ -196,7 +196,7 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
 
     solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
-        `es` for exponential series)
+        `es` for exponential series).
 
     options : :class:`qutip.solver.Options`
         solver options class. `ntraj` is taken as a two-element list because
@@ -286,7 +286,7 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
 
     solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
-        `es` for exponential series)
+        `es` for exponential series).
 
     options : :class:`qutip.solver.Options`
         solver options class. `ntraj` is taken as a two-element list because
@@ -342,8 +342,8 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     tlist : *list* / *array*
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. :math:`t \\rightarrow \\infty`; here tlist is
-        automatically set, ignoring user input.
+        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
+        tlist is automatically set, ignoring user input.
 
     taulist : *list* / *array*
         list of times for :math:`\\tau`. taulist must be positive and contain
@@ -364,7 +364,7 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
 
     solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
-        `es` for exponential series)
+        `es` for exponential series).
 
     options : :class:`qutip.solver.Options`
         solver options class. `ntraj` is taken as a two-element list because
@@ -435,7 +435,7 @@ def coherence_function_g1(H, taulist, c_ops, a_op, solver="me", args={},
 
     solver : *str*
         choice of solver (`me` for master-equation and
-        `es` for exponential series)
+        `es` for exponential series).
 
     options : :class:`qutip.solver.Options`
         solver options class. `ntraj` is taken as a two-element list because
@@ -497,7 +497,7 @@ def coherence_function_g2(H, taulist, c_ops, a_op, solver="me", args={},
 
     solver : *str*
         choice of solver (`me` for master-equation and
-        `es` for exponential series)
+        `es` for exponential series).
 
     options : :class:`qutip.solver.Options`
         solver options class. `ntraj` is taken as a two-element list because
@@ -563,11 +563,11 @@ def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
 
     solver : *str*
         choice of solver (`es` for exponential series and
-        `pi` for psuedo-inverse)
+        `pi` for psuedo-inverse).
 
     use_pinv : *bool*
         For use with the `pi` solver: if `True` use numpy's pinv method,
-        otherwise use a generic solver
+        otherwise use a generic solver.
 
     Returns
     -------
@@ -677,7 +677,7 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
 
     solver : *str*
         choice of solver (`me` for master-equation and
-        `es` for exponential series)
+        `es` for exponential series).
 
     options : :class:`qutip.solver.Options`
         solver options class. `ntraj` is taken as a two-element list because
@@ -734,8 +734,8 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
     tlist : *list* / *array*
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. :math:`t \\rightarrow \\infty`; here tlist is
-        automatically set, ignoring user input.
+        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
+        tlist is automatically set, ignoring user input.
 
     taulist : *list* / *array*
         list of times for :math:`\\tau`. taulist must be positive and contain
@@ -757,7 +757,7 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
 
     solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
-        `es` for exponential series)
+        `es` for exponential series).
 
     options : :class:`qutip.solver.Options`
         solver options class. `ntraj` is taken as a two-element list because
@@ -839,7 +839,7 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
 
     solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
-        `es` for exponential series)
+        `es` for exponential series).
 
     options : :class:`qutip.solver.Options`
         solver options class. `ntraj` is taken as a two-element list because
@@ -851,7 +851,7 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
     -------
 
     corr_vec : *array*
-        An *array* of correlation values for the times specified by `taulist`
+        An *array* of correlation values for the times specified by `taulist`.
 
     References
     ----------
@@ -901,8 +901,8 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
     tlist : *list* / *array*
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. :math:`t \\rightarrow \\infty`; here tlist is
-        automatically set, ignoring user input.
+        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
+        tlist is automatically set, ignoring user input.
 
     taulist : *list* / *array*
         list of times for :math:`\\tau`. taulist must be positive and contain
@@ -926,7 +926,7 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
 
     solver : *str*
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
-        `es` for exponential series)
+        `es` for exponential series).
 
     options : :class:`qutip.solver.Options`
         solver options class. `ntraj` is taken as a two-element list because
@@ -999,7 +999,7 @@ def spectrum_ss(H, wlist, c_ops, a_op, b_op):
         operator B.
 
     use_pinv : *bool*
-        If `True` use numpy's `pinv` method, otherwise use a generic solver
+        If `True` use numpy's `pinv` method, otherwise use a generic solver.
 
     Returns
     -------
@@ -1049,7 +1049,7 @@ def spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
         operator B.
 
     use_pinv : *bool*
-        If `True` use numpy's pinv method, otherwise use a generic solver
+        If `True` use numpy's pinv method, otherwise use a generic solver.
 
     Returns
     -------
@@ -1241,6 +1241,10 @@ def _correlation_mc_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     <A(t)B(t+tau)C(t)>
     using a Monte Carlo solver.
     """
+
+    if not c_ops:
+        raise TypeError("If no collapse operators are required, use the `me`" +
+                        "or `es` solvers")
 
     # the solvers only work for positive time differences and the correlators
     # require positive tau

--- a/qutip/essolve.py
+++ b/qutip/essolve.py
@@ -42,6 +42,7 @@ from qutip.eseries import eseries, estidy, esval
 from qutip.expect import expect
 from qutip.superoperator import liouvillian, mat2vec, vec2mat
 from qutip.solver import Result
+from qutip.operators import qzero
 
 
 # -----------------------------------------------------------------------------
@@ -144,6 +145,11 @@ def ode2es(L, rho0):
             # Got a wave function as initial state: convert to density matrix.
             rho0 = rho0 * rho0.dag()
 
+        # check if state is below error threshold
+        if abs(rho0.full().sum()) < 1e-10 + 1e-24:
+            # enforce zero operator
+            return eseries(qzero(rho0.dims[0]))
+
         w, v = L.eigenstates()
         v = np.hstack([ket.full() for ket in v])
         # w[i]   = eigenvalue i
@@ -167,6 +173,13 @@ def ode2es(L, rho0):
         if not isket(rho0):
             raise TypeError('Second argument must be a ket if first' +
                             'is a Hamiltonian.')
+
+        # check if state is below error threshold
+        if abs(rho0.full().sum()) < 1e-5 + 1e-20:
+            # enforce zero operator
+            dims = rho0.dims
+            return eseries(Qobj(sp.csr_matrix((dims[0][0], dims[1][0]),
+                                              dtype=complex)))
 
         w, v = L.eigenstates()
         v = np.hstack([ket.full() for ket in v])

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -415,7 +415,8 @@ shape = [4, 4], type = oper, isHerm = False
 # a = qeye(N), N is integer & N>0
 #
 def qeye(N):
-    """Identity operator
+    """
+    Identity operator
 
     Parameters
     ----------
@@ -765,25 +766,30 @@ def phase(N, phi0=0):
     return Qobj(np.sum(ops, axis=0))
 
 
-def qzero(N, dims=None):
+def qzero(N):
     """
-    Creates the zero operator with shape NxN and dimensions `dims`.
+    Zero operator
 
     Parameters
     ----------
-    N : int
-        Hilbert space dimensionality
-    dims : list (optional)
-        Dimensions if operator corresponds to
-        a composite Hilbert space.
+    N : int or list of ints
+        Dimension of Hilbert space. If provided as a list of ints,
+        then the dimension is the product over this list, but the
+        ``dims`` property of the new Qobj are set to this list.
 
     Returns
     -------
     qzero : qobj
-        Zero operator on given Hilbert space.
+        Zero operator Qobj.
 
     """
-    return Qobj(sp.csr_matrix((N, N), dtype=complex), dims=dims, isherm=True)
+
+    if isinstance(N, list):
+        return tensor.tensor(*[qzero(n) for n in N])
+    N = int(N)
+    if (not isinstance(N, (int, np.integer))) or N < 0:
+        raise ValueError("N must be integer N>=0")
+    return Qobj(sp.csr_matrix((N, N), dtype=complex), isherm=True)
 
 
 def enr_destroy(dims, excitations):

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -118,11 +118,11 @@ def test_compare_solvers_coherent_state_memc():
     corr1 = correlation_2op_2t(H, psi0, [0, 0.5], taulist, c_ops, a.dag(), a,
                                solver="me")
     corr2 = correlation_2op_2t(H, psi0, [0, 0.5], taulist, c_ops, a.dag(), a,
-                               options=Options(ntraj=[125, 250]), solver="mc")
+                               solver="mc")
 
     # pretty lax criterion, but would otherwise require a quite long simulation
     # time
-    assert_(abs(corr1 - corr2).max() < 0.15)
+    assert_(abs(corr1 - corr2).max() < 0.2)
 
 
 def test_compare_solvers_steadystate_legacy():

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -50,9 +50,9 @@ from qutip import (correlation, destroy, coherent_dm, correlation_2op_2t,
 try:
     import Cython
 except:
-    Cython_found = 0
+    Cython_OK = False
 else:
-    Cython_found = 1
+    Cython_OK = _version2int(Cython.__version__) >= _version2int('0.14')
 
 
 def test_compare_solvers_coherent_state_legacy():
@@ -260,8 +260,7 @@ def test_spectrum_espi():
     assert_(max(abs(spec1 - spec2)) < 1e-3)
 
 
-@unittest.skipIf(_version2int(Cython.__version__) < _version2int('0.14') or
-                 Cython_found == 0, 'Cython not found or version too low.')
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_H_str_list_td_corr():
     """
     correlation: comparing TLS emission correlations, H td (str-list td format)
@@ -297,8 +296,7 @@ def test_H_str_list_td_corr():
     assert_(abs(g20-0.59) < 1e-2)
 
 
-@unittest.skipIf(_version2int(Cython.__version__) < _version2int('0.14') or
-                 Cython_found == 0, 'Cython not found or version too low.')
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_H_np_list_td_corr():
     """
     correlation: comparing TLS emission correlations, H td (np-list td format)
@@ -414,8 +412,7 @@ def test_H_fn_td_corr():
     assert_(abs(g20-0.59) < 1e-2)
 
 
-@unittest.skipIf(_version2int(Cython.__version__) < _version2int('0.14') or
-                 Cython_found == 0, 'Cython not found or version too low.')
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_c_ops_str_list_td_corr():
     """
     correlation: comparing 3LS emission correlations, c_ops td (str-list td format)
@@ -459,8 +456,7 @@ def test_c_ops_str_list_td_corr():
     assert_(abs(gab - 0.185) < 1e-2)
 
 
-@unittest.skipIf(_version2int(Cython.__version__) < _version2int('0.14') or
-                 Cython_found == 0, 'Cython not found or version too low.')
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_np_str_list_td_corr():
     """
     correlation: comparing 3LS emission correlations, c_ops td (np-list td format)
@@ -549,8 +545,7 @@ def test_c_ops_fn_list_td_corr():
     assert_(abs(gab - 0.185) < 1e-2)
 
 
-@unittest.skipIf(_version2int(Cython.__version__) < _version2int('0.14') or
-                 Cython_found == 0, 'Cython not found or version too low.')
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_str_list_td_corr():
     """
     correlation: comparing TLS emission correlations (str-list td format)
@@ -589,8 +584,7 @@ def test_str_list_td_corr():
     assert_(abs(g20 - 0.85) < 1e-2)
 
 
-@unittest.skipIf(_version2int(Cython.__version__) < _version2int('0.14') or
-                 Cython_found == 0, 'Cython not found or version too low.')
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_np_list_td_corr():
     """
     correlation: comparing TLS emission correlations (np-list td format)

--- a/qutip/tests/test_oper_types.py
+++ b/qutip/tests/test_oper_types.py
@@ -129,7 +129,7 @@ def test_squeezing_type():
 
 def test_zero_type():
     "Operator CSR Type: zero_oper"
-    op = qzero(5, [[5], [5]])
+    op = qzero(5)
     assert_equal(isspmatrix_csr(op.data), True)
 
 


### PR DESCRIPTION
This branch adds the ability to calculate two-time correlations with fully time-dependent Hamiltonians and collapse operators. The time-dependence may now either be in the Hamiltonian or the collapse operators, or both. Additionally, support for the numpy list format was added. New tests were made to test all of these functionalities. Bugs were fixed.