### PR TITLE
ENH: Add projector method to Qobj class

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -180,6 +180,8 @@ class Qobj(object):
         Returns norm of a ket or an operator.
     permute(order)
         Returns composite qobj with indices reordered.
+    proj()
+        Computes the projector for a ket or bra vector.
     ptrace(sel)
         Returns quantum object for selected dimensions after performing
         partial trace.

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -64,7 +64,7 @@ from qutip.sparse import (sp_eigs, sp_expm, sp_fro_norm, sp_max_norm,
                           sp_one_norm, sp_L2_norm)
 from qutip.dimensions import type_from_dims, enumerate_flat, collapse_dims_super
 from qutip.cy.spmath import (zcsr_transpose, zcsr_adjoint, zcsr_isherm,
-                            zcsr_trace)
+                            zcsr_trace, zcsr_proj)
 from qutip.cy.spmatfuncs import zcsr_mat_elem
 from qutip.cy.sparse_utils import cy_tidyup
 import sys
@@ -976,6 +976,31 @@ class Qobj(object):
             else:
                 raise ValueError("For vectors, norm must be 'l2', or 'max'.")
 
+    def proj(self):
+        """Form the projector from a given ket or bra vector.
+    
+        Parameters
+        ----------
+        Q : Qobj
+            Input bra or ket vector
+        
+        Returns
+        -------
+        P : Qobj
+            Projection operator.
+        """
+        if self.isket:
+            _out = zcsr_proj(self.data,1)
+            _dims = [self.dims[0],self.dims[0]]
+        elif self.isbra:
+            _out = zcsr_proj(self.data,0)
+            _dims = [self.dims[1],self.dims[1]]
+        else:
+            raise TypeError('Projector can only be formed from a bra or ket.')
+    
+        return Qobj(_out,dims=_dims)
+    
+    
     def tr(self):
         """Trace of a quantum object.
 

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -1022,6 +1022,22 @@ def test_matelem():
         assert_(abs(ans-out2) < 1e-14)
     
     
+def test_projection():
+    """
+    Test Qobj: Projection operator
+    """
+    for kk in range(10):
+        N = 5
+        K = tensor(rand_ket(N,0.75),rand_ket(N,0.75))
+        B = K.dag()
+        
+        ans = K*K.dag()
+        
+        out1 = K.proj()
+        out2 = B.proj()
+        
+        assert_(out1==ans)
+        assert_(out2==ans)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Compute the projector of a ket or bra Qobj via Q.proj().

This routine is ~3x faster than doing the outer product explicitly, and does not need a temp matrix.