### PR TITLE
Fix a missing return in plot_animation helper

### DIFF
--- a/qutip/ipynbtools.py
+++ b/qutip/ipynbtools.py
@@ -42,14 +42,14 @@ import IPython
 if IPython.version_info[0] >= 4:
     try:
         from ipyparallel import Client
-        __all__ = ['version_table', 'parfor', 'plot_animation', 
+        __all__ = ['version_table', 'parfor', 'plot_animation',
                     'parallel_map', 'HTMLProgressBar']
     except:
          __all__ = ['version_table', 'plot_animation', 'HTMLProgressBar']
 else:
     try:
         from IPython.parallel import Client
-        __all__ = ['version_table', 'parfor', 'plot_animation', 
+        __all__ = ['version_table', 'parfor', 'plot_animation',
                     'parallel_map', 'HTMLProgressBar']
     except:
          __all__ = ['version_table', 'plot_animation', 'HTMLProgressBar']
@@ -384,7 +384,7 @@ def plot_animation(plot_setup_func, plot_func, result, name="movie",
     fig, axes = plot_setup_func(result)
 
     def update(n):
-        plot_func(result, n, fig=fig, axes=axes)
+        return plot_func(result, n, fig=fig, axes=axes)
 
     anim = animation.FuncAnimation(
         fig, update, frames=len(result.times), blit=True)


### PR DESCRIPTION
Hi,

As raised by someone on the mailing-list, there is a missing return in `qutip.ipynbtools.plot_animation` helper, leading to a `RuntimeError` when trying to execute the `JC-model-wigner-function.ipynb` example notebook.

This commit should address this issue.

Moreover, the previously mentionned notebook should be updated as well, but I am not sure where the source is. The `plot_result` function should read

```python
cb = None

def plot_result(result, n, fig=None, axes=None):
    
    global cb
    
    if fig is None or axes is None:
        fig, ax = plot_setup(result)
        
    axes.cla()

    # trace out the atom
    rho_cavity = ptrace(result.states[n], 0)

    W = wigner(rho_cavity, xvec, xvec)
    
    surf = axes.plot_surface(X, Y, W, rstride=1, cstride=1, cmap=cm.jet,
                             alpha=1.0, linewidth=0.05, vmax=0.25, vmin=-0.25)

    ax.set_xlim3d(-5, 5)
    ax.set_ylim3d(-5, 5)
    ax.set_zlim3d(-0.25, 0.25)

    if not cb:
        cb = plt.colorbar(surf, shrink=0.65, aspect=20)

    return surf,
```

It might be worth noting also that with proper documentation this notebook could potentially fix https://github.com/qutip/qutip/issues/544 as well.

Thanks,