### PR TITLE
BUG: spmvpy is not void

### DIFF
--- a/qutip/cy/spmatfuncs.pxd
+++ b/qutip/cy/spmatfuncs.pxd
@@ -43,7 +43,7 @@ cpdef np.ndarray[CTYPE_t, ndim=1, mode="c"] spmv_csr(
     np.ndarray[CTYPE_t, ndim=1, mode="c"] vec)
 
 
-cpdef np.ndarray[CTYPE_t, ndim=1, mode="c"] spmvpy(
+cpdef void spmvpy(
         np.ndarray[CTYPE_t, ndim=1, mode="c"] data,
         np.ndarray[ITYPE_t, ndim=1, mode="c"] idx,
         np.ndarray[ITYPE_t, ndim=1, mode="c"] ptr,

--- a/qutip/cy/spmatfuncs.pyx
+++ b/qutip/cy/spmatfuncs.pyx
@@ -107,7 +107,7 @@ cpdef np.ndarray[CTYPE_t, ndim=1, mode="c"] spmv_csr(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef np.ndarray[CTYPE_t, ndim=1, mode="c"] spmvpy(
+cpdef void spmvpy(
         np.ndarray[CTYPE_t, ndim=1, mode="c"] data,
         np.ndarray[ITYPE_t, ndim=1, mode="c"] idx,
         np.ndarray[ITYPE_t, ndim=1, mode="c"] ptr,
@@ -131,7 +131,6 @@ cpdef np.ndarray[CTYPE_t, ndim=1, mode="c"] spmvpy(
             dot = dot + data[jj] * vec[idx[jj]]
         out[row] = out[row] + a * dot
 
-    return out
 
 
 @cython.boundscheck(False)


### PR DESCRIPTION
We were outputting unnecessary arrays for spmvpy when the function should be void