### PR TITLE
hardware_info(): Replacing lscpu with /proc/cpuinfo

### DIFF
--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -58,21 +58,23 @@ def _linux_hardware_info():
     # get cpu number
     sockets = 0
     cores_per_socket = 0
+    frequency = 0
     for l in [l.split(':') for l in open("/proc/cpuinfo").readlines()]:
         if (l[0].strip() == "physical id"):
             sockets = np.maximum(sockets,int(l[1].strip())+1)
         if (l[0].strip() == "cpu cores"):
             cores_per_socket = int(l[1].strip())
+        if (l[0].strip() == "cpu MHz"):
+            frequency = int(l[1].strip())
     results.update({'cpus': sockets * cores_per_socket})
     # get cpu frequency directly (bypasses freq scaling)
     try:
         file = "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"
-        cpu_freq = open(file).readlines()[0]
-        cpu_freq = float(cpu_freq.strip('\n'))
-        results.update({'cpu_freq': cpu_freq / (1000. ** 2)})
+        line = open(file).readlines()[0]
+        frequency = float(line.strip('\n')) / (1000. ** 2)
     except:
-        cpu_freq = float(cpu_info['CPU MHz']) / 1000.
-        results.update({'cpu_freq': cpu_freq})
+        pass
+    results.update({'cpu_freq': frequency})
 
     # get total amount of memory
     mem_info = dict()
@@ -110,14 +112,17 @@ def hardware_info():
         Dictionary containing cpu and memory information.
 
     """
-    if sys.platform == 'darwin':
-        out = _mac_hardware_info()
-    elif sys.platform == 'win32':
-        out = _win_hardware_info()
-    elif sys.platform in ['linux', 'linux2']:
-        out = _linux_hardware_info()
-    else:
-        out = {}
+    try:
+        if sys.platform == 'darwin':
+            out = _mac_hardware_info()
+        elif sys.platform == 'win32':
+            out = _win_hardware_info()
+        elif sys.platform in ['linux', 'linux2']:
+            out = _linux_hardware_info()
+        else:
+            out = {}
+    except:
+        return {}
 
     return out
 

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -110,19 +110,16 @@ def hardware_info():
         Dictionary containing cpu and memory information.
 
     """
-    try:
-        if sys.platform == 'darwin':
-            out = _mac_hardware_info()
-        elif sys.platform == 'win32':
-            out = _win_hardware_info()
-        elif sys.platform in ['linux', 'linux2']:
-            out = _linux_hardware_info()
-        else:
-            out = {}
-    except:
-        return {}
+    if sys.platform == 'darwin':
+        out = _mac_hardware_info()
+    elif sys.platform == 'win32':
+        out = _win_hardware_info()
+    elif sys.platform in ['linux', 'linux2']:
+        out = _linux_hardware_info()
     else:
-        return out
+        out = {}
+
+    return out
 
 if __name__ == '__main__':
     print(hardware_info())

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -112,18 +112,14 @@ def hardware_info():
         Dictionary containing cpu and memory information.
 
     """
-    try:
-        if sys.platform == 'darwin':
-            out = _mac_hardware_info()
-        elif sys.platform == 'win32':
-            out = _win_hardware_info()
-        elif sys.platform in ['linux', 'linux2']:
-            out = _linux_hardware_info()
-        else:
-            out = {}
-    except:
-        return {}
-
+    if sys.platform == 'darwin':
+        out = _mac_hardware_info()
+    elif sys.platform == 'win32':
+        out = _win_hardware_info()
+    elif sys.platform in ['linux', 'linux2']:
+        out = _linux_hardware_info()
+    else:
+        out = {}
     return out
 
 if __name__ == '__main__':

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -36,6 +36,7 @@ __all__ = ['hardware_info']
 import os
 import sys
 import multiprocessing
+import numpy as np
 
 def _mac_hardware_info():
     info = dict()
@@ -55,11 +56,13 @@ def _mac_hardware_info():
 def _linux_hardware_info():
     results = {}
     # get cpu number
-    cpu_info = dict()
-    for l in [l.split(':') for l in os.popen('lscpu').readlines()]:
-        cpu_info[l[0]] = l[1].strip('.\n ').strip('kB')
-    sockets = int(cpu_info['Socket(s)'])
-    cores_per_socket = int(cpu_info['Core(s) per socket'])
+    sockets = 0
+    cores_per_socket = 0
+    for l in [l.split(':') for l in open("/proc/cpuinfo").readlines()]:
+        if (l[0].strip() == "physical id"):
+            sockets = np.maximum(sockets,int(l[1].strip())+1)
+        if (l[0].strip() == "cpu cores"):
+            cores_per_socket = int(l[1].strip())
     results.update({'cpus': sockets * cores_per_socket})
     # get cpu frequency directly (bypasses freq scaling)
     try:

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -58,20 +58,20 @@ def _linux_hardware_info():
     # get cpu number
     sockets = 0
     cores_per_socket = 0
-    frequency = 0
+    frequency = 0.0
     for l in [l.split(':') for l in open("/proc/cpuinfo").readlines()]:
         if (l[0].strip() == "physical id"):
             sockets = np.maximum(sockets,int(l[1].strip())+1)
         if (l[0].strip() == "cpu cores"):
             cores_per_socket = int(l[1].strip())
         if (l[0].strip() == "cpu MHz"):
-            frequency = int(l[1].strip())
+            frequency = float(l[1].strip()) / 1000.
     results.update({'cpus': sockets * cores_per_socket})
     # get cpu frequency directly (bypasses freq scaling)
     try:
         file = "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"
         line = open(file).readlines()[0]
-        frequency = float(line.strip('\n')) / (1000. ** 2)
+        frequency = float(line.strip('\n')) / 1000000.
     except:
         pass
     results.update({'cpu_freq': frequency})


### PR DESCRIPTION
lscpu is localisation dependant and breaks if the OS uses e.g. German. "Core(s) per socket" turns into "Kern(e) pro Socket" and results in a crash.

/proc/cpuinfo on the other hand remains the same same, therefore it is suited more as information source.