### PR TITLE
ENH+BUG: Improved permute

### DIFF
--- a/qutip/cy/spconvert.pyx
+++ b/qutip/cy/spconvert.pyx
@@ -34,7 +34,7 @@ import numpy as np
 from qutip.fastsparse import fast_csr_matrix
 cimport numpy as np
 cimport cython
-from libc.stdlib cimport div
+from libc.stdlib cimport div, malloc, free
 
 cdef extern from "stdlib.h":
     ctypedef struct div_t:
@@ -229,3 +229,39 @@ def zcsr_reshape(object A not None, int new_rows, int new_cols):
     COO_to_CSR_inplace(&out, &mat)
     sort_indices(&out)
     return CSR_to_scipy(&out)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+def cy_index_permute(int [::1] idx_arr,
+                     int [::1] dims,
+                     int [::1] order):
+    
+    cdef int ndims = dims.shape[0]
+    cdef int ii, n, dim, idx, orderr
+    
+    #the fastest way to allocate memory for a temporary array
+    cdef int * multi_idx = <int*> malloc(sizeof(int) * ndims)
+    
+    try:
+        for ii from 0 <= ii < idx_arr.shape[0]:
+            idx = idx_arr[ii]
+            
+            #First, decompose long index into multi-index
+            for n from ndims > n >= 0:
+                dim = dims[n]
+                multi_idx[n] = idx % dim
+                idx = idx // dim
+
+            #Finally, assemble new long index from reordered multi-index
+            dim = 1
+            idx = 0
+            for n from ndims > n >= 0:
+                orderr = order[n]
+                idx += multi_idx[orderr] * dim
+                dim *= dims[orderr]
+
+            idx_arr[ii] = idx
+    finally:
+        free(multi_idx)

--- a/qutip/permute.py
+++ b/qutip/permute.py
@@ -36,7 +36,7 @@ __all__ = ['reshuffle']
 import numpy as np
 import scipy.sparse as sp
 from qutip.cy.ptrace import _select
-from qutip.cy.spconvert import arr_coo2fast
+from qutip.cy.spconvert import arr_coo2fast, cy_index_permute
 
 
 def _chunk_dims(dims, order):
@@ -48,21 +48,34 @@ def _chunk_dims(dims, order):
 
 
 def _permute(Q, order):
-    if Q.isket or Q.isbra or Q.isoper:
-    	Qcoo = Q.data.tocoo()
-    	ridx, cidx = Qcoo.row, Qcoo.col
-    	r_multi_indx = np.unravel_index(ridx, Q.dims[0])
-    	c_multi_indx = np.unravel_index(cidx, Q.dims[1])
-    	r_multi_indx = tuple(r_multi_indx[i] for i in order)
-    	c_multi_indx = tuple(c_multi_indx[i] for i in order)
-    	new_dims = [[Q.dims[0][i] for i in order], [Q.dims[1][i] for i in order]]
-    	ridx = np.asarray(np.ravel_multi_index(r_multi_indx, new_dims[0]), dtype=np.int32)
-    	cidx = np.asarray(np.ravel_multi_index(c_multi_indx, new_dims[1]), dtype=np.int32)
-    	return arr_coo2fast(Qcoo.data, ridx, cidx, Qcoo.shape[0], Qcoo.shape[1]), new_dims
+    Qcoo = Q.data.tocoo()
+    
+    if Q.isket:
+        cy_index_permute(Qcoo.row,
+                         np.array(Q.dims[0], dtype=np.int32),
+                         np.array(order, dtype=np.int32))
+        
+        new_dims = [[Q.dims[0][i] for i in order], Q.dims[1]]
 
+    elif Q.isbra:
+        cy_index_permute(Qcoo.col,
+                         np.array(Q.dims[1], dtype=np.int32),
+                         np.array(order, dtype=np.int32))
+        
+        new_dims = [Q.dims[0], [Q.dims[1][i] for i in order]]
 
-    elif Q.issuper or Q.isoperket:
-        # For superoperators, we expect order to be something like
+    elif Q.isoper:
+        cy_index_permute(Qcoo.row,
+                         np.array(Q.dims[0], dtype=np.int32),
+                         np.array(order, dtype=np.int32))
+        cy_index_permute(Qcoo.col,
+                         np.array(Q.dims[1], dtype=np.int32),
+                         np.array(order, dtype=np.int32))
+        
+        new_dims = [[Q.dims[0][i] for i in order], [Q.dims[1][i] for i in order]]
+    
+    elif Q.isoperket:
+    	# For superoperators, we expect order to be something like
         # [[0, 2], [1, 3]], which tells us to permute according to
         # [0, 2, 1 ,3], and then group indices according to the length
         # of each sublist.
@@ -75,30 +88,45 @@ def _permute(Q, order):
         # Since this is a super, the left index itself breaks into left
         # and right indices, each of which breaks down further.
         # The best way to deal with that here is to flatten dims.
-        flat_order = sum(order, [])
-        q_dims_left = sum(Q.dims[0], [])
-        dims, perm = _perm_inds(q_dims_left, flat_order)
-        dims = dims.flatten()
-
-        data = np.ones(Q.shape[0], dtype=complex)
-        rows = np.arange(Q.shape[0], dtype=np.int32)
-
-        perm_matrix = arr_coo2fast(data, rows, (perm.T[0]).astype(np.int32),
-                                    Q.shape[0], Q.shape[0])
-
-        dims_part = list(dims[flat_order])
-
+        
+        flat_order = np.array(sum(order, []), dtype=np.int32)
+        q_dims = np.array(sum(Q.dims[0], []), dtype=np.int32)
+        
+        cy_index_permute(Qcoo.row, q_dims, flat_order)
+        
         # Finally, we need to restructure the now-decomposed left index
         # into left and right subindices, so that the overall dims we return
         # are of the form specified by order.
