### PR TITLE
qutip/wigner.py: scipy.misc.factorial is deprecated

### DIFF
--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -48,7 +48,7 @@ from qutip.qobj import Qobj, isket, isoper
 from qutip.states import ket2dm
 from qutip.parallel import parfor
 from qutip.utilities import clebsch
-from scipy.misc import factorial
+from scipy.special import factorial
 from qutip.cy.sparse_utils import _csr_get_diag
 
 


### PR DESCRIPTION
There's a bunch of warnings in the build log that indicate that scipy.special.factorial should be used in favor of scipy.misc.factorial.