### PR TITLE
Fixes #746: Trace norm for non-herm

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -953,9 +953,12 @@ class Qobj(object):
         """
         if self.type in ['oper', 'super']:
             if norm is None or norm == 'tr':
-                vals = sp_eigs(self.data, self.isherm, vecs=False,
-                               sparse=sparse, tol=tol, maxiter=maxiter)
-                return np.sum(sqrt(abs(vals) ** 2))
+                if self.isherm:
+                    vals = sp_eigs(self.data, self.isherm, vecs=False,
+                                   sparse=sparse, tol=tol, maxiter=maxiter)
+                    return np.sum(sqrt(abs(vals) ** 2))
+                else:
+                    return (self * self.dag()).sqrtm().tr()
             elif norm == 'fro':
                 return sp_fro_norm(self.data)
             elif norm == 'one':

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -583,6 +583,10 @@ def test_QobjNorm():
     assert_equal(
         np.abs(A.norm('fro') - la.norm(A.full(), 'fro')) < 1e-12, True)
 
+    # Test trace norm for non-hermitian operators
+    s = Qobj([[0., 1], [0., 0.]])
+    assert_equal(s.norm(), 1.)
+
 
 def test_QobjPermute():
     "Qobj permute"


### PR DESCRIPTION
This is the most naive way perhaps to do this. But since it uses Qobj functions to do it I am guessing it is the most efficient and takes into consideration sparse matrices etc.

@ajgpitch 