### PR TITLE
ENH: Allow for Cubic_Spline td-terms for c_ops in mesolve

### DIFF
--- a/qutip/cy/codegen.py
+++ b/qutip/cy/codegen.py
@@ -166,6 +166,14 @@ class Codegen():
                            "complex[::1] data%d," % k +
                            "int[::1] idx%d," % k +
                            "int[::1] ptr%d" % k)
+                           
+        kk = len(self.h_tdterms)
+        for jj in range(len(self.c_td_splines)):
+            input_vars += (",\n        " +
+                           "complex[::1] data%d," % (jj+kk) +
+                           "int[::1] idx%d," % (jj+kk) +
+                           "int[::1] ptr%d" % (jj+kk))
+            
         if any(self.c_tdterms):
             for k in range(len(self.h_terms),
                            len(self.h_terms) + len(self.c_tdterms)):
@@ -275,6 +283,9 @@ class Codegen():
                         else:
                             str_out = "spmvpy(&data%s[0], &idx%s[0], &ptr%s[0], &vec[0], %s, out, num_rows)" % (
                                 ht, ht, ht, interp_str)
+                    #Do nothing if not a specified type
+                    else:
+                        str_out=  ''
                 func_vars.append(str_out)
 
         cstr = 0
@@ -288,26 +299,26 @@ class Codegen():
             for ct in range(terms):
                 cstr = str(ct + hinds + 1)
                 str_out = "spmvpy(&data%s[0], &idx%s[0], &ptr%s[0], &vec[0], %s, out, num_rows)" % (
-                        cstr, cstr, cstr, " abs(" + tdterms[ct] + ")**2")
+                        cstr, cstr, cstr, " (" + tdterms[ct] + ")**2")
                 cinds += 1
                 func_vars.append(str_out)
         
         #Collapse operators have cubic spline td-coeffs
-        c_idx = 0
         if len(self.c_td_splines) > 0:
+            func_vars.append(" ")
             for ct in range(len(self.c_td_splines)):
-                c_idx = str(ht+cstr+ct+1)
                 S = self.c_td_splines[ct]
+                c_idx = self.c_td_spline_flags[ct]
                 if not S.is_complex:
                     interp_str = "interp(t, %s, %s, spline%s)" % (S.a, S.b, spline)
                 else:
                     interp_str = "zinterp(t, %s, %s, spline%s)" % (S.a, S.b, spline)
                 spline += 1
                 
-                #check if need to wrap string with abs()**2
-                if c_td_spline_flags[ct]:
-                    interp_str = "abs("+interp_str+")**2"
-                
+                #check if need to wrap string with ()**2
+                if c_idx > 0:
+                    interp_str = "("+interp_str+")**2"
+                c_idx = abs(c_idx)
                 if self.use_openmp and self.omp_components[ht]:
                     str_out = "spmvpy_openmp(&data%s[0], &idx%s[0], &ptr%s[0], &vec[0], %s, out, num_rows, %s)" % (
                         c_idx, c_idx, c_idx, interp_str, self.omp_threads)

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -645,7 +645,77 @@ class TestMESolveSuperInit:
 
         fid = self.fidelitycheck(out1, out2, rho0vec)
         assert_(max(abs(1.0-fid)) < me_error, True)
-
+    
+    def test_me_interp1(self):
+        "mesolve: interp time-dependent collapse operator #1"
+        
+        N = 10  # number of basis states to consider
+        kappa = 0.2  # coupling to oscillator
+        tlist = np.linspace(0, 10, 100)
+        a = destroy(N)
+        H = a.dag() * a
+        psi0 = basis(N, 9)  # initial state
+        S = Cubic_Spline(tlist[0],tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
+        c_op_list = [[a, S]]
+        medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+        expt = medata.expect[0]
+        actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
+        avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
+        assert_(avg_diff < 1e-5)
+        
+    def test_me_interp2(self):
+         "mesolve: interp time-dependent collapse operator #2"
+         
+         N = 10  # number of basis states to consider
+         kappa = 0.2  # coupling to oscillator
+         tlist = np.linspace(0, 10, 100)
+         C = Cubic_Spline(tlist[0], tlist[-1], np.ones_like(tlist))
+         S = Cubic_Spline(tlist[0],tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
+         a = destroy(N)
+         H = [[a.dag() * a, C]]
+         psi0 = basis(N, 9)  # initial state
+         c_op_list = [[a, S]]
+         medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+         expt = medata.expect[0]
+         actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
+         avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
+         assert_(avg_diff < 1e-5)
+         
+    def test_me_interp3(self):
+        "mesolve: interp time-dependent collapse operator #3"
+        
+        N = 10  # number of basis states to consider
+        kappa = 0.2  # coupling to oscillator
+        tlist = np.linspace(0, 10, 100)
+        C = Cubic_Spline(tlist[0], tlist[-1], np.ones_like(tlist))
+        S = Cubic_Spline(tlist[0],tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
+        a = destroy(N)
+        H = [a.dag() * a, [a.dag() * a, C]]
+        psi0 = basis(N, 9)  # initial state
+        c_op_list = [[a, S]]
+        medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+        expt = medata.expect[0]
+        actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
+        avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
+        assert_(avg_diff < 1e-5)
+        
+    def test_me_interp4(self):
+        "mesolve: interp time-dependent collapse operator #4"
+        
+        N = 10  # number of basis states to consider
+        kappa = 0.2  # coupling to oscillator
+        tlist = np.linspace(0, 10, 100)
+        C = Cubic_Spline(tlist[0], tlist[-1], np.ones_like(tlist))
+        S = Cubic_Spline(tlist[0],tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
+        a = destroy(N)
+        H = [a.dag() * a, [a.dag() * a, C]]
+        psi0 = basis(N, 9)  # initial state
+        c_op_list = [[a, S],[a, S]]
+        medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+        expt = medata.expect[0]
+        actual_answer = 9.0 * np.exp(-2*kappa * (1.0 - np.exp(-tlist)))
+        avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
+        assert_(avg_diff < 1e-5)
 
 class TestMESolverMisc:
     """


### PR DESCRIPTION
Pull allows for passing the interpolation Cubic_Spline functions as time-dependent arguments for the collapse operators in mesolve.