### PR TITLE
Qtrl phase application

### DIFF
--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -647,7 +647,7 @@ class Dynamics(object):
         Set various memory optimisation attributes based on the 
         memory_optimization attribute
         If they have been set already, e.g. in apply_params
-        then they will not be overidden here
+        then they will not be overridden here
         """
         logger.info("Setting memory optimisations for level {}".format(
                     self.memory_optimization))
@@ -916,7 +916,7 @@ class Dynamics(object):
         """
         This default method does nothing.
         It will be set to another method automatically if `phase_application`
-        is 'preop' or 'postop'. It should be overidden repointed if
+        is 'preop' or 'postop'. It should be overridden repointed if
         `phase_application` is 'custom'
         It will never be called if `dyn_gen_phase` is None
         """

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -422,6 +422,7 @@ class Dynamics(object):
         self._ctrl_dyn_gen = None
         self._phased_ctrl_dyn_gen = None
         self._dyn_gen_phase = None
+        self._phase_application = None
         self._initial = None
         self._target = None
         self._onto_evo_target = None
@@ -458,6 +459,7 @@ class Dynamics(object):
         self.log_level = self.config.log_level
         # Internal flags
         self._dyn_gen_mapped = False
+        self._evo_initialized = False
         self._timeslots_initialized = False
         self._ctrls_initialized = False
         self._ctrl_dyn_gen_checked = False
@@ -747,9 +749,11 @@ class Dynamics(object):
             raise TypeError("target must be a Qobj")
 
         self.refresh_drift_attribs()
-        self._set_memory_optimizations()
         self.sys_dims = self.initial.dims
         self.sys_shape = self.initial.shape
+        # Set the phase application method
+        self._init_phase()
+        self._set_memory_optimizations()
         n_ts = self.num_tslots
         n_ctrls = self.num_ctrls
         if self.oper_dtype == Qobj:
@@ -793,8 +797,8 @@ class Dynamics(object):
             logger.warn("Unknown option '{}' for oper_dtype. "
                 "Assuming that internal drift, ctrls, initial and target "
                 "have been set correctly".format(self.oper_dtype))
-            
-        if self.cache_phased_dyn_gen and not self.dyn_gen_phase is None:
+
+        if self.cache_phased_dyn_gen:
             if self.time_depend_ctrl_dyn_gen:
                 self._phased_ctrl_dyn_gen = np.empty([n_ts, n_ctrls], 
                                                      dtype=object)
@@ -823,7 +827,7 @@ class Dynamics(object):
             # Onward propagation overlap with inverse target
             self._onto_evo = [object for x in range(self.num_tslots+1)]
             self._onto_evo[self.num_tslots] = self._get_onto_evo_target()
-
+            
         if isinstance(self.prop_computer, propcomp.PropCompDiag):
             self._create_decomp_lists()
 
@@ -838,7 +842,110 @@ class Dynamics(object):
             self.dump.create_dump_dir()
             logger.info("Dynamics dump will be written to:\n{}".format(
                             self.dump.dump_dir))
+            
+        self._evo_initialized = True
 
+    @property
+    def dyn_gen_phase(self):
+        """
+        Some op that is applied to the dyn_gen before expontiating to
+        get the propagator.
+        See `phase_application` for how this is applied
+        """
+        # Note that if this returns None then _apply_phase will never be
+        # called
+        return self._dyn_gen_phase
+    
+    @dyn_gen_phase.setter
+    def dyn_gen_phase(self, value):
+        self._dyn_gen_phase = value
+    
+    @property
+    def phase_application(self):
+        """
+        phase_application : scalar(string), default='preop'
+        Determines how the phase is applied to the dynamics generators
+         - 'preop'  : P = expm(phase*dyn_gen)
+         - 'postop' : P = expm(dyn_gen*phase)
+         - 'custom' : Customised phase application
+        The 'custom' option assumes that the _apply_phase method has been
+        set to a custom function
+        """
+        return self._phase_application
+
+    @phase_application.setter
+    def phase_application(self, value):
+        self._set_phase_application(value)
+        
+    def _set_phase_application(self, value):
+        self._config_phase_application(value)
+        self._phase_application = value
+
+    def _config_phase_application(self, ph_app=None):
+        """
+        Set the appropriate function for the phase application
+        """
+        err_msg = ("Invalid value '{}' for phase application. Must be either "
+                   "'preop', 'postop' or 'custom'".format(ph_app))
+        
+        if ph_app is None:
+            ph_app = self._phase_application
+            
+        try:
+            ph_app = ph_app.lower()
+        except:
+            raise ValueError(err_msg)
+
+        if ph_app == 'preop':
+            self._apply_phase = self._apply_phase_preop
+        elif ph_app == 'postop':
+            self._apply_phase = self._apply_phase_postop
+        elif ph_app == 'custom':
+            # Do nothing, assume _apply_phase set elsewhere
+            pass
+        else:
+            raise ValueError(err_msg)
+
+    def _init_phase(self):
+        if self.dyn_gen_phase is not None:
+            self._config_phase_application()
+        else:
+            self.cache_phased_dyn_gen = False
+            
+    def _apply_phase(self, dg):
+        """
+        This default method does nothing.
+        It will be set to another method automatically if `phase_application`
+        is 'preop' or 'postop'. It should be overidden repointed if
+        `phase_application` is 'custom'
+        It will never be called if `dyn_gen_phase` is None
+        """
+        return dg
+            
+    def _apply_phase_preop(self, dg):
+        """
+        Apply phasing operator to dynamics generator.
+        This called during the propagator calculation.
+        In this case it will be applied as phase*dg
+        """
+        if hasattr(self.dyn_gen_phase, 'dot'):
+            phased_dg = self._dyn_gen_phase.dot(dg)
+        else:
+            phased_dg = self._dyn_gen_phase*dg
+        return phased_dg
+
+    def _apply_phase_postop(self, dg):
+        """
+        Apply phasing operator to dynamics generator.
+        This called during the propagator calculation.
+        In this case it will be applied as dg*phase
+        """
+        if hasattr(self.dyn_gen_phase, 'dot'):
+            phased_dg = dg.dot(self._dyn_gen_phase)
+        else:
+            phased_dg = dg*self._dyn_gen_phase
+        return phased_dg
+        
     def _create_decomp_lists(self):
         """
         Create lists that will hold the eigen decomposition