-        dims_part = list(_chunk_dims(dims_part, order))
-        perm_left = (perm_matrix * Q.data)
-        if Q.type == 'operator-ket':
-            return perm_left, [dims_part, [1]]
-        elif Q.type == 'super':
-            return perm_left * perm_matrix.T, [dims_part, dims_part]
+        
+        new_dims = [q_dims[i] for i in flat_order]
+        new_dims = list(_chunk_dims(new_dims, order))
+        new_dims = [new_dims, [1]]
+    
+    elif Q.isoperbra:
+        flat_order = np.array(sum(order, []), dtype=np.int32)
+        q_dims = np.array(sum(Q.dims[1], []), dtype=np.int32)
+        
+        cy_index_permute(Qcoo.col, q_dims, flat_order)
+        
+        new_dims = [q_dims[i] for i in flat_order]
+        new_dims = list(_chunk_dims(new_dims, order))
+        new_dims = [[1], new_dims]
+    
+    elif Q.issuper:
+        flat_order = np.array(sum(order, []), dtype=np.int32)
+        q_dims = np.array(sum(Q.dims[0], []), dtype=np.int32)
+        
+        cy_index_permute(Qcoo.row, q_dims, flat_order)
+        cy_index_permute(Qcoo.col, q_dims, flat_order)
+        
+        new_dims = [q_dims[i] for i in flat_order]
+        new_dims = list(_chunk_dims(new_dims, order))
+        new_dims = [new_dims, new_dims]
+        
     else:
         raise TypeError('Invalid quantum object for permutation.')
+    
+    return arr_coo2fast(Qcoo.data, Qcoo.row, Qcoo.col, Qcoo.shape[0], Qcoo.shape[1]), new_dims
 
 
 def _perm_inds(dims, order):

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -623,6 +623,22 @@ def test_QobjPermute():
         rho = tensor(A, B, C)
         rho2 = rho.permute([1, 0, 2])
         assert_(rho2 == tensor(B, A, C))
+        
+        rho_vec = operator_to_vector(rho)
+        rho2_vec = rho_vec.permute([[1, 0, 2],[4,3,5]])
+        assert_(rho2_vec == operator_to_vector(tensor(B, A, C)))
+        
+        rho_vec_bra = operator_to_vector(rho).dag()
+        rho2_vec_bra = rho_vec_bra.permute([[1, 0, 2],[4,3,5]])
+        assert_(rho2_vec_bra == operator_to_vector(tensor(B, A, C)).dag())
+        
+    for ii in range(3):
+        super_dims = [3, 5, 4]
+        U = rand_unitary(np.prod(super_dims), density=0.02, dims=[super_dims, super_dims])
+        Unew = U.permute([2,1,0])
+        S_tens = to_super(U)
+        S_tens_new = to_super(Unew)
+        assert_(S_tens_new == S_tens.permute([[2,1,0],[5,4,3]]))
 
 
 def test_KetType():

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -586,9 +586,9 @@ def test_QobjNorm():
 
 def test_QobjPermute():
     "Qobj permute"
-    A = basis(5, 0)
+    A = basis(3, 0)
     B = basis(5, 4)
-    C = basis(5, 2)
+    C = basis(4, 2)
     psi = tensor(A, B, C)
     psi2 = psi.permute([2, 0, 1])
     assert_(psi2 == tensor(C, A, B))
@@ -597,16 +597,16 @@ def test_QobjPermute():
     psi2_bra = psi_bra.permute([2, 0, 1])
     assert_(psi2_bra == tensor(C, A, B).dag())
 
-    A = fock_dm(5, 0)
+    A = fock_dm(3, 0)
     B = fock_dm(5, 4)
-    C = fock_dm(5, 2)
+    C = fock_dm(4, 2)
     rho = tensor(A, B, C)
     rho2 = rho.permute([2, 0, 1])
     assert_(rho2 == tensor(C, A, B))
 
     for ii in range(3):
-        A = rand_ket(5)
-        B = rand_ket(5)
+        A = rand_ket(3)
+        B = rand_ket(4)
         C = rand_ket(5)
         psi = tensor(A, B, C)
         psi2 = psi.permute([1, 0, 2])
@@ -617,8 +617,8 @@ def test_QobjPermute():
         assert_(psi2_bra == tensor(B, A, C).dag())
 
     for ii in range(3):
-        A = rand_dm(5)
-        B = rand_dm(5)
+        A = rand_dm(3)
+        B = rand_dm(4)
         C = rand_dm(5)
         rho = tensor(A, B, C)
         rho2 = rho.permute([1, 0, 2])


### PR DESCRIPTION
Better way to permute Qobj. Captured a bug where old permute didn't permute dimensions.
UPDATE: Now works for super objects (including operator-bra)
Benchmark (permute 1st and last qubits):
<img width="520" alt="unknown-1" src="https://cloud.githubusercontent.com/assets/4971779/26755844/811dbbce-4896-11e7-89b8-c11251b5a550.png">
<img width="520" alt="unknown-2" src="https://cloud.githubusercontent.com/assets/4971779/26755847/87cbe928-4896-11e7-8143-73ddcc77cd36.png">