### PR TITLE
control memory optimisations

### DIFF
--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -738,7 +738,7 @@ class Dynamics(object):
             logger.warn("Unknown option '{}' for oper_dtype. "
                 "Assuming that internal drift, ctrls, initial and target "
                 "have been set correctly".format(self.oper_dtype))
-        if self.cache_phased_dyn_gen and self.dyn_gen_phase:
+        if self.cache_phased_dyn_gen and not self.dyn_gen_phase is None:
             self._phased_ctrl_dyn_gen = [self._apply_phase(ctrl)
                                             for ctrl in self._ctrl_dyn_gen]
         self._dyn_gen = [object for x in range(self.num_tslots)]
@@ -1606,6 +1606,19 @@ class DynamicsSymplectic(Dynamics):
         # Cannot be calculated until the dyn_shape is set
         # that is after the drift Hamitonan has been set.
         if self._dyn_gen_phase is None:
-            self._dyn_gen_phase = self.omega
+            self._dyn_gen_phase = self._get_omega()
+
         return self._dyn_gen_phase
 
+    def _apply_phase(self, dg):
+        """
+        Apply some phase factor or operator
+        """
+        if self.dyn_gen_phase is None:
+            phased_dg = dg
+        else:
+            if hasattr(self.dyn_gen_phase, 'dot'):
+                phased_dg = -dg.dot(self.dyn_gen_phase)
+            else:
+                phased_dg = -dg*self.dyn_gen_phase
+        return phased_dg

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -719,7 +719,7 @@ class Dynamics(object):
         if self.cache_phased_dyn_gen:
             self._phased_dyn_gen = [object for x in range(self.num_tslots)]
         self._prop = [object for x in range(self.num_tslots)]
-        if self.prop_computer.grad_exact:
+        if self.prop_computer.grad_exact and self.cache_prop_grad:
             self._prop_grad = np.empty([self.num_tslots, self._num_ctrls],
                                       dtype=object)
         # Time evolution operator (forward propagation)
@@ -1109,11 +1109,11 @@ class Dynamics(object):
         
     def _get_prop_grad(self, k, j):
         if self.cache_prop_grad:
-            pg = self._prop_grad[k, j]
+            prop_grad = self._prop_grad[k, j]
         else:
