### PR TITLE
ENH: Use Cubic_Spline in dynamics

### DIFF
--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -258,7 +258,7 @@ from qutip.correlation import *
 from qutip.countstat import *
 from qutip.rcsolve import *
 from qutip.nonmarkov import *
-from qutip.cubic_spline import *
+from qutip.interpolate import *
 
 # quantum information
 from qutip.qip import *

--- a/qutip/cy/interpolate.pxd
+++ b/qutip/cy/interpolate.pxd
@@ -1,0 +1,36 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without 
+#    modification, are permitted provided that the following conditions are 
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice, 
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+cpdef double interp(double x, double a, double b, double[::1] c)
+
+cpdef complex zinterp(double x, double a, double b, complex[::1] c)

--- a/qutip/cy/interpolate.pyx
+++ b/qutip/cy/interpolate.pyx
@@ -15,7 +15,7 @@ cdef inline double phi(double t):
     else:
         return 0
 
-cpdef double _interpolate(double x, double a, double b, double[::1] c):
+cpdef double interp(double x, double a, double b, double[::1] c):
     cdef int n = c.shape[0] - 3
     cdef double h = (b-a) / n
     cdef int l = <int>((x-a)/h) + 1
@@ -28,7 +28,7 @@ cpdef double _interpolate(double x, double a, double b, double[::1] c):
         s += c[ii-1] * phi(pos - ii)
     return s    
 
-cpdef complex _interpolate_complex(double x, double a, double b, complex[::1] c):
+cpdef complex zinterp(double x, double a, double b, complex[::1] c):
     cdef int n = c.shape[0] - 3
     cdef double h = (b-a) / n
     cdef int l = <int>((x-a)/h) + 1
@@ -42,7 +42,7 @@ cpdef complex _interpolate_complex(double x, double a, double b, complex[::1] c)
     return s  
 
 
-def _array_interpolate(double[::1] x, double a, double b, double[::1] c):
+def arr_interp(double[::1] x, double a, double b, double[::1] c):
     cdef int lenx = x.shape[0]
     cdef int lenc = c.shape[0] 
     cdef int n = lenc - 3
@@ -62,7 +62,7 @@ def _array_interpolate(double[::1] x, double a, double b, double[::1] c):
     
     return out
 
-def _array_interpolate_complex(double[::1] x, double a, double b, complex[::1] c):
+def arr_zinterp(double[::1] x, double a, double b, complex[::1] c):
     cdef int lenx = x.shape[0]
     cdef int lenc = c.shape[0] 
     cdef int n = lenc - 3

--- a/qutip/interpolate.py
+++ b/qutip/interpolate.py
@@ -31,9 +31,8 @@
 ###############################################################################
 import numpy as np
 import scipy.linalg as la
-from qutip.cy.interpolate import (_interpolate, _array_interpolate,
-                                 _interpolate_complex,
-                                 _array_interpolate_complex)
+from qutip.cy.interpolate import (interp, arr_interp,
+                                 zinterp, arr_zinterp)
 
 __all__ = ['Cubic_Spline']
 
@@ -110,21 +109,21 @@ class Cubic_Spline(object):
         self.coeffs = coeff # Spline coefficients
         self.is_complex = (y.dtype == complex) #Tells which dtype solver to use
         
-    def __call__(self, pnts):
+    def __call__(self, pnts, *args):
         #If requesting a single return value
         if isinstance(pnts, (int, float, complex)):
             if self.is_complex:
