### PR TITLE
Added exception to use GCC in Windows if running in MSYS2

### DIFF
--- a/qutip/cy/pyxbuilder.py
+++ b/qutip/cy/pyxbuilder.py
@@ -30,7 +30,7 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-import sys
+import sys, os
 import pyximport
 from pyximport import install
 
@@ -39,7 +39,8 @@ old_get_distutils_extension = pyximport.pyximport.get_distutils_extension
 def new_get_distutils_extension(modname, pyxfilename, language_level=None):
     extension_mod, setup_args = old_get_distutils_extension(modname, pyxfilename, language_level)
     extension_mod.language='c++'
-    if sys.platform == 'win32' and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35:
+    # If on Win and Python version >= 3.5 and not in MSYS2 (i.e. Visual studio compile)
+    if sys.platform == 'win32' and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35 and os.environ.get('MSYSTEM') is None:
         extension_mod.extra_compile_args = ['/w', '/O1']
     else:
         extension_mod.extra_compile_args = ['-w', '-O1']

--- a/setup.py
+++ b/setup.py
@@ -150,8 +150,8 @@ cy_exts = ['spmatfuncs', 'stochastic', 'sparse_utils', 'graph_utils', 'interpola
         'spmath', 'heom', 'math', 'spconvert', 'ptrace', 'testing', 'brtools',
         'brtools_testing']
 
-# If on Win and Python version >= 3.5 (i.e. Visual studio compile)
-if sys.platform == 'win32' and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35:
+# If on Win and Python version >= 3.5 and not in MSYS2 (i.e. Visual studio compile)
+if sys.platform == 'win32' and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35 and os.environ.get('MSYSTEM') is None:
     _compiler_flags = ['/w', '/Ox']
 # Everything else
 else:


### PR DESCRIPTION
When installing Qutip from source in an MSYS2 environment, the build flags should be set to GCC-style like in *nix installations - I updated the relevant files to do this. I just check for the existence of the MSYSTEM environment variable to check for this case.