-            pg = self.prop_computer._compute_prop_grad(k, j, 
+            prop_grad = self.prop_computer._compute_prop_grad(k, j, 
                                                        compute_prop = False)
-        return pg
+        return prop_grad
 
     @property
     def evo_init2t(self):

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -166,9 +166,12 @@ class Dynamics(object):
         execution speed is prioritized over memory.
         Setting to 1 means that some memory prioritisation steps will be
         taken, for instance using Qobj (and hence sparse arrays) as the
-        the internal operator data type.
+        the internal operator data type, and not caching some operators
         Potentially further memory saving maybe made with
-        memory_optimization > 1
+        memory_optimization > 1. 
+        The options are processed in _set_memory_optimizations, see
+        this for more information. Individual memory saving  options can be
+        switched by settting them directly (see below)
 
     oper_dtype : type
         Data type for internal dynamics generators, propagators and time
@@ -179,6 +182,28 @@ class Dynamics(object):
         perform better when (custom) fidelity measures use Qobj methods
         such as partial trace.
         See _choose_oper_dtype for how this is chosen when not specified
+        
+    cache_phased_dyn_gen : bool
+        If True then the dynamics generators will be saved with and 
+        without the propagation prefactor (if there is one)
+        Defaults to True when memory_optimization=0, otherwise False
+        
+    cache_prop_grad : bool
+        If the True then the propagator gradients (for exact gradients) will
+        be computed when the propagator are computed and cache until
+        the are used by the fidelity computer. If False then the 
+        fidelity computer will calculate them as needed.
+        Defaults to True when memory_optimization=0, otherwise False
+           
+    cache_dyn_gen_eigenvectors_adj: bool
+        If True then DynamicsUnitary will cached the adjoint of 
+        the Hamiltion eignvector matrix
+        Defaults to True when memory_optimization=0, otherwise False
+        
+    sparse_eigen_decomp: bool
+        If True then DynamicsUnitary will use the sparse eigenvalue 
+        decomposition.
+        Defaults to True when memory_optimization<=1, otherwise False
 
     num_tslots : integer
         Number of timeslots (aka timeslices)
@@ -338,11 +363,11 @@ class Dynamics(object):
         self._num_tslots = None
         # attributes used for processing evolution
         self.memory_optimization = 0
+        self.oper_dtype = None
         self.cache_phased_dyn_gen = None
         self.cache_prop_grad = None
         self.cache_dyn_gen_eigenvectors_adj = None
         self.sparse_eigen_decomp = None
-        self.oper_dtype = None
         self.dyn_dims = None
         self.dyn_shape = None
         self.sys_dims = None
@@ -354,6 +379,7 @@ class Dynamics(object):
         self._drift_dyn_gen = None
         self._ctrl_dyn_gen = None
         self._phased_ctrl_dyn_gen = None
+        self._dyn_gen_phase = None
         self._initial = None
         self._target = None
         self._onto_evo_target = None
@@ -712,7 +738,7 @@ class Dynamics(object):
             logger.warn("Unknown option '{}' for oper_dtype. "
                 "Assuming that internal drift, ctrls, initial and target "
                 "have been set correctly".format(self.oper_dtype))
-        if self.cache_phased_dyn_gen:
+        if self.cache_phased_dyn_gen and self.dyn_gen_phase:
             self._phased_ctrl_dyn_gen = [self._apply_phase(ctrl)
                                             for ctrl in self._ctrl_dyn_gen]
         self._dyn_gen = [object for x in range(self.num_tslots)]
@@ -1022,12 +1048,26 @@ class Dynamics(object):
         if self.cache_phased_dyn_gen:
             self._phased_dyn_gen[k] = self._apply_phase(dg)
 
-    def _apply_phase(self, k):
+    @property
+    def dyn_gen_phase(self):
+        """
+        Some preop that is applied to the dyn_gen before expontiating to
+        get the propagator
+        """
+        return self._dyn_gen_phase
+    
+    def _apply_phase(self, dg):
         """
         Apply some phase factor or operator
         """
-        raise errors.UsageError("Not implemented in the baseclass."
-                                " Choose a subclass")
+        if self.dyn_gen_phase is None:
+            phased_dg = dg
+        else:
+            if hasattr(self.dyn_gen_phase, 'dot'):
+                phased_dg = self.dyn_gen_phase.dot(dg)
+            else:
+                phased_dg = self.dyn_gen_phase*dg
+        return phased_dg
 
     def get_dyn_gen(self, k):
         """
@@ -1039,10 +1079,13 @@ class Dynamics(object):
         return self._get_phased_dyn_gen(k)
 
     def _get_phased_dyn_gen(self, k):
-        if self._phased_dyn_gen is not None:
-            return self._phased_dyn_gen[k]
+        if self.dyn_gen_phase is None:
+            return self._dyn_gen[k]
         else:
-            return self._apply_phase(self._dyn_gen[k])
+            if self._phased_dyn_gen is None:
+                return self._apply_phase(self._dyn_gen[k])
+            else:
+                return self._phased_dyn_gen[k]
 
     def get_ctrl_dyn_gen(self, j):
         """
@@ -1276,12 +1319,7 @@ class DynamicsGenMat(Dynamics):
     def reset(self):
         Dynamics.reset(self)
         self.id_text = 'GEN_MAT'
-
-    def _apply_phase(self, dg):
-        """
-        No phase in general
-        """
-        return dg
+        self.apply_params()
 
 class DynamicsUnitary(Dynamics):
     """
@@ -1313,6 +1351,7 @@ class DynamicsUnitary(Dynamics):
         self.drift_ham = None
         self.ctrl_ham = None
         self.H = None
+        self._dyn_gen_phase = -1j
         self.apply_params()
 
     def _create_computers(self):
@@ -1352,12 +1391,6 @@ class DynamicsUnitary(Dynamics):
             self.ctrl_ham = self.ctrl_dyn_gen
 
         self._dyn_gen_mapped = True
-
-    def _apply_phase(self, dg):
-        """
-        Apply the -i factor
-        """
-        return -1j*dg
 
     @property
     def num_ctrls(self):
@@ -1563,16 +1596,16 @@ class DynamicsSymplectic(Dynamics):
             else:
                  self._omega = omg
         return self._omega
-
-    def _apply_phase(self, dg):
+    
+    @property
+    def dyn_gen_phase(self):
         """
-        Get the combined dynamics generator for the timeslot
-        multiplied by omega
+        The prephasing operator for the symplectic group generators
+        usually refered to as \Omega
         """
-        o = self._get_omega()
-        if self.oper_dtype == Qobj:
-            dg = -dg*o
-        else:
-            dg = -dg.dot(o)
+        # Cannot be calculated until the dyn_shape is set
+        # that is after the drift Hamitonan has been set.
+        if self._dyn_gen_phase is None:
+            self._dyn_gen_phase = self.omega
+        return self._dyn_gen_phase
 
-        return dg

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -338,6 +338,10 @@ class Dynamics(object):
         self._num_tslots = None
         # attributes used for processing evolution
         self.memory_optimization = 0
+        self.cache_phased_dyn_gen = None
+        self.cache_prop_grad = None
+        self.cache_dyn_gen_eigenvectors_adj = None
+        self.sparse_eigen_decomp = None
         self.oper_dtype = None
         self.dyn_dims = None
         self.dyn_shape = None
@@ -565,7 +569,57 @@ class Dynamics(object):
             self.time[t+1] = self.time[t] + self._tau[t]
 
         self._timeslots_initialized = True
-
+        
+    def _set_memory_optimizations(self):
+        """
+        Set various memory optimisation attributes based on the 
+        memory_optimization attribute
+        If they have been set already, e.g. in apply_params
+        then they will not be overidden here
+        """
+        logger.info("Setting memory optimisations for level {}".format(
+                    self.memory_optimization))
+                    
+        if self.oper_dtype is None:
+            self._choose_oper_dtype()
+            logger.info("Internal operator data type choosen to be {}".format(
+                            self.oper_dtype))
+        else:
+            logger.info("Using operator data type {}".format(
+                            self.oper_dtype))
+        
+        if self.cache_phased_dyn_gen is None:
+            if self.memory_optimization > 0:
+                self.cache_phased_dyn_gen = False
+            else:
+                self.cache_phased_dyn_gen = True
+        logger.info("phased dynamics generator caching {}".format(
+                            self.cache_phased_dyn_gen))
+        
+        if self.cache_prop_grad is None:
+            if self.memory_optimization > 0:
+                self.cache_prop_grad = False
+            else:
+                self.cache_prop_grad = True       
+        logger.info("propagator gradient caching {}".format(
+                            self.cache_prop_grad))
+                            
+        if self.cache_dyn_gen_eigenvectors_adj is None:
+            if self.memory_optimization > 0:
+                self.cache_dyn_gen_eigenvectors_adj = False
+            else:
+                self.cache_dyn_gen_eigenvectors_adj = True       
+        logger.info("eigenvector adjoint caching {}".format(
+                            self.cache_dyn_gen_eigenvectors_adj))
+                            
+        if self.sparse_eigen_decomp is None:
+            if self.memory_optimization > 1:
+                self.sparse_eigen_decomp = True
+            else:
+                self.sparse_eigen_decomp = False       
+        logger.info("use sparse eigen decomp {}".format(
+                            self.sparse_eigen_decomp))
+                            
     def _choose_oper_dtype(self):
         """
         Attempt select most efficient internal operator data type
@@ -629,16 +683,8 @@ class Dynamics(object):
         if not isinstance(self.target, Qobj):
             raise TypeError("target must be a Qobj")
 
-
         self.refresh_drift_attribs()
-        if self.oper_dtype is None:
-            self._choose_oper_dtype()
-            logger.info("Internal operator data type choosen to be {}".format(
-                            self.oper_dtype))
-        else:
-            logger.info("Using operator data type {}".format(
-                            self.oper_dtype))
-
+        self._set_memory_optimizations()
         self.sys_dims = self.initial.dims
         self.sys_shape = self.initial.shape
         if self.oper_dtype == Qobj:
@@ -666,11 +712,11 @@ class Dynamics(object):
             logger.warn("Unknown option '{}' for oper_dtype. "
                 "Assuming that internal drift, ctrls, initial and target "
                 "have been set correctly".format(self.oper_dtype))
-        if self.memory_optimization == 0:
+        if self.cache_phased_dyn_gen:
             self._phased_ctrl_dyn_gen = [self._apply_phase(ctrl)
                                             for ctrl in self._ctrl_dyn_gen]
         self._dyn_gen = [object for x in range(self.num_tslots)]
-        if self.memory_optimization == 0:
+        if self.cache_phased_dyn_gen:
             self._phased_dyn_gen = [object for x in range(self.num_tslots)]
         self._prop = [object for x in range(self.num_tslots)]
         if self.prop_computer.grad_exact:
@@ -712,7 +758,7 @@ class Dynamics(object):
         self._decomp_curr = [False for x in range(n_ts)]
         self._prop_eigen = [object for x in range(n_ts)]
         self._dyn_gen_eigenvectors = [object for x in range(n_ts)]
-        if self.memory_optimization == 0:
+        if self.cache_dyn_gen_eigenvectors_adj:
             self._dyn_gen_eigenvectors_adj = [object for x in range(n_ts)]
         self._dyn_gen_factormatrix = [object for x in range(n_ts)]
 
@@ -973,7 +1019,7 @@ class Dynamics(object):
             dg = dg + self.ctrl_amps[k, j]*self._ctrl_dyn_gen[j]
 
         self._dyn_gen[k] = dg
-        if self.memory_optimization == 0:
+        if self.cache_phased_dyn_gen:
             self._phased_dyn_gen[k] = self._apply_phase(dg)
 
     def _apply_phase(self, k):
@@ -1060,6 +1106,14 @@ class Dynamics(object):
                                                     self._prop_grad[k, j],
                                                     dims=self.dyn_dims)
         return self._prop_grad_qobj
