### PR TITLE
Fix deprecated call to NumPy linspace in mesolve test.

### DIFF
--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -662,7 +662,7 @@ class TestMESolverMisc:
         c = tensor(qeye(N+1), qeye(N+1), destroy(N+1))
         H = a*b*c.dag() * c.dag() - a.dag()*b.dag()*c * c
 
-        times = np.linspace(0.0, 2.0, 100.0)
+        times = np.linspace(0.0, 2.0, 100)
         opts = Options(store_states=False, store_final_state=True)
         rho0 = ket2dm(psi0)
         result = mesolve(H, rho0, times, [], [a.dag()*a,b.dag()*b,c.dag()*c],options=opts)
@@ -679,7 +679,7 @@ class TestMESolverMisc:
         c = tensor(qeye(N+1), qeye(N+1), destroy(N+1))
         H = a*b*c.dag() * c.dag() - a.dag()*b.dag()*c * c
 
-        times = np.linspace(0.0, 2.0, 100.0)
+        times = np.linspace(0.0, 2.0, 100)
         opts = Options(store_states=False, store_final_state=True)
         result = mesolve(H, psi0, times, [], [a.dag()*a,b.dag()*b,c.dag()*c],options=opts)
         assert_(psi0.dims == result.final_state.dims)


### PR DESCRIPTION
Since NumPy 1.12, `np.linspace` raises a DeprecationWarning when its third `num` parameter cannot be safely interpreted as an integer. This method is used in the `mesolve` tests.

Fixed by feeding the calls to `linspace` 100 instead of 100.0.

The warning (in Travis CI):
 
![image](https://user-images.githubusercontent.com/220701/27771317-c325fe9c-5f4c-11e7-8d4b-66980255dcfd.png)

The deprecation: https://github.com/numpy/numpy/releases/tag/v1.12.0

