### PR TITLE
Fixed missing brackets in qutip.qip.qubit_states

### DIFF
--- a/qutip/qip/qubits.py
+++ b/qutip/qip/qubits.py
@@ -62,5 +62,5 @@ def qubit_states(N=1, states=[0]):
         else:
             state_list.append(states[i])
 
-    return tensor([alpha * basis(2, 0) + sqrt(1 - alpha**2) * basis(2, 1)
+    return tensor([alpha * basis(2, 1) + sqrt(1 - alpha**2) * basis(2, 0)
                   for alpha in state_list])

--- a/qutip/qip/qubits.py
+++ b/qutip/qip/qubits.py
@@ -34,6 +34,8 @@
 __all__ = ['qubit_states']
 
 from qutip.tensor import tensor
+from numpy import sqrt
+from qutip import basis
 
 
 def qubit_states(N=1, states=[0]):
@@ -51,7 +53,7 @@ def qubit_states(N=1, states=[0]):
     ----------
     qstates : Qobj
         List of qubits.
-    
+
     """
     state_list = []
     for i in range(N):
@@ -60,5 +62,5 @@ def qubit_states(N=1, states=[0]):
         else:
             state_list.append(states[i])
 
-    return tensor(alpha * basis(2, 0) + sqrt(1 - alpha**2) * basis(2, 1)
-                  for alpha in state_list)
+    return tensor([alpha * basis(2, 0) + sqrt(1 - alpha**2) * basis(2, 1)
+                  for alpha in state_list])

--- a/qutip/qip/qubits.py
+++ b/qutip/qip/qubits.py
@@ -35,7 +35,7 @@ __all__ = ['qubit_states']
 
 from qutip.tensor import tensor
 from numpy import sqrt
-from qutip import basis
+from qutip.states import basis
 
 
 def qubit_states(N=1, states=[0]):

--- a/qutip/tests/test_qubits.py
+++ b/qutip/tests/test_qubits.py
@@ -1,6 +1,7 @@
 from numpy.testing import assert_, run_module_suite
 from qutip.qip.qubits import qubit_states
-from qutip import basis, tensor
+from qutip.tensor import tensor
+from qutip.states import basis
 
 
 class TestQubits:

--- a/qutip/tests/test_qubits.py
+++ b/qutip/tests/test_qubits.py
@@ -1,0 +1,28 @@
+from numpy.testing import assert_, run_module_suite
+from qutip.qip.qubits import qubit_states
+from qutip import basis, tensor
+
+
+class TestQubits:
+    """
+    A test class for the QuTiP functions for qubits.
+    """
+    def testQubitStates(self):
+        """
+        Tests the qubit_states function.
+        """
+        psi0_a = basis(2, 0)
+        psi0_b = qubit_states()
+        assert_(psi0_a == psi0_b)
+
+        psi1_a = basis(2, 1)
+        psi1_b = qubit_states(states=[1])
+        assert_(psi1_a == psi1_b)
+
+        psi01_a = tensor(psi0_a, psi1_a)
+        psi01_b = qubit_states(N=2, states=[0, 1])
+        assert_(psi01_a == psi01_b)
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
There were brackets missing in a list comprehension in the function `qip.qubit_states`. 
Additionally puting states = [0] put the qubit in the |1> state and states=[1] put the qubit in the |0> state. I have changed this so that [0] correpsonds to |0> and [1] corresponds to |1>

This pull request addresses these issues and provides a test to test the added functionality. 
