### PR TITLE
BUG: Fix failing cvxopt build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
       fi
     - pip install coverage coveralls
     # Also get optional dependencies (CVXPY, which depends on CVXOPT and SCS).
-    - pip install cvxopt
+    - conda install -c anaconda cvxopt=1.1.8
     - pip install scs
     - pip install cvxpy
     # Finally, install ourselves.

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
       fi
     - pip install coverage coveralls
     # Also get optional dependencies (CVXPY, which depends on CVXOPT and SCS).
-    - conda install -c anaconda cvxopt=1.1.8
+    - pip install cvxopt==1.1.8
     - pip install scs
     - pip install cvxpy
     # Finally, install ourselves.


### PR DESCRIPTION
Fix for recent version of cvxopt failing due to missing `umfpack.h`