### PR TITLE
Fix creation of swap gates in qft_gate_sequence (#688)

### DIFF
--- a/qutip/qip/algorithms/qft.py
+++ b/qutip/qip/algorithms/qft.py
@@ -101,7 +101,7 @@ def qft_steps(N=1, swapping=True):
                 U_step_list.append(cphase(np.pi / (2 ** (i - j)), N,
                                           control=i, target=j))
             U_step_list.append(snot(N, i))
-        if swapping is True:
+        if swapping:
             for i in range(N // 2):
                 U_step_list.append(swap(N, [N - i - 1, i]))
 
@@ -135,12 +135,12 @@ def qft_gate_sequence(N=1, swapping=True):
     else:
         for i in range(N):
             for j in range(i):
-                qc.add_gate(r"CPHASE", targets=[j], controls=[i],
+                qc.add_gate("CPHASE", targets=[j], controls=[i],
                             arg_label=r"{\pi/2^{%d}}" % (i - j),
                             arg_value=np.pi / (2 ** (i - j)))
             qc.add_gate("SNOT", targets=[i])
-        if swapping is True:
+        if swapping:
             for i in range(N // 2):
-                qc.add_gate(r"SWAP", targets=[i], controls=[N - 1 - i])
+                qc.add_gate("SWAP", targets=[N - i - 1, i])
 
     return qc

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -85,9 +85,9 @@ class Gate(object):
         if name in ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
                     "SWAPalpha"]:
             if len(self.targets) != 2:
-                raise ValueError("Gate %s requires two target" % name)
+                raise ValueError("Gate %s requires two targets" % name)
             if self.controls is not None:
-                raise ValueError("Gate %s does not require a control" % name)
+                raise ValueError("Gate %s cannot have a control" % name)
 
         if name in ["CNOT", "CSIGN", "CRX", "CRY", "CRZ"]:
             if self.targets is None or len(self.targets) != 1:

--- a/qutip/tests/test_qft.py
+++ b/qutip/tests/test_qft.py
@@ -80,7 +80,7 @@ class TestQFT:
             swaps = int(N // 2)
             assert_equal(len(circuit.gates), phases + swaps)
 
-            for i in range(phases, phases + swaps - 1):
+            for i in range(phases, phases + swaps):
                 assert_string_equal(circuit.gates[i].name, "SWAP")
 
 if __name__ == "__main__":

--- a/qutip/tests/test_qft.py
+++ b/qutip/tests/test_qft.py
@@ -31,8 +31,8 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-from numpy.testing import assert_, run_module_suite
-from qutip.qip.algorithms.qft import qft, qft_steps
+from numpy.testing import assert_, assert_equal, assert_string_equal, run_module_suite
+from qutip.qip.algorithms.qft import qft, qft_steps, qft_gate_sequence
 from qutip.qip.gates import gate_sequence_product
 
 
@@ -50,6 +50,38 @@ class TestQFT:
             U2 = gate_sequence_product(qft_steps(N))
             assert_((U1 - U2).norm() < 1e-12)
 
+    def testQFTGateSequenceNoSwapping(self):
+        """
+        qft: Inspect key properties of gate sequences of length N,
+        with swapping disabled.
+        """
+        for N in range(1, 6):
+            circuit = qft_gate_sequence(N, swapping=False)
+            assert_equal(circuit.N, N)
+
+            totsize = N * (N + 1) / 2
+            assert_equal(len(circuit.gates), totsize)
+
+            snots = sum(g.name == "SNOT" for g in circuit.gates)
+            assert_equal(snots, N)
+
+            phases = sum(g.name == "CPHASE" for g in circuit.gates)
+            assert_equal(phases, N * (N - 1) / 2)
+
+    def testQFTGateSequenceWithSwapping(self):
+        """
+        qft: Inspect swap gates added to gate sequences if
+        swapping is enabled.
+        """
+        for N in range(1, 6):
+            circuit = qft_gate_sequence(N, swapping=True)
+
+            phases = int(N * (N + 1) / 2)
+            swaps = int(N // 2)
+            assert_equal(len(circuit.gates), phases + swaps)
+
+            for i in range(phases, phases + swaps - 1):
+                assert_string_equal(circuit.gates[i].name, "SWAP")
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This fixes #688, following the suggestion by @mrcalixe.

The fix sets the swap targets to `[N - i - 1, i]`, instead of setting a target and a control separately.

The method `qft_gate_sequence` was untested: This pull request provides various test cases of varying length (1-6) and with and without swapping enabled.