### PR TITLE
Adds input and output states to `QubitCircuit`

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -1019,10 +1019,13 @@ class QubitCircuit(object):
             col.append(r" \qw ")
             rows.append(col)
 
+        input_states = ["\lstick{\ket{"+ x + "}}" if x is not None else "" for x in self.input_states]
+
         code = ""
         n_iter = (reversed(range(self.N)) if self.reverse_states
                   else range(self.N))
         for n in n_iter:
+            code += r" & %s" % input_states[n]
             for m in range(len(gates)):
                 code += r" & %s" % rows[m][n]
             code += r" & \qw \\ " + "\n"

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -36,7 +36,7 @@ import warnings
 
 from qutip.qip.circuit_latex import _latex_compile
 from qutip.qip.gates import *
-
+from qutip.qip.qubits import qubit_states
 
 __all__ = ['Gate', 'QubitCircuit']
 
@@ -165,13 +165,40 @@ class QubitCircuit(object):
     of gates.
     """
 
-    def __init__(self, N, reverse_states=True):
-
+    def __init__(self, N, input_states=None, output_states=None, reverse_states=True):
         # number of qubits in the register
         self.N = N
         self.reverse_states = reverse_states
         self.gates = []
         self.U_list = []
+        self.input_states = [None for i in range(N)]
+        self.output_states = [None for i in range(N)]
+
+    def add_state(self, state, targets=None, state_type="input"):
+        """
+        Add an input or ouput state to the circuit. By default all the input and 
+        output states will be initialized to `None`. A particular state can be added
+        by specifying the state and the qubit where it has to be added along with the
+        type as input or output.
+
+        Parameters
+        ----------
+        state: str
+            The state that has to be added. It can be any string such as `0`, '+', "A", "Y"
+        targets: list
+            A list of qubit positions where the given state has to be added.
+        state_type: str
+            One of either "input" or "output". This specifies whether the state to be added
+            is an input or output.
+            default: "input"
+
+        """
+        if state_type == "input":
+            for i in targets:
+                self.input_states[i] = state
+        if state_type == "output":
+            for i in targets:
+                self.output_states[i] = state
 
     def add_gate(self, gate, targets=None, controls=None, arg_value=None,
                  arg_label=None):

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -165,7 +165,8 @@ class QubitCircuit(object):
     of gates.
     """
 
-    def __init__(self, N, input_states=None, output_states=None, reverse_states=True):
+    def __init__(self, N, input_states=None, output_states=None,
+                 reverse_states=True):
         # number of qubits in the register
         self.N = N
         self.reverse_states = reverse_states
@@ -176,20 +177,21 @@ class QubitCircuit(object):
 
     def add_state(self, state, targets=None, state_type="input"):
         """
-        Add an input or ouput state to the circuit. By default all the input and 
-        output states will be initialized to `None`. A particular state can be added
-        by specifying the state and the qubit where it has to be added along with the
-        type as input or output.
+        Add an input or ouput state to the circuit. By default all the input
+        and output states will be initialized to `None`. A particular state can
+        be added by specifying the state and the qubit where it has to be added
+        along with the type as input or output.
 
         Parameters
         ----------
         state: str
-            The state that has to be added. It can be any string such as `0`, '+', "A", "Y"
+            The state that has to be added. It can be any string such as `0`,
+            '+', "A", "Y"
         targets: list
             A list of qubit positions where the given state has to be added.
         state_type: str
-            One of either "input" or "output". This specifies whether the state to be added
-            is an input or output.
+            One of either "input" or "output". This specifies whether the state
+            to be added is an input or output.
             default: "input"
 
         """
@@ -1019,7 +1021,8 @@ class QubitCircuit(object):
             col.append(r" \qw ")
             rows.append(col)
 
-        input_states = ["\lstick{\ket{"+ x + "}}" if x is not None else "" for x in self.input_states]
+        input_states = ["\lstick{\ket{" + x + "}}" if x is not None
+                        else "" for x in self.input_states]
 
         code = ""
         n_iter = (reversed(range(self.N)) if self.reverse_states

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -158,5 +158,22 @@ class TestQubitCircuit:
         assert_(qc.gates[1].targets == test_gate.targets)
         assert_(qc.gates[1].controls == test_gate.controls)
 
+    def test_add_state(self):
+        """
+        Addition of input and output states to a circuit.
+        """
+        qc = QubitCircuit(3)
+
+        qc.add_state("0", targets=[0])
+        qc.add_state("+", targets=[1], state_type="output")
+        qc.add_state("-", targets=[1])
+
+        assert_(qc.input_states[0] == "0")
+        assert_(qc.input_states[2] == None)
+        assert_(qc.output_states[1] == "+")
+        assert_(qc.output_states[1] == "+")
+        assert_(qc.output_states[2] == None)
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -174,6 +174,27 @@ class TestQubitCircuit:
         assert_(qc.output_states[1] == "+")
         assert_(qc.output_states[2] == None)
 
+        qc1 = QubitCircuit(10)
+
+        qc1.add_state("0", targets=[2, 3, 5, 6])
+        qc1.add_state("+", targets=[1,4,9])
+        qc1.add_state("A", targets=[1,4,9], state_type="output")
+        qc1.add_state("A", targets=[1,4,9], state_type="output")
+        qc1.add_state("beta", targets=[0], state_type="output")
+        assert_(qc1.input_states[0] == None)
+        
+        assert_(qc1.input_states[2] == "0")
+        assert_(qc1.input_states[3] == "0")
+        assert_(qc1.input_states[6] == "0")
+        assert_(qc1.input_states[1] == "+")
+        assert_(qc1.input_states[4] == "+")
+
+        assert_(qc1.output_states[2] == None)        
+        assert_(qc1.output_states[1] == "A")
+        assert_(qc1.output_states[4] == "A")
+        assert_(qc1.output_states[9] == "A")
+
+        assert_(qc1.output_states[0] == "beta")
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This is an attempt to solve #678. The `QubitCircuit` class now has a method to add input and ouput states to a circuit. By default, all inputs and outputs are initialised to None. A new input state can be added similar to adding a gate by using the new function `add_state`. The user can specifying the state, the list of qubits where it should be added and the `state_type` as `input` or `output`.

States can be anything provided they are entered as a string.
```
qc = QubitCircuit(3)
qc.add_state("0", targets=[0])
qc.add_state("+", targets=[1], state_type="output")
qc.add_state("-", targets=[1])
```