+        
+    def _get_prop_grad(self, k, j):
+        if self.cache_prop_grad:
+            pg = self._prop_grad[k, j]
+        else:
+            pg = self.prop_computer._compute_prop_grad(k, j, 
+                                                       compute_prop = False)
+        return pg
 
     @property
     def evo_init2t(self):
@@ -1331,16 +1385,13 @@ class DynamicsUnitary(Dynamics):
         basis, and the 'factormatrix' used in calculating the propagator
         gradient
         """
-        if self.memory_optimization >= 2:
-            sparse = True
-        else:
-            sparse = False
 
         if self.oper_dtype == Qobj:
             H = self._dyn_gen[k]
             # Returns eigenvalues as array (row)
             # and eigenvectors as rows of an array
-            eig_val, eig_vec = sp_eigs(H.data, H.isherm, sparse=sparse)
+            eig_val, eig_vec = sp_eigs(H.data, H.isherm, 
+                                       sparse=self.sparse_eigen_decomp)
             eig_vec = eig_vec.T
 
         elif self.oper_dtype == np.ndarray:

--- a/qutip/control/fidcomp.py
+++ b/qutip/control/fidcomp.py
@@ -545,10 +545,10 @@ class FidCompUnitary(FidelityComputer):
                 fwd_evo = dyn._fwd_evo[k]   
                 onto_evo = dyn._onto_evo[k+1]
                 if dyn.oper_dtype == Qobj:
-                    g = (onto_evo*dyn._prop_grad[k, j]*fwd_evo).tr()
+                    g = (onto_evo*dyn._get_prop_grad(k, j)*fwd_evo).tr()
                 else:
                     g = _trace(onto_evo.dot(
-                                dyn._prop_grad[k, j]).dot(fwd_evo))
+                                dyn._get_prop_grad(k, j)).dot(fwd_evo))
                 grad[k, j] = g
         if dyn.stats is not None:
             dyn.stats.wall_time_gradient_compute += \
@@ -691,7 +691,7 @@ class FidCompTraceDiff(FidelityComputer):
             for k in range(n_ts):
                 fwd_evo = dyn._fwd_evo[k]
                 if dyn.oper_dtype == Qobj:
-                    evo_grad = dyn._prop_grad[k, j]*fwd_evo
+                    evo_grad = dyn._get_prop_grad(k, j)*fwd_evo
                     if k+1 < n_ts:
                         evo_grad = dyn._onwd_evo[k+1]*evo_grad
                     # Note that the value should have not imagnary part, so
@@ -699,7 +699,7 @@ class FidCompTraceDiff(FidelityComputer):
                     g = -2*self.scale_factor*np.real(
                                     (evo_f_diff.dag()*evo_grad).tr())
                 else:
-                    evo_grad = dyn._prop_grad[k, j].dot(fwd_evo)
+                    evo_grad = dyn._get_prop_grad(k, j).dot(fwd_evo)
                     if k+1 < n_ts:
                         evo_grad = dyn._onwd_evo[k+1].dot(evo_grad)
                     g = -2*self.scale_factor*np.real(_trace(

--- a/qutip/control/propcomp.py
+++ b/qutip/control/propcomp.py
@@ -145,7 +145,7 @@ class PropagatorComputer(object):
         _func_deprecation("'compute_propagator' has been replaced "
                         "by '_compute_propagator'")
         return self._compute_propagator(k)
-
+                               
     def _compute_propagator(self, k):
         """
         calculate the progator between X(k) and X(k+1)
