### PR TITLE
ENH: Allow for picking SS solver & access MKL solver internals

### DIFF
--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -229,7 +229,7 @@ def steadystate(A, c_op_list=[], method='direct', solver=None, **kwargs):
         if settings.has_mkl:
             if method in ['direct', 'power']:
                 solver = 'mkl'
-    elif ss_args['solver'] == 'mkl' and \
+    elif solver == 'mkl' and \
             (method not in ['direct', 'power']):
         raise Exception('MKL solver only for direct or power methods.')
         

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -162,6 +162,15 @@ def steadystate(A, c_op_list=[], method='direct', solver=None, **kwargs):
         to the linear solvers.  This is set to the average abs value of the
         Liouvillian elements if not specified by the user.
 
+    max_iter_refine : int {10}
+        MKL ONLY. Max. number of iterative refinements to perform.
+    
+    scaling_vectors : bool {True, False}
+        MKL ONLY.  Scale matrix to unit norm columns and rows.
+    
+    weighted_matching : bool {True, False}
+        MKL ONLY.  Use weighted matching to better condition diagonal.
+    
     x0 : ndarray, optional
         ITERATIVE ONLY. Initial guess for solution vector.
 


### PR DESCRIPTION
This Pull allows users to pick between the scipy and MKL sparse LU solvers for use in the steadystate solver.  This should also address Issue #791 by allowing for modifying the internals for the MKL solver.