### PR TITLE
ENH: Use OPENMP for tidyup if installed.

### DIFF
--- a/qutip/cy/openmp/omp_sparse_utils.pyx
+++ b/qutip/cy/openmp/omp_sparse_utils.pyx
@@ -1,0 +1,80 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without 
+#    modification, are permitted provided that the following conditions are 
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice, 
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+import numpy as np
+cimport numpy as cnp
+cimport cython
+from libcpp cimport bool
+from libc.math cimport fabs
+from cython.parallel cimport parallel, prange
+
+cdef extern from "<complex>" namespace "std" nogil:
+    double real(double complex x)
+    double imag(double complex x)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef bool omp_tidyup(complex[::1] data, double atol, int nnz, int nthr):
+    cdef int kk,
+    cdef double re, im
+    cdef bool re_flag, im_flag, out_flag = 0
+    with nogil, parallel(num_threads = nthr):
+        for kk in prange(nnz, schedule='static'):
+            re_flag = 0
+            im_flag = 0
+            re = real(data[kk]) 
+            im = imag(data[kk]) 
+            if fabs(re) < atol:
+                re = 0
+                re_flag = 1
+            if fabs(im) < atol:
+                im = 0
+                im_flag = 1
+            if re_flag or im_flag:
+                data[kk] = re +1j*im
+            if re_flag and im_flag:
+                out_flag = 1
+    return out_flag
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/qutip/cy/openmp/utilities.py
+++ b/qutip/cy/openmp/utilities.py
@@ -37,7 +37,7 @@ import qutip.settings as qset
 
 def check_use_openmp(options):
     """
-    Check to see if OPENMP should be used.
+    Check to see if OPENMP should be used in dynamic solvers.
     """
     force_omp = False
     if qset.has_openmp and options.use_openmp is None:
@@ -55,6 +55,16 @@ def check_use_openmp(options):
     #Disable OPENMP in parallel mode unless explicitly set.    
     if not force_omp and os.environ['QUTIP_IN_PARALLEL'] == 'TRUE':
         options.use_openmp = False
+
+
+def use_openmp():
+    """
+    Check for using openmp in general cases outside of dynamics
+    """
+    if qset.has_openmp and os.environ['QUTIP_IN_PARALLEL'] != 'TRUE':
+        return True
+    else:
+        return False
 
 
 def openmp_components(ptr_list):

--- a/qutip/cy/sparse_utils.pyx
+++ b/qutip/cy/sparse_utils.pyx
@@ -34,6 +34,7 @@ import numpy as np
 from qutip.fastsparse import fast_csr_matrix
 cimport numpy as cnp
 from libc.math cimport abs, fabs, sqrt
+from libcpp cimport bool
 cimport cython
 cnp.import_array()
 