-                return _interpolate_complex(pnts, self.a, 
+                return zinterp(pnts, self.a, 
                                     self.b, self.coeffs)
             else:
-                return _interpolate(pnts, self.a, self.b, self.coeffs)
+                return interp(pnts, self.a, self.b, self.coeffs)
         #If requesting multiple return values from array_like
         elif isinstance(pnts, (np.ndarray,list)):
             pnts = np.asarray(pnts)
             if self.is_complex:
-                return _array_interpolate_complex(pnts, self.a, 
+                return arr_zinterp(pnts, self.a, 
                                                 self.b, self.coeffs)
             else:
-                return _array_interpolate(pnts, self.a, self.b, self.coeffs)
+                return arr_interp(pnts, self.a, self.b, self.coeffs)
     
     

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -55,6 +55,7 @@ from qutip.cy.utilities import _cython_build_cleanup
 from qutip.rhs_generate import rhs_generate
 from qutip.states import ket2dm
 from qutip.rhs_generate import _td_format_check, _td_wrap_array_str
+from qutip.interpolate import Cubic_Spline
 from qutip.settings import debug
 
 from qutip.sesolve import (_sesolve_list_func_td, _sesolve_list_str_td,
@@ -546,6 +547,7 @@ def _mesolve_list_str_td(H_list, rho0, tlist, c_list, e_ops, args, opt,
     Linds = []
     Lptrs = []
     Lcoeff = []
+    Lobj = []
 
     # loop over all hamiltonian terms, convert to superoperator form and
     # add the data of sparse matrix representation to
@@ -579,6 +581,8 @@ def _mesolve_list_str_td(H_list, rho0, tlist, c_list, e_ops, args, opt,
             Ldata.append(L.data.data)
             Linds.append(L.data.indices)
             Lptrs.append(L.data.indptr)
+            if isinstance(h_coeff, Cubic_Spline):
+                Lobj.append(h_coeff.coeffs)
             Lcoeff.append(h_coeff)
 
         else:
@@ -645,6 +649,9 @@ def _mesolve_list_str_td(H_list, rho0, tlist, c_list, e_ops, args, opt,
     string_list = []
     for k in range(n_L_terms):
         string_list.append("Ldata[%d], Linds[%d], Lptrs[%d]" % (k, k, k))
+    # Add object terms to end of ode args string
+    for k in range(len(Lobj)):
+        string_list.append("Lobj[%d]" % k)
     for name, value in args.items():
         if isinstance(value, np.ndarray):
             string_list.append(name)
@@ -995,7 +1002,7 @@ def _generic_ode_solve(r, rho0, tlist, e_ops, opt, progress_bar):
 
     progress_bar.finished()
 
-    if not opt.rhs_reuse and config.tdname is not None:
+    if (not opt.rhs_reuse) and (config.tdname is not None):
         _cython_build_cleanup(config.tdname)
 
     if opt.store_final_state:

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -47,6 +47,7 @@ from qutip.qobj import Qobj, isket
 from qutip.rhs_generate import rhs_generate
 from qutip.solver import Result, Options, config, _solver_safety_check
 from qutip.rhs_generate import _td_format_check, _td_wrap_array_str
+from qutip.interpolate import Cubic_Spline
 from qutip.settings import debug
 from qutip.cy.spmatfuncs import (cy_expect_psi, cy_ode_rhs,
                                  cy_ode_psi_func_td,
@@ -127,7 +128,6 @@ def sesolve(H, rho0, tlist, e_ops=[], args={}, options=None,
 
     # convert array based time-dependence to string format
     H, _, args = _td_wrap_array_str(H, [], args, tlist)
-
     # check for type (if any) of time-dependent inputs
     n_const, n_func, n_str = _td_format_check(H, [])
 
@@ -335,6 +335,7 @@ def _sesolve_list_str_td(H_list, psi0, tlist, e_ops, args, opt,
     Linds = []
     Lptrs = []
     Lcoeff = []
+    Lobj = []
 
     # loop over all hamiltonian terms, convert to superoperator form and
     # add the data of sparse matrix representation to h_coeff
@@ -357,6 +358,8 @@ def _sesolve_list_str_td(H_list, psi0, tlist, e_ops, args, opt,
         Ldata.append(L.data.data)
         Linds.append(L.data.indices)
         Lptrs.append(L.data.indptr)
+        if isinstance(h_coeff, Cubic_Spline):
+            Lobj.append(h_coeff.coeffs)
         Lcoeff.append(h_coeff)
 
     # the total number of liouvillian terms (hamiltonian terms +
@@ -370,6 +373,10 @@ def _sesolve_list_str_td(H_list, psi0, tlist, e_ops, args, opt,
     string_list = []
     for k in range(n_L_terms):
         string_list.append("Ldata[%d], Linds[%d], Lptrs[%d]" % (k, k, k))
+    # Add object terms to end of ode args string
+    for k in range(len(Lobj)):
+        string_list.append("Lobj[%d]" % k)
+    
     for name, value in args.items():
         if isinstance(value, np.ndarray):
             string_list.append(name)

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -321,6 +321,7 @@ class SolverConfiguration():
 
         # Hamiltonian stuff
         self.h_td_inds = []  # indicies of time-dependent Hamiltonian operators
+        self.h_tdterms = []  # List of td strs and funcs 
         self.h_data = None   # List of sparse matrix data
         self.h_ind = None    # List of sparse matrix indices
         self.h_ptr = None    # List of sparse matrix ptrs
@@ -814,7 +815,7 @@ def _solver_safety_check(H, state, c_ops=[], e_ops=[], args={}):
             _temp_state = c_ops[ii][0]
         else:
             raise Exception('Invalid td-list element.')
-        _structure_check(Hdims,Htype,_temp_state)
+        _structure_check(Hdims, Htype, _temp_state)
     
     for ii in range(len(e_ops)):
             if isinstance(e_ops[ii], Qobj):

--- a/qutip/tests/test_interpolate.py
+++ b/qutip/tests/test_interpolate.py
@@ -81,7 +81,7 @@ def testInterpolate5():
     S = Cubic_Spline(x[0],x[-1],y)
     x2 = np.linspace(0,8*np.pi,400)
     y2 = np.sin(r1*x2)+np.cos(r2*x2)
-    assert_(max(np.abs((S(x2)-y2)/y2)) < 0.05)
+    assert_(max(np.abs((S(x2)-y2)/y2)) < 0.1)
 
 def test_interpolate_evolve1():
     """

--- a/qutip/tests/test_interpolate.py
+++ b/qutip/tests/test_interpolate.py
@@ -71,17 +71,6 @@ def testInterpolate4():
     S2 = sint.interp1d(x,y,'cubic')
     for k in range(x.shape[0]):
         assert_(np.abs(S2(x[k])-S1(x[k])) < 1e-9)
-        
-def testInterpolate5():
-    "Interpolate: Random points in interval"
-    x = np.linspace(0,8*np.pi,200)
-    r1 = 2*np.random.random()
-    r2 = 2*np.random.random()
-    y = np.sin(r1*x)+np.cos(r2*x)
-    S = Cubic_Spline(x[0],x[-1],y)
-    x2 = np.linspace(0,8*np.pi,400)
-    y2 = np.sin(r1*x2)+np.cos(r2*x2)
-    assert_(max(np.abs((S(x2)-y2)/y2)) < 0.1)
 
 def test_interpolate_evolve1():
     """


### PR DESCRIPTION
- Cubic_Spline objects can now be used in the me, se, and mc dynamics
solvers as a time-dependent term.

- If possible, the Cubic_Spline object will be evaluated in the
str-based format.

- I have yet to add this functionality to the collapse terms .