### PR TITLE
Tiny bug-fix in def add_circuit(self, qc, start=0):

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -285,7 +285,7 @@ class QubitCircuit(object):
             The qubit on which the first gate is applied.
         """
 
-        if self.N - start < len(qc.gates):
+        if self.N - start < qc.N:
             raise NotImplementedError("Targets exceed number of qubits.")
 
         for gate in qc.gates:


### PR DESCRIPTION
The semantics seems incorrect.

qc.N should be used instead of len(qc.gates), we are checking if the added circuit (with a certain number of tracks) fits onto the parent circuit.

The number of gates don't feature.

Before:
<         if self.N - start < len(qc.gates):
After:
>         if self.N - start < qc.N: