### PR TITLE
BUG: Do tidyup before calculating isherm

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -363,6 +363,9 @@ class Qobj(object):
                 out.data.data = out.data.data + dat
 
             out.dims = self.dims
+           
+            out.tidyup() if settings.auto_tidyup
+           
             if isinstance(dat, (int, float)):
                 out._isherm = self._isherm
             else:
@@ -373,7 +376,7 @@ class Qobj(object):
 
             out.superrep = self.superrep
 
-            return out.tidyup() if settings.auto_tidyup else out
+            return out
 
         elif np.prod(self.shape) == 1 and np.prod(other.shape) != 1:
             # case for scalar quantum object
@@ -388,7 +391,9 @@ class Qobj(object):
                 out.data = other.data
                 out.data.data = out.data.data + dat
             out.dims = other.dims
-
+            
+            out.tidyup() if settings.auto_tidyup
+            
             if isinstance(dat, complex):
                 out._isherm = out.isherm
             else:
@@ -396,7 +401,7 @@ class Qobj(object):
 
             out.superrep = self.superrep
 
-            return out.tidyup() if settings.auto_tidyup else out
+            return out
 
         elif self.dims != other.dims:
             raise TypeError('Incompatible quantum object dimensions')
@@ -408,7 +413,8 @@ class Qobj(object):
             out = Qobj()
             out.data = self.data + other.data
             out.dims = self.dims
-
+            out.tidyup() if settings.auto_tidyup
+           
             if self.type in ['ket', 'bra', 'operator-ket', 'operator-bra']:
                 out._isherm = False
             elif self._isherm is None or other._isherm is None:
@@ -426,7 +432,7 @@ class Qobj(object):
 
                 out.superrep = self.superrep
 
-            return out.tidyup() if settings.auto_tidyup else out
+            return out
 
     def __radd__(self, other):
         """
@@ -456,7 +462,7 @@ class Qobj(object):
                 out.data = self.data * other.data
                 dims = [self.dims[0], other.dims[1]]
                 out.dims = dims
-
+                out.tidyup() if settings.auto_tidyup
                 if (not isinstance(dims[0][0], list) and
                         not isinstance(dims[1][0], list)):
                     # If neither left or right is a superoperator,
@@ -491,7 +497,7 @@ class Qobj(object):
 
                     out.superrep = self.superrep
 
-                return out.tidyup() if settings.auto_tidyup else out
+                return out
 
             elif np.prod(self.shape) == 1:
                 out = Qobj(other)
@@ -530,12 +536,13 @@ class Qobj(object):
             out.data = self.data * other
             out.dims = self.dims
             out.superrep = self.superrep
+            out.tidyup() if settings.auto_tidyup
             if isinstance(other, complex):
                 out._isherm = out.isherm
             else:
                 out._isherm = self._isherm
 
-            return out.tidyup() if settings.auto_tidyup else out
+            return out
 
         else:
             raise TypeError("Incompatible object for multiplication")
@@ -565,12 +572,13 @@ class Qobj(object):
             out.data = other * self.data
             out.dims = self.dims
             out.superrep = self.superrep
+            out.tidyup() if settings.auto_tidyup
             if isinstance(other, complex):
                 out._isherm = out.isherm
             else:
                 out._isherm = self._isherm
 
-            return out.tidyup() if settings.auto_tidyup else out
+            return out
 
         else:
             raise TypeError("Incompatible object for multiplication")
@@ -591,6 +599,7 @@ class Qobj(object):
             out = Qobj()
             out.data = self.data / other
             out.dims = self.dims
+            out.tidyup() if settings.auto_tidyup
             if isinstance(other, complex):
                 out._isherm = out.isherm
             else:
@@ -598,7 +607,7 @@ class Qobj(object):
 
             out.superrep = self.superrep
 
-            return out.tidyup() if settings.auto_tidyup else out
+            return out
 
         else:
             raise TypeError("Incompatible object for division")
@@ -611,8 +620,9 @@ class Qobj(object):
         out.data = -self.data
         out.dims = self.dims
         out.superrep = self.superrep
+        out.tidyup() if settings.auto_tidyup
         out._isherm = self._isherm
-        return out.tidyup() if settings.auto_tidyup else out
+        return out
 
     def __getitem__(self, ind):
         """

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -364,7 +364,7 @@ class Qobj(object):
 
             out.dims = self.dims
            
-            out.tidyup() if settings.auto_tidyup
+            if settings.auto_tidyup: out.tidyup()
            
             if isinstance(dat, (int, float)):
                 out._isherm = self._isherm
@@ -392,7 +392,7 @@ class Qobj(object):
                 out.data.data = out.data.data + dat
             out.dims = other.dims
             
-            out.tidyup() if settings.auto_tidyup
+            if settings.auto_tidyup: out.tidyup()
             
             if isinstance(dat, complex):
                 out._isherm = out.isherm
@@ -413,7 +413,7 @@ class Qobj(object):
             out = Qobj()
             out.data = self.data + other.data
             out.dims = self.dims
-            out.tidyup() if settings.auto_tidyup
+            if settings.auto_tidyup: out.tidyup()
            
             if self.type in ['ket', 'bra', 'operator-ket', 'operator-bra']:
                 out._isherm = False
@@ -462,7 +462,7 @@ class Qobj(object):
                 out.data = self.data * other.data
                 dims = [self.dims[0], other.dims[1]]
                 out.dims = dims
-                out.tidyup() if settings.auto_tidyup
+                if settings.auto_tidyup: out.tidyup()
                 if (not isinstance(dims[0][0], list) and
                         not isinstance(dims[1][0], list)):
                     # If neither left or right is a superoperator,
@@ -536,7 +536,7 @@ class Qobj(object):
             out.data = self.data * other
             out.dims = self.dims
             out.superrep = self.superrep
-            out.tidyup() if settings.auto_tidyup
+            if settings.auto_tidyup: out.tidyup()
             if isinstance(other, complex):
                 out._isherm = out.isherm
             else:
@@ -572,7 +572,7 @@ class Qobj(object):
             out.data = other * self.data
             out.dims = self.dims
             out.superrep = self.superrep
-            out.tidyup() if settings.auto_tidyup
+            if settings.auto_tidyup: out.tidyup()
             if isinstance(other, complex):
                 out._isherm = out.isherm
             else:
@@ -599,7 +599,7 @@ class Qobj(object):
             out = Qobj()
             out.data = self.data / other
             out.dims = self.dims
-            out.tidyup() if settings.auto_tidyup
+            if settings.auto_tidyup: out.tidyup()
             if isinstance(other, complex):
                 out._isherm = out.isherm
             else:
@@ -620,7 +620,7 @@ class Qobj(object):
         out.data = -self.data
         out.dims = self.dims
         out.superrep = self.superrep
-        out.tidyup() if settings.auto_tidyup
+        if settings.auto_tidyup: out.tidyup()
         out._isherm = self._isherm
         return out
 


### PR DESCRIPTION
There are issues where small flaoting point elements can give isherm=False, but are then removed by tidyup which should then result in isherm=True.  This does the tidyup and then isherm check.