@@ -345,17 +346,31 @@ cpdef double zcsr_inf_norm(complex[::1] data, int[::1] ind, int[::1] ptr,
     
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def cy_tidyup(complex[::1] data, double atol, unsigned int nnz):
+cpdef bool cy_tidyup(complex[::1] data, double atol, unsigned int nnz):
     """
     Performs an in-place tidyup of CSR matrix data
     """
     cdef size_t kk
     cdef double re, im
+    cdef bool re_flag, im_flag, out_flag = 0
     for kk in range(nnz):
+        re_flag = 0
+        im_flag = 0
         re = real(data[kk])
         im = imag(data[kk])
         if fabs(re) < atol:
             re = 0
+            re_flag = 1
         if fabs(im) < atol:
             im = 0
-        data[kk] = re + 1j*im
+            im_flag = 1
+        
+        if re_flag or im_flag:
+            data[kk] = re + 1j*im
+            
+        if re_flag and im_flag:
+            out_flag = 1
+    return out_flag
+        
+        
+        

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1265,12 +1265,12 @@ class Qobj(object):
             #This does the tidyup and returns True if
             #The sparse data needs to be shortened
             if use_openmp() and self.data.nnz > 500:
-                omp_tidyup(self.data.data,atol,self.data.nnz, 
-                            settings.num_cpus)
-                self.data.eliminate_zeros()
+                if omp_tidyup(self.data.data,atol,self.data.nnz, 
+                            settings.num_cpus):
+                            self.data.eliminate_zeros()
             else:
-                cy_tidyup(self.data.data,atol,self.data.nnz)
-                self.data.eliminate_zeros()
+                if cy_tidyup(self.data.data,atol,self.data.nnz):
+                    self.data.eliminate_zeros()
             return self
         else:
             return self

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -72,8 +72,9 @@ elif sys.version_info.major < 3:
     from itertools import izip_longest
     zip_longest = izip_longest
 
+#OPENMP stuff
+from qutip.cy.openmp.utilities import use_openmp
 if settings.has_openmp:
-    from qutip.cy.openmp.utilities import use_openmp
     from qutip.cy.openmp.omp_sparse_utils import omp_tidyup
 
 

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -72,6 +72,10 @@ elif sys.version_info.major < 3:
     from itertools import izip_longest
     zip_longest = izip_longest
 
+if settings.has_openmp:
+    from qutip.cy.openmp.utilities import use_openmp
+    from qutip.cy.openmp.omp_sparse_utils import omp_tidyup
+
 
 class Qobj(object):
     """A class for representing quantum objects, such as quantum operators
@@ -1241,7 +1245,7 @@ class Qobj(object):
         q.data, q.dims = _permute(self, order)
         return q.tidyup() if settings.auto_tidyup else q
 
-    def tidyup(self, atol=None):
+    def tidyup(self, atol=settings.auto_tidyup_atol):
         """Removes small elements from the quantum object.
 
         Parameters
@@ -1256,12 +1260,16 @@ class Qobj(object):
             Quantum object with small elements removed.
 
         """
-        if atol is None:
-            atol = settings.auto_tidyup_atol
-
         if self.data.nnz:
-            cy_tidyup(self.data.data,atol,self.data.nnz)
-            self.data.eliminate_zeros()
+            #This does the tidyup and returns True if
+            #The sparse data needs to be shortened
+            if use_openmp() and self.data.nnz > 500:
+                if omp_tidyup(self.data.data,atol,self.data.nnz,
+                            settings.num_cpus):
+                    self.data.eliminate_zeros()
+            else:
+                if cy_tidyup(self.data.data,atol,self.data.nnz):
+                    self.data.eliminate_zeros()
             return self
         else:
             return self

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1265,12 +1265,12 @@ class Qobj(object):
             #This does the tidyup and returns True if
             #The sparse data needs to be shortened
             if use_openmp() and self.data.nnz > 500:
-                if omp_tidyup(self.data.data,atol,self.data.nnz,
-                            settings.num_cpus):
-                    self.data.eliminate_zeros()
+                omp_tidyup(self.data.data,atol,self.data.nnz, 
+                            settings.num_cpus)
+                self.data.eliminate_zeros()
             else:
-                if cy_tidyup(self.data.data,atol,self.data.nnz):
-                    self.data.eliminate_zeros()
+                cy_tidyup(self.data.data,atol,self.data.nnz)
+                self.data.eliminate_zeros()
             return self
         else:
             return self

--- a/setup.py
+++ b/setup.py
@@ -214,6 +214,15 @@ if "--with-openmp" in sys.argv:
             extra_link_args=[],
             language='c++')
     EXT_MODULES.append(_mod)
+    
+    # Add omp_sparse_utils
+    _mod = Extension('qutip.cy.openmp.omp_sparse_utils',
+            sources = ['qutip/cy/openmp/omp_sparse_utils.pyx'],
+            include_dirs = [np.get_include()],
+            extra_compile_args=_compiler_flags+omp_flags,
+            extra_link_args=omp_args,
+            language='c++')
+    EXT_MODULES.append(_mod)
 
 
 # Remove -Wstrict-prototypes from cflags


### PR DESCRIPTION
It is much faster to use openmp to do the tidyup operation when NNZ > ~500.  Also, in many cases the tidyup operation does not actually result in any zero values in the sparse data, and as such, it is unnecessary to run the eliminate_zeros function.  Tidyup now returns a flag that indicates whether eliminate_zeros should be run.