@@ -1119,28 +1226,7 @@ class Dynamics(object):
         self._dyn_gen[k] = dg
         if self.cache_phased_dyn_gen:
             self._phased_dyn_gen[k] = self._apply_phase(dg)
-
-    @property
-    def dyn_gen_phase(self):
-        """
-        Some preop that is applied to the dyn_gen before expontiating to
-        get the propagator
-        """
-        return self._dyn_gen_phase
-    
-    def _apply_phase(self, dg):
-        """
-        Apply some phase factor or operator
-        """
-        if self.dyn_gen_phase is None:
-            phased_dg = dg
-        else:
-            if hasattr(self.dyn_gen_phase, 'dot'):
-                phased_dg = self.dyn_gen_phase.dot(dg)
-            else:
-                phased_dg = self.dyn_gen_phase*dg
-        return phased_dg
-
+   
     def get_dyn_gen(self, k):
         """
         Get the combined dynamics generator for the timeslot
@@ -1176,9 +1262,15 @@ class Dynamics(object):
                 return self._phased_ctrl_dyn_gen[j]
         else:
             if self.time_depend_ctrl_dyn_gen:
-                return self._apply_phase(self._ctrl_dyn_gen[k, j])
+                if self.dyn_gen_phase is None:
+                    return self._ctrl_dyn_gen[k, j]
+                else:
+                    return self._apply_phase(self._ctrl_dyn_gen[k, j])
             else:
-                return self._apply_phase(self._ctrl_dyn_gen[j])
+                if self.dyn_gen_phase is None:
+                    return self._ctrl_dyn_gen[j]
+                else:
+                    return self._apply_phase(self._ctrl_dyn_gen[j])
 
     @property
     def dyn_gen(self):
@@ -1430,6 +1522,7 @@ class DynamicsUnitary(Dynamics):
         self.ctrl_ham = None
         self.H = None
         self._dyn_gen_phase = -1j
+        self._phase_application = 'preop'
         self.apply_params()
 
     def _create_computers(self):
@@ -1636,6 +1729,7 @@ class DynamicsSymplectic(Dynamics):
         self.id_text = 'SYMPL'
         self._omega = None
         self._omega_qobj = None
+        self._phase_application = 'postop'
         self.grad_exact = True
         self.apply_params()
 
@@ -1674,29 +1768,38 @@ class DynamicsSymplectic(Dynamics):
             else:
                  self._omega = omg
         return self._omega
-    
+        
+    def _set_phase_application(self, value):
+        Dynamics._set_phase_application(self, value)
+        if self._evo_initialized:
+            phase = self._get_dyn_gen_phase()
+            if phase is not None:
+                self._dyn_gen_phase = phase
+
+    def _get_dyn_gen_phase(self):
+        if self._phase_application == 'postop':
+            phase = -self._get_omega()
+        elif self._phase_application == 'preop':
+            phase = self._get_omega()
+        elif self._phase_application == 'custom':
+            phase = None
+            # Assume phase set by user
+        else:
+            raise ValueError("No option for phase_application "
+                             "'{}'".format(self._phase_application))
+        return phase
+                
     @property
     def dyn_gen_phase(self):
         """
-        The prephasing operator for the symplectic group generators
+        The phasing operator for the symplectic group generators
         usually refered to as \Omega
+        By default this is applied as 'postop' dyn_gen*-\Omega
+        If phase_application is 'preop' it is applied as \Omega*dyn_gen
         """
         # Cannot be calculated until the dyn_shape is set
-        # that is after the drift Hamitonan has been set.
+        # that is after the drift dyn gen has been set.
         if self._dyn_gen_phase is None:
-            self._dyn_gen_phase = self._get_omega()
-
+            self._dyn_gen_phase = self._get_dyn_gen_phase()
         return self._dyn_gen_phase
 
-    def _apply_phase(self, dg):
-        """
-        Apply some phase factor or operator
-        """
-        if self.dyn_gen_phase is None:
-            phased_dg = dg
-        else:
-            if hasattr(self.dyn_gen_phase, 'dot'):
-                phased_dg = -dg.dot(self.dyn_gen_phase)
-            else:
-                phased_dg = -dg*self.dyn_gen_phase
-        return phased_dg

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -1802,4 +1802,3 @@ class DynamicsSymplectic(Dynamics):
         if self._dyn_gen_phase is None:
             self._dyn_gen_phase = self._get_dyn_gen_phase()
         return self._dyn_gen_phase
-


### PR DESCRIPTION
New dynamics property `phase_application` added to set whether dyn gen phase operator is applied as LHS or RHS operator. Specifically added for use with DynamicsSymplectic, as it would seem there are some cases where one might want to apply $\Omega$ as a 'prepop' rather than a 'postop'.

A bit of general tidying up of the _apply_phase function and phase caching as well