### PR TITLE
Bloch-Redfield master equation solver for time-dependent Hamiltonians and c_ops

### DIFF
--- a/qutip/bloch_redfield.py
+++ b/qutip/bloch_redfield.py
@@ -56,7 +56,9 @@ def brmesolve(H, state0, tlist, a_ops, e_ops=[], spectra_cb=[], c_ops=[],
     .. note::
 
         This solver only supports time-dependent Hamiltonians and collapse
-        operators using the `list array format`.
+        operators using the `list array format`. This is due to the
+        implementation of time-dependence with piece-wise constant
+        Liouvillians.
 
     Parameters
     ----------

--- a/qutip/bloch_redfield.py
+++ b/qutip/bloch_redfield.py
@@ -115,10 +115,7 @@ def brmesolve(H, state0, tlist, a_ops, e_ops=[], spectra_cb=[], c_ops=[],
     #
     H_time_dependent = False
     c_ops_time_dependent = False
-    if isinstance(H, Qobj):
-        # no time-dependence
-        pass
-    elif isinstance(H, list):
+    if isinstance(H, list):
         for Hk in H:
             if isinstance(Hk, list):
                 # check time-dependence is list array format
@@ -128,7 +125,7 @@ def brmesolve(H, state0, tlist, a_ops, e_ops=[], spectra_cb=[], c_ops=[],
                     raise TypeError("Incorrect hamiltonian specification, " +
                                     "the Bloch Redfield solver requires " +
                                     "list array format")
-    elif isinstance(c_ops, list):
+    if isinstance(c_ops, list):
         for ck in c_ops:
             if isinstance(ck, list):
                 # check time-dependence is list array format
@@ -138,8 +135,6 @@ def brmesolve(H, state0, tlist, a_ops, e_ops=[], spectra_cb=[], c_ops=[],
                     raise TypeError("Incorrect collapse operator " +
                                     "specification, the Bloch Redfield " +
                                     "solver requires list array format")
-    else:
-        raise TypeError("Incorrect hamiltonian specification")
 
     #
     # Compute Bloch Redfield evolution
@@ -176,6 +171,7 @@ def brmesolve(H, state0, tlist, a_ops, e_ops=[], spectra_cb=[], c_ops=[],
         for i in range(len(tlist) - 1):
             # re-compute Hamiltonian and c_ops for current time step
             if H_time_dependent:
+                # we can just add the Hamiltonian operators together
                 H_i = 0
                 for Hk in H:
                     if isinstance(Hk, list):
@@ -185,12 +181,13 @@ def brmesolve(H, state0, tlist, a_ops, e_ops=[], spectra_cb=[], c_ops=[],
             else:
                 H_i = H
             if c_ops_time_dependent:
-                c_ops_i = 0
+                # but c_ops needs to be in a list format
+                c_ops_i = []
                 for ck in c_ops:
                     if isinstance(ck, list):
-                        c_ops_i += ck[0]*ck[1][i]
+                        c_ops_i.append(ck[0]*ck[1][i])
                     else:
-                        c_ops_i += ck
+                        c_ops_i.append(ck)
             else:
                 c_ops_i = c_ops
 

--- a/qutip/bloch_redfield.py
+++ b/qutip/bloch_redfield.py
@@ -72,7 +72,7 @@ def brmesolve(H, state0, tlist, a_ops, e_ops=[], spectra_cb=[], c_ops=[],
         :math:`\\psi(t_0)`.
 
     tlist : ``list`` or ``numpy.array``
-        ``list`` of times for :math:`t`.
+        ``list`` or ``numpy.array`` of times for :math:`t`.
 
     a_ops : ``list`` of :class:`qutip.Qobj`
         ``list`` of system operators that couple to bath degrees of
@@ -354,7 +354,7 @@ def bloch_redfield_tensor(H, a_ops, spectra_cb=[], c_ops=[], use_secular=True):
         ``list`` of callback functions that evaluate the noise power
         spectra at a given frequency.
 
-    c_ops : ``list``
+    c_ops : ``list`` of :class:`qutip.Qobj`
         ``list`` of system collapse operators.
 
     use_secular : ``bool``

--- a/qutip/bloch_redfield.py
+++ b/qutip/bloch_redfield.py
@@ -161,8 +161,27 @@ def brmesolve(H, state0, tlist, a_ops, e_ops=[], spectra_cb=[], c_ops=[],
         # step through tlist and compute a new Redfield tensor at each step,
         # using the final state of the previous step as the input to the next
         for i in range(len(tlist) - 1):
-            H_i = ...
-            c_ops_i = ...
+            # re-compute Hamiltonian and c_ops for current time step
+            if H_time_dependent:
+                H_i = 0
+                for Hk in H:
+                    if isinstance(Hk, list):
+                        H_i += Hk[0]*Hk[1][i]
+                    else:
+                        H_i += Hk
+            else:
+                H_i = H
+            if c_ops_time_dependent:
+                c_ops_i = 0
+                for ck in c_ops:
+                    if isinstance(ck, list):
+                        c_ops_i += ck[0]*ck[1][i]
+                    else:
+                        c_ops_i += ck
+            else:
+                c_ops_i = c_ops
+
+            # create Redfield tensor and evolve
             R, ekets = bloch_redfield_tensor(H_i, a_ops, spectra_cb,
                                              c_ops=c_ops_i, use_secular=False)
             rho = bloch_redfield_solve(

--- a/qutip/bloch_redfield.py
+++ b/qutip/bloch_redfield.py
@@ -56,49 +56,57 @@ def brmesolve(H, state0, tlist, a_ops, e_ops=[], spectra_cb=[], c_ops=[],
     .. note::
 
         This solver only supports time-dependent Hamiltonians and collapse
-        operators using the *list array format*.
+        operators using the `list array format`.
 
     Parameters
     ----------
 
-    H : :class:`qutip.Qobj`
-        System Hamiltonian, may be time-dependent using the *list array
-        format*.
+    H : :class:`qutip.Qobj` or ``list``
+        system Hamiltonian, either time-independent with a system operator
+        :class:`qutip.Qobj` or time-dependent with a ``list`` of
+        :class:`qutip.Qobj` or [:class:`qutip.Qobj`, ``numpy.array``]
+        pairs.
 
-    state0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
         :math:`\\psi(t_0)`.
 
-    tlist : array_like
-        List of times for :math:`t`.
+    tlist : ``list`` or ``numpy.array``
+        ``list`` of times for :math:`t`.
 
-    a_ops : list of :class:`qutip.qobj`
-        List of system operators that couple to bath degrees of freedom.
+    a_ops : ``list`` of :class:`qutip.Qobj`
+        ``list`` of system operators that couple to bath degrees of
+        freedom.
 
-    e_ops : list of :class:`qutip.qobj` / callback function
-        List of operators for which to evaluate expectation values.
+    e_ops : ``list`` of :class:`qutip.Qobj`
+        ``list`` of operators for which to evaluate expectation values.
 
-    c_ops : list of :class:`qutip.qobj`
-        List of system collapse operators, may be time-dependent using the
-        *list array format*.
+    spectra_cb : ``list`` of callback functions
+        ``list`` of callback functions that evaluate the noise power
+        spectrum at a given frequency.
 
-    use_secular : bool
-        Flag (True of False) that indicates if the secular approximation should
-        be used.
+    c_ops : ``list``
+        ``list`` of system collapse operators, either :class:`qutip.Qobj`
+        or [:class:`qutip.Qobj`, ``numpy.array``] pairs.
 
-    args : dictionary
-        Placeholder for future implementation, kept for API consistency.
+    use_secular : ``bool``
+        boolean flag that indicates if the secular approximation should be
+        used.
+
+    args : ``dict``
+        placeholder for future implementation, kept for API consistency.
 
     options : :class:`qutip.solver.Options`
-        Options for the solver.
+        options for the solver.
 
     Returns
     -------
 
-    result: :class:`qutip.solver.Result`
-        An instance of the class :class:`qutip.solver.Result`, which contains
-        either an array of expectation values, for operators given in e_ops,
-        or a list of states for the times specified by `tlist`.
+    result : :class:`qutip.solver.Result`
+        an instance of the class :class:`qutip.solver.Result`, which contains
+        either a ``list`` with ``numpy.array`` s of expectation
+        values for each operators given in `e_ops` or a ``list`` of states
+        for the times specified by `tlist`.
 
     """
 
@@ -217,31 +225,33 @@ def bloch_redfield_solve(R, ekets, state0, tlist, e_ops=[], options=None):
     Parameters
     ----------
 
-    R : :class:`qutip.qobj`
+    R : :class:`qutip.Qobj`
         Bloch-Redfield tensor.
 
-    ekets : array of :class:`qutip.qobj`
-        Array of kets that make up a basis tranformation for the eigenbasis.
+    ekets : ``list`` of :class:`qutip.Qobj`
+        ``list`` of kets that make up a basis tranformation for the
+        eigenbasis.
 
-    state0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
         :math:`\\psi(t_0)`.
 
-    tlist : array_like
-        List of times for :math:`t`.
+    tlist : ``list`` or ``numpy.array``
+        ``list`` of times for :math:`t`.
 
-    e_ops : list of :class:`qutip.qobj` / callback function
-        List of operators for which to evaluate expectation values.
+    e_ops : ``list`` of :class:`qutip.Qobj`
+        ``list`` of operators for which to evaluate expectation values.
 
-    options : :class:`qutip.Qdeoptions`
-        Options for the ODE solver.
+    options : :class:`qutip.solver.Options`
+        options for the solver.
 
     Returns
     -------
 
-    output: :class:`qutip.solver`
-        An instance of the class :class:`qutip.solver`, which contains either
-        an array of expectation values for the times specified by `tlist`.
+    output : ``list``
+        a ``list`` that contains ``numpy.array`` s of expectation
+        values for each operators given in `e_ops` or a ``list`` of states
+        for the times specified by `tlist`.
 
     """
 
@@ -319,7 +329,7 @@ def bloch_redfield_solve(R, ekets, state0, tlist, e_ops=[], options=None):
 # Functions for calculating the Bloch-Redfield tensor for a time-independent
 # system.
 #
-def bloch_redfield_tensor(H, a_ops, spectra_cb, c_ops=[], use_secular=True):
+def bloch_redfield_tensor(H, a_ops, spectra_cb=[], c_ops=[], use_secular=True):
     """
     Calculate the Bloch-Redfield tensor for a system given a set of operators
     and corresponding spectral functions that describes the system's coupling
@@ -327,34 +337,36 @@ def bloch_redfield_tensor(H, a_ops, spectra_cb, c_ops=[], use_secular=True):
 
     .. note::
 
-        This tensor generation requires a time-independent Hamiltonian.
+        This tensor generation requires a time-independent Hamiltonian and
+        collapse operators.
 
     Parameters
     ----------
 
-    H : :class:`qutip.qobj`
-        System Hamiltonian.
+    H : :class:`qutip.Qobj`
+        system Hamiltonian.
 
-    a_ops : list of :class:`qutip.qobj`
-        List of system operators that couple to the environment.
+    a_ops : ``list`` of :class:`qutip.Qobj`
+        ``list`` of system operators that couple to bath degrees of
+        freedom.
 
-    spectra_cb : list of callback functions
-        List of callback functions that evaluate the noise power spectrum
-        at a given frequency.
+    spectra_cb : ``list`` of callback functions
+        ``list`` of callback functions that evaluate the noise power
+        spectra at a given frequency.
 
-    c_ops : list of :class:`qutip.qobj`
-        List of system collapse operators.
+    c_ops : ``list``
+        ``list`` of system collapse operators.
 
-    use_secular : bool
-        Flag (True of False) that indicates if the secular approximation should
-        be used.
+    use_secular : ``bool``
+        boolean flag that indicates if the secular approximation should be
+        used.
 
     Returns
     -------
 
-    R, kets: :class:`qutip.Qobj`, list of :class:`qutip.Qobj`
-        R is the Bloch-Redfield tensor and kets is a list eigenstates of the
-        Hamiltonian.
+    R, kets : :class:`qutip.Qobj`, ``list`` of :class:`qutip.Qobj`
+        `R` is the Bloch-Redfield tensor and `kets` is a ``list`` of the
+        eigenstates of the Hamiltonian.
 
     """
 

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -82,7 +82,7 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
     ----------
 
     H : Qobj
-        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     state0 : Qobj
         Initial state density matrix :math:`\\rho(t_0)` or state vector
@@ -90,20 +90,20 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
-        list of collapse operators, may be time-dependent for solver choice of
+        List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
     a_op : Qobj
-        operator A.
+        Operator A.
     b_op : Qobj
-        operator B.
+        Operator B.
     reverse : bool {False, True}
         If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
     solver : str {'me', 'mc', 'es'}
-        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
@@ -150,7 +150,7 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
     Parameters
     ----------
     H : Qobj
-        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     state0 : Qobj
         Initial state density matrix :math:`\\rho_0` or state vector
@@ -158,36 +158,36 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     tlist : array_like
-        list of times for :math:`t`. tlist must be positive and contain the
+        List of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
         value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
         tlist is automatically set, ignoring user input.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
-        list of collapse operators, may be time-dependent for solver choice of
+        List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
     a_op : Qobj
-        operator A.
+        Operator A.
     b_op : Qobj
-        operator B.
+        Operator B.
     reverse : bool {False, True}
         If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
     solver : str
-        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
     options : Options
-        solver options class. `ntraj` is taken as a two-element list because
+        Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
         `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
         the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
-    corr_mat : ndarray
-        An 2-dimensional array (matrix) of correlation values for the times
+    corr_mat : array
+        A 2-dimensional array (matrix) of correlation values for the times
         specified by `tlist` (first index) and `taulist` (second index). If
         `tlist` is `None`, then a 1-dimensional array of correlation values
         is returned instead.
@@ -229,7 +229,7 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
     along one time axis using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
-    Note: it is not possibly to calculate a physically meaningful correlation
+    Note: it is not possible to calculate a physically meaningful correlation
     of this form where :math:`\\tau<0`.
 
     Parameters
@@ -290,13 +290,13 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     along two time axes using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
-    Note: it is not possibly to calculate a physically meaningful correlation
+    Note: it is not possible to calculate a physically meaningful correlation
     of this form where :math:`\\tau<0`.
 
     Parameters
     ----------
     H : Qobj
-        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     rho0 : Qobj
         Initial state density matrix :math:`\\rho_0` or state vector
@@ -304,27 +304,27 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     tlist : array_like
-        list of times for :math:`t`. tlist must be positive and contain the
+        List of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
         value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
         tlist is automatically set, ignoring user input.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
-        list of collapse operators, may be time-dependent for solver choice of
+        List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
     a_op : Qobj
-        operator A.
+        Operator A.
     b_op : Qobj
-        operator B.
+        Operator B.
     c_op : Qobj
-        operator C.
+        Operator C.
     solver : str
-        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
     options : Options
-        solver options class. `ntraj` is taken as a two-element list because
+        Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
         `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
         the `mc` correlator; by default, `mc_corr_eps=1e-10`.
@@ -376,7 +376,7 @@ def coherence_function_g1(H, state0, taulist, c_ops, a_op, solver="me",
     Parameters
     ----------
     H : Qobj
-        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     state0 : Qobj
         Initial state density matrix :math:`\\rho(t_0)` or state vector
@@ -384,18 +384,18 @@ def coherence_function_g1(H, state0, taulist, c_ops, a_op, solver="me",
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
-        list of collapse operators, may be time-dependent for solver choice of
+        List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
     a_op : Qobj
-        operator A.
+        Operator A.
     solver : str
-        choice of solver (`me` for master-equation and
+        Choice of solver (`me` for master-equation and
         `es` for exponential series).
     options : Options
-        solver options class. `ntraj` is taken as a two-element list because
+        Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
         `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
         the `mc` correlator; by default, `mc_corr_eps=1e-10`.
@@ -441,7 +441,7 @@ def coherence_function_g2(H, state0, taulist, c_ops, a_op, solver="me", args={},
     Parameters
     ----------
     H : Qobj
-        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     state0 : Qobj
         Initial state density matrix :math:`\\rho(t_0)` or state vector
@@ -449,18 +449,18 @@ def coherence_function_g2(H, state0, taulist, c_ops, a_op, solver="me", args={},
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
-        list of collapse operators, may be time-dependent for solver choice of
+        List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
     a_op : Qobj
-        operator A.
+        Operator A.
     solver : str
-        choice of solver (`me` for master-equation and
+        Choice of solver (`me` for master-equation and
         `es` for exponential series).
     options : Options
-        solver options class. `ntraj` is taken as a two-element list because
+        Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
         `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
         the `mc` correlator; by default, `mc_corr_eps=1e-10`.
@@ -508,17 +508,17 @@ def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
     Parameters
     ----------
     H : :class:`qutip.qobj`
-        system Hamiltonian.
+        System Hamiltonian.
     wlist : array_like
-        list of frequencies for :math:`\\omega`.
+        List of frequencies for :math:`\\omega`.
     c_ops : list
-        list of collapse operators.
+        List of collapse operators.
     a_op : Qobj
-        operator A.
+        Operator A.
     b_op : Qobj
-        operator B.
+        Operator B.
     solver : str
-        choice of solver (`es` for exponential series and
+        Choice of solver (`es` for exponential series and
         `pi` for psuedo-inverse).
     use_pinv : bool
         For use with the `pi` solver: if `True` use numpy's pinv method,
@@ -552,9 +552,9 @@ def spectrum_correlation_fft(taulist, y):
     Parameters
     ----------
     tlist : array_like
-        list/array of times :math:`t` which the correlation function is given.
+        List of times :math:`t` which the correlation function is given.
     y : array_like
-        list/array of correlations corresponding to time delays :math:`t`.
+        List of correlations corresponding to time delays :math:`t`.
 
     Returns
     -------
@@ -606,32 +606,32 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
     ----------
 
     H : Qobj
-        system Hamiltonian.
+        System Hamiltonian.
 
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
     c_ops : list
-        list of collapse operators.
+        List of collapse operators.
 
     a_op : Qobj
-        operator A.
+        Operator A.
 
     b_op : Qobj
-        operator B.
+        Operator B.
 
-    reverse : *bool*
+    reverse : bool
         If `True`, calculate
         :math:`\lim_{t \\to \\infty} \left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>`.
 
     solver : str
-        choice of solver (`me` for master-equation and
+        Choice of solver (`me` for master-equation and
         `es` for exponential series).
 
     options : Options
-        solver options class. `ntraj` is taken as a two-element list because
+        Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
         `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
         the `mc` correlator; by default, `mc_corr_eps=1e-10`.
@@ -673,7 +673,7 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
     ----------
 
     H : Qobj
-        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
 
     state0 : Qobj
@@ -683,35 +683,35 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
         for the `me` and `es` solvers.
 
     tlist : array_like
-        list of times for :math:`t`. tlist must be positive and contain the
+        List of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
         value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
         tlist is automatically set, ignoring user input.
 
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
     c_ops : list
-        list of collapse operators, may be time-dependent for solver choice of
+        List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
 
     a_op : Qobj
-        operator A.
+        Operator A.
 
     b_op : Qobj
-        operator B.
+        Operator B.
 
-    reverse : *bool*
+    reverse : bool
         If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
 
     solver : str
-        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
     options : Options
-        solver options class. `ntraj` is taken as a two-element list because
+        Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
         `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
         the `mc` correlator; by default, `mc_corr_eps=1e-10`.
@@ -720,7 +720,7 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
     -------
 
     corr_mat : array
-        An 2-dimensional array (matrix) of correlation values for the times
+        A 2-dimensional array (matrix) of correlation values for the times
         specified by `tlist` (first index) and `taulist` (second index). If
         `tlist` is `None`, then a 1-dimensional array of correlation values
         is returned instead.
@@ -752,13 +752,13 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
     along one time axis using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
-    Note: it is not possibly to calculate a physically meaningful correlation
+    Note: it is not possible to calculate a physically meaningful correlation
     of this form where :math:`\\tau<0`.
 
     Parameters
     ----------
     H : Qobj
-        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     rho0 : Qobj
         Initial state density matrix :math:`\\rho(t_0)` or state vector
@@ -766,30 +766,30 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
-        list of collapse operators, may be time-dependent for solver choice of
+        List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
 
     a_op : Qobj
-        operator A.
+        Operator A.
 
     b_op : Qobj
-        operator B.
+        Operator B.
 
     c_op : Qobj
-        operator C.
+        Operator C.
 
     d_op : Qobj
-        operator D.
+        Operator D.
 
     solver : str
-        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
     options : Options
-        solver options class. `ntraj` is taken as a two-element list because
+        Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
         `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
         the `mc` correlator; by default, `mc_corr_eps=1e-10`.
@@ -830,14 +830,14 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
     along two time axes using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
-    Note: it is not possibly to calculate a physically meaningful correlation
+    Note: it is not possible to calculate a physically meaningful correlation
     of this form where :math:`\\tau<0`.
 
     Parameters
     ----------
 
     H : Qobj
-        system Hamiltonian, may be time-dependent for solver choice of `me` or
+        System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
 
     rho0 : Qobj
@@ -847,37 +847,37 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
         for the `me` and `es` solvers.
 
     tlist : array_like
-        list of times for :math:`t`. tlist must be positive and contain the
+        List of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
         value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
         tlist is automatically set, ignoring user input.
 
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
 
     c_ops : list
-        list of collapse operators, may be time-dependent for solver choice of
+        List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
 
     a_op : Qobj
-        operator A.
+        Operator A.
 
     b_op : Qobj
-        operator B.
+        Operator B.
 
     c_op : Qobj
-        operator C.
+        Operator C.
 
     d_op : Qobj
-        operator D.
+        Operator D.
 
     solver : str
-        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
     options : Options
-        solver options class. `ntraj` is taken as a two-element list because
+        Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
         `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
         the `mc` correlator; by default, `mc_corr_eps=1e-10`.
@@ -886,7 +886,7 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
     -------
 
     corr_mat : array
-        An 2-dimensional array (matrix) of correlation values for the times
+        A 2-dimensional array (matrix) of correlation values for the times
         specified by `tlist` (first index) and `taulist` (second index). If
         `tlist` is `None`, then a 1-dimensional array of correlation values
         is returned instead.
@@ -932,21 +932,21 @@ def spectrum_ss(H, wlist, c_ops, a_op, b_op):
     ----------
 
     H : :class:`qutip.qobj`
-        system Hamiltonian.
+        System Hamiltonian.
 
     wlist : array_like
-        list of frequencies for :math:`\\omega`.
+        List of frequencies for :math:`\\omega`.
 
-    c_ops : *list* of :class:`qutip.qobj`
-        list of collapse operators.
+    c_ops : list of :class:`qutip.qobj`
+        List of collapse operators.
 
     a_op : :class:`qutip.qobj`
-        operator A.
+        Operator A.
 
     b_op : :class:`qutip.qobj`
-        operator B.
+        Operator B.
 
-    use_pinv : *bool*
+    use_pinv : bool
         If `True` use numpy's `pinv` method, otherwise use a generic solver.
 
     Returns
@@ -982,21 +982,21 @@ def spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
     ----------
 
     H : :class:`qutip.qobj`
-        system Hamiltonian.
+        System Hamiltonian.
 
     wlist : array_like
-        list of frequencies for :math:`\\omega`.
+        List of frequencies for :math:`\\omega`.
 
-    c_ops : *list* of :class:`qutip.qobj`
-        list of collapse operators.
+    c_ops : list of :class:`qutip.qobj`
+        List of collapse operators.
 
     a_op : :class:`qutip.qobj`
-        operator A.
+        Operator A.
 
     b_op : :class:`qutip.qobj`
-        operator B.
+        Operator B.
 
-    use_pinv : *bool*
+    use_pinv : bool
         If `True` use numpy's pinv method, otherwise use a generic solver.
 
     Returns

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -84,27 +84,35 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
     H : Qobj
         System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
+
     state0 : Qobj
         Initial state density matrix :math:`\\rho(t_0)` or state vector
         :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
+
     taulist : array_like
         List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
+
     c_ops : list
         List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
+
     a_op : Qobj
         Operator A.
+
     b_op : Qobj
         Operator B.
+
     reverse : bool {False, True}
         If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
+
     solver : str {'me', 'mc', 'es'}
         Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
+
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -113,11 +121,13 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
 
     Returns
     -------
+
     corr_vec : ndarray
         An array of correlation values for the times specified by `tlist`.
 
     References
     ----------
+
     See, Gardiner, Quantum Noise, Section 5.2.
 
     """
@@ -149,35 +159,45 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
 
     Parameters
     ----------
+
     H : Qobj
         System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
+
     state0 : Qobj
         Initial state density matrix :math:`\\rho_0` or state vector
         :math:`\\psi_0`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
+
     tlist : array_like
         List of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
         value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
         tlist is automatically set, ignoring user input.
+
     taulist : array_like
         List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
+
     c_ops : list
         List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
+
     a_op : Qobj
         Operator A.
+
     b_op : Qobj
         Operator B.
+
     reverse : bool {False, True}
         If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
+
     solver : str
         Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
+
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -186,6 +206,7 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
 
     Returns
     -------
+
     corr_mat : array
         A 2-dimensional array (matrix) of correlation values for the times
         specified by `tlist` (first index) and `taulist` (second index). If
@@ -194,6 +215,7 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
 
     References
     ----------
+
     See, Gardiner, Quantum Noise, Section 5.2.
 
     """
@@ -234,29 +256,38 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
 
     Parameters
     ----------
+
     H : Qobj
         system Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
+
     rho0 : Qobj
         Initial state density matrix :math:`\\rho(t_0)` or state vector
         :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
+
     taulist : array_like
         list of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
+
     c_ops : list
         list of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
+
     a_op : Qobj
         operator A.
+
     b_op : Qobj
         operator B.
+
     c_op : Qobj
         operator C.
+
     solver : str
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
+
     options : Options
         solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -265,11 +296,13 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
 
     Returns
     -------
+
     corr_vec : array
         An array of correlation values for the times specified by `taulist`
 
     References
     ----------
+
     See, Gardiner, Quantum Noise, Section 5.2.
 
     """
@@ -295,34 +328,44 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
 
     Parameters
     ----------
+
     H : Qobj
         System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
+
     rho0 : Qobj
         Initial state density matrix :math:`\\rho_0` or state vector
         :math:`\\psi_0`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
+
     tlist : array_like
         List of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
         value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
         tlist is automatically set, ignoring user input.
+
     taulist : array_like
         List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
+
     c_ops : list
         List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
+
     a_op : Qobj
         Operator A.
+
     b_op : Qobj
         Operator B.
+
     c_op : Qobj
         Operator C.
+
     solver : str
         Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
+
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -331,6 +374,7 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
 
     Returns
     -------
+
     corr_mat : array
         An 2-dimensional array (matrix) of correlation values for the times
         specified by `tlist` (first index) and `taulist` (second index). If
@@ -375,25 +419,32 @@ def coherence_function_g1(H, state0, taulist, c_ops, a_op, solver="me",
 
     Parameters
     ----------
+
     H : Qobj
         System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
+
     state0 : Qobj
         Initial state density matrix :math:`\\rho(t_0)` or state vector
         :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
+
     taulist : array_like
         List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
+
     c_ops : list
         List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
+
     a_op : Qobj
         Operator A.
+
     solver : str
         Choice of solver (`me` for master-equation and
         `es` for exponential series).
+
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -402,6 +453,7 @@ def coherence_function_g1(H, state0, taulist, c_ops, a_op, solver="me",
 
     Returns
     -------
+
     g1, G1 : tuple
         The normalized and unnormalized second-order coherence function.
 
@@ -440,25 +492,32 @@ def coherence_function_g2(H, state0, taulist, c_ops, a_op, solver="me", args={},
 
     Parameters
     ----------
+
     H : Qobj
         System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
+
     state0 : Qobj
         Initial state density matrix :math:`\\rho(t_0)` or state vector
         :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
+
     taulist : array_like
         List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
+
     c_ops : list
         List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
+
     a_op : Qobj
         Operator A.
+
     solver : str
         Choice of solver (`me` for master-equation and
         `es` for exponential series).
+
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -467,6 +526,7 @@ def coherence_function_g2(H, state0, taulist, c_ops, a_op, solver="me", args={},
 
     Returns
     -------
+
     g2, G2 : tuple
         The normalized and unnormalized second-order coherence function.
 
@@ -507,25 +567,33 @@ def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
 
     Parameters
     ----------
+
     H : :class:`qutip.qobj`
         System Hamiltonian.
+
     wlist : array_like
         List of frequencies for :math:`\\omega`.
+
     c_ops : list
         List of collapse operators.
+
     a_op : Qobj
         Operator A.
+
     b_op : Qobj
         Operator B.
+
     solver : str
         Choice of solver (`es` for exponential series and
         `pi` for psuedo-inverse).
+
     use_pinv : bool
         For use with the `pi` solver: if `True` use numpy's pinv method,
         otherwise use a generic solver.
 
     Returns
     -------
+
     spectrum : array
         An array with spectrum :math:`S(\omega)` for the frequencies
         specified in `wlist`.
@@ -551,13 +619,16 @@ def spectrum_correlation_fft(taulist, y):
 
     Parameters
     ----------
+
     tlist : array_like
         List of times :math:`t` which the correlation function is given.
+
     y : array_like
         List of correlations corresponding to time delays :math:`t`.
 
     Returns
     -------
+
     w, S : tuple
         Returns an array of angular frequencies 'w' and the corresponding
         one-sided power spectrum 'S(w)'.
@@ -757,17 +828,21 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
 
     Parameters
     ----------
+
     H : Qobj
         System Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
+
     rho0 : Qobj
         Initial state density matrix :math:`\\rho(t_0)` or state vector
         :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
+
     taulist : array_like
         List of times for :math:`\\tau`. taulist must be positive and contain
         the element `0`.
+
     c_ops : list
         List of collapse operators, may be time-dependent for solver choice of
         `me` or `mc`.
@@ -796,11 +871,13 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
 
     Returns
     -------
+
     corr_vec : array
         An array of correlation values for the times specified by `taulist`.
 
     References
     ----------
+
     See, Gardiner, Quantum Noise, Section 5.2.
                        
     .. note:: Deprecated in QuTiP 3.1

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -113,6 +113,10 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
         Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
+    args : dictionary
+        dictionary of parameters for time-dependent Hamiltonians and
+        collapse operators.
+
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -197,6 +201,10 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
     solver : str
         Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
+
+    args : dictionary
+        dictionary of parameters for time-dependent Hamiltonians and
+        collapse operators.
 
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
@@ -290,6 +298,10 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
+    args : dictionary
+        dictionary of parameters for time-dependent Hamiltonians and
+        collapse operators.
+
     options : Options
         solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -370,6 +382,10 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
         Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
+    args : dictionary
+        dictionary of parameters for time-dependent Hamiltonians and
+        collapse operators.
+
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -449,6 +465,10 @@ def coherence_function_g1(H, state0, taulist, c_ops, a_op, solver="me",
         Choice of solver (`me` for master-equation and
         `es` for exponential series).
 
+    args : dictionary
+        dictionary of parameters for time-dependent Hamiltonians and
+        collapse operators.
+
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -521,6 +541,10 @@ def coherence_function_g2(H, state0, taulist, c_ops, a_op, solver="me", args={},
     solver : str
         Choice of solver (`me` for master-equation and
         `es` for exponential series).
+
+    args : dictionary
+        dictionary of parameters for time-dependent Hamiltonians and
+        collapse operators.
 
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
@@ -709,6 +733,10 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
         Choice of solver (`me` for master-equation and
         `es` for exponential series).
 
+    args : dictionary
+        dictionary of parameters for time-dependent Hamiltonians and
+        collapse operators.
+
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
         the `mc` correlator calls `mcsolve()` recursively; by default,
@@ -788,6 +816,10 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
     solver : str
         Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
+
+    args : dictionary
+        dictionary of parameters for time-dependent Hamiltonians and
+        collapse operators.
 
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
@@ -872,6 +904,10 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
     solver : str
         Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
+
+    args : dictionary
+        dictionary of parameters for time-dependent Hamiltonians and
+        collapse operators.
 
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because
@@ -964,6 +1000,10 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
     solver : str
         Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
+
+    args : dictionary
+        dictionary of parameters for time-dependent Hamiltonians and
+        collapse operators.
 
     options : Options
         Solver options class. `ntraj` is taken as a two-element list because

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -251,8 +251,10 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
     along one time axis using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
-    Note: it is not possible to calculate a physically meaningful correlation
-    of this form where :math:`\\tau<0`.
+    .. note::
+
+        It is not possible to calculate a physically meaningful correlation of
+        this form where :math:`\\tau<0`.
 
     Parameters
     ----------
@@ -323,8 +325,10 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     along two time axes using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
-    Note: it is not possible to calculate a physically meaningful correlation
-    of this form where :math:`\\tau<0`.
+    .. note::
+
+        It is not possible to calculate a physically meaningful correlation of
+        this form where :math:`\\tau<0`.
 
     Parameters
     ----------
@@ -562,8 +566,12 @@ def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
         \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
         e^{-i\omega\\tau} d\\tau.
 
-    using the solver indicated by the `solver` parameter. Note: this spectrum
-    is only defined for stationary statistics (uses steady state rho0)
+    using the solver indicated by the `solver` parameter.
+
+    .. note::
+
+        This spectrum is only defined for stationary statistics (uses steady
+        state rho0).
 
     Parameters
     ----------
@@ -823,8 +831,10 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
     along one time axis using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
-    Note: it is not possible to calculate a physically meaningful correlation
-    of this form where :math:`\\tau<0`.
+    .. note::
+
+        It is not possible to calculate a physically meaningful correlation of
+        this form where :math:`\\tau<0`.
 
     Parameters
     ----------
@@ -907,8 +917,10 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
     along two time axes using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
-    Note: it is not possible to calculate a physically meaningful correlation
-    of this form where :math:`\\tau<0`.
+    .. note::
+
+        It is not possible to calculate a physically meaningful correlation of
+        this form where :math:`\\tau<0`.
 
     Parameters
     ----------
@@ -1002,8 +1014,12 @@ def spectrum_ss(H, wlist, c_ops, a_op, b_op):
         \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
         e^{-i\omega\\tau} d\\tau.
 
-    using an eseries based solver Note: this spectrum is only defined for
-    stationary statistics (uses steady state rho0).
+    using an eseries based solver.
+
+    .. note::
+
+        This spectrum is only defined for stationary statistics (uses steady
+        state rho0).
 
     Parameters
     ----------
@@ -1052,8 +1068,12 @@ def spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
         \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
         e^{-i\omega\\tau} d\\tau.
 
-    using a psuedo-inverse method. Note: this spectrum is only defined for
-    stationary statistics (uses steady state rho0)
+    using a psuedo-inverse method.
+
+    .. note::
+
+        This spectrum is only defined for stationary statistics (uses steady
+        state rho0).
 
     Parameters
     ----------

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -81,53 +81,57 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
     Parameters
     ----------
 
-    H : Qobj
-        System Hamiltonian, may be time-dependent for solver choice of `me` or
-        `mc`.
+    H : :class:`qutip.Qobj` or ``list``
+        system Hamiltonian, either time-independent with a system operator
+        :class:`qutip.Qobj` or time-dependent with a ``list`` of
+        :class:`qutip.Qobj` or [:class:`qutip.Qobj`, ``time-dependent format``]
+        pairs. May be time-dependent for solver choice of `me` or `mc` only.
 
-    state0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
+        :math:`\\psi(t_0)`. If `state0` is ``None``, then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
-    taulist : array_like
-        List of times for :math:`\\tau`. taulist must be positive and contain
-        the element `0`.
+    taulist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`\\tau`. `taulist` must
+        be positive and contain the element `0`.
 
-    c_ops : list
-        List of collapse operators, may be time-dependent for solver choice of
-        `me` or `mc`.
+    c_ops : ``list``
+        ``list`` of system collapse operators, either :class:`qutip.Qobj`
+        or [:class:`qutip.Qobj`, ``time-dependent format``] pairs. May be
+        time-dependent for solver choice of `me` or `mc` only.
 
-    a_op : Qobj
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    b_op : Qobj
-        Operator B.
+    b_op : :class:`qutip.Qobj`
+        operator B.
 
-    reverse : bool {False, True}
-        If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
+    reverse : ``bool``
+        if `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
 
-    solver : str {'me', 'mc', 'es'}
-        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+    solver : ``str`` {'me', 'mc', 'es'}
+        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
-    args : dictionary
+    args : ``dict``
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : Options
-        Solver options class. `ntraj` is taken as a two-element list because
-        the `mc` correlator calls `mcsolve()` recursively; by default,
-        `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
-        the `mc` correlator; by default, `mc_corr_eps=1e-10`.
+    options : :class:`qutip.solver.Options`
+        options for the solver. `ntraj` is taken as a two-element ``list``
+        because the `mc` correlator calls :func:`qutip.mcsolve` recursively; by
+        default, `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero
+        errors in the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
 
-    corr_vec : ndarray
-        An array of correlation values for the times specified by `tlist`.
+    corr_vec : ``numpy.array``
+        a ``numpy.array`` of correlation values for the times specified by
+        `tlist`.
 
     References
     ----------
@@ -164,62 +168,66 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
     Parameters
     ----------
 
-    H : Qobj
-        System Hamiltonian, may be time-dependent for solver choice of `me` or
-        `mc`.
+    H : :class:`qutip.Qobj` or ``list``
+        system Hamiltonian, either time-independent with a system operator
+        :class:`qutip.Qobj` or time-dependent with a ``list`` of
+        :class:`qutip.Qobj` or [:class:`qutip.Qobj`, ``time-dependent format``]
+        pairs. May be time-dependent for solver choice of `me` or `mc` only.
 
-    state0 : Qobj
-        Initial state density matrix :math:`\\rho_0` or state vector
-        :math:`\\psi_0`. If 'state0' is 'None', then the steady state will
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
+        :math:`\\psi(t_0)`. If `state0` is ``None``, then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
-    tlist : array_like
-        List of times for :math:`t`. tlist must be positive and contain the
-        element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
-        tlist is automatically set, ignoring user input.
+    tlist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`t`. `tlist` must be
+        positive and contain the element `0`. When taking steady-steady
+        correlations only one `tlist` value is necessary, i.e. when
+        :math:`t \\rightarrow \\infty`; here tlist is automatically set,
+        ignoring user input.
 
-    taulist : array_like
-        List of times for :math:`\\tau`. taulist must be positive and contain
-        the element `0`.
+    taulist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`\\tau`. `taulist` must
+        be positive and contain the element `0`.
 
-    c_ops : list
-        List of collapse operators, may be time-dependent for solver choice of
-        `me` or `mc`.
+    c_ops : ``list``
+        ``list`` of system collapse operators, either :class:`qutip.Qobj`
+        or [:class:`qutip.Qobj`, ``time-dependent format``] pairs. May be
+        time-dependent for solver choice of `me` or `mc` only.
 
-    a_op : Qobj
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    b_op : Qobj
-        Operator B.
+    b_op : :class:`qutip.Qobj`
+        operator B.
 
-    reverse : bool {False, True}
-        If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
+    reverse : ``bool``
+        if `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
 
-    solver : str
-        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+    solver : ``str`` {'me', 'mc', 'es'}
+        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
-    args : dictionary
+    args : ``dict``
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : Options
-        Solver options class. `ntraj` is taken as a two-element list because
-        the `mc` correlator calls `mcsolve()` recursively; by default,
-        `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
-        the `mc` correlator; by default, `mc_corr_eps=1e-10`.
+    options : :class:`qutip.solver.Options`
+        options for the solver. `ntraj` is taken as a two-element ``list``
+        because the `mc` correlator calls :func:`qutip.mcsolve` recursively; by
+        default, `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero
+        errors in the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
 
-    corr_mat : array
-        A 2-dimensional array (matrix) of correlation values for the times
-        specified by `tlist` (first index) and `taulist` (second index). If
-        `tlist` is `None`, then a 1-dimensional array of correlation values
-        is returned instead.
+    corr_mat : ``numpy.array``
+        a 2-dimensional ``numpy.array`` (matrix) of correlation values for the
+        times specified by `tlist` (first index) and `taulist` (second index).
+        If `tlist` is ``None``, then a 1-dimensional ``numpy.array`` of
+        correlation values is returned instead.
 
     References
     ----------
@@ -267,52 +275,56 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
     Parameters
     ----------
 
-    H : Qobj
-        system Hamiltonian, may be time-dependent for solver choice of `me` or
-        `mc`.
+    H : :class:`qutip.Qobj` or ``list``
+        system Hamiltonian, either time-independent with a system operator
+        :class:`qutip.Qobj` or time-dependent with a ``list`` of
+        :class:`qutip.Qobj` or [:class:`qutip.Qobj`, ``time-dependent format``]
+        pairs. May be time-dependent for solver choice of `me` or `mc` only.
 
-    rho0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
+        :math:`\\psi(t_0)`. If `state0` is ``None``, then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
-    taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
-        the element `0`.
+    taulist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`\\tau`. `taulist` must
+        be positive and contain the element `0`.
 
-    c_ops : list
-        list of collapse operators, may be time-dependent for solver choice of
-        `me` or `mc`.
+    c_ops : ``list``
+        ``list`` of system collapse operators, either :class:`qutip.Qobj`
+        or [:class:`qutip.Qobj`, ``time-dependent format``] pairs. May be
+        time-dependent for solver choice of `me` or `mc` only.
 
-    a_op : Qobj
+    a_op : :class:`qutip.Qobj`
         operator A.
 
-    b_op : Qobj
+    b_op : :class:`qutip.Qobj`
         operator B.
 
-    c_op : Qobj
+    c_op : :class:`qutip.Qobj`
         operator C.
 
-    solver : str
+    solver : ``str`` {'me', 'mc', 'es'}
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
-    args : dictionary
+    args : ``dict``
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : Options
-        solver options class. `ntraj` is taken as a two-element list because
-        the `mc` correlator calls `mcsolve()` recursively; by default,
-        `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
-        the `mc` correlator; by default, `mc_corr_eps=1e-10`.
+    options : :class:`qutip.solver.Options`
+        options for the solver. `ntraj` is taken as a two-element ``list``
+        because the `mc` correlator calls :func:`qutip.mcsolve` recursively; by
+        default, `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero
+        errors in the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
 
-    corr_vec : array
-        An array of correlation values for the times specified by `taulist`
+    corr_vec : ``numpy.array``
+        a ``numpy.array`` of correlation values for the times specified by
+        `taulist`.
 
     References
     ----------
@@ -345,61 +357,65 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     Parameters
     ----------
 
-    H : Qobj
-        System Hamiltonian, may be time-dependent for solver choice of `me` or
-        `mc`.
+    H : :class:`qutip.Qobj` or ``list``
+        system Hamiltonian, either time-independent with a system operator
+        :class:`qutip.Qobj` or time-dependent with a ``list`` of
+        :class:`qutip.Qobj` or [:class:`qutip.Qobj`, ``time-dependent format``]
+        pairs. May be time-dependent for solver choice of `me` or `mc` only.
 
-    rho0 : Qobj
-        Initial state density matrix :math:`\\rho_0` or state vector
-        :math:`\\psi_0`. If 'state0' is 'None', then the steady state will
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
+        :math:`\\psi(t_0)`. If `state0` is ``None``, then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
-    tlist : array_like
-        List of times for :math:`t`. tlist must be positive and contain the
-        element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
-        tlist is automatically set, ignoring user input.
+    tlist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`t`. `tlist` must be
+        positive and contain the element `0`. When taking steady-steady
+        correlations only one `tlist` value is necessary, i.e. when
+        :math:`t \\rightarrow \\infty`; here tlist is automatically set,
+        ignoring user input.
 
-    taulist : array_like
-        List of times for :math:`\\tau`. taulist must be positive and contain
-        the element `0`.
+    taulist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`\\tau`. `taulist` must
+        be positive and contain the element `0`.
 
-    c_ops : list
-        List of collapse operators, may be time-dependent for solver choice of
-        `me` or `mc`.
+    c_ops : ``list``
+        ``list`` of system collapse operators, either :class:`qutip.Qobj`
+        or [:class:`qutip.Qobj`, ``time-dependent format``] pairs. May be
+        time-dependent for solver choice of `me` or `mc` only.
 
-    a_op : Qobj
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    b_op : Qobj
-        Operator B.
+    b_op : :class:`qutip.Qobj`
+        operator B.
 
-    c_op : Qobj
-        Operator C.
+    c_op : :class:`qutip.Qobj`
+        operator C.
 
-    solver : str
-        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+    solver : ``str`` {'me', 'mc', 'es'}
+        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
-    args : dictionary
+    args : ``dict``
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : Options
-        Solver options class. `ntraj` is taken as a two-element list because
-        the `mc` correlator calls `mcsolve()` recursively; by default,
-        `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
-        the `mc` correlator; by default, `mc_corr_eps=1e-10`.
+    options : :class:`qutip.solver.Options`
+        options for the solver. `ntraj` is taken as a two-element ``list``
+        because the `mc` correlator calls :func:`qutip.mcsolve` recursively; by
+        default, `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero
+        errors in the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
 
-    corr_mat : array
-        An 2-dimensional array (matrix) of correlation values for the times
-        specified by `tlist` (first index) and `taulist` (second index). If
-        `tlist` is `None`, then a 1-dimensional array of correlation values
-        is returned instead.
+    corr_mat : ``numpy.array``
+        a 2-dimensional ``numpy.array`` (matrix) of correlation values for the
+        times specified by `tlist` (first index) and `taulist` (second index).
+        If `tlist` is ``None``, then a 1-dimensional ``numpy.array`` of
+        correlation values is returned instead.
 
     References
     ----------
@@ -440,46 +456,49 @@ def coherence_function_g1(H, state0, taulist, c_ops, a_op, solver="me",
     Parameters
     ----------
 
-    H : Qobj
-        System Hamiltonian, may be time-dependent for solver choice of `me` or
-        `mc`.
+    H : :class:`qutip.Qobj` or ``list``
+        system Hamiltonian, either time-independent with a system operator
+        :class:`qutip.Qobj` or time-dependent with a ``list`` of
+        :class:`qutip.Qobj` or [:class:`qutip.Qobj`, ``time-dependent format``]
+        pairs. May be time-dependent for solver choice of `me` or `mc` only.
 
-    state0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
+        :math:`\\psi(t_0)`. If `state0` is ``None``, then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
-    taulist : array_like
-        List of times for :math:`\\tau`. taulist must be positive and contain
-        the element `0`.
+    taulist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`\\tau`. `taulist` must
+        be positive and contain the element `0`.
 
-    c_ops : list
-        List of collapse operators, may be time-dependent for solver choice of
-        `me` or `mc`.
+    c_ops : ``list``
+        ``list`` of system collapse operators, either :class:`qutip.Qobj`
+        or [:class:`qutip.Qobj`, ``time-dependent format``] pairs. May be
+        time-dependent for solver choice of `me` or `mc` only.
 
-    a_op : Qobj
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    solver : str
-        Choice of solver (`me` for master-equation and
+    solver : ``str`` {'me', 'mc', 'es'}
+        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
-    args : dictionary
+    args : ``dict``
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : Options
-        Solver options class. `ntraj` is taken as a two-element list because
-        the `mc` correlator calls `mcsolve()` recursively; by default,
-        `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
-        the `mc` correlator; by default, `mc_corr_eps=1e-10`.
+    options : :class:`qutip.solver.Options`
+        options for the solver. `ntraj` is taken as a two-element ``list``
+        because the `mc` correlator calls :func:`qutip.mcsolve` recursively; by
+        default, `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero
+        errors in the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
 
-    g1, G1 : tuple
-        The normalized and unnormalized second-order coherence function.
+    g1, G1 : ``tuple``
+        the normalized and unnormalized second-order coherence functions.
 
     """
 
@@ -517,46 +536,49 @@ def coherence_function_g2(H, state0, taulist, c_ops, a_op, solver="me", args={},
     Parameters
     ----------
 
-    H : Qobj
-        System Hamiltonian, may be time-dependent for solver choice of `me` or
-        `mc`.
+    H : :class:`qutip.Qobj` or ``list``
+        system Hamiltonian, either time-independent with a system operator
+        :class:`qutip.Qobj` or time-dependent with a ``list`` of
+        :class:`qutip.Qobj` or [:class:`qutip.Qobj`, ``time-dependent format``]
+        pairs. May be time-dependent for solver choice of `me` or `mc` only.
 
-    state0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
+        :math:`\\psi(t_0)`. If `state0` is ``None``, then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
-    taulist : array_like
-        List of times for :math:`\\tau`. taulist must be positive and contain
-        the element `0`.
+    taulist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`\\tau`. `taulist` must
+        be positive and contain the element `0`.
 
-    c_ops : list
-        List of collapse operators, may be time-dependent for solver choice of
-        `me` or `mc`.
+    c_ops : ``list``
+        ``list`` of system collapse operators, either :class:`qutip.Qobj`
+        or [:class:`qutip.Qobj`, ``time-dependent format``] pairs. May be
+        time-dependent for solver choice of `me` or `mc` only.
 
-    a_op : Qobj
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    solver : str
-        Choice of solver (`me` for master-equation and
+    solver : ``str`` {'me', 'mc', 'es'}
+        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
-    args : dictionary
+    args : ``dict``
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : Options
-        Solver options class. `ntraj` is taken as a two-element list because
-        the `mc` correlator calls `mcsolve()` recursively; by default,
-        `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
-        the `mc` correlator; by default, `mc_corr_eps=1e-10`.
+    options : :class:`qutip.solver.Options`
+        options for the solver. `ntraj` is taken as a two-element ``list``
+        because the `mc` correlator calls :func:`qutip.mcsolve` recursively; by
+        default, `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero
+        errors in the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
 
-    g2, G2 : tuple
-        The normalized and unnormalized second-order coherence function.
+    g2, G2 : ``tuple``
+        the normalized and unnormalized second-order coherence functions.
 
     """
 
@@ -586,9 +608,8 @@ def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
 
     .. math::
 
-        S(\omega) = \int_{-\infty}^{\infty}
-        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
-        e^{-i\omega\\tau} d\\tau.
+        S(\omega) = \lim_{t \\to \\infty} \int_{-\infty}^{\infty}
+        d\\tau \, e^{-i\omega\\tau} \left<A(t+\\tau)B(t)\\right>
 
     using the solver indicated by the `solver` parameter.
 
@@ -600,34 +621,34 @@ def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
     Parameters
     ----------
 
-    H : :class:`qutip.qobj`
-        System Hamiltonian.
+    H : :class:`qutip.Qobj`
+        system Hamiltonian.
 
     wlist : array_like
         List of frequencies for :math:`\\omega`.
 
-    c_ops : list
-        List of collapse operators.
+    c_ops : ``list`` of :class:`qutip.Qobj`
+        ``list`` of system collapse operators.
 
-    a_op : Qobj
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    b_op : Qobj
-        Operator B.
+    b_op : :class:`qutip.Qobj`
+        operator B.
 
-    solver : str
-        Choice of solver (`es` for exponential series and
+    solver : ``str``
+        choice of solver (`es` for exponential series and
         `pi` for psuedo-inverse).
 
-    use_pinv : bool
-        For use with the `pi` solver: if `True` use numpy's pinv method,
+    use_pinv : ``bool``
+        for use with the `pi` solver: if `True` use numpy's pinv method,
         otherwise use a generic solver.
 
     Returns
     -------
 
-    spectrum : array
-        An array with spectrum :math:`S(\omega)` for the frequencies
+    spectrum : ``numpy.array``
+        a ``numpy.array`` with spectrum :math:`S(\omega)` for the frequencies
         specified in `wlist`.
 
     """
@@ -652,17 +673,19 @@ def spectrum_correlation_fft(taulist, y):
     Parameters
     ----------
 
-    tlist : array_like
-        List of times :math:`t` which the correlation function is given.
+    tlist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times :math:`t` for which the correlation
+        function is given.
 
-    y : array_like
-        List of correlations corresponding to time delays :math:`t`.
+    y : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of correlations corresponding to time
+        delays :math:`t`.
 
     Returns
     -------
 
     w, S : tuple
-        Returns an array of angular frequencies 'w' and the corresponding
+        a ``numpy.array`` of angular frequencies 'w' and the corresponding
         one-sided power spectrum 'S(w)'.
 
     """
@@ -708,46 +731,47 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
     Parameters
     ----------
 
-    H : Qobj
-        System Hamiltonian.
+    H : :class:`qutip.Qobj`
+        system Hamiltonian.
 
-    taulist : array_like
-        List of times for :math:`\\tau`. taulist must be positive and contain
-        the element `0`.
+    taulist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`\\tau`. `taulist` must
+        be positive and contain the element `0`.
 
-    c_ops : list
-        List of collapse operators.
+    c_ops : ``list`` of :class:`qutip.Qobj`
+        ``list`` of system collapse operators.
 
-    a_op : Qobj
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    b_op : Qobj
-        Operator B.
+    b_op : :class:`qutip.Qobj`
+        operator B.
 
-    reverse : bool
-        If `True`, calculate
+    reverse : ``bool``
+        if `True`, calculate
         :math:`\lim_{t \\to \\infty} \left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>`.
 
-    solver : str
-        Choice of solver (`me` for master-equation and
+    solver : ``str``
+        choice of solver (`me` for master-equation and
         `es` for exponential series).
 
-    args : dictionary
+    args : ``dict``
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : Options
-        Solver options class. `ntraj` is taken as a two-element list because
-        the `mc` correlator calls `mcsolve()` recursively; by default,
-        `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
-        the `mc` correlator; by default, `mc_corr_eps=1e-10`.
+    options : :class:`qutip.solver.Options`
+        options for the solver. `ntraj` is taken as a two-element ``list``
+        because the `mc` correlator calls :func:`qutip.mcsolve` recursively; by
+        default, `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero
+        errors in the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
 
-    corr_vec : array
-        An array of correlation values for the times specified by `tlist`.
+    corr_vec : ``numpy.array``
+        a ``numpy.array`` of correlation values for the times specified by
+        `tlist`.
 
     References
     ----------
@@ -779,62 +803,66 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
     Parameters
     ----------
 
-    H : Qobj
-        System Hamiltonian, may be time-dependent for solver choice of `me` or
-        `mc`.
+    H : :class:`qutip.Qobj` or ``list``
+        system Hamiltonian, either time-independent with a system operator
+        :class:`qutip.Qobj` or time-dependent with a ``list`` of
+        :class:`qutip.Qobj` or [:class:`qutip.Qobj`, ``time-dependent format``]
+        pairs. May be time-dependent for solver choice of `me` or `mc` only.
 
-    state0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
+        :math:`\\psi(t_0)`. If `state0` is ``None``, then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
-    tlist : array_like
-        List of times for :math:`t`. tlist must be positive and contain the
-        element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
-        tlist is automatically set, ignoring user input.
+    tlist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`t`. `tlist` must be
+        positive and contain the element `0`. When taking steady-steady
+        correlations only one `tlist` value is necessary, i.e. when
+        :math:`t \\rightarrow \\infty`; here tlist is automatically set,
+        ignoring user input.
 
-    taulist : array_like
-        List of times for :math:`\\tau`. taulist must be positive and contain
-        the element `0`.
+    taulist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`\\tau`. `taulist` must
+        be positive and contain the element `0`.
 
-    c_ops : list
-        List of collapse operators, may be time-dependent for solver choice of
-        `me` or `mc`.
+    c_ops : ``list``
+        ``list`` of system collapse operators, either :class:`qutip.Qobj`
+        or [:class:`qutip.Qobj`, ``time-dependent format``] pairs. May be
+        time-dependent for solver choice of `me` or `mc` only.
 
-    a_op : Qobj
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    b_op : Qobj
-        Operator B.
+    b_op : :class:`qutip.Qobj`
+        operator B.
 
-    reverse : bool
-        If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
+    reverse : ``bool``
+        if `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
         :math:`\left<A(t+\\tau)B(t)\\right>`.
 
-    solver : str
-        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+    solver : ``str``
+        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
-    args : dictionary
+    args : ``dict``
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : Options
-        Solver options class. `ntraj` is taken as a two-element list because
-        the `mc` correlator calls `mcsolve()` recursively; by default,
-        `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
-        the `mc` correlator; by default, `mc_corr_eps=1e-10`.
+    options : :class:`qutip.solver.Options`
+        options for the solver. `ntraj` is taken as a two-element ``list``
+        because the `mc` correlator calls :func:`qutip.mcsolve` recursively; by
+        default, `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero
+        errors in the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
 
-    corr_mat : array
-        A 2-dimensional array (matrix) of correlation values for the times
-        specified by `tlist` (first index) and `taulist` (second index). If
-        `tlist` is `None`, then a 1-dimensional array of correlation values
-        is returned instead.
+    corr_mat : ``numpy.array``
+        a 2-dimensional ``numpy.array`` (matrix) of correlation values for the
+        times specified by `tlist` (first index) and `taulist` (second index).
+        If `tlist` is ``None``, then a 1-dimensional ``numpy.array`` of
+        correlation values is returned instead.
 
     References
     ----------
@@ -871,55 +899,59 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
     Parameters
     ----------
 
-    H : Qobj
-        System Hamiltonian, may be time-dependent for solver choice of `me` or
-        `mc`.
+    H : :class:`qutip.Qobj` or ``list``
+        system Hamiltonian, either time-independent with a system operator
+        :class:`qutip.Qobj` or time-dependent with a ``list`` of
+        :class:`qutip.Qobj` or [:class:`qutip.Qobj`, ``time-dependent format``]
+        pairs. May be time-dependent for solver choice of `me` or `mc` only.
 
-    rho0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
+        :math:`\\psi(t_0)`. If `state0` is ``None``, then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
-    taulist : array_like
-        List of times for :math:`\\tau`. taulist must be positive and contain
-        the element `0`.
+    taulist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`\\tau`. `taulist` must
+        be positive and contain the element `0`.
 
-    c_ops : list
-        List of collapse operators, may be time-dependent for solver choice of
-        `me` or `mc`.
+    c_ops : ``list``
+        ``list`` of system collapse operators, either :class:`qutip.Qobj`
+        or [:class:`qutip.Qobj`, ``time-dependent format``] pairs. May be
+        time-dependent for solver choice of `me` or `mc` only.
 
-    a_op : Qobj
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    b_op : Qobj
-        Operator B.
+    b_op : :class:`qutip.Qobj`
+        operator B.
 
-    c_op : Qobj
-        Operator C.
+    c_op : :class:`qutip.Qobj`
+        operator C.
 
-    d_op : Qobj
-        Operator D.
+    d_op : :class:`qutip.Qobj`
+        operator D.
 
-    solver : str
-        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+    solver : ``str``
+        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
-    args : dictionary
+    args : ``dict``
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : Options
-        Solver options class. `ntraj` is taken as a two-element list because
-        the `mc` correlator calls `mcsolve()` recursively; by default,
-        `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
-        the `mc` correlator; by default, `mc_corr_eps=1e-10`.
+    options : :class:`qutip.solver.Options`
+        options for the solver. `ntraj` is taken as a two-element ``list``
+        because the `mc` correlator calls :func:`qutip.mcsolve` recursively; by
+        default, `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero
+        errors in the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
 
-    corr_vec : array
-        An array of correlation values for the times specified by `taulist`.
+    corr_vec : ``numpy.array``
+        a ``numpy.array`` of correlation values for the times specified by
+        `taulist`.
 
     References
     ----------
@@ -927,7 +959,7 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
     See, Gardiner, Quantum Noise, Section 5.2.
                        
     .. note:: Deprecated in QuTiP 3.1
-              Use correlation_3op_1t() instead.
+              Use :func:`qutip.correlation_3op_1t` instead.
 
     """
 
@@ -961,64 +993,68 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
     Parameters
     ----------
 
-    H : Qobj
-        System Hamiltonian, may be time-dependent for solver choice of `me` or
-        `mc`.
+    H : :class:`qutip.Qobj` or ``list``
+        system Hamiltonian, either time-independent with a system operator
+        :class:`qutip.Qobj` or time-dependent with a ``list`` of
+        :class:`qutip.Qobj` or [:class:`qutip.Qobj`, ``time-dependent format``]
+        pairs. May be time-dependent for solver choice of `me` or `mc` only.
 
-    rho0 : Qobj
-        Initial state density matrix :math:`\\rho_0` or state vector
-        :math:`\\psi_0`. If 'state0' is 'None', then the steady state will
+    state0 : :class:`qutip.Qobj`
+        initial state density matrix :math:`\\rho(t_0)` or state vector
+        :math:`\\psi(t_0)`. If `state0` is ``None``, then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
-    tlist : array_like
-        List of times for :math:`t`. tlist must be positive and contain the
-        element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
-        tlist is automatically set, ignoring user input.
+    tlist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`t`. `tlist` must be
+        positive and contain the element `0`. When taking steady-steady
+        correlations only one `tlist` value is necessary, i.e. when
+        :math:`t \\rightarrow \\infty`; here tlist is automatically set,
+        ignoring user input.
 
-    taulist : array_like
-        List of times for :math:`\\tau`. taulist must be positive and contain
-        the element `0`.
+    taulist : ``list`` or ``numpy.array``
+        ``list`` or ``numpy.array`` of times for :math:`\\tau`. `taulist` must
+        be positive and contain the element `0`.
 
-    c_ops : list
-        List of collapse operators, may be time-dependent for solver choice of
-        `me` or `mc`.
+    c_ops : ``list``
+        ``list`` of system collapse operators, either :class:`qutip.Qobj`
+        or [:class:`qutip.Qobj`, ``time-dependent format``] pairs. May be
+        time-dependent for solver choice of `me` or `mc` only.
 
-    a_op : Qobj
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    b_op : Qobj
-        Operator B.
+    b_op : :class:`qutip.Qobj`
+        operator B.
 
-    c_op : Qobj
-        Operator C.
+    c_op : :class:`qutip.Qobj`
+        operator C.
 
-    d_op : Qobj
-        Operator D.
+    d_op : :class:`qutip.Qobj`
+        operator D.
 
-    solver : str
-        Choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
+    solver : ``str``
+        choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
 
-    args : dictionary
+    args : ``dict``
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : Options
-        Solver options class. `ntraj` is taken as a two-element list because
-        the `mc` correlator calls `mcsolve()` recursively; by default,
-        `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero errors in
-        the `mc` correlator; by default, `mc_corr_eps=1e-10`.
+    options : :class:`qutip.solver.Options`
+        options for the solver. `ntraj` is taken as a two-element ``list``
+        because the `mc` correlator calls :func:`qutip.mcsolve` recursively; by
+        default, `ntraj=[20, 100]`. `mc_corr_eps` prevents divide-by-zero
+        errors in the `mc` correlator; by default, `mc_corr_eps=1e-10`.
 
     Returns
     -------
 
-    corr_mat : array
-        A 2-dimensional array (matrix) of correlation values for the times
-        specified by `tlist` (first index) and `taulist` (second index). If
-        `tlist` is `None`, then a 1-dimensional array of correlation values
-        is returned instead.
+    corr_mat : ``numpy.array``
+        a 2-dimensional ``numpy.array`` (matrix) of correlation values for the
+        times specified by `tlist` (first index) and `taulist` (second index).
+        If `tlist` is ``None``, then a 1-dimensional ``numpy.array`` of
+        correlation values is returned instead.
 
     References
     ----------
@@ -1050,9 +1086,8 @@ def spectrum_ss(H, wlist, c_ops, a_op, b_op):
 
     .. math::
 
-        S(\omega) = \int_{-\infty}^{\infty}
-        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
-        e^{-i\omega\\tau} d\\tau.
+        S(\omega) = \lim_{t \\to \\infty} \int_{-\infty}^{\infty}
+        d\\tau \, e^{-i\omega\\tau} \left<A(t+\\tau)B(t)\\right>
 
     using an eseries based solver.
 
@@ -1064,29 +1099,29 @@ def spectrum_ss(H, wlist, c_ops, a_op, b_op):
     Parameters
     ----------
 
-    H : :class:`qutip.qobj`
-        System Hamiltonian.
+    H : :class:`qutip.Qobj`
+        system Hamiltonian.
 
     wlist : array_like
         List of frequencies for :math:`\\omega`.
 
-    c_ops : list of :class:`qutip.qobj`
-        List of collapse operators.
+    c_ops : ``list`` of :class:`qutip.Qobj`
+        ``list`` of system collapse operators.
 
-    a_op : :class:`qutip.qobj`
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    b_op : :class:`qutip.qobj`
-        Operator B.
+    b_op : :class:`qutip.Qobj`
+        operator B.
 
-    use_pinv : bool
-        If `True` use numpy's `pinv` method, otherwise use a generic solver.
+    use_pinv : ``bool``
+        if `True` use numpy's `pinv` method, otherwise use a generic solver.
 
     Returns
     -------
 
-    spectrum : array
-        An array with spectrum :math:`S(\omega)` for the frequencies
+    spectrum : ``numpy.array``
+        a ``numpy.array`` with spectrum :math:`S(\omega)` for the frequencies
         specified in `wlist`.
 
     """
@@ -1104,9 +1139,8 @@ def spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
 
     .. math::
 
-        S(\omega) = \int_{-\infty}^{\infty}
-        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
-        e^{-i\omega\\tau} d\\tau.
+        S(\omega) = \lim_{t \\to \\infty} \int_{-\infty}^{\infty}
+        d\\tau \, e^{-i\omega\\tau} \left<A(t+\\tau)B(t)\\right>
 
     using a psuedo-inverse method.
 
@@ -1118,29 +1152,29 @@ def spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
     Parameters
     ----------
 
-    H : :class:`qutip.qobj`
-        System Hamiltonian.
+    H : :class:`qutip.Qobj`
+        system Hamiltonian.
 
     wlist : array_like
         List of frequencies for :math:`\\omega`.
 
-    c_ops : list of :class:`qutip.qobj`
-        List of collapse operators.
+    c_ops : ``list`` of :class:`qutip.Qobj`
+        ``list`` of system collapse operators.
 
-    a_op : :class:`qutip.qobj`
-        Operator A.
+    a_op : :class:`qutip.Qobj`
+        operator A.
 
-    b_op : :class:`qutip.qobj`
-        Operator B.
+    b_op : :class:`qutip.Qobj`
+        operator B.
 
-    use_pinv : bool
-        If `True` use numpy's pinv method, otherwise use a generic solver.
+    use_pinv : ``bool``
+        if `True` use numpy's pinv method, otherwise use a generic solver.
 
     Returns
     -------
 
-    spectrum : array
-        An array with spectrum :math:`S(\omega)` for the frequencies
+    spectrum : ``numpy.array``
+        a ``numpy.array`` with spectrum :math:`S(\omega)` for the frequencies
         specified in `wlist`.
 
     """


### PR DESCRIPTION
Implemented a time-dependent version of the Bloch-Redfield master equation solver for time-dependent Hamiltonians and c_ops. It makes use of the list array format.

Also fixed some formatting inconsistencies in the correlation docstrings (yet again... I think I got it this time)
