### PR TITLE
BUG: Move pyximport to end of init.

### DIFF
--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -113,14 +113,10 @@ try:
               ("(%s), requiring %s." %
                (Cython.__version__, _cython_requirement)))
 
-    import pyximport
-    os.environ['CFLAGS'] = '-O2 -w -ffast-math'
-    pyximport.install(setup_args={'include_dirs': [numpy.get_include()]})
-
 except Exception as e:
     print("QuTiP warning: Cython setup failed: " + str(e))
 else:
-    del Cython, pyximport
+    del Cython
 
 # -----------------------------------------------------------------------------
 # Load user configuration if present: override defaults.
@@ -202,11 +198,6 @@ else:
     del matplotlib
 
 # -----------------------------------------------------------------------------
-# Clean name space
-#
-del os, sys, numpy, scipy, multiprocessing
-
-# -----------------------------------------------------------------------------
 # Load modules
 #
 
@@ -268,3 +259,14 @@ from qutip.parallel import *
 from qutip.utilities import *
 from qutip.fileio import *
 from qutip.about import *
+
+# Setup pyximport 
+import pyximport
+os.environ['CFLAGS'] = '-O2 -w -ffast-math'
+pyximport.install(setup_args={'include_dirs': [numpy.get_include()]})
+del pyximport
+
+# -----------------------------------------------------------------------------
+# Clean name space
+#
+del os, sys, numpy, scipy, multiprocessing

--- a/setup.py
+++ b/setup.py
@@ -92,8 +92,7 @@ PACKAGES = ['qutip', 'qutip/ui', 'qutip/cy', 'qutip/qip', 'qutip/qip/models',
 PACKAGE_DATA = {
     'qutip': ['configspec.ini'],
     'qutip/tests': ['bucky.npy', 'bucky_perm.npy'],
-    'qutip/cy': ['*.pxi', '*.pxd'],
-    'qutip/control': ['*.pyx']
+    'qutip/cy': ['*.pxi', '*.pxd']
 }
 # If we're missing numpy, exclude import directories until we can
 # figure them out properly.


### PR DESCRIPTION
- This should (hopefully) fix any issue where *.pyx files are being compiled twice.

- Remove control module *.pyx package data.