@@ -154,8 +154,13 @@ class PropagatorComputer(object):
         i.e. drift and ctrls combined
         Return the propagator
         """
-        raise errors.UsageError("Not implemented in the baseclass."
-                                " Choose a subclass")
+        dyn = self.parent
+        dgt = dyn._get_phased_dyn_gen(k)*dyn.tau[k]
+        if dyn.oper_dtype == Qobj:
+            dyn._prop[k] = dgt.expm()
+        else:
+            dyn._prop[k] = la.expm(dgt)
+        return dyn._prop[k]
 
     def compute_diff_prop(self, k, j, epsilon):
         _func_deprecation("'compute_diff_prop' has been replaced "
@@ -201,22 +206,6 @@ class PropCompApproxGrad(PropagatorComputer):
         self.id_text = 'APPROX'
         self.grad_exact = False
         self.apply_params()
-
-    def _compute_propagator(self, k):
-        """
-        calculate the progator between X(k) and X(k+1)
-        Uses matrix expm of the dyn_gen at that point (in time)
-        Assumes that the dyn_gen have been been calculated,
-        i.e. drift and ctrls combined
-        Return the propagator
-        """
-        dyn = self.parent
-        dgt = dyn._get_phased_dyn_gen(k)*dyn.tau[k]
-        if dyn.oper_dtype == Qobj:
-            dyn._prop[k] = dgt.expm()
-        else:
-            dyn._prop[k] = la.expm(dgt)
-        return dyn._prop[k]
 
     def _compute_diff_prop(self, k, j, epsilon):
         """

