### PR TITLE
WIP: Citation message and bibtex generator

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include LICENSE.txt
 include requirements.txt
+include qutip.bib

--- a/qutip.bib
+++ b/qutip.bib
@@ -1,0 +1,26 @@
+@article{Johansson2013,
+  doi = {10.1016/j.cpc.2012.11.019},
+  url = {https://doi.org/10.1016/j.cpc.2012.11.019},
+  year  = {2013},
+  month = {apr},
+  publisher = {Elsevier {BV}},
+  volume = {184},
+  number = {4},
+  pages = {1234--1240},
+  author = {J.R. Johansson and P.D. Nation and Franco Nori},
+  title = {{QuTiP} 2: A Python framework for the dynamics of open quantum systems},
+  journal = {Computer Physics Communications}
+}
+@article{Johansson2012,
+  doi = {10.1016/j.cpc.2012.02.021},
+  url = {https://doi.org/10.1016/j.cpc.2012.02.021},
+  year  = {2012},
+  month = {aug},
+  publisher = {Elsevier {BV}},
+  volume = {183},
+  number = {8},
+  pages = {1760--1772},
+  author = {J.R. Johansson and P.D. Nation and Franco Nori},
+  title = {{QuTiP}: An open-source Python framework for the dynamics of open quantum systems},
+  journal = {Computer Physics Communications}
+}

--- a/qutip.bib
+++ b/qutip.bib
@@ -1,4 +1,4 @@
-@article{Johansson2013,
+@article{qutip2,
   doi = {10.1016/j.cpc.2012.11.019},
   url = {https://doi.org/10.1016/j.cpc.2012.11.019},
   year  = {2013},
@@ -11,7 +11,7 @@
   title = {{QuTiP} 2: A Python framework for the dynamics of open quantum systems},
   journal = {Computer Physics Communications}
 }
-@article{Johansson2012,
+@article{qutip1,
   doi = {10.1016/j.cpc.2012.02.021},
   url = {https://doi.org/10.1016/j.cpc.2012.02.021},
   year  = {2012},

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -33,7 +33,7 @@
 """
 Command line output of information on QuTiP and dependencies.
 """
-__all__ = ['about']
+__all__ = ['about', 'cite']
 
 import sys
 import os
@@ -84,7 +84,54 @@ def about():
     print("Installation path:  %s" % qutip_install_path)
     print("")
 
+
+def cite(path=None, verbose=True):
+    """
+    Citation information and bibtex generator for QuTiP
+
+    Parameters
+    ----------
+    path: str
+        The complete directory path to generate the bibtex file.
+        If not specified then the citation will be generated in cwd
+    """
+    citation = ["@article{Johansson2013,",
+                "doi = {10.1016/j.cpc.2012.11.019},",
+                "url = {https://doi.org/10.1016/j.cpc.2012.11.019},",
+                "year  = {2013},",
+                "month = {apr},",
+                "publisher = {Elsevier {BV}},",
+                "volume = {184},",
+                "number = {4},",
+                "pages = {1234--1240},",
+                "author = {J.R. Johansson and P.D. Nation and Franco Nori},",
+                "title = {{QuTiP} 2: A Python framework for the dynamics of open quantum systems},",
+                "journal = {Computer Physics Communications}",
+                "}",
+                "@article{Johansson2012,",
+                "doi = {10.1016/j.cpc.2012.02.021},",
+                "url = {https://doi.org/10.1016/j.cpc.2012.02.021},",
+                "year  = {2012},",
+                "month = {aug},",
+                "publisher = {Elsevier {BV}},",
+                "volume = {183},",
+                "number = {8},",
+                "pages = {1760--1772},",
+                "author = {J.R. Johansson and P.D. Nation and Franco Nori},",
+                "title = {{QuTiP}: An open-source Python framework for the dynamics of open quantum systems},",
+                "journal = {Computer Physics Communications}",
+                "}"]
+
+    if verbose:
+        print("\n".join(citation))
+
+    if not path:
+        path = os.getcwd()
+
+    filename = "qutip.bib"
+    with open(os.path.join(path, filename), 'w') as f:
+        f.write("\n".join(citation))
+
+
 if __name__ == "__main__":
     about()
-
-

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -82,7 +82,8 @@ def about():
                                            platform.machine()))
     qutip_install_path = os.path.dirname(inspect.getsourcefile(qutip))
     print("Installation path:  %s" % qutip_install_path)
-    print("Please cite QuTiP in your publication - for you convenience a bibtex file can be easily generated using `qutip.about.cite()`")
+    print("Please cite QuTiP in your publication.")
+    print("For your convenience a bibtex file can be easily generated using `qutip.about.cite()`")
 
 def cite(path=None, verbose=True):
     """

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -82,8 +82,7 @@ def about():
                                            platform.machine()))
     qutip_install_path = os.path.dirname(inspect.getsourcefile(qutip))
     print("Installation path:  %s" % qutip_install_path)
-    print("")
-
+    print("Please cite QuTiP in your publication - for you convenience a bibtex file can be easily generated using `qutip.about.cite()`")
 
 def cite(path=None, verbose=True):
     """
@@ -95,7 +94,7 @@ def cite(path=None, verbose=True):
         The complete directory path to generate the bibtex file.
         If not specified then the citation will be generated in cwd
     """
-    citation = ["@article{Johansson2013,",
+    citation = ["@article{qutip2,",
                 "doi = {10.1016/j.cpc.2012.11.019},",
                 "url = {https://doi.org/10.1016/j.cpc.2012.11.019},",
                 "year  = {2013},",
@@ -108,7 +107,7 @@ def cite(path=None, verbose=True):
                 "title = {{QuTiP} 2: A Python framework for the dynamics of open quantum systems},",
                 "journal = {Computer Physics Communications}",
                 "}",
-                "@article{Johansson2012,",
+                "@article{qutip1,",
                 "doi = {10.1016/j.cpc.2012.02.021},",
                 "url = {https://doi.org/10.1016/j.cpc.2012.02.021},",
                 "year  = {2012},",

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,8 @@ cy_exts = ['spmatfuncs', 'stochastic', 'sparse_utils', 'graph_utils', 'interpola
         'brtools_testing', 'br_tensor']
 
 # If on Win and Python version >= 3.5 and not in MSYS2 (i.e. Visual studio compile)
-if sys.platform == 'win32' and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35 and os.environ.get('MSYSTEM') is None:
+if (sys.platform == 'win32' and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35
+    and os.environ.get('MSYSTEM') is None):
     _compiler_flags = ['/w', '/Ox']
 # Everything else
 else:
@@ -257,4 +258,5 @@ setup(
     **EXTRA_KWARGS
 )
 
-print("Installation complete\nPlease cite QuTiP in your publication - for you convenience a bibtex file can be easily generated using `qutip.about.cite()`")
+print("Installation complete\nPlease cite QuTiP in your publication.\n"
+      "For your convenience a bibtex file can be easily generated using `qutip.about.cite()`")

--- a/setup.py
+++ b/setup.py
@@ -256,3 +256,5 @@ setup(
     install_requires=INSTALL_REQUIRES,
     **EXTRA_KWARGS
 )
+
+print("Installation complete\nPlease cite QuTiP in your publication - for you convenience a bibtex file can be easily generated using `qutip.about.cite()`")


### PR DESCRIPTION
As discussed in #664 this PR is regarding citation reminders for QuTiP as it seems that many times users are unaware of the papers to cite when they use QuTiP.

I have added a bibtex file in the source now and into the MANIFEST file. We should discuss how to get this to the users attention. Creation of a cite() function which generates a bibtex entry in the working directory whenever qutip is imported could be one option. The other option is to put it in /home/qutip or print it out whenever a result class is called. We can also add a welcome message at setup which reminds users regarding the papers and points them to the bibtex file.

I am in favour of having a bibtex generator in __init__.py such that qutip.bib appears in the code folder whenever QuTiP is used.