### PR TITLE
Fix redundancy and sign error in jmat.

### DIFF
--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -102,10 +102,7 @@ shape = [3, 3], type = oper, isHerm = True
         raise TypeError('j must be a non-negative integer or half-integer')
 
     if not args:
-        a1 = Qobj(0.5 * (_jplus(j) + _jplus(j).conj().T))
-        a2 = Qobj(0.5 * 1j * (_jplus(j) - _jplus(j).conj().T))
-        a3 = Qobj(_jz(j))
-        return np.array([a1, a2, a3])
+        return jmat(j, 'x'), jmat(j, 'y'), jmat(j, 'z')        
 
     if args[0] == '+':
         A = _jplus(j)

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -82,9 +82,9 @@ shape = [3, 3], type = oper, isHerm = True
      Quantum object: dims = [[3], [3]], \
 shape = [3, 3], type = oper, isHerm = True
     Qobj data =
-    [[ 0.+0.j          0.+0.70710678j  0.+0.j        ]
-     [ 0.-0.70710678j  0.+0.j          0.+0.70710678j]
-     [ 0.+0.j          0.-0.70710678j  0.+0.j        ]]
+    [[ 0.+0.j          0.-0.70710678j  0.+0.j        ]
+     [ 0.+0.70710678j  0.+0.j          0.-0.70710678j]
+     [ 0.+0.j          0.+0.70710678j  0.+0.j        ]]
      Quantum object: dims = [[3], [3]], \
 shape = [3, 3], type = oper, isHerm = True
     Qobj data =


### PR DESCRIPTION
In the case when no args were given, a sign was missing in Jy in the extra piece of code written specifically for this purpose. I propose recursive calls to the function with the respective arguments.