--- a/qutip/control/propcomp.py
+++ b/qutip/control/propcomp.py
@@ -157,10 +157,10 @@ class PropagatorComputer(object):
         dyn = self.parent
         dgt = dyn._get_phased_dyn_gen(k)*dyn.tau[k]
         if dyn.oper_dtype == Qobj:
-            dyn._prop[k] = dgt.expm()
+            prop = dgt.expm()
         else:
-            dyn._prop[k] = la.expm(dgt)
-        return dyn._prop[k]
+            prop = la.expm(dgt)
+        return prop
 
     def compute_diff_prop(self, k, j, epsilon):
         _func_deprecation("'compute_diff_prop' has been replaced "
@@ -251,14 +251,14 @@ class PropCompDiag(PropagatorComputer):
 
         if dyn.oper_dtype == Qobj:
 
-            dyn._prop[k] = (dyn._dyn_gen_eigenvectors[k]*dyn._prop_eigen[k]*
+            prop = (dyn._dyn_gen_eigenvectors[k]*dyn._prop_eigen[k]*
                                 dyn._get_dyn_gen_eigenvectors_adj(k))
         else:
-            dyn._prop[k] = dyn._dyn_gen_eigenvectors[k].dot(
+            prop = dyn._dyn_gen_eigenvectors[k].dot(
                                     dyn._prop_eigen[k]).dot(
                                 dyn._get_dyn_gen_eigenvectors_adj(k))
 
-        return dyn._prop[k]
+        return prop
 
     def _compute_prop_grad(self, k, j, compute_prop=True):
         """
@@ -272,7 +272,7 @@ class PropCompDiag(PropagatorComputer):
         dyn._ensure_decomp_curr(k)
 
         if compute_prop:
-            self._compute_propagator(k)
+            prop = self._compute_propagator(k)
 
         if dyn.oper_dtype == Qobj:
             # put control dyn_gen in combined dg diagonal basis
@@ -283,7 +283,7 @@ class PropCompDiag(PropagatorComputer):
             cdg = Qobj(np.multiply(cdg.full()*dyn.tau[k],
                         dyn._dyn_gen_factormatrix[k]), dims=dyn.dyn_dims)
             # Return to canonical basis
-            dyn._prop_grad[k, j] = (dyn._dyn_gen_eigenvectors[k]*cdg*
+            prop_grad = (dyn._dyn_gen_eigenvectors[k]*cdg*
                         dyn._get_dyn_gen_eigenvectors_adj(k))
         else:
             # put control dyn_gen in combined dg diagonal basis
@@ -293,13 +293,13 @@ class PropCompDiag(PropagatorComputer):
             # multiply (elementwise) by timeslice and factor matrix
             cdg = np.multiply(cdg*dyn.tau[k], dyn._dyn_gen_factormatrix[k])
             # Return to canonical basis
-            dyn._prop_grad[k, j] = dyn._dyn_gen_eigenvectors[k].dot(cdg).dot(
+            prop_grad = dyn._dyn_gen_eigenvectors[k].dot(cdg).dot(
                         dyn._get_dyn_gen_eigenvectors_adj(k))
 
         if compute_prop:
-            return dyn._prop[k], dyn._prop_grad[k, j]
+            return prop, prop_grad
         else:
-            return dyn._prop_grad[k, j]
+            return prop_grad
 
 
 class PropCompAugMat(PropagatorComputer):
@@ -368,21 +368,21 @@ class PropCompAugMat(PropagatorComputer):
 
         if dyn.oper_dtype == Qobj:
             aug_exp = aug.expm()
-            dyn._prop_grad[k, j] = Qobj(aug_exp.data[:dg.shape[0], dg.shape[1]:],
+            prop_grad = Qobj(aug_exp.data[:dg.shape[0], dg.shape[1]:],
                          dims=dyn.dyn_dims)
             if compute_prop:
-                dyn._prop[k] = Qobj(aug_exp.data[:dg.shape[0], :dg.shape[1]],
+                prop = Qobj(aug_exp.data[:dg.shape[0], :dg.shape[1]],
                             dims=dyn.dyn_dims)
         else:
             aug_exp = la.expm(aug)
-            dyn._prop_grad[k, j] = aug_exp[:dg.shape[0], dg.shape[1]:]
+            prop_grad = aug_exp[:dg.shape[0], dg.shape[1]:]
             if compute_prop:
-                dyn._prop[k] = aug_exp[:dg.shape[0], :dg.shape[1]]
+                prop = aug_exp[:dg.shape[0], :dg.shape[1]]
 
         if compute_prop:
-            return dyn._prop[k], dyn._prop_grad[k, j]
+            return prop, prop_grad
         else:
-            return dyn._prop_grad[k, j]
+            return prop_grad
 
 
 class PropCompFrechet(PropagatorComputer):
@@ -415,20 +415,20 @@ class PropCompFrechet(PropagatorComputer):
             E = dyn._get_phased_ctrl_dyn_gen(j).full()*dyn.tau[k]
             if compute_prop:
                 prop_dense, prop_grad_dense = la.expm_frechet(A, E)
-                dyn._prop[k] = Qobj(prop_dense, dims=dyn.dyn_dims)
-                dyn._prop_grad[k, j] = Qobj(prop_grad_dense,
+                prop = Qobj(prop_dense, dims=dyn.dyn_dims)
+                prop_grad = Qobj(prop_grad_dense,
                                             dims=dyn.dyn_dims)
             else:
                 prop_grad_dense = la.expm_frechet(A, E, compute_expm=False)
-                dyn._prop_grad[k, j] = Qobj(prop_grad_dense,
+                prop_grad = Qobj(prop_grad_dense,
                                             dims=dyn.dyn_dims)
         elif dyn.oper_dtype == np.ndarray:
             A = dyn._get_phased_dyn_gen(k)*dyn.tau[k]
             E = dyn._get_phased_ctrl_dyn_gen(j)*dyn.tau[k]
             if compute_prop:
-                dyn._prop[k], dyn._prop_grad[k, j] = la.expm_frechet(A, E)
+                prop, prop_grad = la.expm_frechet(A, E)
             else:
-                dyn._prop_grad[k, j] = la.expm_frechet(A, E,
+                prop_grad = la.expm_frechet(A, E,
                                                     compute_expm=False)
         else:
             # Assuming some sparse matrix
@@ -437,13 +437,13 @@ class PropCompFrechet(PropagatorComputer):
             E = (dyn._get_phased_ctrl_dyn_gen(j)*dyn.tau[k]).toarray()
             if compute_prop:
                 prop_dense, prop_grad_dense = la.expm_frechet(A, E)
-                dyn._prop[k] = spcls(prop_dense)
-                dyn._prop_grad[k, j] = spcls(prop_grad_dense)
+                prop = spcls(prop_dense)
+                prop_grad = spcls(prop_grad_dense)
             else:
                 prop_grad_dense = la.expm_frechet(A, E, compute_expm=False)
-                dyn._prop_grad[k, j] = spcls(prop_grad_dense)
+                prop_grad = spcls(prop_grad_dense)
 
         if compute_prop:
-            return dyn._prop[k], dyn._prop_grad[k, j]
+            return prop, prop_grad
         else:
-            return dyn._prop_grad[k, j]
+            return prop_grad

--- a/qutip/control/tslotcomp.py
+++ b/qutip/control/tslotcomp.py
@@ -292,16 +292,19 @@ class TSlotCompUpdateAll(TimeslotComputer):
         # calculate the propagators and the propagotor gradients
         if ecs: time_start = timeit.default_timer()
         for k in range(n_ts):
-            if prop_comp.grad_exact and dyn.cache_prop_grad :
+            if prop_comp.grad_exact and dyn.cache_prop_grad:
                 for j in range(n_ctrls):
                     if j == 0:
-                        prop_comp._compute_prop_grad(k, j)
+                        dyn._prop[k], dyn._prop_grad[k, j] = \
+                                    prop_comp._compute_prop_grad(k, j)
                         if self.log_level <= logging.DEBUG_INTENSE:
                             logger.log(logging.DEBUG_INTENSE,
                                        "propagator {}:\n{:10.3g}".format(
                                            k, self._prop[k]))
                     else:
-                        prop_comp._compute_prop_grad(k, j, compute_prop=False)
+                        dyn._prop_grad[k, j] = \
+                            prop_comp._compute_prop_grad(k, j, 
+                                                         compute_prop=False)
             else:
                 dyn._prop[k] = prop_comp._compute_propagator(k)
         

--- a/qutip/control/tslotcomp.py
+++ b/qutip/control/tslotcomp.py
@@ -292,7 +292,7 @@ class TSlotCompUpdateAll(TimeslotComputer):
         # calculate the propagators and the propagotor gradients
         if ecs: time_start = timeit.default_timer()
         for k in range(n_ts):
-            if prop_comp.grad_exact:
+            if prop_comp.grad_exact and dyn.cache_prop_grad :
                 for j in range(n_ctrls):
                     if j == 0:
                         prop_comp._compute_prop_grad(k, j)


### PR DESCRIPTION
Various memory optimisations options in the control time evolution computation.
The main new one is the non-caching of propagator gradients
Most memory optimisations switched on with single dynamics attribute, although each can now be switched individually. All have some cost in execution speed, but can be very beneficial when working with large systems, especially if they have a lots of controls.