### PR TITLE
Improve analytic calculation of coherent states.

### DIFF
--- a/qutip/states.py
+++ b/qutip/states.py
@@ -123,11 +123,6 @@ def qutrit_basis():
     return np.array([basis(3, 0), basis(3, 1), basis(3, 2)], dtype=object)
 
 
-def _sqrt_factorial(n_vec):
-    # take the square root before multiplying
-    return np.array([np.prod(np.sqrt(np.arange(1, n + 1))) for n in n_vec])
-
-
 def coherent(N, alpha, offset=0, method='operator'):
     """Generates a coherent state with eigenvalue alpha.
 
@@ -188,9 +183,14 @@ def coherent(N, alpha, offset=0, method='operator'):
     elif method == "analytic" or offset > 0:
 
         data = np.zeros([N, 1], dtype=complex)
-        n = arange(N) + offset
-        data[:, 0] = np.exp(-(abs(alpha) ** 2) / 2.0) * (alpha ** (n)) / \
-            _sqrt_factorial(n)
+        if offset == 0:
+            data[0] = np.exp(-abs(alpha)**2 / 2.0)
+        else:
+            s = np.prod(np.sqrt(np.arange(1, offset + 1))) # sqrt factorial
+            data[0] = np.exp(-abs(alpha)**2 / 2.0) * alpha**(offset) / s
+        for n in range(N-1):
+            data[n+1] = data[n]*alpha/np.sqrt(offset + n + 1)
+
         return Qobj(data)
 
     else:
@@ -478,7 +478,7 @@ def projection(N, n, m, offset=0):
     -------
     oper : qobj
          Requested projection operator.
-    
+
     """
     ket1 = basis(N, n, offset=offset)
     ket2 = basis(N, m, offset=offset)

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -182,16 +182,16 @@ def coherent(N, alpha, offset=0, method='operator'):
 
     elif method == "analytic" or offset > 0:
 
-        data = np.zeros([N, 1], dtype=complex)
+        sqrtn = np.sqrt(np.arange(offset, offset+N, dtype=complex))
+        sqrtn[0] = 1 # Get rid of divide by zero warning
+        data = alpha/sqrtn
         if offset == 0:
             data[0] = np.exp(-abs(alpha)**2 / 2.0)
         else:
             s = np.prod(np.sqrt(np.arange(1, offset + 1))) # sqrt factorial
             data[0] = np.exp(-abs(alpha)**2 / 2.0) * alpha**(offset) / s
-        for n in range(N-1):
-            data[n+1] = data[n]*alpha/np.sqrt(offset + n + 1)
-
-        return Qobj(data)
+        np.cumprod(data, out=sqrtn) # Reuse sqrtn array
+        return Qobj(sqrtn)
 
     else:
         raise TypeError(

--- a/qutip/tests/test_states.py
+++ b/qutip/tests/test_states.py
@@ -32,13 +32,26 @@
 ###############################################################################
 
 from numpy.testing import assert_, run_module_suite
-from qutip import coherent_dm, thermal_dm, fock_dm, triplet_states
+from qutip import (expect, destroy, coherent, coherent_dm, thermal_dm,
+                    fock_dm, triplet_states)
 
 
 class TestStates:
     """
     A test class for the QuTiP functions for generating quantum states
     """
+
+    def testCoherentState(self):
+        """
+        states: coherent state
+        """
+        N = 10
+        alpha = 0.5
+        c1 = coherent(N, alpha) # displacement method
+        c2 = coherent(7, alpha, offset=3) # analytic method
+        assert_(abs(expect(destroy(N), c1) - alpha) < 1e-10)
+        assert_((c1[3:]-c2).norm() < 1e-7)
+
 
     def testCoherentDensityMatrix(self):
         """


### PR DESCRIPTION
Instead of calculating the alpha**n/sqrt(n!) for every entry, calculate
it recursively by x_{n+1} = x_{n}*alpha/sqrt(n), thereby avoiding the
explicit calculation of the factorial. This way it works also for
dimensions>400 where it would fail before.

This comes with a speed improvement:
![benchmark_coherentstate](https://cloud.githubusercontent.com/assets/102507/24836249/399a4fba-1d17-11e7-9387-dd6ab9da1172.png)