### PR TITLE
ENH: Faster Q.matrix_element 

### DIFF
--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -973,6 +973,9 @@ def test_dual_channel():
 
 
 def test_call():
+    """
+    Test Qobj: Call
+    """
     # Make test objects.
     psi = rand_ket(3)
     rho = rand_dm_ginibre(3)
@@ -995,6 +998,30 @@ def test_call():
     # Case 4: super(super). Should raise TypeError.
     with expect_exception(TypeError):
         S(S)
+
+def test_matelem():
+    """
+    Test Qobj: Compute matrix elements
+    """
+    for kk in range(10):
+        N = 20
+        H = rand_herm(N,0.2)
+
+        L = rand_ket(N,0.3)
+        Ld = L.dag()
+        R = rand_ket(N,0.3)
+    
+        ans = (Ld*H*R).tr()
+    
+        #bra-ket
+        out1 = H.matrix_element(Ld,R)
+        #ket-ket
+        out2 = H.matrix_element(Ld,R)
+    
+        assert_(abs(ans-out1) < 1e-14)
+        assert_(abs(ans-out2) < 1e-14)
+    
+    
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Routine computes matrix elements about 10x faster than previous method.  It is slightly better not to actually use a bra-vector, but use a ket-vector instead, and let the computation handle the difference internally.