### PR TITLE
ENH: BR solver updates

### DIFF
--- a/qutip/bloch_redfield.py
+++ b/qutip/bloch_redfield.py
@@ -43,6 +43,7 @@ import scipy.integrate
 import scipy.sparse as sp
 from qutip.qobj import Qobj, isket
 from qutip.states import ket2dm
+from qutip.operators import qdiags
 from qutip.superoperator import spre, spost, vec2mat, mat2vec, vec2mat_index
 from qutip.expect import expect
 from qutip.solver import Options, Result, config, _solver_safety_check
@@ -439,7 +440,7 @@ def bloch_redfield_tensor(H, a_ops, spectra_cb=None, c_ops=[], use_secular=True,
     
     #only Lindblad collapse terms
     if K==0:
-        Heb = H.transform(ekets)
+        Heb = qdiags(evals,0,dims=H.dims)
         L = liouvillian(Heb, c_ops=[c_op.transform(ekets) for c_op in c_ops])
         return L, ekets
     
@@ -467,7 +468,7 @@ def bloch_redfield_tensor(H, a_ops, spectra_cb=None, c_ops=[], use_secular=True,
         Iab[1:] = vec2mat_index(N, I)
 
     # unitary part + dissipation from c_ops (if given):
-    Heb = H.transform(ekets)
+    Heb = qdiags(evals,0,dims=H.dims)
     L = liouvillian(Heb, c_ops=[c_op.transform(ekets) for c_op in c_ops])
     
     # dissipative part:

--- a/qutip/cy/openmp/br_omp.pyx
+++ b/qutip/cy/openmp/br_omp.pyx
@@ -192,9 +192,6 @@ cdef void br_term_mult_openmp(double t, complex[::1,:] A, complex[::1,:] evecs,
     cdef CSR_Matrix csr
     cdef complex[:,::1] non_sec_mat
     
-    if not use_secular:
-        non_sec_mat = <complex[:nrows**2, :nrows**2]><complex *>PyDataMem_NEW(nrows**4 * sizeof(complex))
-    
     for I in range(nrows**2):
         vec2mat_index(nrows, I, ab)
         for J in range(nrows**2):
@@ -216,35 +213,29 @@ cdef void br_term_mult_openmp(double t, complex[::1,:] A, complex[::1,:] evecs,
                         bd_elem += A_eig[ab[0],kk]*A_eig[kk,cd[0]] * spectral(skew[cd[0],kk],t)
                     elem -= 0.5*bd_elem
                     
-                if use_secular:
-                    if (elem != 0):
-                        coo_rows.push_back(I)
-                        coo_cols.push_back(J)
-                        coo_data.push_back(elem)
-                else:
-                    non_sec_mat[I,J] = elem
+                if (elem != 0):
+                    coo_rows.push_back(I)
+                    coo_cols.push_back(J)
+                    coo_data.push_back(elem)
     
     PyDataMem_FREE(&A_eig[0,0])
-    if use_secular:
-        #Number of elements in BR tensor
-        nnz = coo_rows.size()
-        coo.nnz = nnz
-        coo.rows = coo_rows.data()
-        coo.cols = coo_cols.data()
-        coo.data = coo_data.data()
-        coo.nrows = nrows**2
-        coo.ncols = nrows**2
-        coo.is_set = 1 
-        coo.max_length = nnz
-        COO_to_CSR(&csr, &coo)
-        if csr.nnz > omp_thresh:
-            spmvpy_openmp(csr.data, csr.indices, csr.indptr, vec, 1, out, nrows**2, nthr)
-        else:
-            spmvpy(csr.data, csr.indices, csr.indptr, vec, 1, out, nrows**2)
-        free_CSR(&csr)
+    
+    #Number of elements in BR tensor
+    nnz = coo_rows.size()
+    coo.nnz = nnz
+    coo.rows = coo_rows.data()
+    coo.cols = coo_cols.data()
+    coo.data = coo_data.data()
+    coo.nrows = nrows**2
+    coo.ncols = nrows**2
+    coo.is_set = 1 
+    coo.max_length = nnz
+    COO_to_CSR(&csr, &coo)
+    if csr.nnz > omp_thresh:
+        spmvpy_openmp(csr.data, csr.indices, csr.indptr, vec, 1, out, nrows**2, nthr)
     else:
-        ZGEMV(&non_sec_mat[0,0], vec, out, nrows**2, nrows**2, 1, 1, 1)
-        PyDataMem_FREE(&non_sec_mat[0,0])
+        spmvpy(csr.data, csr.indices, csr.indptr, vec, 1, out, nrows**2)
+    free_CSR(&csr)
  
 
  


### PR DESCRIPTION
- Favor sparse matrix BR tensor for non-secular evolution.

- Build diagonal Hamiltonian directly from evals to avoid small
off-diagonal nonzeros that popup when doing a basis transformation.