### PR TITLE
Stochastic 

### DIFF
--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -169,6 +169,7 @@ else:
 
 # core
 from qutip.qobj import *
+from qutip.td_qobj import *
 from qutip.states import *
 from qutip.operators import *
 from qutip.expect import *

--- a/qutip/cy/inter.pxd
+++ b/qutip/cy/inter.pxd
@@ -1,6 +1,6 @@
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
-#    Copyright (c) 2011 and later, The QuTiP Project.
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
 #    Redistribution and use in source and binary forms, with or without
@@ -31,27 +31,18 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-from qutip.cy.sparse_structs cimport CSR_Matrix
+cpdef complex spline_complex_t_second(double x, double[::1] t,
+                                      complex[::1] y, complex[::1] M,
+                                      int N)
 
-cdef void _zcsr_add(CSR_Matrix * A, CSR_Matrix * B,
-                    CSR_Matrix * C, double complex alpha)
+cpdef complex spline_complex_cte_second(double x, double[::1] t,
+                                        complex[::1] y, complex[::1] M,
+                                        int N, double dt)
 
-cdef int _zcsr_add_core(double complex * Adata, int * Aind, int * Aptr,
-                        double complex * Bdata, int * Bind, int * Bptr,
-                        double complex alpha,
-                        CSR_Matrix * C,
-                        int nrows, int ncols) nogil
+cpdef double spline_float_t_second(double x, double[::1] t,
+                                   double[::1] y, double[::1] M,
+                                   int N)
 
-cdef void _zcsr_mult(CSR_Matrix * A, CSR_Matrix * B, CSR_Matrix * C)
-
-
-cdef void _zcsr_kron(CSR_Matrix * A, CSR_Matrix * B, CSR_Matrix * C)
-
-cdef void _zcsr_kron_core(double complex * dataA, int * indsA, int * indptrA,
-                          double complex * dataB, int * indsB, int * indptrB,
-                          CSR_Matrix * out,
-                          int rowsA, int rowsB, int colsB) nogil
-
-cdef void _zcsr_transpose(CSR_Matrix * A, CSR_Matrix * B)
-
-cdef void _zcsr_adjoint(CSR_Matrix * A, CSR_Matrix * B)
+cpdef double spline_float_cte_second(double x, double[::1] t,
+                                     double[::1] y, double[::1] M,
+                                     int N, double dt)

--- a/qutip/cy/inter.pyx
+++ b/qutip/cy/inter.pyx
@@ -1,0 +1,192 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+import cython
+cimport cython
+
+import numpy as np
+cimport numpy as cnp
+
+import scipy.linalg
+
+def prep_cubic_spline(array, tlist):
+    """ Prepare coefficients for interpalation of array.
+    boudary conditions assumed: second derivative null at the extremities.
+
+    Input:
+      array:
+        nd.array of double / complex
+        Array to interpolate
+
+      tlist:
+        nd.array of double
+        times or x of the array, must be inscreasing,
+          the step size do not need to be constant.
+
+    Output:
+        the second derivative at each time
+        np.array [N]
+
+    """
+    N = len(tlist)
+    M = np.zeros((3,N), dtype=array.dtype)
+    x = np.zeros(N, dtype=array.dtype)
+    M[1,:] = 2.
+    dt_cte = True
+    dt0 = tlist[1]-tlist[0]
+    for i in range(1,N-1):
+        dt1 = tlist[i]-tlist[i-1]
+        dt2 = tlist[i+1]-tlist[i]
+        if ((dt2 - dt0) > 10e-10):
+            dt_cte = False
+        M[0,i+1] =  dt1 / (dt1+dt2)
+        M[2,i-1] =  dt2 / (dt1+dt2)
+        x[i] = ((array[i-1] - array[i]) / dt1 - (array[i] - array[i+1]) / dt2) \
+               * 6 / (dt1+dt2)
+    Ms = scipy.linalg.solve_banded((1,1), M, x, True, True) / 6
+    return (Ms, dt_cte)
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef int binary_search(double x, double[::1] t, int N):
+    #Binary search for the interval
+    cdef int low = 0
+    cdef int high = N
+    cdef int middle
+    cdef int count = 0
+    while low+1 != high and count < 30:
+        middle = (low+high)//2
+        if x < t[middle]:
+            high = middle
+        else:
+            low = middle
+        count += 1
+    return low
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cpdef double spline_float_cte_second(double x,
+                                     double[::1] t,
+                                     double[::1] y,
+                                     double[::1] M,
+                                     int N,
+                                     double dt):
+    # inbound?
+    if x < t[0]:
+        return y[0]
+    elif x > t[N-1]:
+        return y[N-1]
+    cdef int p = <int>(x/dt)
+    cdef double tb = (x/dt - p)
+    cdef double te = 1 - tb
+    cdef double dt2 = dt * dt
+    cdef double Me = M[p+1] * dt2
+    cdef double Mb = M[p] * dt2
+    return te * (Mb * te * te + (y[p]   - Mb)) + \
+           tb * (Me * tb * tb + (y[p+1] - Me))
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cpdef double spline_float_t_second(double x,
+                                   double[::1] t,
+                                   double[::1] y,
+                                   double[::1] M,
+                                   int N):
+    # inbound?
+    if x < t[0]:
+        return y[0]
+    elif x > t[N-1]:
+        return y[N-1]
+    cdef int p = binary_search(x, t, N)
+    cdef double dt = t[p+1] - t[p]
+    cdef double tb = (x - t[p]) / dt
+    cdef double te = 1 - tb
+    cdef double dt2 = dt * dt
+    cdef double Me = M[p+1] * dt2
+    cdef double Mb = M[p] * dt2
+    return te * (Mb * te * te + (y[p]   - Mb)) + \
+           tb * (Me * tb * tb + (y[p+1] - Me))
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cpdef complex spline_complex_cte_second(double x,
+                                        double[::1] t,
+                                        complex[::1] y,
+                                        complex[::1] M,
+                                        int N,
+                                        double dt):
+    # inbound?
+    if x < t[0]:
+        return y[0]
+    elif x > t[N-1]:
+        return y[N-1]
+    cdef int p = <int>(x/dt)
+    cdef double tb = (x/dt - p)
+    cdef double te = 1 - tb
+    cdef double dt2 = dt * dt
+    cdef complex Me = M[p+1] * dt2
+    cdef complex Mb = M[p] * dt2
+    return te * (Mb * te * te + (y[p]   - Mb)) + \
+           tb * (Me * tb * tb + (y[p+1] - Me))
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cpdef complex spline_complex_t_second(double x,
+                                      double[::1] t,
+                                      complex[::1] y,
+                                      complex[::1] M,
+                                      int N):
+    # inbound?
+    if x < t[0]:
+        return y[0]
+    elif x > t[N-1]:
+        return y[N-1]
+    cdef int p = binary_search(x, t, N)
+    cdef double dt = t[p+1] - t[p]
+    cdef double tb = (x - t[p]) / dt
+    cdef double te = 1 - tb
+    cdef double dt2 = dt * dt
+    cdef complex Me = M[p+1] * dt2
+    cdef complex Mb = M[p] * dt2
+    return te * (Mb * te * te + (y[p]   - Mb)) + \
+           tb * (Me * tb * tb + (y[p+1] - Me))

--- a/qutip/cy/sparse_routines.pxi
+++ b/qutip/cy/sparse_routines.pxi
@@ -103,11 +103,11 @@ cdef inline int int_min(int a, int b) nogil:
     return b if b < a else a
 
 cdef inline int int_max(int a, int b) nogil:
-    return a if a > b else b 
-    
+    return a if a > b else b
+
 
 @cython.boundscheck(False)
-@cython.wraparound(False)        
+@cython.wraparound(False)
 cdef void init_CSR(CSR_Matrix * mat, int nnz, int nrows, int ncols = 0,
                 int max_length = 0, int init_zeros = 1):
     """
@@ -121,7 +121,7 @@ cdef void init_CSR(CSR_Matrix * mat, int nnz, int nrows, int ncols = 0,
     nnz : int
         Length of data and indices arrays. Also number of nonzero elements
     nrows : int
-        Number of rows in matrix. Also gives length 
+        Number of rows in matrix. Also gives length
         of indptr array (nrows+1).
     ncols : int (default = 0)
         Number of cols in matrix. Default is ncols = nrows.
@@ -157,7 +157,7 @@ cdef void init_CSR(CSR_Matrix * mat, int nnz, int nrows, int ncols = 0,
 
 
 @cython.boundscheck(False)
-@cython.wraparound(False)        
+@cython.wraparound(False)
 cdef void copy_CSR(CSR_Matrix * out, CSR_Matrix * mat):
     """
     Copy a CSR_Matrix.
@@ -176,10 +176,10 @@ cdef void copy_CSR(CSR_Matrix * out, CSR_Matrix * mat):
     for kk in range(mat.nrows+1):
         out.indptr[kk] = mat.indptr[kk]
 
-    
+
 @cython.boundscheck(False)
-@cython.wraparound(False)        
-cdef void init_COO(COO_Matrix * mat, int nnz, int nrows, int ncols = 0, 
+@cython.wraparound(False)
+cdef void init_COO(COO_Matrix * mat, int nnz, int nrows, int ncols = 0,
                 int max_length = 0, int init_zeros = 1):
     """
     Initialize COO_Matrix struct. Matrix is assumed to be square with
@@ -260,10 +260,10 @@ cdef void free_COO(COO_Matrix * mat):
         mat.is_set = 0
     else:
         raise_error_COO(-2)
-    
-    
+
+
 @cython.boundscheck(False)
-@cython.wraparound(False)       
+@cython.wraparound(False)
 cdef void shorten_CSR(CSR_Matrix * mat, int N):
     """
     Shortends the length of CSR data and indices arrays.
@@ -277,7 +277,7 @@ cdef void shorten_CSR(CSR_Matrix * mat, int N):
             raise_error_CSR(-4, mat)
         elif not mat.is_set:
             raise_error_CSR(-3, mat)
-    
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -300,7 +300,7 @@ cdef void expand_CSR(CSR_Matrix * mat, int init_zeros=0):
             if init_zeros == 1:
                 for ii in range(mat.nnz, new_size):
                     mat.data[ii] = 0
-                
+
         new_ind = <int *>PyDataMem_RENEW(mat.indices, new_size * sizeof(int))
         mat.indices = new_ind
         if init_zeros == 1:
@@ -320,7 +320,7 @@ cdef object CSR_to_scipy(CSR_Matrix * mat):
     """
     Converts a CSR_Matrix struct to a SciPy csr_matrix class object.
     The NumPy arrays are generated from the pointers, and the lifetime
-    of the pointer memory is tied to that of the NumPy array 
+    of the pointer memory is tied to that of the NumPy array
     (i.e. automatic garbage cleanup.)
 
     Parameters
@@ -357,7 +357,7 @@ cdef object COO_to_scipy(COO_Matrix * mat):
     """
     Converts a COO_Matrix struct to a SciPy coo_matrix class object.
     The NumPy arrays are generated from the pointers, and the lifetime
-    of the pointer memory is tied to that of the NumPy array 
+    of the pointer memory is tied to that of the NumPy array
     (i.e. automatic garbage cleanup.)
 
     Parameters
@@ -440,7 +440,7 @@ cdef void CSR_to_COO(COO_Matrix * out, CSR_Matrix * mat):
         k2 = mat.indptr[kk]
         for jj in range(k2, k1):
             out.rows[jj] = kk
-            
+
 
 
 @cython.boundscheck(False)
@@ -535,21 +535,21 @@ cdef void sort_indices(CSR_Matrix * mat):
         row_end = mat.indptr[ii+1]
         length = row_end - row_start
         pairs.resize(length)
-    
+
         for jj in range(length):
             pairs[jj].data = mat.data[row_start+jj]
             pairs[jj].ind = mat.indices[row_start+jj]
-        
+
         sort(pairs.begin(),pairs.end(),cfptr_)
-    
+
         for jj in range(length):
             mat.data[row_start+jj] = pairs[jj].data
             mat.indices[row_start+jj] = pairs[jj].ind
-        
-    
+
+
 
 @cython.boundscheck(False)
-@cython.wraparound(False)  
+@cython.wraparound(False)
 cdef CSR_Matrix CSR_from_scipy(object A):
     """
     Converts a SciPy CSR sparse matrix to a
@@ -561,9 +561,9 @@ cdef CSR_Matrix CSR_from_scipy(object A):
     cdef int nrows = A.shape[0]
     cdef int ncols = A.shape[1]
     cdef int nnz = ptr[nrows]
-    
+
     cdef CSR_Matrix mat
-    
+
     mat.data = &data[0]
     mat.indices = &ind[0]
     mat.indptr = &ptr[0]
@@ -575,10 +575,35 @@ cdef CSR_Matrix CSR_from_scipy(object A):
     mat.numpy_lock = 1
     
     return mat
-    
+
 
 @cython.boundscheck(False)
-@cython.wraparound(False)  
+@cython.wraparound(False)
+cdef void CSR_from_scipy_inplace(object A, CSR_Matrix* mat):
+    """
+    Converts a SciPy CSR sparse matrix to a
+    CSR_Matrix struct.
+    """
+    cdef complex[::1] data = A.data
+    cdef int[::1] ind = A.indices
+    cdef int[::1] ptr = A.indptr
+    cdef int nrows = A.shape[0]
+    cdef int ncols = A.shape[1]
+    cdef int nnz = ptr[nrows]
+
+    mat.data = &data[0]
+    mat.indices = &ind[0]
+    mat.indptr = &ptr[0]
+    mat.nrows = nrows
+    mat.ncols = ncols
+    mat.nnz = nnz
+    mat.max_length = nnz
+    mat.is_set = 1
+    mat.numpy_lock = 1
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
 cdef COO_Matrix COO_from_scipy(object A):
     """
     Converts a SciPy COO sparse matrix to a
@@ -590,7 +615,7 @@ cdef COO_Matrix COO_from_scipy(object A):
     cdef int nrows = A.shape[0]
     cdef int ncols = A.shape[1]
     cdef int nnz = data.shape[0]
-    
+
     cdef COO_Matrix mat
     mat.data = &data[0]
     mat.rows = &rows[0]
@@ -601,10 +626,10 @@ cdef COO_Matrix COO_from_scipy(object A):
     mat.max_length = nnz
     mat.is_set = 1
     mat.numpy_lock = 1
-    
+
     return mat
-     
-     
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef void identity_CSR(CSR_Matrix * mat, unsigned int nrows):

--- a/qutip/cy/stochastic.pyx
+++ b/qutip/cy/stochastic.pyx
@@ -3,11 +3,11 @@
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,142 +18,1435 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 import numpy as np
-cimport numpy as cnp
+cimport numpy as np
 cimport cython
 cimport libc.math
-from qutip.cy.spmatfuncs cimport (spmv_csr,
-                                  cy_expect_rho_vec_csr, cy_expect_psi_csr)
-
+from qutip.cy.td_qobj_cy cimport cy_qobj
+from qutip.qobj import Qobj
+from qutip.superoperator import vec2mat
 include "parameters.pxi"
+include "complex_math.pxi"
+import scipy.sparse as sp
+from scipy.sparse.linalg import LinearOperator
+from scipy.linalg.cython_blas cimport zaxpy, zdotu, zdotc, zcopy, zdscal, zscal
+from scipy.linalg.cython_blas cimport dznrm2 as raw_dznrm2
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef cnp.ndarray[CTYPE_t, ndim=1] cy_rhs_psi_deterministic(object H,
-                               cnp.ndarray[CTYPE_t, ndim=1] state,
-                               double t,
-                               double dt,
-                               object args):
-    """
-    Deterministic contribution to the density matrix change; cython
-    implementation.
-    """
-    cdef cnp.ndarray[CTYPE_t, ndim=1] dpsi_t 
+cdef int ZERO=0
+cdef double DZERO=0
+cdef complex ZZERO=0j
+cdef int ONE=1
 
-    dpsi_t = (-1.0j * dt) * spmv_csr(H.data, H.indices, H.indptr, state)
+cpdef void axpy(complex a, complex[::1] x, complex[::1] y):
+    cdef int l = x.shape[0]
+    zaxpy(&l, &a, <complex*>&x[0], &ONE, <complex*>&y[0], &ONE)
 
-    return dpsi_t
+cpdef void copy(complex[::1] x, complex[::1] y):
+    cdef int l = x.shape[0]
+    zcopy(&l, <complex*>&x[0], &ONE, <complex*>&y[0], &ONE)
+
+cpdef complex dot(complex[::1] x,complex[::1] y):
+    cdef int l = x.shape[0]
+    return zdotu(&l, <complex*>&x[0], &ONE, <complex*>&y[0], &ONE)
+
+cpdef complex dotc(complex[::1] x,complex[::1] y):
+    cdef int l = x.shape[0]
+    return zdotc(&l, <complex*>&x[0], &ONE, <complex*>&y[0], &ONE)
+
+cpdef double dznrm2(complex[::1] vec):
+    cdef int l = vec.shape[0]
+    return raw_dznrm2(&l, <complex*>&vec[0], &ONE)
+
+@cython.cdivision(True)
+cpdef void normalize_inplace(complex[::1] vec):
+    cdef int l = vec.shape[0]
+    cdef double norm = 1.0/dznrm2(vec)
+    zdscal(&l, &norm, <complex*>&vec[0], &ONE)
+
+cdef void scale(double a, complex[::1] x):
+    cdef int l = x.shape[0]
+    zdscal(&l, &a, <complex*>&x[0], &ONE)
+
+cdef void zscale(complex a, complex[::1] x):
+    cdef int l = x.shape[0]
+    zscal(&l, &a, <complex*>&x[0], &ONE)
+
+cdef void zero(complex[::1] x):
+    cdef int l = x.shape[0]
+    zdscal(&l, &DZERO, <complex*>&x[0], &ONE)
+
+cdef void zero_2d(complex[:,::1] x):
+    cdef int l = x.shape[0]*x.shape[1]
+    zdscal(&l, &DZERO, <complex*>&x[0,0], &ONE)
+
+cdef void zero_3d(complex[:,:,::1] x):
+    cdef int l = x.shape[0]*x.shape[1]*x.shape[2]
+    zdscal(&l, &DZERO, <complex*>&x[0,0,0], &ONE)
+
+cdef void zero_4d(complex[:,:,:,::1] x):
+    cdef int l = x.shape[0]*x.shape[1]*x.shape[2]*x.shape[3]
+    zdscal(&l, &DZERO, <complex*>&x[0,0,0,0], &ONE)
+
+"""
+Solver:
+  order 0.5
+    euler-maruyama     50
+  order 0.5? 1.0?
+    pred_corr         101
+    pred_corr(2)      104
+  order 1.0
+    platen            100
+    milstein          102
+    milstein-imp      103
+  order 1.5
+    platen1.5         150
+    taylor1.5         152
+    taylor1.5-imp     153
+"""
+
+cdef class ssolvers:
+    cdef int l_vec, N_ops
+    cdef int solver#, noise_type
+    cdef int N_step, N_substeps, N_dw
+    cdef int normalize
+    cdef double dt
+    cdef int noise_type
+    cdef object custom_noise
+    cdef double[::1] dW_factor
+    cdef unsigned int[::1] seed
+
+    # buffer to not redo the initialisation at each substep
+    cdef complex[:, ::1] buffer_1d
+    cdef complex[:, :, ::1] buffer_2d
+    cdef complex[:, :, :, ::1] buffer_3d
+    cdef complex[:, :, :, ::1] buffer_4d
+    cdef complex[:, ::1] expect_buffer_1d
+    cdef complex[:, ::1] expect_buffer_2d
+    cdef complex[:, :, ::1] expect_buffer_3d
+    cdef complex[:, ::1] func_buffer_1d
+    cdef complex[:, ::1] func_buffer_2d
+    cdef complex[:, :, ::1] func_buffer_3d
+
+    def __init__(self):
+        self.l_vec = 0
+        self.N_ops = 0
+        self.solver = 0
+
+    def set_solver(self, sso):
+        self.solver = sso.solver_code
+        self.dt = sso.dt
+        self.N_substeps = sso.nsubsteps
+        self.normalize = sso.normalize and not sso.me
+        self.N_step = len(sso.times)
+        self.N_dw = len(sso.sops)
+        if self.solver in [150, 152, 153]:
+            self.N_dw *= 2
+        # prepare buffers for the solvers
+        nb_solver = [0,0,0,0]
+        nb_func = [0,0,0]
+        nb_expect = [0,0,0]
+
+        if self.solver == 50:
+            nb_solver = [0,1,0,0]
+        elif self.solver == 60:
+            nb_solver = [0,1,0,0]
+            nb_func = [1,0,0]
+        elif self.solver == 100:
+            nb_solver = [2,5,0,0]
+        elif self.solver == 101:
+            nb_solver = [4,1,1,0]
+        elif self.solver == 102:
+            nb_solver = [0,1,1,0]
+        elif self.solver == 103:
+            nb_solver = [1,1,1,0]
+        elif self.solver == 104:
+            nb_solver = [5,1,1,0]
+        elif self.solver == 150:
+            nb_solver = [5,8,3,0]
+        elif self.solver == 152:
+            nb_solver = [2,3,1,1]
+        elif self.solver == 153:
+            nb_solver = [2,3,1,1]
+
+        if self.solver in [101,102,103,104,152,153]:
+          if sso.me:
+            nb_func = [1,0,0]
+            nb_expect = [1,1,0]
+          else:
+            nb_func = [2,1,1]
+            nb_expect = [2,1,1]
+        else:
+          if not sso.me:
+            nb_func = [1,0,0]
+
+        self.buffer_1d = np.zeros((nb_solver[0],self.l_vec),dtype=complex)
+        self.buffer_2d = np.zeros((nb_solver[1],self.N_ops,self.l_vec),dtype=complex)
+        self.buffer_3d = np.zeros((nb_solver[2],self.N_ops,self.N_ops,self.l_vec),
+                                        dtype=complex)
+        if nb_solver[3]:
+          self.buffer_4d = np.zeros((self.N_ops,self.N_ops,self.N_ops,self.l_vec),
+                                        dtype=complex)
+
+        self.expect_buffer_1d = np.zeros((nb_expect[0],self.N_ops),dtype=complex)
+        if nb_expect[1]:
+          self.expect_buffer_2d = np.zeros((self.N_ops,self.N_ops),dtype=complex)
+        if nb_expect[2]:
+          self.expect_buffer_3d = np.zeros((self.N_ops,self.N_ops,self.N_ops),dtype=complex)
+
+        self.func_buffer_1d = np.zeros((nb_func[0],self.l_vec),dtype=complex)
+        if nb_func[1]:
+          self.func_buffer_2d = np.zeros((self.N_ops,self.l_vec),dtype=complex)
+        if nb_func[2]:
+          self.func_buffer_3d = np.zeros((self.N_ops,self.N_ops,self.l_vec),dtype=complex)
+
+        self.noise_type = sso.noise_type
+        self.dW_factor = np.array(sso.dW_factors,dtype=np.float64)
+        if self.noise_type == 1:
+            self.custom_noise = sso.noise
+        elif self.noise_type == 0:
+            self.seed = sso.noise
+
+    cdef np.ndarray[double, ndim=3] make_noise(self, int n):
+        if self.solver == 60 and self.noise_type == 0:
+            # photocurrent, just seed,
+            np.random.seed(self.seed[n])
+            return np.empty((self.N_step, self.N_substeps, self.N_dw))
+        if self.noise_type == 0:
+            np.random.seed(self.seed[n])
+            return np.random.randn(self.N_step, self.N_substeps, self.N_dw) *\
+                                   np.sqrt(self.dt)
+        elif self.noise_type == 1:
+            return self.custom_noise[n,:,:,:]
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    def cy_sesolve_single_trajectory(self, int n, sso):
+        cdef double[::1] times = sso.times
+        cdef complex[::1] rho_t
+        cdef double t
+        cdef int m_idx, t_idx, e_idx
+        cdef np.ndarray[double, ndim=3] noise = self.make_noise(n)
+        cdef int tlast = times.shape[0]
+
+        rho_t = sso.rho0.copy()
+        dims = sso.state0.dims
+
+        expect = np.zeros((len(sso.ce_ops), len(sso.times)), dtype=complex)
+        ss = np.zeros((len(sso.ce_ops), len(sso.times)), dtype=complex)
+        measurements = np.zeros((len(times), len(sso.cm_ops)), dtype=complex)
+        states_list = []
+        for t_idx, t in enumerate(times):
+            if sso.ce_ops:
+                for e_idx, e in enumerate(sso.ce_ops):
+                    s = e.compiled_Qobj.expect(t, rho_t, 0)
+                    expect[e_idx, t_idx] = s
+                    ss[e_idx, t_idx] = s ** 2
+            if sso.store_states or not sso.ce_ops:
+                if sso.me:
+                    states_list.append(Qobj(vec2mat(np.asarray(rho_t)),
+                        dims=dims))
+                else:
+                    states_list.append(Qobj(np.asarray(rho_t), dims=dims))
+
+            if sso.store_measurement:
+                for m_idx, m in enumerate(sso.cm_ops):
+                    m_expt = m.compiled_Qobj.expect(t, rho_t, 0)
+                    measurements[t_idx, m_idx] = m_expt + self.dW_factor[m_idx] * \
+                        sum(noise[t_idx, :, m_idx]) / (self.dt * self.N_substeps)
+            if t_idx != tlast-1:
+                rho_t = self.run(t, self.dt, noise[t_idx, :, :],
+                                 rho_t, self.N_substeps)
+
+        if sso.method == 'heterodyne':
+            measurements = measurements.reshape(len(times),len(sso.cm_ops)//2,2)
+
+        return states_list, noise, measurements, expect, ss
+
+    cdef complex[::1] run(self, double t, double dt, double[:, ::1] noise,
+                          complex[::1] vec, int N_substeps):
+        cdef complex[::1] out = np.zeros(self.l_vec, dtype=complex)
+        cdef int i
+        if self.solver == 50:
+            for i in range(N_substeps):
+                self.euler(t + i*dt, dt, noise[i, :], vec, out)
+                out, vec = vec, out
+
+        elif self.solver == 60:
+            for i in range(N_substeps):
+                self.photocurrent(t + i*dt, dt, noise[i, :], vec, out)
+                out, vec = vec, out
+
+        elif self.solver == 100:
+            for i in range(N_substeps):
+                self.platen(t + i*dt, dt, noise[i, :], vec, out)
+                out, vec = vec, out
+
+        elif self.solver == 101:
+            for i in range(N_substeps):
+                self.pred_corr(t + i*dt, dt, noise[i, :], vec, out)
+                out, vec = vec, out
+
+        elif self.solver == 102:
+            for i in range(N_substeps):
+                self.milstein(t + i*dt, dt, noise[i, :], vec, out)
+                out, vec = vec, out
+
+        elif self.solver == 103:
+            for i in range(N_substeps):
+                self.milstein_imp(t + i*dt, dt, noise[i, :], vec, out)
+                out, vec = vec, out
+
+        elif self.solver == 104:
+            for i in range(N_substeps):
+                self.pred_corr_a(t + i*dt, dt, noise[i, :], vec, out)
+                out, vec = vec, out
+
+        elif self.solver == 150:
+            for i in range(N_substeps):
+                self.platen15(t + i*dt, dt, noise[i, :], vec, out)
+                out, vec = vec, out
+
+        elif self.solver == 152:
+            for i in range(N_substeps):
+                self.taylor15(t + i*dt, dt, noise[i, :], vec, out)
+                out, vec = vec, out
+
+        elif self.solver == 153:
+            for i in range(N_substeps):
+                self.taylor15_imp(t + i*dt, dt, noise[i, :], vec, out)
+                out, vec = vec, out
+
+        if self.normalize:
+            normalize_inplace(vec)
+        return vec
+
+    # Dummy functions
+    cdef void d1(self, double t, complex[::1] v, complex[::1] out):
+        pass
+
+    cdef void d2(self, double t, complex[::1] v, complex[:, ::1] out):
+        pass
+
+    cdef void implicit(self, double t,  np.ndarray[complex, ndim=1] dvec,
+                       complex[::1] out, np.ndarray[complex, ndim=1] guess):
+        pass
+
+    cdef void derivatives(self, double t, int deg, complex[::1] rho,
+                              complex[::1] a, complex[:, ::1] b,
+                              complex[:, :, ::1] Lb, complex[:,::1] La,
+                              complex[:, ::1] L0b, complex[:, :, :, ::1] LLb,
+                              complex[::1] L0a):
+        pass
+
+    def set_implicit(self, sso):
+        pass
+
+    cdef void photocurrent(self, double t, double dt, double[:] noise,
+                           complex[::1] vec, complex[::1] out):
+        pass
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef cnp.ndarray[CTYPE_t, ndim=1] cy_rhs_rho_deterministic(object L,
-                               cnp.ndarray[CTYPE_t, ndim=1] rho_t,
-                               double t,
-                               double dt,
-                               object args):
-    """
-    Deterministic contribution to the density matrix change; cython
-    implementation.
-    """
-    return spmv_csr(L.data, L.indices, L.indptr, rho_t) * dt
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cdef void euler(self, double t, double dt, double[:] noise,
+                    complex[::1] vec, complex[::1] out):
+        cdef int i, j
+        cdef complex[:, ::1] d2 = self.buffer_2d[0,:,:]
+        zero_2d(d2)
+        copy(vec, out)
+        self.d1(t, vec, out)
+        self.d2(t, vec, d2)
+        for i in range(self.N_ops):
+            axpy(noise[i], d2[i,:], out)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void platen(self, double t, double dt, double[:] noise,
+                       complex[::1] vec, complex[::1] out):
+        """
+        Platen rhs function for both master eq and schrodinger eq.
+        dV = -iH* (V+Vt)/2 * dt + (d1(V)+d1(Vt))/2 * dt
+             + (2*d2_i(V)+d2_i(V+)+d2_i(V-))/4 * dW_i
+             + (d2_i(V+)-d2_i(V-))/4 * (dW_i**2 -dt) * dt**(-.5)
+
+        Vt = V -iH*V*dt + d1*dt + d2_i*dW_i
+        V+/- = V -iH*V*dt + d1*dt +/- d2_i*dt**.5
+        """
+        cdef int i, j, k
+        cdef double sqrt_dt = np.sqrt(dt)
+        cdef double sqrt_dt_inv = 0.25/sqrt_dt
+        cdef double dw, dw2
+        cdef complex[::1] d1 = self.buffer_1d[0,:]
+        cdef complex[::1] Vt = self.buffer_1d[1,:]
+        cdef complex[:, ::1] d2 = self.buffer_2d[0,:,:]
+        cdef complex[:, ::1] Vm = self.buffer_2d[1,:,:]
+        cdef complex[:, ::1] Vp = self.buffer_2d[2,:,:]
+        cdef complex[:, ::1] d2p = self.buffer_2d[3,:,:]
+        cdef complex[:, ::1] d2m = self.buffer_2d[4,:,:]
+        zero(d1)
+        zero_2d(d2)
+
+        self.d1(t, vec, d1)
+        self.d2(t, vec, d2)
+        axpy(1.0,vec,d1)
+        copy(d1,Vt)
+        copy(d1,out)
+        scale(0.5,out)
+        for i in range(self.N_ops):
+            copy(d1,Vp[i,:])
+            copy(d1,Vm[i,:])
+            axpy( sqrt_dt,d2[i,:],Vp[i,:])
+            axpy(-sqrt_dt,d2[i,:],Vm[i,:])
+            axpy(noise[i],d2[i,:],Vt)
+        zero(d1)
+        self.d1(t, Vt, d1)
+        axpy(0.5,d1,out)
+        axpy(0.5,vec,out)
+        for i in range(self.N_ops):
+            zero_2d(d2p)
+            zero_2d(d2m)
+            self.d2(t, Vp[i,:], d2p)
+            self.d2(t, Vm[i,:], d2m)
+            dw = noise[i] * 0.25
+            axpy(dw,d2m[i,:],out)
+            axpy(2*dw,d2[i,:],out)
+            axpy(dw,d2p[i,:],out)
+            for j in range(self.N_ops):
+                if i == j:
+                    dw2 = sqrt_dt_inv * (noise[i]*noise[i] - dt)
+                else:
+                    dw2 = sqrt_dt_inv * noise[i] * noise[j]
+                axpy(dw2,d2p[j,:],out)
+                axpy(-dw2,d2m[j,:],out)
+
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
+    @cython.cdivision(True)
+    cdef void pred_corr(self, double t, double dt, double[:] noise,
+                    complex[::1] vec, complex[::1] out):
+        """
+        Chapter 15.5 Eq. (5.4)
+        Numerical Solution of Stochastic Differential Equations
+        By Peter E. Kloeden, Eckhard Platen
+        """
+        # a=0. b=0.5
+        cdef double dt_2 = dt*0.5
+        cdef complex[::1] euler = self.buffer_1d[0,:]
+        cdef complex[::1] a_pred = self.buffer_1d[1,:]
+        cdef complex[::1] b_pred = self.buffer_1d[2,:]
+        cdef complex[:, ::1] d2 = self.buffer_2d[0,:,:]
+        cdef complex[:, :, ::1] dd2 = self.buffer_3d[0,:,:,:]
+        zero(a_pred)
+        zero(b_pred)
+        zero_2d(d2)
+        zero_3d(dd2)
+        self.derivatives(t, 1, vec, a_pred, d2, dd2, None, None, None, None)
+        copy(vec, euler)
+        copy(vec, out)
+        axpy(1.0, a_pred, euler)
+        for i in range(self.N_ops):
+            axpy(noise[i], d2[i,:], b_pred)
+            axpy(-dt_2, dd2[i,i,:], a_pred)
+        axpy(1.0, a_pred, out)
+        axpy(1.0, b_pred, euler)
+        axpy(0.5, b_pred, out)
+        zero_2d(d2)
+        self.d2(t + dt, euler, d2)
+        for i in range(self.N_ops):
+            axpy(noise[i]*0.5, d2[i,:], out)
+
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
+    @cython.cdivision(True)
+    cdef void pred_corr_a(self, double t, double dt, double[:] noise,
+                    complex[::1] vec, complex[::1] out):
+        """
+        Chapter 15.5 Eq. (5.4)
+        Numerical Solution of Stochastic Differential Equations
+        By Peter E. Kloeden, Eckhard Platen
+        """
+        # a=0.5, b=0.5
+        cdef int i, j, k
+        cdef complex[::1] euler = self.buffer_1d[0,:]
+        cdef complex[::1] a_pred = self.buffer_1d[1,:]
+        zero(a_pred)
+        cdef complex[::1] a_corr = self.buffer_1d[2,:]
+        zero(a_corr)
+        cdef complex[::1] b_pred = self.buffer_1d[3,:]
+        zero(b_pred)
+        cdef complex[:, ::1] d2 = self.buffer_2d[0,:,:]
+        zero_2d(d2)
+        cdef complex[:, :, ::1] dd2 = self.buffer_3d[0,:,:,:]
+        zero_3d(dd2)
+
+        cdef double dt_2 = dt*0.5
+        self.derivatives(t, 1, vec, a_pred, d2, dd2, None, None, None, None)
+        copy(vec, euler)
+        axpy(1.0, a_pred, euler)
+        for i in range(self.N_ops):
+            axpy(noise[i], d2[i,:], b_pred)
+            axpy(-dt_2, dd2[i,i,:], a_pred)
+        axpy(1.0, b_pred, euler)
+        copy(vec, out)
+        axpy(0.5, a_pred, out)
+        axpy(0.5, b_pred, out)
+        zero_2d(d2)
+        zero_3d(dd2)
+        self.derivatives(t, 1, euler, a_corr, d2, dd2, None, None, None, None)
+        for i in range(self.N_ops):
+            axpy(noise[i]*0.5, d2[i,:], out)
+            axpy(-dt_2, dd2[i,i,:], a_corr)
+        axpy(0.5, a_corr, out)
+
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
+    @cython.cdivision(True)
+    cdef void milstein(self, double t, double dt, double[:] noise,
+                    complex[::1] vec, complex[::1] out):
+        """
+        Chapter 10.3 Eq. (3.1)
+        Numerical Solution of Stochastic Differential Equations
+        By Peter E. Kloeden, Eckhard Platen
+
+        dV = -iH*V*dt + d1*dt + d2_i*dW_i
+             + 0.5*d2_i' d2_j*(dW_i*dw_j -dt*delta_ij)
+        """
+        cdef int i, j, k
+        cdef double dw
+        cdef complex[:, ::1] d2 = self.buffer_2d[0,:,:]
+        cdef complex[:, :, ::1] dd2 = self.buffer_3d[0,:,:,:]
+        zero_2d(d2)
+        zero_3d(dd2)
+        copy(vec,out)
+        self.derivatives(t, 1, vec, out, d2, dd2, None, None, None, None)
+        for i in range(self.N_ops):
+            axpy(noise[i],d2[i,:],out)
+        for i in range(self.N_ops):
+            for j in range(i, self.N_ops):
+                if (i == j):
+                    dw = (noise[i] * noise[i] - dt) * 0.5
+                else:
+                    dw = (noise[i] * noise[j])
+                axpy(dw,dd2[i,j,:],out)
+
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
+    @cython.cdivision(True)
+    cdef void milstein_imp(self, double t, double dt, double[:] noise,
+                           complex[::1] vec, complex[::1] out):
+        """
+        Chapter 12.2 Eq. (2.9)
+        Numerical Solution of Stochastic Differential Equations
+        By Peter E. Kloeden, Eckhard Platen
+        """
+        cdef int i, j, k
+        cdef double dw
+        cdef np.ndarray[complex, ndim=1] guess = np.zeros((self.l_vec, ),
+                                                          dtype=complex)
+        cdef np.ndarray[complex, ndim=1] dvec = np.zeros((self.l_vec, ),
+                                                         dtype=complex)
+        cdef complex[::1] a = self.buffer_1d[0,:]
+        cdef complex[:, ::1] d2 = self.buffer_2d[0,:,:]
+        cdef complex[:, :, ::1] dd2 = self.buffer_3d[0,:,:,:]
+        zero(a)
+        zero_2d(d2)
+        zero_3d(dd2)
+        self.derivatives(t, 1, vec, a, d2, dd2, None, None, None, None)
+        copy(vec, dvec)
+        axpy(0.5, a, dvec)
+        for i in range(self.N_ops):
+            axpy(noise[i], d2[i,:], dvec)
+        for i in range(self.N_ops):
+            for j in range(i, self.N_ops):
+                if (i == j):
+                    dw = (noise[i] * noise[i] - dt) * 0.5
+                else:
+                    dw = (noise[i] * noise[j])
+                axpy(dw, dd2[i,j,:], dvec)
+        copy(dvec, guess)
+        axpy(0.5, a, guess)
+        self.implicit(t+dt, dvec, out, guess)
+
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
+    @cython.cdivision(True)
+    cdef void taylor15(self, double t, double dt, double[:] noise,
+                           complex[::1] vec, complex[::1] out):
+        """
+        Chapter 12.2 Eq. (2.18),
+        Numerical Solution of Stochastic Differential Equations
+        By Peter E. Kloeden, Eckhard Platen
+        """
+        cdef complex[::1] a = self.buffer_1d[0, :]
+        cdef complex[:, ::1] b = self.buffer_2d[0, :, :]
+        cdef complex[:, :, ::1] Lb = self.buffer_3d[0, :, :, :]
+        cdef complex[:, ::1] L0b = self.buffer_2d[1,:,:]
+        cdef complex[:, ::1] La = self.buffer_2d[2,:,:]
+        cdef complex[:, :, :, ::1] LLb = self.buffer_4d[:, :, :, :]
+        cdef complex[::1] L0a = self.buffer_1d[1, :]
+        zero(a)
+        zero_2d(b)
+        zero_3d(Lb)
+        zero_2d(L0b)
+        zero_2d(La)
+        zero_4d(LLb)
+        zero(L0a)
+        self.derivatives(t, 2, vec, a, b, Lb, La, L0b, LLb, L0a)
+
+        cdef int i,j,k
+        cdef double[::1] dz, dw
+        dw = np.empty(self.N_ops)
+        dz = np.empty(self.N_ops)
+        # The dt of dz is included in the d1 part (Ldt) and the noise (dt**.5)
+        for i in range(self.N_ops):
+            dw[i] = noise[i]
+            dz[i] = 0.5 *(noise[i] + 1./np.sqrt(3) * noise[i+self.N_ops])
+        copy(vec,out)
+        axpy(1.0, a, out)
+        axpy(0.5, L0a, out)
+
+        for i in range(self.N_ops):
+            axpy(dw[i], b[i,:], out)
+            axpy(0.5*(dw[i]*dw[i]-dt), Lb[i,i,:], out)
+            axpy(dz[i], La[i,:], out)
+            axpy(dw[i]-dz[i], L0b[i,:], out)
+            axpy(0.5 * (0.3333333333333333 * dw[i] * dw[i] - dt) * dw[i],
+                        LLb[i,i,i,:], out)
+            for j in range(i+1,self.N_ops):
+                axpy((dw[i]*dw[j]), Lb[i,j,:], out)
+                axpy(0.5*(dw[j]*dw[j]-dt)*dw[i], LLb[i,j,j,:], out)
+                axpy(0.5*(dw[i]*dw[i]-dt)*dw[j], LLb[i,i,j,:], out)
+                for k in range(j+1,self.N_ops):
+                    axpy(dw[i]*dw[j]*dw[k], LLb[i,j,k,:], out)
+
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
+    @cython.cdivision(True)
+    cdef void taylor15_imp(self, double t, double dt, double[:] noise,
+                           complex[::1] vec, complex[::1] out):
+        """
+        Chapter 12.2 Eq. (2.18),
+        Numerical Solution of Stochastic Differential Equations
+        By Peter E. Kloeden, Eckhard Platen
+        """
+        cdef complex[::1] a = self.buffer_1d[0, :]
+        cdef complex[:, ::1] b = self.buffer_2d[0, :, :]
+        cdef complex[:, :, ::1] Lb = self.buffer_3d[0, :, :, :]
+        cdef complex[:, ::1] L0b = self.buffer_2d[1,:,:]
+        cdef complex[:, ::1] La = self.buffer_2d[2,:,:]
+        cdef complex[:, :, :, ::1] LLb = self.buffer_4d[:, :, :, :]
+        cdef complex[::1] L0a = self.buffer_1d[1, :]
+        zero(a)
+        zero_2d(b)
+        zero_3d(Lb)
+        zero_2d(L0b)
+        zero_2d(La)
+        zero_4d(LLb)
+        zero(L0a)
+        cdef np.ndarray[complex, ndim=1] guess = np.zeros((self.l_vec, ),
+                   dtype=complex)
+        cdef np.ndarray[complex, ndim=1] vec_t = np.zeros((self.l_vec, ),
+                  dtype=complex)
+        self.derivatives(t, 3, vec, a, b, Lb, La, L0b, LLb, L0a)
+
+        cdef int i,j,k
+        cdef double[::1] dz, dw
+        dw = np.empty(self.N_ops)
+        dz = np.empty(self.N_ops)
+        # The dt of dz is included in the d1 part (Ldt) and the noise (dt**.5)
+        for i in range(self.N_ops):
+            dw[i] = noise[i]
+            dz[i] = 0.5 *(noise[i] + 1./np.sqrt(3) * noise[i+self.N_ops])
+        copy(vec, vec_t)
+        axpy(0.5, a, vec_t)
+        for i in range(self.N_ops):
+            axpy(dw[i], b[i,:], vec_t)
+            axpy(0.5*(dw[i]*dw[i]-dt), Lb[i,i,:], vec_t)
+            axpy(dz[i]-dw[i]*0.5, La[i,:], vec_t)
+            axpy(dw[i]-dz[i] , L0b[i,:], vec_t)
+            axpy(0.5 * (0.3333333333333333 * dw[i] * dw[i] - dt) * dw[i],
+                        LLb[i,i,i,:], vec_t)
+            for j in range(i+1,self.N_ops):
+                axpy((dw[i]*dw[j]), Lb[i,j,:], vec_t)
+                axpy(0.5*(dw[j]*dw[j]-dt)*dw[i], LLb[i,j,j,:], vec_t)
+                axpy(0.5*(dw[i]*dw[i]-dt)*dw[j], LLb[i,i,j,:], vec_t)
+                for k in range(j+1,self.N_ops):
+                    axpy(dw[i]*dw[j]*dw[k], LLb[i,j,k,:], vec_t)
+        copy(vec_t, guess)
+        axpy(0.5, a, guess)
+
+        self.implicit(t+dt, vec_t, out, guess)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void platen15(self, double t, double dt, double[:] noise,
+                    complex[::1] vec, complex[::1] out):
+        """
+        Chapter 11.2 Eq. (2.13)
+        Numerical Solution of Stochastic Differential Equations
+        By Peter E. Kloeden, Eckhard Platen
+        """
+        cdef int i, j, k
+        cdef double sqrt_dt = np.sqrt(dt)
+        cdef double sqrt_dt_inv = 1./sqrt_dt
+        cdef double ddz, ddw, ddd
+        cdef double[::1] dz, dw
+        dw = np.empty(self.N_ops)
+        dz = np.empty(self.N_ops)
+        for i in range(self.N_ops):
+            dw[i] = noise[i]
+            dz[i] = 0.5 *(noise[i] + 1./np.sqrt(3) * noise[i+self.N_ops])
+
+        cdef complex[::1] d1 = self.buffer_1d[0,:]
+        cdef complex[::1] d1p = self.buffer_1d[1,:]
+        cdef complex[::1] d1m = self.buffer_1d[2,:]
+        cdef complex[::1] V = self.buffer_1d[3,:]
+        cdef complex[:, ::1] d2 = self.buffer_2d[0,:,:]
+        cdef complex[:, ::1] dd2 = self.buffer_2d[1,:,:]
+        cdef complex[:, ::1] d2p = self.buffer_2d[2,:,:]
+        cdef complex[:, ::1] d2m = self.buffer_2d[3,:,:]
+        cdef complex[:, ::1] d2pp = self.buffer_2d[4,:,:]
+        cdef complex[:, ::1] d2mm = self.buffer_2d[5,:,:]
+        cdef complex[:, ::1] v2p = self.buffer_2d[6,:,:]
+        cdef complex[:, ::1] v2m = self.buffer_2d[7,:,:]
+        cdef complex[:, :, ::1] p2p = self.buffer_3d[0,:,:,:]
+        cdef complex[:, : ,::1] p2m = self.buffer_3d[1,:,:,:]
+
+        zero(d1)
+        zero_2d(d2)
+        zero_2d(dd2)
+        self.d1(t, vec, d1)
+        self.d2(t, vec, d2)
+        self.d2(t + dt, vec, dd2)
+        # Euler part
+        copy(vec,out)
+        axpy(1., d1, out)
+        for i in range(self.N_ops):
+            axpy(dw[i], d2[i,:], out)
+
+        zero(V)
+        axpy(1., vec, V)
+        axpy(1./self.N_ops, d1, V)
+
+        zero_2d(v2p)
+        zero_2d(v2m)
+        for i in range(self.N_ops):
+            axpy(1., V, v2p[i,:])
+            axpy(sqrt_dt, d2[i,:], v2p[i,:])
+            axpy(1., V, v2m[i,:])
+            axpy(-sqrt_dt, d2[i,:], v2m[i,:])
+
+        zero_3d(p2p)
+        zero_3d(p2m)
+        for i in range(self.N_ops):
+            zero_2d(d2p)
+            zero_2d(d2m)
+            self.d2(t, v2p[i,:], d2p)
+            self.d2(t, v2m[i,:], d2m)
+            ddw = (dw[i]*dw[i]-dt)*0.25/sqrt_dt  # 1.0
+            axpy( ddw, d2p[i,:], out)
+            axpy(-ddw, d2m[i,:], out)
+            for j in range(self.N_ops):
+                axpy(      1., v2p[i,:], p2p[i,j,:])
+                axpy( sqrt_dt, d2p[j,:], p2p[i,j,:])
+                axpy(      1., v2p[i,:], p2m[i,j,:])
+                axpy(-sqrt_dt, d2p[j,:], p2m[i,j,:])
+
+        axpy(-0.5*(self.N_ops), d1, out)
+        for i in range(self.N_ops):
+            ddz = dz[i]*0.5/sqrt_dt  # 1.5
+            ddd = 0.25*(dw[i]*dw[i]/3-dt)*dw[i]/dt  # 1.5
+            zero(d1p)
+            zero(d1m)
+            zero_2d(d2m)
+            zero_2d(d2p)
+            zero_2d(d2pp)
+            zero_2d(d2mm)
+            self.d1(t + dt/self.N_ops, v2p[i,:], d1p)
+            self.d1(t + dt/self.N_ops, v2m[i,:], d1m)
+            self.d2(t, v2p[i,:], d2p)
+            self.d2(t, v2m[i,:], d2m)
+            self.d2(t, p2p[i,i,:], d2pp)
+            self.d2(t, p2m[i,i,:], d2mm)
+
+            axpy( ddz+0.25, d1p, out)
+            axpy(-ddz+0.25, d1m, out)
+
+            axpy((dw[i]-dz[i]), dd2[i,:], out)
+            axpy((dz[i]-dw[i]), d2[i,:], out)
+
+            axpy( ddd, d2pp[i,:], out)
+            axpy(-ddd, d2mm[i,:], out)
+            axpy(-ddd, d2p[i,:], out)
+            axpy( ddd, d2m[i,:], out)
+
+            for j in range(self.N_ops):
+              ddw = 0.5*(dw[j]-dz[j]) # 1.5
+              axpy(ddw, d2p[j,:], out)
+              axpy(-2*ddw, d2[j,:], out)
+              axpy(ddw, d2m[j,:], out)
+
+              if j>i:
+                ddw = 0.5*(dw[i]*dw[j])/sqrt_dt # 1.0
+                axpy( ddw, d2p[j,:], out)
+                axpy(-ddw, d2m[j,:], out)
+
+                ddw = 0.25*(dw[j]*dw[j]-dt)*dw[i]/dt # 1.5
+                zero_2d(d2pp)
+                zero_2d(d2mm)
+                self.d2(t, p2p[j,i,:], d2pp)
+                self.d2(t, p2m[j,i,:], d2mm)
+                axpy( ddw, d2pp[j,:], out)
+                axpy(-ddw, d2mm[j,:], out)
+                axpy(-ddw, d2p[j,:], out)
+                axpy( ddw, d2m[j,:], out)
+
+                for k in range(j+1,self.N_ops):
+                    ddw = 0.5*dw[i]*dw[j]*dw[k]/dt # 1.5
+                    axpy( ddw, d2pp[k,:], out)
+                    axpy(-ddw, d2mm[k,:], out)
+                    axpy(-ddw, d2p[k,:], out)
+                    axpy( ddw, d2m[k,:], out)
+
+              if j<i:
+                ddw = 0.25*(dw[j]*dw[j]-dt)*dw[i]/dt # 1.5
+                zero_2d(d2pp)
+                zero_2d(d2mm)
+                self.d2(t, p2p[j,i,:], d2pp)
+                self.d2(t, p2m[j,i,:], d2mm)
+                axpy( ddw, d2pp[j,:], out)
+                axpy(-ddw, d2mm[j,:], out)
+                axpy(-ddw, d2p[j,:], out)
+                axpy( ddw, d2m[j,:], out)
+
+    def checks(self, double t, double dt, complex[::1] vec):
+        cdef complex[::1] a = np.zeros((self.l_vec), dtype=complex)
+        cdef complex[::1] a1 = np.zeros((self.l_vec), dtype=complex)
+        cdef complex[:, ::1] b = np.zeros((self.N_ops, self.l_vec),
+                                           dtype=complex)
+        cdef complex[:, ::1] b1 = np.zeros((self.N_ops, self.l_vec),
+                                           dtype=complex)
+        cdef complex[:, ::1] b2 = np.zeros((self.N_ops, self.l_vec),
+                                           dtype=complex)
+        cdef complex[:, :, ::1] Lb = np.zeros((self.N_ops, self.N_ops,
+                    self.l_vec), dtype=complex)
+        cdef complex[:, :, ::1] Lb2 = np.zeros((self.N_ops, self.N_ops,
+                                               self.l_vec), dtype=complex)
+        cdef complex[:, ::1] L0b = np.zeros((self.N_ops,
+                                             self.l_vec), dtype=complex)
+        cdef complex[:,::1] La = np.zeros((self.N_ops,
+                                           self.l_vec), dtype=complex)
+        cdef complex[:, :, :, ::1] LLb = np.zeros((self.N_ops, self.N_ops,
+                                        self.N_ops, self.l_vec), dtype=complex)
+        cdef complex[::1] L0a = np.zeros((self.l_vec), dtype=complex)
+
+        cdef complex[:, ::1] dvec = np.zeros((7, self.l_vec), dtype=complex)
+
+        self.d1(t, vec, a)
+        self.d2(t, vec, b)
+        self.d2d2p(t, vec, b1, Lb)
+        self.derivatives(t, 2, vec, a1, b2, Lb2, La, L0b, LLb, L0a)
+        self.taylor_15_1(t, vec, dvec)
+
+        print("a[0]",a[0],a1[0],dvec[0,0])
+        print("a[1]",a[1],a1[1],dvec[0,1])
+        for i in range(self.N_ops):
+            print(i)
+            print("b[0]",b[i,0],b1[i,0],b2[i,0],dvec[1,0])
+            print("b[1]",b[i,1],b1[i,1],b2[i,1],dvec[1,1])
+        for i in range(self.N_ops):
+          for j in range(self.N_ops):
+            print(i,j)
+            print("Lb[0]",Lb[i,j,0],Lb[i,j,0],dvec[2,0])
+            print("Lb[1]",Lb[i,j,1],Lb[i,j,1],dvec[2,1])
+        for i in range(self.N_ops):
+            print(i)
+            print("La[0]",La[i,0],dvec[3,0])
+            print("La[1]",La[i,1],dvec[3,1])
+            print("L0b[0]",L0b[i,0],dvec[4,0])
+            print("L0b[1]",L0b[i,1],dvec[4,1])
+        for i in range(self.N_ops):
+          for j in range(self.N_ops):
+            for k in range(self.N_ops):
+              print(i,j,k)
+              print("LLb[0]",LLb[i,j,k,0],dvec[6,0])
+              print("LLb[1]",LLb[i,j,k,1],dvec[6,1])
+        print("L0a[0]",L0a[0],dvec[5,0])
+        print("L0a[1]",L0a[1],dvec[5,1])
 
 
-# -----------------------------------------------------------------------------
-# Wave function d1 and d2 functions
-#
+cdef class sse(ssolvers):
+    cdef cy_qobj L
+    cdef object c_ops
+    cdef object cpcd_ops
+    cdef object imp
+    cdef double tol, imp_t
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef cy_d1_psi_photocurrent(double t, cnp.ndarray[CTYPE_t, ndim=1] psi,
-                             object A, object args):
-    """
-    Cython version of d1_psi_photocurrent. See d1_psi_photocurrent for docs.
-    """
-    a0 = A[0]
-    a3 = A[3]
-    return (-0.5 * (spmv_csr(a3.data, a3.indices, a3.indptr, psi)
-            - psi * np.linalg.norm(spmv_csr(a0.data, a0.indices, a0.indptr, psi)) ** 2))
+    def set_data(self, sso):
+        L = sso.LH
+        c_ops = sso.sops
+        self.l_vec = L.cte.shape[0]
+        self.N_ops = len(c_ops)
+        self.L = L.compiled_Qobj
+        self.c_ops = []
+        self.cpcd_ops = []
+        for i, op in enumerate(c_ops):
+            self.c_ops.append(op[0].compiled_Qobj)
+            self.cpcd_ops.append(op[1].compiled_Qobj)
+        if sso.solver_code in [103, 153]:
+            self.tol = sso.tol
+            self.imp = LinearOperator( (self.l_vec,self.l_vec),
+                                      matvec=self.implicit_op, dtype=complex)
 
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef cy_d2_psi_photocurrent(double t, cnp.ndarray[CTYPE_t, ndim=1] psi,
-                             object A, object args):
-    """
-    Cython version of d2_psi_photocurrent. See d2_psi_photocurrent for docs.
-    """
-    cdef cnp.ndarray[CTYPE_t, ndim=1] psi1 
-
-    psi1 = spmv_csr(A[0].data, A[0].indices, A[0].indptr, psi)
-    n1 = np.linalg.norm(psi1)
-    if n1 != 0:
-        return psi1 / n1 - psi
-    else:
-        return - psi
+    def implicit_op(self, vec):
+        cdef np.ndarray[complex, ndim=1] out = np.zeros(self.l_vec, dtype=complex)
+        self.d1(self.imp_t, vec, out)
+        cdef int i
+        scale(-0.5,out)
+        axpy(1.,vec,out)
+        return out
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef d1_psi_homodyne(t, psi, A, args):
-    """
-    Cython version of d2_psi_homodyne. See d2_psi_homodyne for docs.
-    """
-    e1 = cy_expect_psi_csr(A[1].data, A[1].indices, A[1].indptr, psi, 0)
-    return 0.5 * (e1 * spmv_csr(A[0].data, A[0].indices, A[0].indptr, psi) -
-                  spmv_csr(A[3].data, A[3].indices, A[3].indptr, psi) -
-                  0.25 * e1 ** 2 * psi)
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void d1(self, double t, complex[::1] vec, complex[::1] out):
+        self.L._rhs_mat(t, &vec[0], &out[0])
+        cdef int i
+        cdef complex e
+        cdef cy_qobj c_op
+        cdef complex[::1] temp = self.func_buffer_1d[0,:]
+        zero(temp)
+        for i in range(self.N_ops):
+            c_op = self.cpcd_ops[i]
+            e = c_op._expect_mat(t, &vec[0], 0)
+            zero(temp)
+            c_op = self.c_ops[i]
+            c_op._rhs_mat(t, &vec[0], &temp[0])
+            axpy(-0.125 * e * e * self.dt, vec, out)
+            axpy(0.5 * e * self.dt, temp, out)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void d2(self, double t, complex[::1] vec, complex[:, ::1] out):
+        cdef int i, k
+        cdef cy_qobj c_op
+        cdef complex expect
+        for i in range(self.N_ops):
+            c_op = self.c_ops[i]
+            c_op._rhs_mat(t, &vec[0], &out[i,0])
+            c_op = self.cpcd_ops[i]
+            expect = c_op._expect_mat(t, &vec[0], 0)
+            axpy(-0.5*expect,vec,out[i,:])
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void derivatives(self, double t, int deg, complex[::1] vec,
+                          complex[::1] a, complex[:, ::1] b,
+                          complex[:, :, ::1] Lb, complex[:,::1] La,
+                          complex[:, ::1] L0b, complex[:, :, :, ::1] LLb,
+                          complex[::1] L0a):
+        """
+        combinaisons of a and b derivatives for taylor order 1.5
+        dY ~ a dt + bi dwi
+                                         deg   use        noise
+        b[i.:]       bi                   >=0   d2 euler   dwi
+        a[:]         a                    >=0   d1 euler   dt
+        Lb[i,i,:]    bi'bi                >=1   milstein   (dwi^2-dt)/2
+        Lb[i,j,:]    bj'bi                >=1   milstein   dwi*dwj
+
+        L0b[i,:]     ab' +db/dt +bbb"/2   >=2   taylor15   dwidt-dzi
+        La[i,:]      ba'                  >=2   taylor15   dzi
+        LLb[i,i,i,:] bi(bibi"+bi'bi')     >=2   taylor15   (dwi^2/3-dt)dwi/2
+        LLb[i,j,j,:] bi(bjbj"+bj'bj')     >=2   taylor15   (dwj^2-dt)dwj/2
+        LLb[i,j,k,:] bi(bjbk"+bj'bk')     >=2   taylor15   dwi*dwj*dwk
+        L0a[:]       aa' +da/dt +bba"/2    2    taylor15   dt^2/2
+        """
+        cdef int i, j, k, l
+        cdef double dt = self.dt
+        cdef cy_qobj c_op
+        cdef complex e, de_bb
+
+        cdef complex[::1] e_real = self.expect_buffer_1d[0,:]
+        cdef complex[:, ::1] de_b = self.expect_buffer_2d[:,:]
+        cdef complex[::1] de_a = self.expect_buffer_1d[1,:]
+        cdef complex[:, :, ::1] dde_bb = self.expect_buffer_3d[:,:,:]
+        zero_3d(dde_bb)
+        cdef complex[:, ::1] Cvec = self.func_buffer_2d[:,:]
+        cdef complex[:, :, ::1] Cb = self.func_buffer_3d[:,:,:]
+        cdef complex[::1] temp = self.func_buffer_1d[0,:]
+        cdef complex[::1] temp2 = self.func_buffer_1d[1,:]
+        zero(temp)
+        zero(temp2)
+        zero_2d(Cvec)
+        zero_3d(Cb)
+
+        # a b
+        self.L._rhs_mat(t, &vec[0], &a[0])
+        for i in range(self.N_ops):
+            c_op = self.c_ops[i]
+            c_op._rhs_mat(t, &vec[0], &Cvec[i,0])
+            e = dotc(vec,Cvec[i,:])
+            e_real[i] = real(e)
+            axpy(1., Cvec[i,:], b[i,:])
+            axpy(-e_real[i], vec, b[i,:])
+            axpy(-0.5 * e_real[i] * e_real[i] * dt, vec, a[:])
+            axpy(e_real[i] * dt, Cvec[i,:], a[:])
+
+        #Lb bb'
+        if deg >= 1:
+          for i in range(self.N_ops):
+            c_op = self.c_ops[i]
+            for j in range(self.N_ops):
+              c_op._rhs_mat(t, &b[j,0], &Cb[i,j,0])
+              for k in range(self.l_vec):
+                  temp[k] = conj(b[j,k])
+                  temp2[k] = 0.
+              c_op._rhs_mat(t, &temp[0], &temp2[0])
+              de_b[i,j] = (dotc(vec, Cb[i,j,:]) + dot(b[j,:], Cvec[i,:]) + \
+                          conj(dotc(b[j,:], Cvec[i,:]) + dotc(vec, temp2))) * 0.5
+              axpy(1., Cb[i,j,:], Lb[i,j,:])
+              axpy(-e_real[i], b[j,:], Lb[i,j,:])
+              axpy(-de_b[i,j], vec, Lb[i,j,:])
+
+              for k in range(self.N_ops):
+                dde_bb[i,j,k] += (dot(b[j,:], Cb[i,k,:]) + \
+                                  dot(b[k,:], Cb[i,j,:]) + \
+                                  conj(dotc(b[k,:], temp2)))*.5
+                dde_bb[i,k,j] += conj(dotc(b[k,:], temp2))*.5
+
+        #L0b La LLb
+        if deg >= 2:
+          for i in range(self.N_ops):
+              #ba'
+              self.L._rhs_mat(t, &b[i,0], &La[i,0])
+              for j in range(self.N_ops):
+                  axpy(-0.5 * e_real[j] * e_real[j] * dt, b[i,:], La[i,:])
+                  axpy(-e_real[j] * de_b[i,j] * dt, vec, La[i,:])
+                  axpy(e_real[j] * dt, Cb[i,j,:], La[i,:])
+                  axpy(de_b[i,j] * dt, Cvec[i,:], La[i,:])
+
+              #ab' + db/dt + bbb"/2
+              c_op = self.c_ops[i]
+              c_op._rhs_mat(t, &a[0], &L0b[i,0])
+              for k in range(self.l_vec):
+                  temp[k] = conj(a[k])
+                  temp2[k] = 0.
+              c_op._rhs_mat(t, &temp[0], &temp2[0])
+              de_a[i] = (dotc(vec, L0b[i,:]) + dot(a, Cvec[i,:]) + \
+                        conj(dotc(a, Cvec[i,:]) + dotc(vec, temp2))) * 0.5
+              axpy(-e_real[i], a, L0b[i,:])
+              axpy(-de_a[i], vec, L0b[i,:])
+
+              temp = np.zeros(self.l_vec, dtype=complex)
+              c_op._rhs_mat(t + self.dt, &vec[0], &temp[0])
+              e = dotc(vec,temp)
+              axpy(1., temp, L0b[i,:])
+              axpy(-real(e), vec, L0b[i,:])
+              axpy(-1., b[i,:], L0b[i,:])
+
+              for j in range(self.N_ops):
+                  axpy(-de_b[i,j]*dt, b[j,:], L0b[i,:])
+                  axpy(-dde_bb[i,j,j]*dt, vec, L0b[i,:])
+
+              #b(bb"+b'b')
+              for j in range(i,self.N_ops):
+                  for k in range(j, self.N_ops):
+                      c_op._rhs_mat(t, &Lb[j,k,0], &LLb[i,j,k,0])
+                      for l in range(self.l_vec):
+                          temp[l] = conj(Lb[j,k,l])
+                          temp2[l] = 0.
+                      c_op._rhs_mat(t, &temp[0], &temp2[0])
+                      de_bb = (dotc(vec, LLb[i,j,k,:]) + \
+                               dot(Lb[j,k,:], Cvec[i,:]) + \
+                               conj(dotc(Lb[j,k,:], Cvec[i,:]) +\
+                               dotc(vec, temp2)))*0.5
+                      axpy(-e_real[i], Lb[j,k,:], LLb[i,j,k,:])
+                      axpy(-de_bb, vec, LLb[i,j,k,:])
+                      axpy(-dde_bb[i,j,k], vec, LLb[i,j,k,:])
+                      axpy(-de_b[i,j], b[k,:], LLb[i,j,k,:])
+                      axpy(-de_b[i,k], b[j,:], LLb[i,j,k,:])
+
+        #da/dt + aa' + bba"
+        if deg == 2:
+          self.d1(t + dt, vec, L0a)
+          axpy(-1.0, a, L0a)
+          self.L._rhs_mat(t, &a[0], &L0a[0])
+          for j in range(self.N_ops):
+              c_op = self.c_ops[j]
+              temp = np.zeros(self.l_vec, dtype=complex)
+              c_op._rhs_mat(t, &a[0], &temp[0])
+              axpy(-0.5 * e_real[j] * e_real[j] * dt, a[:], L0a[:])
+              axpy(-e_real[j] * de_a[j] * dt, vec, L0a[:])
+              axpy(e_real[j] * dt, temp, L0a[:])
+              axpy(de_a[j] * dt, Cvec[j,:], L0a[:])
+              for i in range(self.N_ops):
+                  axpy(-0.5*(e_real[i] * dde_bb[i,j,j] +
+                          de_b[i,j] * de_b[i,j]) * dt * dt, vec, L0a[:])
+                  axpy(-e_real[i] * de_b[i,j] * dt * dt, b[j,:], L0a[:])
+                  axpy(0.5*dde_bb[i,j,j] * dt * dt, Cvec[i,:], L0a[:])
+                  axpy(de_b[i,j] * dt * dt, Cb[i,j,:], L0a[:])
+
+    cdef void implicit(self, double t,  np.ndarray[complex, ndim=1] dvec,
+                                        complex[::1] out,
+                                        np.ndarray[complex, ndim=1] guess):
+        # np.ndarray to memoryview is OK but not the reverse
+        # scipy function only take np array, not memoryview
+        self.imp_t = t
+        spout, check = sp.linalg.bicgstab(self.imp,
+                                        dvec, x0 = guess, tol=self.tol)
+        cdef int i
+        copy(spout, out)
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef d2_psi_homodyne(t, psi, A, args):
-    """
-    Cython version of d2_psi_homodyne. See d2_psi_homodyne for docs.
-    """
-    e1 = cy_expect_psi_csr(A[1].data, A[1].indices, A[1].indptr, psi, 0)
-    return [spmv_csr(A[0].data, A[0].indices, A[0].indptr, psi) - 0.5 * e1 * psi]
+cdef class sme(ssolvers):
+    cdef cy_qobj L
+    cdef object imp
+    cdef object c_ops
+    cdef int N_root
+    cdef double tol
 
-# -----------------------------------------------------------------------------
-# density matric (vector form) d1 and d2 functions
-#
+    def set_data(self, sso):
+        L = sso.LH
+        c_ops = sso.sops
+        self.l_vec = L.cte.shape[0]
+        self.N_ops = len(c_ops)
+        self.L = L.compiled_Qobj
+        self.c_ops = []
+        self.N_root = np.sqrt(self.l_vec)
+        for i, op in enumerate(c_ops):
+            self.c_ops.append(op.compiled_Qobj)
+        if sso.solver_code in [103, 153]:
+            self.tol = sso.tol
+            self.imp = sso.imp
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef cy_d1_rho_photocurrent(double t, cnp.ndarray[CTYPE_t, ndim=1] rho_vec,
-                             object A, object args):
-    """
-    Photo-current D1 function
-    """
-    n = A[4] + A[5]
-    e1 = cy_expect_rho_vec_csr(n.data, n.indices, n.indptr, rho_vec, 0)
-    return 0.5 * (e1 * rho_vec - spmv_csr(n.data, n.indices, n.indptr, rho_vec))
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef complex expect(self, complex[::1] rho):
+        cdef complex e = 0.
+        cdef int k
+        for k in range(self.N_root):
+            e += rho[k*(self.N_root+1)]
+        return e
 
+    cdef void d1(self, double t, complex[::1] rho, complex[::1] out):
+        self.L._rhs_mat(t, &rho[0], &out[0])
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef cy_d2_rho_photocurrent(double t, cnp.ndarray[CTYPE_t, ndim=1] rho_vec,
-                             object A, object args):
-    """
-    Photo-current D2 function
-    """
-    a = A[6]
-    e1 = cy_expect_rho_vec_csr(a.data, a.indices, a.indptr, rho_vec, 0)
-    if e1.real > 1e-12:
-        return [spmv_csr(a.data, a.indices, a.indptr, rho_vec) / e1 - rho_vec]
-    else:
-        return [- rho_vec]
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void d2(self, double t, complex[::1] rho, complex[:, ::1] out):
+        cdef int i, k
+        cdef cy_qobj c_op
+        cdef complex expect
+        for i in range(self.N_ops):
+            c_op = self.c_ops[i]
+            c_op._rhs_mat(t, &rho[0], &out[i,0])
+            expect = self.expect(out[i,:])
+            axpy(-expect, rho, out[i,:])
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void derivatives(self, double t, int deg, complex[::1] rho,
+                          complex[::1] a, complex[:, ::1] b,
+                          complex[:, :, ::1] Lb, complex[:,::1] La,
+                          complex[:, ::1] L0b, complex[:, :, :, ::1] LLb,
+                          complex[::1] L0a):
+        """
+        combinaisons of a and b derivative for m sc_ops up to order dt**1.5
+        dY ~ a dt + bi dwi
+                                         deg   use        noise
+        b[i.:]       bi                   >=0   d2 euler   dwi
+        a[:]         a                    >=0   d1 euler   dt
+        Lb[i,i,:]    bi'bi                >=1   milstein   (dwi^2-dt)/2
+        Lb[i,j,:]    bj'bi                >=1   milstein   dwi*dwj
+        L0b[i,:]     ab' +db/dt +bbb"/2   >=2   taylor15   dwidt-dzi
+        La[i,:]      ba'                  >=2   taylor15   dzi
+        LLb[i,i,i,:] bi(bibi"+bi'bi')     >=2   taylor15   (dwi^2/3-dt)dwi/2
+        LLb[i,j,j,:] bi(bjbj"+bj'bj')     >=2   taylor15   (dwj^2-dt)dwj/2
+        LLb[i,j,k,:] bi(bjbk"+bj'bk')     >=2   taylor15   dwi*dwj*dwk
+        L0a[:]       aa' +da/dt +bba"/2    2    taylor15   dt^2/2
+        """
+        cdef int i, j, k
+        cdef cy_qobj c_op
+        cdef cy_qobj c_opj
+        cdef complex trApp, trAbb, trAa
+        cdef complex[::1] trAp = self.expect_buffer_1d[0,:]
+        cdef complex[:, ::1] trAb = self.expect_buffer_2d
+        cdef complex[::1] temp = self.func_buffer_1d[0,:]
+        zero(temp)
 
+        # a
+        self.L._rhs_mat(t, &rho[0], &a[0])
+
+        # b
+        for i in range(self.N_ops):
+            c_op = self.c_ops[i]
+            # bi
+            c_op._rhs_mat(t, &rho[0], &b[i,0])
+            trAp[i] = self.expect(b[i,:])
+            axpy(-trAp[i], rho, b[i,:])
+
+        # Libj = bibj', i<=j
+        # sc_ops must commute (Libj = Ljbi)
+        if deg >= 1:
+          for i in range(self.N_ops):
+            c_op = self.c_ops[i]
+            for j in range(i, self.N_ops):
+                c_op._rhs_mat(t, &b[j,0], &Lb[i,j,0])
+                trAb[i,j] = self.expect(Lb[i,j,:])
+                axpy(-trAp[j], b[i,:], Lb[i,j,:])
+                axpy(-trAb[i,j], rho, Lb[i,j,:])
+
+        # L0b La LLb
+        if deg >= 2:
+          for i in range(self.N_ops):
+            c_op = self.c_ops[i]
+            # Lia = bia'
+            self.L._rhs_mat(t, &b[i,0], &La[i,0])
+
+            # L0bi = abi' + dbi/dt + Sum_j bjbjbi"/2
+            # db/dt
+            c_op._rhs_mat(t + self.dt, &rho[0], &L0b[i,0])
+            trApp = self.expect(L0b[i,:])
+            axpy(-trApp, rho, L0b[i,:])
+            axpy(-1, b[i,:], L0b[i,:])
+            # ab'
+            temp = np.zeros((self.l_vec, ), dtype=complex)
+            c_op._rhs_mat(t, &a[0], &temp[0])
+            trAa = self.expect(temp)
+            axpy(1., temp, L0b[i,:])
+            axpy(-trAp[i], a[:], L0b[i,:])
+            axpy(-trAa, rho, L0b[i,:])
+            # bbb" : trAb[i,j] only defined for j>=i
+            for j in range(i):
+                axpy(-trAb[j,i]*self.dt, b[j,:], L0b[i,:])  # L contain dt
+            for j in range(i,self.N_ops):
+                axpy(-trAb[i,j]*self.dt, b[j,:], L0b[i,:])  # L contain dt
+
+            # LLb
+            # LiLjbk = bi(bj'bk'+bjbk"), i<=j<=k
+            # sc_ops must commute (LiLjbk = LjLibk = LkLjbi)
+            for j in range(i,self.N_ops):
+              for k in range(j,self.N_ops):
+                c_op._rhs_mat(t, &Lb[j,k,0], &LLb[i,j,k,0])
+                trAbb = self.expect(LLb[i,j,k,:])
+                axpy(-trAp[i], Lb[j,k,:], LLb[i,j,k,:])
+                axpy(-trAbb, rho, LLb[i,j,k,:])
+                axpy(-trAb[i,k], b[j,:], LLb[i,j,k,:])
+                axpy(-trAb[i,j], b[k,:], LLb[i,j,k,:])
+
+        # L0a = a'a + da/dt + bba"/2  (a" = 0)
+        if deg == 2:
+            self.L._rhs_mat(t, &a[0], &L0a[0])
+            self.L._rhs_mat(t+self.dt, &rho[0], &L0a[0])
+            axpy(-1, a, L0a)
+
+    cdef void implicit(self, double t,  np.ndarray[complex, ndim=1] dvec,
+                                        complex[::1] out,
+                                        np.ndarray[complex, ndim=1] guess):
+        # np.ndarray to memoryview is OK but not the reverse
+        # scipy function only take np array, not memoryview
+        spout, check = sp.linalg.bicgstab(self.imp(t, data=1),
+                                        dvec, x0 = guess, tol=self.tol)
+        cdef int i
+        copy(spout,out)
+
+cdef class psse(ssolvers):
+    cdef cy_qobj L
+    cdef object c_ops
+    cdef object cdc_ops
+
+    def set_data(self, sso):
+        L = sso.LH
+        c_ops = sso.sops
+        self.l_vec = L.cte.shape[0]
+        self.N_ops = len(c_ops)
+        self.L = L.compiled_Qobj
+        self.c_ops = []
+        self.cdc_ops = []
+        for i, op in enumerate(c_ops):
+            self.c_ops.append(op[0].compiled_Qobj)
+            self.cdc_ops.append(op[0].compiled_Qobj)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cdef void photocurrent(self, double t, double dt, double[:] noise,
+                           complex[::1] vec, complex[::1] out):
+        cdef cy_qobj
+        cdef double expect
+        cdef int i
+        cdef complex[:, ::1] d2 = self.buffer_2d[0,:,:]
+        zero_2d(d2)
+        copy(vec,out)
+        self.d1(t, vec, out)
+        self.d2(t, vec, d2)
+        for i in range(self.N_ops):
+            c_op = self.cdc_ops[i]
+            expect = c_op.expect(t, vec, 1).real * dt
+            if expect > 0:
+              noise[i] = np.random.poisson(expect, 1)[0]
+            else:
+              noise[i] = 0.
+            axpy(noise[i], d2[i,:], out)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void d1(self, double t, complex[::1] vec, complex[::1] out):
+        self.L._rhs_mat(t, &vec[0], &out[0])
+        cdef int i
+        cdef complex e
+        cdef cy_qobj c_op
+        cdef complex[::1] temp = self.func_buffer_1d[0,:]
+        for i in range(self.N_ops):
+            zero(temp)
+            c_op = self.c_ops[i]
+            c_op._rhs_mat(t, &vec[0], &temp[0])
+            e = dznrm2(temp)
+            axpy(-e * e * self.dt, vec, out)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void d2(self, double t, complex[::1] vec, complex[:, ::1] out):
+        cdef int i
+        cdef cy_qobj c_op
+        cdef complex expect
+        for i in range(self.N_ops):
+            c_op = self.c_ops[i]
+            c_op._rhs_mat(t, &vec[0], &out[i,0])
+            expect = dznrm2(out[i,:])
+            if expect.real >= 1e-15:
+                zscale(1/expect, out[i,:])
+            else:
+                zero(out[i,:])
+            axpy(-1, vec, out[i,:])
+
+cdef class psme(ssolvers):
+    cdef cy_qobj L
+    cdef object cdcr_cdcl_ops
+    cdef object cdcl_ops
+    cdef object clcdr_ops
+    cdef int N_root
+
+    def set_data(self, sso):
+        L = sso.LH
+        c_ops = sso.sops
+        self.l_vec = L.cte.shape[0]
+        self.N_ops = len(c_ops)
+        self.L = L.compiled_Qobj
+        self.cdcr_cdcl_ops = []
+        self.cdcl_ops = []
+        self.clcdr_ops = []
+        self.N_root = np.sqrt(self.l_vec)
+        for i, op in enumerate(c_ops):
+            self.cdcr_cdcl_ops.append(op[0].compiled_Qobj)
+            self.cdcl_ops.append(op[1].compiled_Qobj)
+            self.clcdr_ops.append(op[2].compiled_Qobj)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cdef void photocurrent(self, double t, double dt,  double[:] noise,
+                           complex[::1] vec, complex[::1] out):
+        cdef double expect
+        cdef int i
+        cdef complex[:, ::1] d2 = self.buffer_2d[0,:,:]
+        zero_2d(d2)
+        copy(vec,out)
+        self.d1(t, vec, out)
+        self.d2(t, vec, d2)
+        for i in range(self.N_ops):
+            c_op = self.cdcl_ops[i]
+            expect = c_op.expect(t, vec, 1).real * dt
+            if expect > 0:
+              noise[i] = np.random.poisson(expect, 1)[0]
+            else:
+              noise[i] = 0.
+            axpy(noise[i], d2[i,:], out)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef complex expect(self, complex[::1] rho):
+        cdef complex e = 0.
+        cdef int k
+        for k in range(self.N_root):
+            e += rho[k*(self.N_root+1)]
+        return e
+
+    cdef void d1(self, double t, complex[::1] rho, complex[::1] out):
+        cdef int i
+        cdef cy_qobj c_op
+        cdef complex[::1] Crho = self.func_buffer_1d[0,:]
+        cdef complex expect
+        self.L._rhs_mat(t, &rho[0], &out[0])
+        for i in range(self.N_ops):
+            c_op = self.cdcr_cdcl_ops[i]
+            zero(Crho)
+            c_op._rhs_mat(t, &rho[0], &Crho[0])
+            expect = self.expect(Crho)
+            axpy(0.5*expect* self.dt, rho, out)
+            axpy(-0.5* self.dt, Crho, out)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void d2(self, double t, complex[::1] rho, complex[:, ::1] out):
+        cdef int i
+        cdef cy_qobj c_op
+        cdef complex expect
+        for i in range(self.N_ops):
+            c_op = self.clcdr_ops[i]
+            c_op._rhs_mat(t, &rho[0], &out[i,0])
+            expect = self.expect(out[i,:])
+            if expect.real >= 1e-15:
+                zscale((1.+0j)/expect, out[i,:])
+            else:
+                zero(out[i,:])
+            axpy(-1, rho, out[i,:])
+
+cdef class generic(ssolvers):
+    cdef object d1_func, d2_func
+
+    def set_data(self, sso):
+        self.l_vec = sso.rho0.shape[0]
+        self.N_ops = len(sso.sops)
+        self.d1_func = sso.d1
+        self.d2_func = sso.d2
+
+    cdef void d1(self, double t, complex[::1] rho, complex[::1] out):
+        cdef np.ndarray[complex, ndim=1] in_np
+        cdef np.ndarray[complex, ndim=1] out_np
+        in_np = np.zeros((self.l_vec, ), dtype=complex)
+        copy(rho, in_np)
+        out_np = self.d1_func(t, in_np)
+        axpy(self.dt, out_np, out) # d1 is += and * dt
+
+    cdef void d2(self, double t, complex[::1] rho, complex[:, ::1] out):
+        cdef np.ndarray[complex, ndim=1] in_np
+        cdef np.ndarray[complex, ndim=2] out_np
+        cdef int i
+        in_np = np.zeros((self.l_vec, ), dtype=complex)
+        copy(rho, in_np)
+        out_np = self.d2_func(t, in_np)
+        for i in range(self.N_ops):
+            copy(out_np[i,:], out[i,:])

--- a/qutip/cy/td_qobj_cy.pyx
+++ b/qutip/cy/td_qobj_cy.pyx
@@ -1,0 +1,477 @@
+# distutils: language = c++
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+import numpy as np
+cimport numpy as np
+import cython
+cimport cython
+from qutip.qobj import Qobj
+from qutip.cy.spmath cimport _zcsr_add_core
+from qutip.cy.spmatfuncs cimport spmvpy
+#from libc.stdlib cimport malloc, free
+cimport libc.math
+
+include "complex_math.pxi"
+include "sparse_routines.pxi"
+
+cdef extern from "numpy/arrayobject.h" nogil:
+    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
+    void PyDataMem_FREE(void * ptr)
+    void PyDataMem_RENEW(void * ptr, size_t size)
+    void PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
+    void PyDataMem_NEW(size_t size)
+
+cdef extern from "Python.h":
+    object PyLong_FromVoidPtr(void *)
+    void* PyLong_AsVoidPtr(object)
+
+
+"""@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef void CSR_from_scipy_inplace(object A, CSR_Matrix* mat):
+    ""
+    Converts a SciPy CSR sparse matrix to a
+    CSR_Matrix struct.
+    ""
+    cdef complex[::1] data = A.data
+    cdef int[::1] ind = A.indices
+    cdef int[::1] ptr = A.indptr
+    cdef int nrows = A.shape[0]
+    cdef int ncols = A.shape[1]
+    cdef int nnz = ptr[nrows]
+
+    mat.data = &data[0]
+    mat.indices = &ind[0]
+    mat.indptr = &ptr[0]
+    mat.nrows = nrows
+    mat.ncols = ncols
+    mat.nnz = nnz
+    mat.max_length = nnz
+    mat.is_set = 1
+    mat.numpy_lock = 1"""
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef shallow_get_state(CSR_Matrix* mat):
+    """
+    Converts a CSR sparse matrix to a tuples for pickling.
+    No deep copy of the data, pointer are passed.
+    """
+    long_data = PyLong_FromVoidPtr(<void *>&mat.data[0])
+    long_indices = PyLong_FromVoidPtr(<void *>&mat.indices[0])
+    long_indptr = PyLong_FromVoidPtr(<void *>&mat.indptr[0])
+    return (long_data,  long_indices,  long_indptr,
+            mat.nrows, mat.ncols, mat.nnz, mat.max_length,
+            mat.is_set, mat.numpy_lock)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef shallow_set_state(CSR_Matrix* mat, state):
+    """
+    Converts a CSR sparse matrix to a tuples for pickling.
+    No deep copy of the data, pointer are passed.
+    """
+    mat.data = <complex*>PyLong_AsVoidPtr(state[0])
+    mat.indices = <int*>PyLong_AsVoidPtr(state[1])
+    mat.indptr = <int*>PyLong_AsVoidPtr(state[2])
+    mat.nrows = state[3]
+    mat.ncols = state[4]
+    mat.nnz = state[5]
+    mat.max_length = state[6]
+    mat.is_set = state[7]
+    mat.numpy_lock = state[8]
+
+
+cdef class cy_qobj:
+    cdef void _rhs_mat(self, double t, complex* vec, complex* out):
+        pass
+
+    cdef complex _expect_mat(self, double t, complex* vec, int isherm):
+        return 0.
+
+    cdef complex _expect_mat_super(self, double t, complex* vec, int isherm):
+        return 0.
+
+
+cdef class cy_cte_qobj(cy_qobj):
+    def __init__(self):
+        pass
+
+    def set_data(self, cte):
+        self.shape0 = cte.shape[0]
+        self.shape1 = cte.shape[1]
+        self.dims = cte.dims
+        self.cte = CSR_from_scipy(cte.data)
+        self.total_elem = cte.data.data.shape[0]
+        self.super = cte.issuper
+
+    def __getstate__(self):
+        CSR_info = shallow_get_state(&self.cte)
+        return (self.shape0, self.shape1, self.dims,
+                self.total_elem, self.super, CSR_info)
+
+    def __setstate__(self, state):
+        self.shape0 = state[0]
+        self.shape1 = state[1]
+        self.dims = state[2]
+        self.total_elem = state[3]
+        self.super = state[4]
+        shallow_set_state(&self.cte, state[5])
+
+    def call(self, double t, int data=0):
+        cdef CSR_Matrix out
+        out.is_set = 0
+        copy_CSR(&out, &self.cte)
+        scipy_obj = CSR_to_scipy(&out)
+        # free_CSR(&out)? data is own by the scipy_obj?
+        if data:
+            return scipy_obj
+        else:
+            return Qobj(scipy_obj,dims = self.dims)
+
+    def call_with_coeff(self, double t, complex[::1] coeff, int data=0):
+        cdef CSR_Matrix out
+        out.is_set = 0
+        copy_CSR(&out, &self.cte)
+        scipy_obj = CSR_to_scipy(&out)
+        # free_CSR(&out)? data is own by the scipy_obj?
+        if data:
+            return scipy_obj
+        else:
+            return Qobj(scipy_obj)
+
+    def get_ptr(self):
+        return PyLong_FromVoidPtr(<void*> self)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void _rhs_mat(self, double t, complex* vec, complex* out):
+        spmvpy(self.cte.data, self.cte.indices, self.cte.indptr, vec, 1.,
+               out, self.shape0)
+
+    def rhs(self, double t, complex[::1] vec):
+        cdef np.ndarray[complex, ndim=1] out = np.zeros(self.shape0,
+                                                        dtype=complex)
+        self._rhs_mat(t, &vec[0], &out[0])
+        return out
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef complex _expect_mat(self, double t, complex* vec, int isherm):
+        cdef complex[::1] y = np.zeros(self.shape0, dtype=complex)
+        spmvpy(self.cte.data, self.cte.indices, self.cte.indptr, vec, 1.,
+               &y[0], self.shape0)
+        cdef int row
+        cdef complex dot = 0
+        for row from 0 <= row < self.shape0:
+            dot += conj(vec[row])*y[row]
+        if isherm:
+            return real(dot)
+        else:
+            return dot
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef complex _expect_mat_super(self, double t, complex* vec, int isherm):
+        cdef int row
+        cdef int jj, row_start, row_end
+        cdef int num_rows = self.shape0
+        cdef int n = <int>libc.math.sqrt(num_rows)
+        cdef complex dot = 0.0
+
+        for row from 0 <= row < num_rows by n+1:
+            row_start = self.cte.indptr[row]
+            row_end = self.cte.indptr[row+1]
+            for jj from row_start <= jj < row_end:
+                dot += self.cte.data[jj]*vec[self.cte.indices[jj]]
+
+        if isherm:
+            return real(dot)
+        else:
+            return dot
+
+    def expect(self, double t, complex[::1] vec, int isherm):
+        if self.super:
+            return self._expect_mat_super(t, &vec[0], isherm)
+        else:
+            return self._expect_mat(t, &vec[0], isherm)
+
+
+cdef class cy_td_qobj(cy_qobj):
+    def __init__(self):
+        self.N_ops = 0
+        self.ops = <CSR_Matrix**> PyDataMem_NEW(0 * sizeof(CSR_Matrix*))
+
+    def __del__(self):
+        for i in range(self.N_ops):
+            PyDataMem_FREE(self.ops[i])
+        PyDataMem_FREE(self.ops)
+
+    def set_data(self, cte, ops):
+        cdef int i
+        self.shape0 = cte.shape[0]
+        self.shape1 = cte.shape[1]
+        self.dims = cte.dims
+        self.cte = CSR_from_scipy(cte.data)
+        cummulative_op = cte.data
+        self.super = cte.issuper
+
+        self.N_ops = len(ops)
+        PyDataMem_FREE(self.ops)
+        self.ops = <CSR_Matrix**> PyDataMem_NEW(self.N_ops * sizeof(CSR_Matrix*))
+        self.sum_elem = np.zeros(self.N_ops, dtype=int)
+        for i, op in enumerate(ops):
+            self.ops[i] = <CSR_Matrix*> PyDataMem_NEW(sizeof(CSR_Matrix))
+            CSR_from_scipy_inplace(op[0].data, self.ops[i])
+            cummulative_op += op[0].data
+            self.sum_elem[i] = cummulative_op.data.shape[0]
+
+        self.total_elem = self.sum_elem[self.N_ops-1]
+
+    def set_factor(self, func=None, ptr=False):
+        cdef void* f_ptr
+        if ptr:
+            self.factor_use_ptr = 1
+            f_ptr = PyLong_AsVoidPtr(ptr)
+            self.factor_ptr = <void(*)(double, complex*)> f_ptr
+        else:
+            self.factor_use_ptr = 0
+            self.factor_func = func
+
+    def __getstate__(self):
+        cte_info = shallow_get_state(&self.cte)
+        ops_info = ()
+        sum_elem = ()
+        for i in range(self.N_ops):
+            ops_info += (shallow_get_state(self.ops[i]),)
+            sum_elem += (self.sum_elem[i],)
+
+        factor_ptr = PyLong_FromVoidPtr(<void*>self.factor_ptr)
+        factor_func = PyLong_FromVoidPtr(<void*>self.factor_func)
+        return (self.shape0, self.shape1, self.dims, self.total_elem, self.super,
+                self.factor_use_ptr, factor_ptr, factor_func, self.N_ops,
+                sum_elem, cte_info, ops_info)
+
+    def __setstate__(self, state):
+        self.shape0 = state[0]
+        self.shape1 = state[1]
+        self.dims = state[2]
+        self.total_elem = state[3]
+        self.super = state[4]
+        self.factor_use_ptr = state[5]
+        self.factor_ptr = <void(*)(double, complex*)> PyLong_AsVoidPtr(state[6])
+        self.factor_func = <object> PyLong_AsVoidPtr(state[7])
+        self.N_ops = state[8]
+        shallow_set_state(&self.cte, state[10])
+        self.sum_elem = np.zeros(self.N_ops, dtype=int)
+        self.ops = <CSR_Matrix**> PyDataMem_NEW(self.N_ops * sizeof(CSR_Matrix*))
+        for i in range(self.N_ops):
+            self.ops[i] = <CSR_Matrix*> PyDataMem_NEW(sizeof(CSR_Matrix))
+            self.sum_elem[i] = state[9][i]
+            shallow_set_state(self.ops[i], state[11][i])
+
+    cdef void factor(self, double t, complex* out):
+        cdef int i
+        if self.factor_use_ptr:
+            self.factor_ptr(t, out)
+        else:
+            coeff = self.factor_func(t)
+            for i in range(self.N_ops):
+                out[i] = coeff[i]
+
+    def get_ptr(self):
+        return PyLong_FromVoidPtr(<void*> self)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void _call_core(self, double t, CSR_Matrix * out,
+                                    complex* coeff):
+        cdef int i
+        cdef CSR_Matrix previous, next
+
+        if(self.N_ops ==1):
+            _zcsr_add_core(self.cte.data, self.cte.indices, self.cte.indptr,
+                         self.ops[0].data, self.ops[0].indices,
+                         self.ops[0].indptr,
+                         coeff[0], out, self.shape0, self.shape1)
+        else:
+            # Ugly with a loop for 1 to N-2...
+            # It save the copy of data from cte and out
+            # no init/free to cte, out
+            init_CSR(&next, self.sum_elem[0], self.shape0, self.shape1)
+            _zcsr_add_core(self.cte.data, self.cte.indices, self.cte.indptr,
+                           self.ops[0].data,
+                           self.ops[0].indices,
+                           self.ops[0].indptr,
+                           coeff[0], &next, self.shape0, self.shape1)
+            previous = next
+            next = CSR_Matrix()
+
+            for i in range(1,self.N_ops-1):
+                init_CSR(&next, self.sum_elem[i], self.shape0, self.shape1)
+                _zcsr_add_core(previous.data, previous.indices,
+                               previous.indptr,
+                               self.ops[i].data,
+                               self.ops[i].indices,
+                               self.ops[i].indptr,
+                               coeff[i], &next, self.shape0, self.shape1)
+                free_CSR(&previous)
+                previous = next
+                next = CSR_Matrix()
+
+            _zcsr_add_core(previous.data, previous.indices, previous.indptr,
+                           self.ops[self.N_ops-1].data,
+                           self.ops[self.N_ops-1].indices,
+                           self.ops[self.N_ops-1].indptr,
+                           coeff[self.N_ops-1], out, self.shape0, self.shape1)
+            free_CSR(&previous)
+
+    def call(self, double t, int data=0):
+        cdef CSR_Matrix out
+        init_CSR(&out, self.total_elem, self.shape0, self.shape1)
+        cdef np.ndarray[complex, ndim=1] coeff = np.empty(self.N_ops,
+                                                          dtype=complex)
+        self.factor(t, &coeff[0])
+        self._call_core(t, &out, &coeff[0])
+        scipy_obj = CSR_to_scipy(&out)
+        # free_CSR(&out)? data is own by the scipy_obj?
+        if data:
+            return scipy_obj
+        else:
+            return Qobj(scipy_obj,dims = self.dims)
+
+    def call_with_coeff(self, double t, complex[::1] coeff, int data=0):
+        cdef CSR_Matrix out
+        init_CSR(&out, self.total_elem, self.shape0, self.shape1)
+        self._call_core(t, &out, &coeff[0])
+        scipy_obj = CSR_to_scipy(&out)
+        # free_CSR(&out)? data is own by the scipy_obj?
+        if data:
+            return scipy_obj
+        else:
+            return Qobj(scipy_obj)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void _rhs_mat(self, double t, complex* vec, complex* out):
+        cdef np.ndarray[complex, ndim=1] coeff = np.empty(self.N_ops,
+                                                          dtype=complex)
+        self.factor(t, &coeff[0])
+        cdef int i
+
+        spmvpy(self.cte.data, self.cte.indices, self.cte.indptr, vec,
+               1., out, self.shape0)
+        for i in range(self.N_ops):
+            spmvpy(self.ops[i].data, self.ops[i].indices, self.ops[i].indptr,
+                   vec, coeff[i], out, self.shape0)
+
+    def rhs(self, double t, complex[::1] vec):
+        cdef np.ndarray[complex, ndim=1] out = np.zeros(self.shape0,
+                                                        dtype=complex)
+        self._rhs_mat(t, &vec[0], &out[0])
+        return out
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef complex _expect_psi(self, complex* data, int* idx, int* ptr,
+                             complex* vec, int isherm):
+        cdef complex [::1] y = np.zeros(self.shape0, dtype=complex)
+        spmvpy(data, idx, ptr, vec, 1., &y[0], self.shape0)
+        cdef int row, num_rows = self.shape0
+        cdef complex dot = 0
+        for row from 0 <= row < num_rows:
+            dot += conj(vec[row]) * y[row]
+        if isherm:
+            return real(dot)
+        else:
+            return dot
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef complex _expect_mat(self, double t, complex* vec, int isherm):
+        cdef complex [::1] y = np.zeros(self.shape0, dtype=complex)
+        cdef int row
+        cdef complex dot = 0
+        self._rhs_mat(t, &vec[0], &y[0])
+        for row from 0 <= row < self.shape0:
+            dot += conj(vec[row]) * y[row]
+        if isherm:
+            return real(dot)
+        else:
+            return dot
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef complex _expect_mat_super(self, double t, complex* vec, int isherm):
+        cdef int row, i
+        cdef int jj, row_start, row_end
+        cdef int num_rows = self.shape0
+        cdef int n = <int>libc.math.sqrt(num_rows)
+        cdef complex dot = 0.0
+        cdef np.ndarray[complex, ndim=1] coeff = np.empty(self.N_ops,
+                                                          dtype=complex)
+        self.factor(t, &coeff[0])
+
+        for row from 0 <= row < num_rows by n+1:
+            row_start = self.cte.indptr[row]
+            row_end = self.cte.indptr[row+1]
+            for jj from row_start <= jj < row_end:
+                dot += self.cte.data[jj]*vec[self.cte.indices[jj]]
+        for i in range(self.N_ops):
+            for row from 0 <= row < num_rows by n+1:
+                row_start = self.ops[i].indptr[row]
+                row_end = self.ops[i].indptr[row+1]
+                for jj from row_start <= jj < row_end:
+                    dot += self.ops[i].data[jj] * \
+                          vec[self.ops[i].indices[jj]] * coeff[i]
+        if isherm:
+            return real(dot)
+        else:
+            return dot
+
+    def expect(self, double t, complex[::1] vec, int isherm):
+        if self.super:
+            return self._expect_mat_super(t, &vec[0], isherm)
+        else:
+            return self._expect_mat(t, &vec[0], isherm)

--- a/qutip/pdpsolve.py
+++ b/qutip/pdpsolve.py
@@ -1,0 +1,627 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+import numpy as np
+import scipy.sparse as sp
+from scipy.linalg.blas import get_blas_funcs
+try:
+    norm = get_blas_funcs("znrm2", dtype=np.float64)
+except:
+    from scipy.linalg import norm
+
+from numpy.random import RandomState
+
+from qutip.qobj import Qobj, isket
+from qutip.states import ket2dm
+from qutip.solver import Result
+from qutip.expect import expect, expect_rho_vec
+from qutip.superoperator import (spre, spost, mat2vec, vec2mat,
+                                 liouvillian, lindblad_dissipator)
+from qutip.cy.spmatfuncs import cy_expect_psi_csr, spmv, cy_expect_rho_vec
+from qutip.parallel import serial_map
+from qutip.ui.progressbar import TextProgressBar
+from qutip.solver import Options, _solver_safety_check
+from qutip.settings import debug
+
+class StochasticSolverOptions:
+    """Class of options for stochastic (piecewse deterministic process) PDP
+    solvers such as :func:`qutip.pdpsolve.ssepdpsolve`,
+    :func:`qutip.pdpsolve.smepdpsolve`.
+    Options can be specified either as arguments to the constructor::
+
+        sso = StochasticSolverOptions(nsubsteps=100, ...)
+
+    or by changing the class attributes after creation::
+
+        sso = StochasticSolverOptions()
+        sso.nsubsteps = 1000
+
+    The stochastic solvers :func:`qutip.pdpsolve.ssepdpsolve` and
+    :func:`qutip.pdpsolve.smepdpsolve` all take the same keyword arguments as
+    the constructor of these class, and internally they use these arguments to
+    construct an instance of this class, so it is rarely needed to explicitly
+    create an instance of this class.
+
+    Attributes
+    ----------
+
+    H : :class:`qutip.Qobj`
+        System Hamiltonian.
+
+    state0 : :class:`qutip.Qobj`
+        Initial state vector (ket) or density matrix.
+
+    times : *list* / *array*
+        List of times for :math:`t`. Must be uniformly spaced.
+
+    c_ops : list of :class:`qutip.Qobj`
+        List of deterministic collapse operators.
+
+    sc_ops : list of :class:`qutip.Qobj`
+        List of stochastic collapse operators. Each stochastic collapse
+        operator will give a deterministic and stochastic contribution
+        to the equation of motion according to how the d1 and d2 functions
+        are defined.
+
+    e_ops : list of :class:`qutip.Qobj`
+        Single operator or list of operators for which to evaluate
+        expectation values.
+
+    m_ops : list of :class:`qutip.Qobj`
+        List of operators representing the measurement operators. The expected
+        format is a nested list with one measurement operator for each
+        stochastic increament, for each stochastic collapse operator.
+
+    args : dict / list
+        List of dictionary of additional problem-specific parameters.
+        Implicit methods can adjust tolerance via args = {'tol':value}
+
+    ntraj : int
+        Number of trajectors.
+
+    nsubsteps : int
+        Number of sub steps between each time-spep given in `times`.
+
+    d1 : function
+        Function for calculating the operator-valued coefficient to the
+        deterministic increment dt.
+
+    d2 : function
+        Function for calculating the operator-valued coefficient to the
+        stochastic increment(s) dW_n, where n is in [0, d2_len[.
+
+    d2_len : int (default 1)
+        The number of stochastic increments in the process.
+
+    dW_factors : array
+        Array of length d2_len, containing scaling factors for each
+        measurement operator in m_ops.
+
+    rhs : function
+        Function for calculating the deterministic and stochastic contributions
+        to the right-hand side of the stochastic differential equation. This
+        only needs to be specified when implementing a custom SDE solver.
+
+    generate_A_ops : function
+        Function that generates a list of pre-computed operators or super-
+        operators. These precomputed operators are used in some d1 and d2
+        functions.
+
+    generate_noise : function
+        Function for generate an array of pre-computed noise signal.
+
+    homogeneous : bool (True)
+        Wheter or not the stochastic process is homogenous. Inhomogenous
+        processes are only supported for poisson distributions.
+
+    solver : string
+        Name of the solver method to use for solving the stochastic
+        equations. Valid values are:
+        1/2 order algorithms: 'euler-maruyama', 'fast-euler-maruyama',
+        'pc-euler' is a predictor-corrector method which is more
+        stable than explicit methods,
+        1 order algorithms: 'milstein', 'fast-milstein', 'platen',
+        'milstein-imp' is semi-implicit Milstein method,
+        3/2 order algorithms: 'taylor15',
+        'taylor15-imp' is semi-implicit Taylor 1.5 method.
+        Implicit methods can adjust tolerance via args = {'tol':value},
+        default is {'tol':1e-6}
+
+    method : string ('homodyne', 'heterodyne', 'photocurrent')
+        The name of the type of measurement process that give rise to the
+        stochastic equation to solve. Specifying a method with this keyword
+        argument is a short-hand notation for using pre-defined d1 and d2
+        functions for the corresponding stochastic processes.
+
+    distribution : string ('normal', 'poisson')
+        The name of the distribution used for the stochastic increments.
+
+    store_measurements : bool (default False)
+        Whether or not to store the measurement results in the
+        :class:`qutip.solver.SolverResult` instance returned by the solver.
+
+    noise : array
+        Vector specifying the noise.
+
+    normalize : bool (default True)
+        Whether or not to normalize the wave function during the evolution.
+
+    options : :class:`qutip.solver.Options`
+        Generic solver options.
+
+    map_func: function
+        A map function or managing the calls to single-trajactory solvers.
+
+    map_kwargs: dictionary
+        Optional keyword arguments to the map_func function function.
+
+    progress_bar : :class:`qutip.ui.BaseProgressBar`
+        Optional progress bar class instance.
+
+    """
+    def __init__(self, H=None, state0=None, times=None, c_ops=[], sc_ops=[],
+                 e_ops=[], m_ops=None, args=None, ntraj=1, nsubsteps=1,
+                 d1=None, d2=None, d2_len=1, dW_factors=None, rhs=None,
+                 generate_A_ops=None, generate_noise=None, homogeneous=True,
+                 solver=None, method=None, distribution='normal',
+                 store_measurement=False, noise=None, normalize=True,
+                 options=None, progress_bar=None, map_func=None,
+                 map_kwargs=None):
+
+        if options is None:
+            options = Options()
+
+        if progress_bar is None:
+            progress_bar = TextProgressBar()
+
+        self.H = H
+        self.d1 = d1
+        self.d2 = d2
+        self.d2_len = d2_len
+        self.dW_factors = dW_factors# if dW_factors else np.ones(d2_len)
+        self.state0 = state0
+        self.times = times
+        self.c_ops = c_ops
+        self.sc_ops = sc_ops
+        self.e_ops = e_ops
+
+        #if m_ops is None:
+        #    self.m_ops = [[c for _ in range(d2_len)] for c in sc_ops]
+        #else:
+        #    self.m_ops = m_ops
+
+        self.m_ops = m_ops
+
+        self.ntraj = ntraj
+        self.nsubsteps = nsubsteps
+        self.solver = solver
+        self.method = method
+        self.distribution = distribution
+        self.homogeneous = homogeneous
+        self.rhs = rhs
+        self.options = options
+        self.progress_bar = progress_bar
+        self.store_measurement = store_measurement
+        self.store_states = options.store_states
+        self.noise = noise
+        self.args = args
+        self.normalize = normalize
+
+        self.generate_noise = generate_noise
+        self.generate_A_ops = generate_A_ops
+
+        if self.ntraj > 1 and map_func:
+            self.map_func = map_func
+        else:
+            self.map_func = serial_map
+
+        self.map_kwargs = map_kwargs if map_kwargs is not None else {}
+
+        #Does any operator depend on time?
+        self.td = False
+        if not isinstance(H, Qobj):
+            self.td = True
+        for ops in c_ops:
+            if not isinstance(ops, Qobj):
+                self.td = True
+        for ops in sc_ops:
+            if not isinstance(ops, Qobj):
+                self.td = True
+
+def main_ssepdpsolve(H, psi0, times, c_ops, e_ops, **kwargs):
+    """
+    A stochastic (piecewse deterministic process) PDP solver for wavefunction
+    evolution. For most purposes, use :func:`qutip.mcsolve` instead for quantum
+    trajectory simulations.
+
+    Parameters
+    ----------
+
+    H : :class:`qutip.Qobj`
+        System Hamiltonian.
+
+    psi0 : :class:`qutip.Qobj`
+        Initial state vector (ket).
+
+    times : *list* / *array*
+        List of times for :math:`t`. Must be uniformly spaced.
+
+    c_ops : list of :class:`qutip.Qobj`
+        Deterministic collapse operator which will contribute with a standard
+        Lindblad type of dissipation.
+
+    e_ops : list of :class:`qutip.Qobj` / callback function single
+        single operator or list of operators for which to evaluate
+        expectation values.
+
+    kwargs : *dictionary*
+        Optional keyword arguments. See
+        :class:`qutip.stochastic.StochasticSolverOptions`.
+
+    Returns
+    -------
+
+    output: :class:`qutip.solver.SolverResult`
+
+        An instance of the class :class:`qutip.solver.SolverResult`.
+
+    """
+    if debug:
+        logger.debug(inspect.stack()[0][3])
+
+    if isinstance(e_ops, dict):
+        e_ops_dict = e_ops
+        e_ops = [e for e in e_ops.values()]
+    else:
+        e_ops_dict = None
+
+    sso = StochasticSolverOptions(H=H, state0=psi0, times=times, c_ops=c_ops,
+                                  e_ops=e_ops, **kwargs)
+
+    res = _ssepdpsolve_generic(sso, sso.options, sso.progress_bar)
+
+    if e_ops_dict:
+        res.expect = {e: res.expect[n]
+                      for n, e in enumerate(e_ops_dict.keys())}
+    return res
+
+def main_smepdpsolve(H, rho0, times, c_ops, e_ops, **kwargs):
+    """
+    A stochastic (piecewse deterministic process) PDP solver for density matrix
+    evolution.
+
+    Parameters
+    ----------
+
+    H : :class:`qutip.Qobj`
+        System Hamiltonian.
+
+    rho0 : :class:`qutip.Qobj`
+        Initial density matrix.
+
+    times : *list* / *array*
+        List of times for :math:`t`. Must be uniformly spaced.
+
+    c_ops : list of :class:`qutip.Qobj`
+        Deterministic collapse operator which will contribute with a standard
+        Lindblad type of dissipation.
+
+    sc_ops : list of :class:`qutip.Qobj`
+        List of stochastic collapse operators. Each stochastic collapse
+        operator will give a deterministic and stochastic contribution
+        to the eqaution of motion according to how the d1 and d2 functions
+        are defined.
+
+    e_ops : list of :class:`qutip.Qobj` / callback function single
+        single operator or list of operators for which to evaluate
+        expectation values.
+
+    kwargs : *dictionary*
+        Optional keyword arguments. See
+        :class:`qutip.stochastic.StochasticSolverOptions`.
+
+    Returns
+    -------
+
+    output: :class:`qutip.solver.SolverResult`
+
+        An instance of the class :class:`qutip.solver.SolverResult`.
+
+    """
+    if debug:
+        logger.debug(inspect.stack()[0][3])
+
+    if isinstance(e_ops, dict):
+        e_ops_dict = e_ops
+        e_ops = [e for e in e_ops.values()]
+    else:
+        e_ops_dict = None
+
+    sso = StochasticSolverOptions(H=H, state0=rho0, times=times, c_ops=c_ops,
+                                  e_ops=e_ops, **kwargs)
+
+    res = _smepdpsolve_generic(sso, sso.options, sso.progress_bar)
+
+    if e_ops_dict:
+        res.expect = {e: res.expect[n]
+                      for n, e in enumerate(e_ops_dict.keys())}
+    return res
+
+
+# -----------------------------------------------------------------------------
+# Generic parameterized stochastic SE PDP solver
+#
+def _ssepdpsolve_generic(sso, options, progress_bar):
+    """
+    For internal use. See ssepdpsolve.
+    """
+    if debug:
+        logger.debug(inspect.stack()[0][3])
+
+    N_store = len(sso.times)
+    N_substeps = sso.nsubsteps
+    dt = (sso.times[1] - sso.times[0]) / N_substeps
+    nt = sso.ntraj
+
+    data = Result()
+    data.solver = "sepdpsolve"
+    data.times = sso.tlist
+    data.expect = np.zeros((len(sso.e_ops), N_store), dtype=complex)
+    data.ss = np.zeros((len(sso.e_ops), N_store), dtype=complex)
+    data.jump_times = []
+    data.jump_op_idx = []
+
+    # effective hamiltonian for deterministic part
+    Heff = sso.H
+    for c in sso.c_ops:
+        Heff += -0.5j * c.dag() * c
+
+    progress_bar.start(sso.ntraj)
+    for n in range(sso.ntraj):
+        progress_bar.update(n)
+        psi_t = sso.state0.full().ravel()
+
+        states_list, jump_times, jump_op_idx = \
+            _ssepdpsolve_single_trajectory(data, Heff, dt, sso.times,
+                                           N_store, N_substeps,
+                                           psi_t, sso.state0.dims,
+                                           sso.c_ops, sso.e_ops)
+
+        data.states.append(states_list)
+        data.jump_times.append(jump_times)
+        data.jump_op_idx.append(jump_op_idx)
+
+    progress_bar.finished()
+
+    # average density matrices
+    if options.average_states and np.any(data.states):
+        data.states = [sum([data.states[m][n] for m in range(nt)]).unit()
+                       for n in range(len(data.times))]
+
+    # average
+    data.expect = data.expect / nt
+
+    # standard error
+    if nt > 1:
+        data.se = (data.ss - nt * (data.expect ** 2)) / (nt * (nt - 1))
+    else:
+        data.se = None
+
+    # convert complex data to real if hermitian
+    data.expect = [np.real(data.expect[n, :])
+                   if e.isherm else data.expect[n, :]
+                   for n, e in enumerate(sso.e_ops)]
+
+    return data
+
+def _ssepdpsolve_single_trajectory(data, Heff, dt, times, N_store, N_substeps, psi_t, dims, c_ops, e_ops):
+    """
+    Internal function. See ssepdpsolve.
+    """
+    states_list = []
+
+    phi_t = np.copy(psi_t)
+
+    prng = RandomState()  # todo: seed it
+    r_jump, r_op = prng.rand(2)
+
+    jump_times = []
+    jump_op_idx = []
+
+    for t_idx, t in enumerate(times):
+
+        if e_ops:
+            for e_idx, e in enumerate(e_ops):
+                s = cy_expect_psi_csr(
+                    e.data.data, e.data.indices, e.data.indptr, psi_t, 0)
+                data.expect[e_idx, t_idx] += s
+                data.ss[e_idx, t_idx] += s ** 2
+        else:
+            states_list.append(Qobj(psi_t, dims=dims))
+
+        for j in range(N_substeps):
+
+            if norm(phi_t) ** 2 < r_jump:
+                # jump occurs
+                p = np.array([norm(c.data * psi_t) ** 2 for c in c_ops])
+                p = np.cumsum(p / np.sum(p))
+                n = np.where(p >= r_op)[0][0]
+
+                # apply jump
+                psi_t = c_ops[n].data * psi_t
+                psi_t /= norm(psi_t)
+                phi_t = np.copy(psi_t)
+
+                # store info about jump
+                jump_times.append(times[t_idx] + dt * j)
+                jump_op_idx.append(n)
+
+                # get new random numbers for next jump
+                r_jump, r_op = prng.rand(2)
+
+            # deterministic evolution wihtout correction for norm decay
+            dphi_t = (-1.0j * dt) * (Heff.data * phi_t)
+
+            # deterministic evolution with correction for norm decay
+            dpsi_t = (-1.0j * dt) * (Heff.data * psi_t)
+            A = 0.5 * np.sum([norm(c.data * psi_t) ** 2 for c in c_ops])
+            dpsi_t += dt * A * psi_t
+
+            # increment wavefunctions
+            phi_t += dphi_t
+            psi_t += dpsi_t
+
+            # ensure that normalized wavefunction remains normalized
+            # this allows larger time step than otherwise would be possible
+            psi_t /= norm(psi_t)
+
+    return states_list, jump_times, jump_op_idx
+
+
+# -----------------------------------------------------------------------------
+# Generic parameterized stochastic ME PDP solver
+#
+def _smepdpsolve_generic(sso, options, progress_bar):
+    """
+    For internal use. See smepdpsolve.
+    """
+    if debug:
+        logger.debug(inspect.stack()[0][3])
+
+    N_store = len(sso.times)
+    N_substeps = sso.nsubsteps
+    dt = (sso.times[1] - sso.times[0]) / N_substeps
+    nt = sso.ntraj
+
+    data = Result()
+    data.solver = "smepdpsolve"
+    data.times = sso.times
+    data.expect = np.zeros((len(sso.e_ops), N_store), dtype=complex)
+    data.jump_times = []
+    data.jump_op_idx = []
+
+    # Liouvillian for the deterministic part.
+    # needs to be modified for TD systems
+    L = liouvillian(sso.H, sso.c_ops)
+
+    progress_bar.start(sso.ntraj)
+
+    for n in range(sso.ntraj):
+        progress_bar.update(n)
+        rho_t = mat2vec(sso.rho0.full()).ravel()
+
+        states_list, jump_times, jump_op_idx = \
+            _smepdpsolve_single_trajectory(data, L, dt, sso.times,
+                                           N_store, N_substeps,
+                                           rho_t, sso.rho0.dims,
+                                           sso.c_ops, sso.e_ops)
+
+        data.states.append(states_list)
+        data.jump_times.append(jump_times)
+        data.jump_op_idx.append(jump_op_idx)
+
+    progress_bar.finished()
+
+    # average density matrices
+    if options.average_states and np.any(data.states):
+        data.states = [sum([data.states[m][n] for m in range(nt)]).unit()
+                       for n in range(len(data.times))]
+
+    # average
+    data.expect = data.expect / sso.ntraj
+
+    # standard error
+    if nt > 1:
+        data.se = (data.ss - nt * (data.expect ** 2)) / (nt * (nt - 1))
+    else:
+        data.se = None
+
+    return data
+
+def _smepdpsolve_single_trajectory(data, L, dt, times, N_store, N_substeps, rho_t, dims, c_ops, e_ops):
+    """
+    Internal function. See smepdpsolve.
+    """
+    states_list = []
+
+    rho_t = np.copy(rho_t)
+    sigma_t = np.copy(rho_t)
+
+    prng = RandomState()  # todo: seed it
+    r_jump, r_op = prng.rand(2)
+
+    jump_times = []
+    jump_op_idx = []
+
+    for t_idx, t in enumerate(times):
+
+        if e_ops:
+            for e_idx, e in enumerate(e_ops):
+                data.expect[e_idx, t_idx] += expect_rho_vec(e, rho_t)
+        else:
+            states_list.append(Qobj(vec2mat(rho_t), dims=dims))
+
+        for j in range(N_substeps):
+
+            if sigma_t.norm() < r_jump:
+                # jump occurs
+                p = np.array([expect(c.dag() * c, rho_t) for c in c_ops])
+                p = np.cumsum(p / np.sum(p))
+                n = np.where(p >= r_op)[0][0]
+
+                # apply jump
+                rho_t = c_ops[n] * rho_t * c_ops[n].dag()
+                rho_t /= expect(c_ops[n].dag() * c_ops[n], rho_t)
+                sigma_t = np.copy(rho_t)
+
+                # store info about jump
+                jump_times.append(times[t_idx] + dt * j)
+                jump_op_idx.append(n)
+
+                # get new random numbers for next jump
+                r_jump, r_op = prng.rand(2)
+
+            # deterministic evolution wihtout correction for norm decay
+            dsigma_t = spmv(L.data, sigma_t) * dt
+
+            # deterministic evolution with correction for norm decay
+            drho_t = spmv(L.data, rho_t) * dt
+
+            rho_t += drho_t
+
+            # increment density matrices
+            sigma_t += dsigma_t
+            rho_t += drho_t
+
+    return states_list, jump_times, jump_op_idx

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -145,7 +145,7 @@ class StochasticSolverOptions:
     Attributes
     ----------
 
-    H : :class:`qutip.Qobj`
+    H : :class:`qutip.Qobj`, :class:`qutip.td_Qobj`, time-dependent Qobj as a list*
         System Hamiltonian.
 
     state0 : :class:`qutip.Qobj`
@@ -154,10 +154,10 @@ class StochasticSolverOptions:
     times : *list* / *array*
         List of times for :math:`t`. Must be uniformly spaced.
 
-    c_ops : list of :class:`qutip.Qobj`
+    c_ops : list of :class:`qutip.Qobj`, :class:`qutip.td_Qobj` or [Qobj, coeff*]
         List of deterministic collapse operators.
 
-    sc_ops : list of :class:`qutip.Qobj`
+    sc_ops : list of :class:`qutip.Qobj`, :class:`qutip.td_Qobj` or [Qobj, coeff*]
         List of stochastic collapse operators. Each stochastic collapse
         operator will give a deterministic and stochastic contribution
         to the equation of motion according to how the d1 and d2 functions
@@ -230,6 +230,27 @@ class StochasticSolverOptions:
     progress_bar : :class:`qutip.ui.BaseProgressBar`
         Optional progress bar class instance.
 
+    *
+    time-dependent Qobj can be used for H, c_ops and sc_ops.
+    The format for time-dependent system hamiltonian is:
+    H = [Qobj0,[Qobj1,coeff1],[Qobj2,coeff2],...]
+      = Qobj0 + Qobj1 * coeff1(t) + Qobj2 * coeff2(t)
+
+    coeff function can be:
+        function: coeff(t, args) -> complex
+        str: "sin(1j*w*t)"
+        np.array[complex, 1d] of length equal to the times array
+    The argument args for the function coeff is the args keyword argument of the
+        stochastic solver.
+    Likewisem in str cases, the parameters ('w' in this case) are taken from the
+        args keywords argument.
+    *While mixing coeff type does not results in errors, it is not recommended.*
+
+    For the collapse operators (c_ops, sc_ops):
+    Each operators can only be composed of 1 Qobj.
+    c_ops = [c_op1, c_op2, ...]
+    c_opN = Qobj or [Qobj,coeff]
+    The coeff format is the same as for the Hamiltonian.
     """
     def __init__(self, H=None, c_ops=[], sc_ops=[], state0=None,
                  e_ops=[], m_ops=None, store_measurement=False, dW_factors=None,
@@ -398,8 +419,9 @@ def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
     Parameters
     ----------
 
-    H : :class:`qutip.Qobj`
+    H : :class:`qutip.Qobj`, or time dependent system.
         System Hamiltonian.
+        Can depend on time, see StochasticSolverOptions help for format.
 
     rho0 : :class:`qutip.Qobj`
         Initial density matrix or state vector (ket).
@@ -407,15 +429,17 @@ def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
     times : *list* / *array*
         List of times for :math:`t`. Must be uniformly spaced.
 
-    c_ops : list of :class:`qutip.Qobj`
+    c_ops : list of :class:`qutip.Qobj`, or time dependent Qobjs.
         Deterministic collapse operator which will contribute with a standard
         Lindblad type of dissipation.
+        Can depend on time, see StochasticSolverOptions help for format.
 
-    sc_ops : list of :class:`qutip.Qobj`
+    sc_ops : list of :class:`qutip.Qobj`, or time dependent Qobjs.
         List of stochastic collapse operators. Each stochastic collapse
         operator will give a deterministic and stochastic contribution
         to the eqaution of motion according to how the d1 and d2 functions
         are defined.
+        Can depend on time, see StochasticSolverOptions help for format.
 
     e_ops : list of :class:`qutip.Qobj`
         single operator or list of operators for which to evaluate
@@ -520,8 +544,9 @@ def ssesolve(H, rho0, times, sc_ops=[], e_ops=[],
     Parameters
     ----------
 
-    H : :class:`qutip.Qobj`
+    H : :class:`qutip.Qobj`, or time dependent system.
         System Hamiltonian.
+        Can depend on time, see StochasticSolverOptions help for format.
 
     rho0 : :class:`qutip.Qobj`
         State vector (ket).
@@ -529,11 +554,12 @@ def ssesolve(H, rho0, times, sc_ops=[], e_ops=[],
     times : *list* / *array*
         List of times for :math:`t`. Must be uniformly spaced.
 
-    sc_ops : list of :class:`qutip.Qobj`
+    sc_ops : list of :class:`qutip.Qobj`, or time dependent Qobjs.
         List of stochastic collapse operators. Each stochastic collapse
         operator will give a deterministic and stochastic contribution
         to the eqaution of motion according to how the d1 and d2 functions
         are defined.
+        Can depend on time, see StochasticSolverOptions help for format.
 
     e_ops : list of :class:`qutip.Qobj`
         single operator or list of operators for which to evaluate
@@ -633,8 +659,9 @@ def photocurrentmesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
     Parameters
     ----------
 
-    H : :class:`qutip.Qobj`
+    H : :class:`qutip.Qobj`, or time dependent system.
         System Hamiltonian.
+        Can depend on time, see StochasticSolverOptions help for format.
 
     rho/psi : :class:`qutip.Qobj`
         Initial density matrix or state vector (ket).
@@ -642,16 +669,17 @@ def photocurrentmesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
     times : *list* / *array*
         List of times for :math:`t`. Must be uniformly spaced.
 
-    c_ops : list of :class:`qutip.Qobj`
-        If master equation,
+    c_ops : list of :class:`qutip.Qobj`, or time dependent Qobjs.
         Deterministic collapse operator which will contribute with a standard
         Lindblad type of dissipation.
+        Can depend on time, see StochasticSolverOptions help for format.
 
-    sc_ops : list of :class:`qutip.Qobj`
+    sc_ops : list of :class:`qutip.Qobj`, or time dependent Qobjs.
         List of stochastic collapse operators. Each stochastic collapse
         operator will give a deterministic and stochastic contribution
         to the eqaution of motion according to how the d1 and d2 functions
         are defined.
+        Can depend on time, see StochasticSolverOptions help for format.
 
     e_ops : list of :class:`qutip.Qobj` / callback function single
         single operator or list of operators for which to evaluate
@@ -724,8 +752,9 @@ def photocurrentsesolve(H, rho0, times, sc_ops=[], e_ops=[],
     Parameters
     ----------
 
-    H : :class:`qutip.Qobj`
+    H : :class:`qutip.Qobj`, or time dependent system.
         System Hamiltonian.
+        Can depend on time, see StochasticSolverOptions help for format.
 
     rho/psi : :class:`qutip.Qobj`
         Initial density matrix or state vector (ket).
@@ -733,11 +762,12 @@ def photocurrentsesolve(H, rho0, times, sc_ops=[], e_ops=[],
     times : *list* / *array*
         List of times for :math:`t`. Must be uniformly spaced.
 
-    sc_ops : list of :class:`qutip.Qobj`
+    sc_ops : list of :class:`qutip.Qobj`, or time dependent Qobjs.
         List of stochastic collapse operators. Each stochastic collapse
         operator will give a deterministic and stochastic contribution
         to the eqaution of motion according to how the d1 and d2 functions
         are defined.
+        Can depend on time, see StochasticSolverOptions help for format.
 
     e_ops : list of :class:`qutip.Qobj` / callback function single
         single operator or list of operators for which to evaluate
@@ -994,7 +1024,7 @@ def _safety_checks(sso):
 
 def _sesolve_generic(sso, options, progress_bar):
     """
-    Internal function. See smesolve.   Not Good yet ------------------------------------------
+    Internal function. See smesolve.
     """
     data = Result()
     data.times = sso.times

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -31,64 +31,113 @@
 #    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-#    Significant parts of this code were contributed by Denis Vasilyev.
-#
 ###############################################################################
-"""
-This module contains functions for solving stochastic schrodinger and master
-equations. The API should not be considered stable, and is subject to change
-when we work more on optimizing this module for performance and features.
-"""
-
-__all__ = ['ssesolve', 'ssepdpsolve', 'smesolve', 'smepdpsolve']
-
 import numpy as np
 import scipy.sparse as sp
-from scipy.linalg.blas import get_blas_funcs
-try:
-    norm = get_blas_funcs("znrm2", dtype=np.float64)
-except:
-    from scipy.linalg import norm
-
-from numpy.random import RandomState
-
-from qutip.qobj import Qobj, isket
+from qutip.cy.stochastic import sme, sse, psme, psse, generic
+from qutip.qobj import Qobj, isket, isoper, issuper
 from qutip.states import ket2dm
 from qutip.solver import Result
-from qutip.expect import expect, expect_rho_vec
+from qutip.td_qobj import td_Qobj
 from qutip.superoperator import (spre, spost, mat2vec, vec2mat,
                                  liouvillian, lindblad_dissipator)
-from qutip.cy.spmatfuncs import cy_expect_psi_csr, spmv, cy_expect_rho_vec
-from qutip.cy.stochastic import (cy_d1_rho_photocurrent,
-                                 cy_d2_rho_photocurrent)
+from qutip.solver import Options, _solver_safety_check
 from qutip.parallel import serial_map
 from qutip.ui.progressbar import TextProgressBar
-from qutip.solver import Options, _solver_safety_check
-from qutip.settings import debug
+from qutip.pdpsolve import main_ssepdpsolve, main_smepdpsolve
 
+__all__ = ['ssesolve', 'photocurrentsesolve', 'smepdpsolve',
+           'smesolve', 'photocurrentmesolve', 'ssepdpsolve',
+           'stochastic_solver_info', 'general_stochastic']
 
-if debug:
-    import qutip.logging_utils
-    import inspect
-    logger = qutip.logging_utils.get_logger()
+def stochastic_solver_info():
+    print( """Available solvers
+    euler-maruyama:
+        A simple generalization of the Euler method for ordinary
+        differential equations to stochastic differential equations.
+        Only solver which could take non-commuting sc_ops. *not tested*
+        -Order 0.5
+        -Code: 'euler-maruyama', 'euler', 0.5
 
+    milstein, Order 1.0 strong Taylor scheme:
+        Better approximate numerical solution to stochastic
+        differential equations.
+        -Order strong 1.0
+        -Code: 'milstein', 1.0
+        Numerical Solution of Stochastic Differential Equations
+        Chapter 10.3 Eq. (3.1), By Peter E. Kloeden, Eckhard Platen
+
+    milstein-imp, Order 1.0 implicit strong Taylor scheme:
+        Implicit milstein scheme for the numerical simulation of stiff
+        stochastic differential equations.
+        -Order strong 1.0
+        -Code: 'milstein-imp'
+        Numerical Solution of Stochastic Differential Equations
+        Chapter 12.2 Eq. (2.9), By Peter E. Kloeden, Eckhard Platen
+
+    predictor-corrector:
+        Generalization of the trapezoidal method to stochastic
+        differential equations. More stable than explicit methods.
+        -Order strong 0.5, weak 1.0
+        Only the stochastic part is corrected.
+            (alpha = 0, eta = 1/2)
+            -Code: 'pred-corr', 'predictor-corrector', 'pc-euler'
+        Both the deterministic and stochastic part corrected.
+            (alpha = 1/2, eta = 1/2)
+            -Code: 'pred-corr-2', 'pc-euler-2'
+        Numerical Solution of Stochastic Differential Equations
+        Chapter 15.5 Eq. (5.4), By Peter E. Kloeden, Eckhard Platen
+
+    platen:
+        Explicit scheme, create the milstein using finite difference instead of
+        derivatives. Also contain some higher order terms, thus converge better
+        than milstein while staying strong order 1.0.
+        Do not require derivatives, therefore usable for
+        :func:`qutip.stochastic.general_stochastic`
+        -Order strong 1.0, weak 2.0
+        -Code: 'platen', 'platen1', 'explicit1'
+        The Theory of Open Quantum Systems
+        Chapter 7 Eq. (7.47), H.-P Breuer, F. Petruccione
+
+    taylor15, Order 1.5 strong Taylor scheme:
+        Solver with more terms of the Ito-Taylor expansion.
+        Default solver for smesolve and ssesolve.
+        -Order strong 1.5
+        -Code: 'taylor15', 1.5
+        Numerical Solution of Stochastic Differential Equations
+        Chapter 10.4 Eq. (4.6), By Peter E. Kloeden, Eckhard Platen
+
+    taylor15-imp, Order 1.5 implicit strong Taylor scheme:
+        implicit Taylor 1.5 (alpha = 1/2, beta = doesn't matter)
+        -Order strong 1.5
+        -Code: 'taylor15-imp'
+        Numerical Solution of Stochastic Differential Equations
+        Chapter 12.2 Eq. (2.18), By Peter E. Kloeden, Eckhard Platen
+
+    explicit15, Explicit Order 1.5 Strong Schemes:
+        Reproduce the order 1.5 strong Taylor scheme using finite difference
+        instead of derivatives. Slower than taylor15 but usable by
+        :func:`qutip.stochastic.general_stochastic`
+        -Order strong 1.5
+        -Code: 'explicit15', 'platen15'
+        Numerical Solution of Stochastic Differential Equations
+        Chapter 11.2 Eq. (2.13), By Peter E. Kloeden, Eckhard Platen
+
+    ---All solvers are usable in both smesolve and ssesolve and
+    for both heterodyne and homodyne.
+    The :func:`qutip.stochastic.general_stochastic` only accept derivatives free
+    solvers: ['euler', 'platen', 'explicit15'].
+    """)
 
 class StochasticSolverOptions:
     """Class of options for stochastic solvers such as
     :func:`qutip.stochastic.ssesolve`, :func:`qutip.stochastic.smesolve`, etc.
-    Options can be specified either as arguments to the constructor::
 
-        sso = StochasticSolverOptions(nsubsteps=100, ...)
-
-    or by changing the class attributes after creation::
-
-        sso = StochasticSolverOptions()
-        sso.nsubsteps = 1000
-
-    The stochastic solvers :func:`qutip.stochastic.ssesolve`,
-    :func:`qutip.stochastic.smesolve`, :func:`qutip.stochastic.ssepdpsolve` and
-    :func:`qutip.stochastic.smepdpsolve` all take the same keyword arguments as
+    The stochastic solvers :func:`qutip.stochastic.general_stochastic`,
+    :func:`qutip.stochastic.ssesolve`, :func:`qutip.stochastic.smesolve`,
+    :func:`qutip.stochastic.photocurrentsesolve` and
+    :func:`qutip.stochastic.photocurrentmesolve`
+    all take the same keyword arguments as
     the constructor of these class, and internally they use these arguments to
     construct an instance of this class, so it is rarely needed to explicitly
     create an instance of this class.
@@ -123,9 +172,11 @@ class StochasticSolverOptions:
         format is a nested list with one measurement operator for each
         stochastic increament, for each stochastic collapse operator.
 
-    args : dict / list
-        List of dictionary of additional problem-specific parameters.
-        Implicit methods can adjust tolerance via args = {'tol':value}
+    args : dict
+        Dictionary of parameters for time dependent systems.
+
+    tol : float
+        Tolerance of the solver for implicit methods.
 
     ntraj : int
         Number of trajectors.
@@ -133,72 +184,42 @@ class StochasticSolverOptions:
     nsubsteps : int
         Number of sub steps between each time-spep given in `times`.
 
-    d1 : function
-        Function for calculating the operator-valued coefficient to the
-        deterministic increment dt.
-
-    d2 : function
-        Function for calculating the operator-valued coefficient to the
-        stochastic increment(s) dW_n, where n is in [0, d2_len[.
-
-    d2_len : int (default 1)
-        The number of stochastic increments in the process.
-
     dW_factors : array
-        Array of length d2_len, containing scaling factors for each
+        Array of length len(sc_ops), containing scaling factors for each
         measurement operator in m_ops.
-
-    rhs : function
-        Function for calculating the deterministic and stochastic contributions
-        to the right-hand side of the stochastic differential equation. This
-        only needs to be specified when implementing a custom SDE solver.
-
-    generate_A_ops : function
-        Function that generates a list of pre-computed operators or super-
-        operators. These precomputed operators are used in some d1 and d2
-        functions.
-
-    generate_noise : function
-        Function for generate an array of pre-computed noise signal.
-
-    homogeneous : bool (True)
-        Wheter or not the stochastic process is homogenous. Inhomogenous
-        processes are only supported for poisson distributions.
 
     solver : string
         Name of the solver method to use for solving the stochastic
-        equations. Valid values are: 
-        1/2 order algorithms: 'euler-maruyama', 'fast-euler-maruyama',
-        'pc-euler' is a predictor-corrector method which is more 
-        stable than explicit methods,
-        1 order algorithms: 'milstein', 'fast-milstein', 'platen',
-        'milstein-imp' is semi-implicit Milstein method,
-        3/2 order algorithms: 'taylor15', 
-        'taylor15-imp' is semi-implicit Taylor 1.5 method.
-        Implicit methods can adjust tolerance via args = {'tol':value},
+        equations. Valid values are:
+        1/2 order algorithms: 'euler-maruyama', 'pc-euler'
+        1 order algorithms: 'milstein', 'platen', 'milstein-imp'
+        3/2 order algorithms: 'taylor15', 'taylor15-imp', 'explicit15'
+        call :func:`qutip.stochastic.stochastic_solver_info` for a description
+        of the solvers.
+        Implicit methods can adjust tolerance via the kw 'tol'
         default is {'tol':1e-6}
 
-    method : string ('homodyne', 'heterodyne', 'photocurrent')
+    method : string ('homodyne', 'heterodyne')
         The name of the type of measurement process that give rise to the
-        stochastic equation to solve. Specifying a method with this keyword
-        argument is a short-hand notation for using pre-defined d1 and d2
-        functions for the corresponding stochastic processes.
-
-    distribution : string ('normal', 'poission')
-        The name of the distribution used for the stochastic increments.
+        stochastic equation to solve.
 
     store_measurements : bool (default False)
         Whether or not to store the measurement results in the
         :class:`qutip.solver.SolverResult` instance returned by the solver.
 
-    noise : array
-        Vector specifying the noise.
+    noise : int, array[int, 1d], array[double, 4d]
+        int : seed of the noise
+        array[int, 1d], length = ntraj, seeds for each trajectories
+        array[double, 4d] (ntraj, len(times), nsubsteps, len(sc_ops)*[1|2])
+            vector for the noise, the len of the last dimensions is doubled for
+            solvers of order 1.5. The correspond to results.noise
 
-    normalize : bool (default True)
+    normalize : bool (default True for ssesolve)
         Whether or not to normalize the wave function during the evolution.
 
     options : :class:`qutip.solver.Options`
-        Generic solver options.
+        Generic solver options. Only options.average_states and
+        options.store_states are used.
 
     map_func: function
         A map function or managing the calls to single-trajactory solvers.
@@ -210,14 +231,13 @@ class StochasticSolverOptions:
         Optional progress bar class instance.
 
     """
-    def __init__(self, H=None, state0=None, times=None, c_ops=[], sc_ops=[],
-                 e_ops=[], m_ops=None, args=None, ntraj=1, nsubsteps=1,
-                 d1=None, d2=None, d2_len=1, dW_factors=None, rhs=None,
-                 generate_A_ops=None, generate_noise=None, homogeneous=True,
-                 solver=None, method=None, distribution='normal',
-                 store_measurement=False, noise=None, normalize=True,
-                 options=None, progress_bar=None, map_func=None,
-                 map_kwargs=None):
+    def __init__(self, H=None, c_ops=[], sc_ops=[], state0=None,
+                 e_ops=[], m_ops=None, store_measurement=False, dW_factors=None,
+                 solver="euler", method="homodyne", normalize=1,
+                 times=None, nsubsteps=1, ntraj=1, tol=None,
+                 generate_noise=None, noise=None,
+                 progress_bar=None, map_func=None, map_kwargs=None,
+                 args={}, options=None):
 
         if options is None:
             options = Options()
@@ -225,166 +245,152 @@ class StochasticSolverOptions:
         if progress_bar is None:
             progress_bar = TextProgressBar()
 
-        self.H = H
-        self.d1 = d1
-        self.d2 = d2
-        self.d2_len = d2_len
-        self.dW_factors = dW_factors if dW_factors else np.ones(d2_len)
-        self.state0 = state0
-        self.times = times
-        self.c_ops = c_ops
-        self.sc_ops = sc_ops
-        self.e_ops = e_ops
-
-        if m_ops is None:
-            self.m_ops = [[c for _ in range(d2_len)] for c in sc_ops]
+        # System
+        # Cast to td_Qobj so the code has only one version for both the
+        # constant and time-dependent case.
+        if H is not None:
+            try:
+                self.H = td_Qobj(H, args=args, tlist=times, raw_str=True)
+            except:
+                raise Exception("The hamiltonian format is not valid")
         else:
-            self.m_ops = m_ops
+            self.H = H
 
-        self.ntraj = ntraj
-        self.nsubsteps = nsubsteps
-        self.solver = solver
-        self.method = method
-        self.distribution = distribution
-        self.homogeneous = homogeneous
-        self.rhs = rhs
-        self.options = options
-        self.progress_bar = progress_bar
+        if sc_ops:
+            try:
+                self.sc_ops = [td_Qobj(op, args=args, tlist=times,
+                                 raw_str=True) for op in sc_ops]
+            except:
+                raise Exception("The sc_ops format is not valid.\n"+
+                                "[ Qobj / td_Qobj / [Qobj,coeff]]")
+        else:
+            self.sc_ops = sc_ops
+
+        if c_ops:
+            try:
+                self.c_ops = [td_Qobj(op, args=args, tlist=times,
+                              raw_str=True) for op in c_ops]
+            except:
+                raise Exception("The c_ops format is not valid.\n"+
+                                "[ Qobj / td_Qobj / [Qobj,coeff]]")
+        else:
+            self.c_ops = c_ops
+
+        self.state0 = state0
+        self.rho0 = mat2vec(state0.full()).ravel()
+        #print(self.rho0.shape)
+
+        # Observation
+        self.e_ops = e_ops
+        self.m_ops = m_ops
         self.store_measurement = store_measurement
         self.store_states = options.store_states
-        self.noise = noise
-        self.args = args
+        self.dW_factors = dW_factors
+
+        # Solver
+        self.solver = solver
+        self.method = method
         self.normalize = normalize
+        self.times = times
+        self.nsubsteps = nsubsteps
+        self.dt = (times[1] - times[0]) / self.nsubsteps
+        self.ntraj = ntraj
+        if tol is not None:
+            self.tol = tol
+        elif "tol" in args:
+            self.tol = args["tol"]
+        else:
+            self.tol = 1e-7
 
-        self.generate_noise = generate_noise
-        self.generate_A_ops = generate_A_ops
+        # Noise
+        if noise is not None:
+            if isinstance(noise, int):
+                # noise contain a seed
+                np.random.seed(noise)
+                noise = np.random.randint(0, 2**32, ntraj)
+            noise = np.array(noise)
+            if len(noise.shape) == 1:
+                if noise.shape[0] < ntraj:
+                    raise Exception("'noise' does not have enought seeds" +
+                                    "len(noise) >= ntraj")
+                # numpy seed must be between 0 and 2**32-1
+                # 'u4': unsigned 32bit int
+                self.noise = noise.astype("u4")
+                self.noise_type = 0
 
+            elif len(noise.shape) == 4:
+                # taylor case not included
+                dw_len = (2 if method == "heterodyne" else 1)
+                dw_len_str = (" * 2" if method == "heterodyne" else "")
+                if noise.shape[0] < ntraj:
+                    raise Exception("'noise' does not have the right shape" +
+                                    "shape[0] >= ntraj")
+                if noise.shape[1] < len(times):
+                    raise Exception("'noise' does not have the right shape" +
+                                    "shape[1] >= len(times)")
+                if noise.shape[2] < nsubsteps:
+                    raise Exception("'noise' does not have the right shape" +
+                                    "shape[2] >= nsubsteps")
+                if noise.shape[3] < len(self.sc_ops) * dw_len:
+                    raise Exception("'noise' does not have the right shape" +
+                                    "shape[3] >= len(self.sc_ops)" + dw_len_str)
+                self.noise_type = 1
+                self.noise = noise
+
+        else:
+            self.noise = np.random.randint(0, 2**32, ntraj).astype("u4")
+            self.noise_type = 0
+
+        # Map
+        self.progress_bar = progress_bar
         if self.ntraj > 1 and map_func:
             self.map_func = map_func
         else:
             self.map_func = serial_map
-
         self.map_kwargs = map_kwargs if map_kwargs is not None else {}
 
+        # Other
+        self.options = options
+        self.args = args
 
-def ssesolve(H, psi0, times, sc_ops=[], e_ops=[], _safe_mode=True, **kwargs):
-    """
-    Solve the stochastic Schrödinger equation. Dispatch to specific solvers
-    depending on the value of the `solver` keyword argument.
+        if self.solver in ['euler-maruyama', 'euler', 50, 0.5]:
+            self.solver_code = 50
+            self.solver = 'euler-maruyama'
 
-    Parameters
-    ----------
+        elif self.solver in ['platen', 'platen1', 'explicit1', 100]:
+            self.solver_code = 100
+            self.solver = 'platen'
+        elif self.solver in ['pred-corr', 'predictor-corrector', 'pc-euler', 101]:
+            self.solver_code = 101
+            self.solver = 'pred-corr'
+        elif self.solver in ['milstein', 102, 1.0]:
+            self.solver_code = 102
+            self.solver = 'milstein'
+        elif self.solver in ['milstein-imp', 103]:
+            self.solver_code = 103
+            self.solver = 'milstein-imp'
+        elif self.solver in ['pred-corr-2', 'pc-euler-2', 104]:
+            self.solver_code = 104
+            self.solver = 'pred-corr-2'
 
-    H : :class:`qutip.Qobj`
-        System Hamiltonian.
-
-    psi0 : :class:`qutip.Qobj`
-        Initial state vector (ket).
-
-    times : *list* / *array*
-        List of times for :math:`t`. Must be uniformly spaced.
-
-    sc_ops : list of :class:`qutip.Qobj`
-        List of stochastic collapse operators. Each stochastic collapse
-        operator will give a deterministic and stochastic contribution
-        to the equation of motion according to how the d1 and d2 functions
-        are defined.
-
-    e_ops : list of :class:`qutip.Qobj`
-        Single operator or list of operators for which to evaluate
-        expectation values.
-
-    kwargs : *dictionary*
-        Optional keyword arguments. See
-        :class:`qutip.stochastic.StochasticSolverOptions`.
-
-    Returns
-    -------
-
-    output: :class:`qutip.solver.SolverResult`
-        An instance of the class :class:`qutip.solver.SolverResult`.
-    """
-    if debug:
-        logger.debug(inspect.stack()[0][3])
-
-    if isinstance(e_ops, dict):
-        e_ops_dict = e_ops
-        e_ops = [e for e in e_ops.values()]
-    else:
-        e_ops_dict = None
-    
-    if _safe_mode:
-        _solver_safety_check(H, psi0, sc_ops, e_ops)
-    
-    sso = StochasticSolverOptions(H=H, state0=psi0, times=times,
-                                  sc_ops=sc_ops, e_ops=e_ops, **kwargs)
-
-    if sso.generate_A_ops is None:
-        sso.generate_A_ops = _generate_psi_A_ops
-
-    if (sso.d1 is None) or (sso.d2 is None):
-
-        if sso.method == 'homodyne':
-            sso.d1 = d1_psi_homodyne
-            sso.d2 = d2_psi_homodyne
-            sso.d2_len = 1
-            sso.homogeneous = True
-            sso.distribution = 'normal'
-            if "dW_factors" not in kwargs:
-                sso.dW_factors = np.array([1])
-            if "m_ops" not in kwargs:
-                sso.m_ops = [[c + c.dag()] for c in sso.sc_ops]
-
-        elif sso.method == 'heterodyne':
-            sso.d1 = d1_psi_heterodyne
-            sso.d2 = d2_psi_heterodyne
-            sso.d2_len = 2
-            sso.homogeneous = True
-            sso.distribution = 'normal'
-            if "dW_factors" not in kwargs:
-                sso.dW_factors = np.array([np.sqrt(2), np.sqrt(2)])
-            if "m_ops" not in kwargs:
-                sso.m_ops = [[(c + c.dag()), (-1j) * (c - c.dag())]
-                             for idx, c in enumerate(sso.sc_ops)]
-
-        elif sso.method == 'photocurrent':
-            sso.d1 = d1_psi_photocurrent
-            sso.d2 = d2_psi_photocurrent
-            sso.d2_len = 1
-            sso.homogeneous = False
-            sso.distribution = 'poisson'
-
-            if "dW_factors" not in kwargs:
-                sso.dW_factors = np.array([1])
-            if "m_ops" not in kwargs:
-                sso.m_ops = [[None] for c in sso.sc_ops]
-
+        elif self.solver in ['platen15', 'explicit15', 150]:
+            self.solver_code = 150
+            self.solver = 'explicit15'
+        elif self.solver in ['taylor15', None, 1.5, 152]:
+            self.solver_code = 152
+            self.solver = 'taylor15'
+        elif self.solver in ['taylor15-imp', 153]:
+            self.solver_code = 153
+            self.solver = 'taylor15-imp'
         else:
-            raise Exception("Unrecognized method '%s'." % sso.method)
-
-    if sso.distribution == 'poisson':
-        sso.homogeneous = False
-
-    if sso.solver == 'euler-maruyama' or sso.solver is None:
-        sso.rhs = _rhs_psi_euler_maruyama
-
-    elif sso.solver == 'platen':
-        sso.rhs = _rhs_psi_platen
-
-    else:
-        raise Exception("Unrecognized solver '%s'." % sso.solver)
-
-    res = _ssesolve_generic(sso, sso.options, sso.progress_bar)
-
-    if e_ops_dict:
-        res.expect = {e: res.expect[n]
-                      for n, e in enumerate(e_ops_dict.keys())}
-
-    return res
+            raise Exception("The solver should be one of "+\
+                            "[None, 'euler-maruyama', 'platen', 'pc-euler', "+\
+                            "'pc-euler-2', 'milstein', 'milstein-imp', "+\
+                            "'taylor15', 'taylor15-imp', 'explicit15']")
 
 
-def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[], 
-            _safe_mode=True ,**kwargs):
+def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
+                 _safe_mode=True, args={}, **kwargs):
     """
     Solve stochastic master equation. Dispatch to specific solvers
     depending on the value of the `solver` keyword argument.
@@ -411,7 +417,7 @@ def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
         to the eqaution of motion according to how the d1 and d2 functions
         are defined.
 
-    e_ops : list of :class:`qutip.Qobj` / callback function single
+    e_ops : list of :class:`qutip.Qobj`
         single operator or list of operators for which to evaluate
         expectation values.
 
@@ -426,13 +432,7 @@ def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
 
         An instance of the class :class:`qutip.solver.SolverResult`.
 
-    TODO
-    ----
-        Add checks for commuting jump operators in Milstein method.
     """
-
-    if debug:
-        logger.debug(inspect.stack()[0][3])
 
     if isket(rho0):
         rho0 = ket2dm(rho0)
@@ -442,155 +442,181 @@ def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
         e_ops = [e for e in e_ops.values()]
     else:
         e_ops_dict = None
-    
-    if _safe_mode:
-        _solver_safety_check(H, rho0, c_ops+sc_ops, e_ops)
 
     sso = StochasticSolverOptions(H=H, state0=rho0, times=times, c_ops=c_ops,
-                                  sc_ops=sc_ops, e_ops=e_ops, **kwargs)
+                                  sc_ops=sc_ops, e_ops=e_ops, args= args,
+                                  **kwargs)
 
-    if (sso.d1 is None) or (sso.d2 is None):
+    sso.me = True
+    if _safe_mode:
+        _safety_checks(sso)
 
-        if sso.method == 'homodyne' or sso.method is None:
-            sso.d1 = d1_rho_homodyne
-            sso.d2 = d2_rho_homodyne
-            sso.d2_len = 1
-            sso.homogeneous = True
-            sso.distribution = 'normal'
-            if "dW_factors" not in kwargs:
-                sso.dW_factors = np.array([np.sqrt(1)])
-            if "m_ops" not in kwargs:
-                sso.m_ops = [[c + c.dag()] for c in sso.sc_ops]
+    sso.LH = liouvillian(sso.H, c_ops = sso.sc_ops + sso.c_ops) * sso.dt
+    #sso.d1 = 1 + sso.LH * sso.dt
+    if sso.method == 'homodyne' or sso.method is None:
+        if sso.m_ops is None:
+            sso.m_ops = [op + op.dag() for op in sso.sc_ops]
+        sso.sops = [spre(op) + spost(op.dag()) for op in sso.sc_ops]
+        if not isinstance(sso.dW_factors, list):
+            sso.dW_factors = [1] * len(sso.sops)
+        elif len(sso.dW_factors) != len(sso.sops):
+            raise Exception("The len of dW_factors is not the same as sc_ops")
 
-        elif sso.method == 'heterodyne':
-            sso.d1 = d1_rho_heterodyne
-            sso.d2 = d2_rho_heterodyne
-            sso.d2_len = 2
-            sso.homogeneous = True
-            sso.distribution = 'normal'
-            if "dW_factors" not in kwargs:
-                sso.dW_factors = np.array([np.sqrt(2), np.sqrt(2)])
-            if "m_ops" not in kwargs:
-                sso.m_ops = [[(c + c.dag()), -1j * (c - c.dag())]
-                             for c in sso.sc_ops]
+    elif sso.method == 'heterodyne':
+        if sso.m_ops is None:
+            m_ops = []
+        sso.sops = []
+        for c in sso.sc_ops:
+            if sso.m_ops is None:
+                m_ops += [c + c.dag(), -1j * c - c.dag() ]
+            sso.sops += [(spre(c) + spost(c.dag())) / np.sqrt(2),
+                         (spre(c) - spost(c.dag())) * -1j / np.sqrt(2)]
+        sso.m_ops = m_ops
+        if not isinstance(sso.dW_factors, list):
+            sso.dW_factors = [np.sqrt(2)] * len(sso.sops)
+        elif len(sso.dW_factors) == len(sso.sc_ops):
+            dW_factors = []
+            for fact in sso.dW_factors:
+                dW_factors += [np.sqrt(2) * fact, np.sqrt(2) * fact]
+            sso.dW_factors = dW_factors
+        elif len(sso.dW_factors) != len(sso.sops):
+            raise Exception("The len of dW_factors is not the same as sc_ops")
 
-        elif sso.method == 'photocurrent':
-            sso.d1 = cy_d1_rho_photocurrent
-            sso.d2 = cy_d2_rho_photocurrent
-            sso.d2_len = 1
-            sso.homogeneous = False
-            sso.distribution = 'poisson'
+    elif sso.method == "photocurrent":
+        raise NotImplementedError("Not yet")
 
-            if "dW_factors" not in kwargs:
-                sso.dW_factors = np.array([1])
-            if "m_ops" not in kwargs:
-                sso.m_ops = [[None] for c in sso.sc_ops]
-        else:
-            raise Exception("Unrecognized method '%s'." % sso.method)
+    else:
+        raise Exception("The method must be one of None, homodyne, heterodyne")
 
-    if sso.distribution == 'poisson':
-        sso.homogeneous = False
+    sso.ce_ops = [td_Qobj(spre(op)) for op in sso.e_ops]
+    sso.cm_ops = [td_Qobj(spre(op)) for op in sso.m_ops]
 
-    if sso.generate_A_ops is None:
-        sso.generate_A_ops = _generate_rho_A_ops
+    sso.LH.compile()
+    [op.compile() for op in sso.sops]
+    [op.compile() for op in sso.cm_ops]
+    [op.compile() for op in sso.ce_ops]
 
-    if sso.rhs is None:
-        if sso.solver == 'euler-maruyama' or sso.solver is None:
-            sso.rhs = _rhs_rho_euler_maruyama
+    if sso.solver_code in [103, 153]:
+        sso.imp = 1 - sso.LH * 0.5
+        sso.imp.compile()
 
-        elif sso.solver == 'milstein':
-            if sso.method == 'homodyne' or sso.method is None:
-                if len(sc_ops) == 1:
-                    sso.rhs = _rhs_rho_milstein_homodyne_single
-                else:
-                    sso.rhs = _rhs_rho_milstein_homodyne
+    sso.solver_obj = sme
+    sso.solver_name = "smesolve_" + sso.solver
 
-            elif sso.method == 'heterodyne':
-                sso.rhs = _rhs_rho_milstein_homodyne
-                sso.d2_len = 1
-                sso.sc_ops = []
-                for sc in iter(sc_ops):
-                    sso.sc_ops += [sc / np.sqrt(2), -1.0j * sc / np.sqrt(2)]
+    res = _sesolve_generic(sso, sso.options, sso.progress_bar)
 
-        elif sso.solver == 'fast-euler-maruyama' and sso.method == 'homodyne':
-            sso.rhs = _rhs_rho_euler_homodyne_fast
-            sso.generate_A_ops = _generate_A_ops_Euler
+    if e_ops_dict:
+        res.expect = {e: res.expect[n]
+                      for n, e in enumerate(e_ops_dict.keys())}
 
-        elif sso.solver == 'fast-milstein':
-            sso.generate_A_ops = _generate_A_ops_Milstein
-            sso.generate_noise = _generate_noise_Milstein
-            if sso.method == 'homodyne' or sso.method is None:
-                if len(sc_ops) == 1:
-                    sso.rhs = _rhs_rho_milstein_homodyne_single_fast
-                elif len(sc_ops) == 2:
-                    sso.rhs = _rhs_rho_milstein_homodyne_two_fast
-                else:
-                    sso.rhs = _rhs_rho_milstein_homodyne_fast
+    return res
 
-            elif sso.method == 'heterodyne':
-                sso.d2_len = 1
-                sso.sc_ops = []
-                for sc in iter(sc_ops):
-                    sso.sc_ops += [sc / np.sqrt(2), -1.0j * sc / np.sqrt(2)]
-                if len(sc_ops) == 1:
-                    sso.rhs = _rhs_rho_milstein_homodyne_two_fast
-                else:
-                    sso.rhs = _rhs_rho_milstein_homodyne_fast
-                 
-        elif sso.solver == 'taylor15':
-            sso.generate_A_ops = _generate_A_ops_simple
-            sso.generate_noise = _generate_noise_Taylor_15
-            if sso.method == 'homodyne' or sso.method is None:
-                if len(sc_ops) == 1:
-                    sso.rhs = _rhs_rho_taylor_15_one
-                #elif len(sc_ops) == 2:
-                #    sso.rhs = _rhs_rho_taylor_15_two
-                else:
-                    raise Exception("Only one stochastic operator is supported")
-            else:
-                raise Exception("Only homodyne is available")
+def ssesolve(H, rho0, times, sc_ops=[], e_ops=[],
+                 _safe_mode=True, args={}, **kwargs):
+    """
+    Solve stochastic master equation. Dispatch to specific solvers
+    depending on the value of the `solver` keyword argument.
 
-        elif sso.solver == 'milstein-imp':
-            sso.generate_A_ops = _generate_A_ops_implicit
-            sso.generate_noise = _generate_noise_Milstein
-            if sso.args == None:
-                sso.args = {'tol':1e-6}
-            if sso.method == 'homodyne' or sso.method is None:
-                if len(sc_ops) == 1:
-                    sso.rhs = _rhs_rho_milstein_implicit
-                else:
-                    raise Exception("Only one stochastic operator is supported")
-            else:
-                raise Exception("Only homodyne is available") 
+    Parameters
+    ----------
 
-        elif sso.solver == 'taylor15-imp':  
-            sso.generate_A_ops = _generate_A_ops_implicit
-            sso.generate_noise = _generate_noise_Taylor_15
-            if sso.args == None:
-                sso.args = {'tol':1e-6}
-            if sso.method == 'homodyne' or sso.method is None:
-                if len(sc_ops) == 1:
-                    sso.rhs = _rhs_rho_taylor_15_implicit
-                else:
-                    raise Exception("Only one stochastic operator is supported")
-            else:
-                raise Exception("Only homodyne is available")
+    H : :class:`qutip.Qobj`
+        System Hamiltonian.
 
-        elif sso.solver == 'pc-euler':
-            sso.generate_A_ops = _generate_A_ops_Milstein
-            sso.generate_noise = _generate_noise_Milstein # could also work without this
-            if sso.method == 'homodyne' or sso.method is None:
-                if len(sc_ops) == 1:
-                    sso.rhs = _rhs_rho_pred_corr_homodyne_single
-                else:
-                    raise Exception("Only one stochastic operator is supported")
-            else:
-                raise Exception("Only homodyne is available")
+    rho0 : :class:`qutip.Qobj`
+        State vector (ket).
 
-        else:
-            raise Exception("Unrecognized solver '%s'." % sso.solver)
+    times : *list* / *array*
+        List of times for :math:`t`. Must be uniformly spaced.
 
-    res = _smesolve_generic(sso, sso.options, sso.progress_bar)
+    sc_ops : list of :class:`qutip.Qobj`
+        List of stochastic collapse operators. Each stochastic collapse
+        operator will give a deterministic and stochastic contribution
+        to the eqaution of motion according to how the d1 and d2 functions
+        are defined.
+
+    e_ops : list of :class:`qutip.Qobj`
+        single operator or list of operators for which to evaluate
+        expectation values.
+
+    kwargs : *dictionary*
+        Optional keyword arguments. See
+        :class:`qutip.stochastic.StochasticSolverOptions`.
+
+    Returns
+    -------
+
+    output: :class:`qutip.solver.SolverResult`
+
+        An instance of the class :class:`qutip.solver.SolverResult`.
+    """
+
+    if isinstance(e_ops, dict):
+        e_ops_dict = e_ops
+        e_ops = [e for e in e_ops.values()]
+    else:
+        e_ops_dict = None
+
+    sso = StochasticSolverOptions(H=H, state0=rho0, times=times, sc_ops=sc_ops,
+                                  e_ops=e_ops, args= args, **kwargs)
+
+    sso.me = False
+    if _safe_mode:
+        _safety_checks(sso)
+
+    if sso.method == 'homodyne' or sso.method is None:
+        if sso.m_ops is None:
+            sso.m_ops = [op + op.dag() for op in sso.sc_ops]
+        sso.sops = [[op, op + op.dag()] for op in sso.sc_ops]
+        if not isinstance(sso.dW_factors, list):
+            sso.dW_factors = [1] * len(sso.sops)
+        elif len(sso.dW_factors) != len(sso.sops):
+            raise Exception("The len of dW_factors is not the same as sc_ops")
+
+    elif sso.method == 'heterodyne':
+        if sso.m_ops is None:
+            m_ops = []
+        sso.sops = []
+        for c in sso.sc_ops:
+            if sso.m_ops is None:
+                m_ops += [c + c.dag(), -1j * (c - c.dag()) ]
+            c1 = c / np.sqrt(2)
+            c2 = c * (-1j / np.sqrt(2))
+            sso.sops += [[c1, c1 + c1.dag()],
+                         [c2, c2 + c2.dag()]]
+        sso.m_ops = m_ops
+        if not isinstance(sso.dW_factors, list):
+            sso.dW_factors = [np.sqrt(2)] * len(sso.sops)
+        elif len(sso.dW_factors) == len(sso.sc_ops):
+            dW_factors = []
+            for fact in sso.dW_factors:
+                dW_factors += [np.sqrt(2) * fact, np.sqrt(2) * fact]
+            sso.dW_factors = dW_factors
+        elif len(sso.dW_factors) != len(sso.sops):
+            raise Exception("The len of dW_factors is not the same as sc_ops")
+
+    elif sso.method == "photocurrent":
+        raise NotImplementedError("Not yet")
+
+    else:
+        raise Exception("The method must be one of None, homodyne, heterodyne")
+
+    sso.LH = sso.H * (-1j*sso.dt )
+    for ops in sso.sops:
+        sso.LH -= ops[0].norm()*0.5*sso.dt
+
+    sso.ce_ops = [td_Qobj(op) for op in sso.e_ops]
+    sso.cm_ops = [td_Qobj(op) for op in sso.m_ops]
+
+    sso.LH.compile()
+    [[op.compile() for op in ops] for ops in sso.sops]
+    [op.compile() for op in sso.cm_ops]
+    [op.compile() for op in sso.ce_ops]
+
+    sso.solver_obj = sse
+    sso.solver_name = "ssesolve_" + sso.solver
+
+    res = _sesolve_generic(sso, sso.options, sso.progress_bar)
 
     if e_ops_dict:
         res.expect = {e: res.expect[n]
@@ -599,6 +625,436 @@ def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
     return res
 
 
+def photocurrentmesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
+                        _safe_mode=True, args={}, **kwargs):
+    """
+    Solve stochastic master equation using the photocurrent method.
+
+    Parameters
+    ----------
+
+    H : :class:`qutip.Qobj`
+        System Hamiltonian.
+
+    rho/psi : :class:`qutip.Qobj`
+        Initial density matrix or state vector (ket).
+
+    times : *list* / *array*
+        List of times for :math:`t`. Must be uniformly spaced.
+
+    c_ops : list of :class:`qutip.Qobj`
+        If master equation,
+        Deterministic collapse operator which will contribute with a standard
+        Lindblad type of dissipation.
+
+    sc_ops : list of :class:`qutip.Qobj`
+        List of stochastic collapse operators. Each stochastic collapse
+        operator will give a deterministic and stochastic contribution
+        to the eqaution of motion according to how the d1 and d2 functions
+        are defined.
+
+    e_ops : list of :class:`qutip.Qobj` / callback function single
+        single operator or list of operators for which to evaluate
+        expectation values.
+
+    kwargs : *dictionary*
+        Optional keyword arguments. See
+        :class:`qutip.stochastic.StochasticSolverOptions`.
+
+    Returns
+    -------
+
+    output: :class:`qutip.solver.SolverResult`
+
+        An instance of the class :class:`qutip.solver.SolverResult`.
+    """
+    if isket(rho0):
+        rho0 = ket2dm(rho0)
+
+    if isinstance(e_ops, dict):
+        e_ops_dict = e_ops
+        e_ops = [e for e in e_ops.values()]
+    else:
+        e_ops_dict = None
+
+    sso = StochasticSolverOptions(H=H, state0=rho0, times=times,
+                                  c_ops=c_ops, sc_ops=sc_ops, e_ops=e_ops,
+                                  args=args, **kwargs)
+    sso.solver_code = 60
+    sso.me = True
+    if _safe_mode:
+        _safety_checks(sso)
+
+    if sso.m_ops is None:
+        sso.m_ops = [op + op.dag() for op in sso.sc_ops]
+    if not isinstance(sso.dW_factors, list):
+        sso.dW_factors = [1] * len(sso.sc_ops)
+    elif len(sso.dW_factors) != len(sso.sc_ops):
+        raise Exception("The len of dW_factors is not the same as sc_ops")
+
+    sso.solver_obj = psme
+    sso.solver_name = "photocurrent_mesolve_" + sso.solver
+    sso.LH = liouvillian(sso.H, c_ops = sso.c_ops) * sso.dt
+    def _prespostdag(op):
+        return spre(op) * spost(op.dag())
+    sso.sops = [[spre(op.norm()) + spost(op.norm()),
+                 spre(op.norm()),
+                 op.apply(_prespostdag)._f_norm2()] for op in sso.sc_ops]
+    sso.ce_ops = [td_Qobj(spre(op)) for op in sso.e_ops]
+    sso.cm_ops = [td_Qobj(spre(op)) for op in sso.m_ops]
+
+    sso.LH.compile()
+    [[op.compile() for op in ops] for ops in sso.sops]
+    [op.compile() for op in sso.cm_ops]
+    [op.compile() for op in sso.ce_ops]
+
+    res = _sesolve_generic(sso, sso.options, sso.progress_bar)
+
+    if e_ops_dict:
+        res.expect = {e: res.expect[n]
+                      for n, e in enumerate(e_ops_dict.keys())}
+
+    return res
+
+def photocurrentsesolve(H, rho0, times, sc_ops=[], e_ops=[],
+                 _safe_mode=True, args={}, **kwargs):
+    """
+    Solve stochastic schrodinger equation using the photocurrent method.
+
+    Parameters
+    ----------
+
+    H : :class:`qutip.Qobj`
+        System Hamiltonian.
+
+    rho/psi : :class:`qutip.Qobj`
+        Initial density matrix or state vector (ket).
+
+    times : *list* / *array*
+        List of times for :math:`t`. Must be uniformly spaced.
+
+    sc_ops : list of :class:`qutip.Qobj`
+        List of stochastic collapse operators. Each stochastic collapse
+        operator will give a deterministic and stochastic contribution
+        to the eqaution of motion according to how the d1 and d2 functions
+        are defined.
+
+    e_ops : list of :class:`qutip.Qobj` / callback function single
+        single operator or list of operators for which to evaluate
+        expectation values.
+
+    kwargs : *dictionary*
+        Optional keyword arguments. See
+        :class:`qutip.stochastic.StochasticSolverOptions`.
+
+    Returns
+    -------
+
+    output: :class:`qutip.solver.SolverResult`
+
+        An instance of the class :class:`qutip.solver.SolverResult`.
+    """
+    if isinstance(e_ops, dict):
+        e_ops_dict = e_ops
+        e_ops = [e for e in e_ops.values()]
+    else:
+        e_ops_dict = None
+
+    sso = StochasticSolverOptions(H=H, state0=rho0, times=times,
+                                  sc_ops=sc_ops, e_ops=e_ops,
+                                  args=args, **kwargs)
+    sso.solver_code = 60
+    sso.me = False
+    if _safe_mode:
+        _safety_checks(sso)
+
+    if sso.m_ops is None:
+        sso.m_ops = [op + op.dag() for op in sso.sc_ops]
+    if not isinstance(sso.dW_factors, list):
+        sso.dW_factors = [1] * len(sso.sc_ops)
+    elif len(sso.dW_factors) != len(sso.sc_ops):
+        raise Exception("The len of dW_factors is not the same as sc_ops")
+
+    sso.solver_obj = psse
+    sso.solver_name = "photocurrent_sesolve_" + sso.solver
+    sso.sops = [[op, op.norm()] for op in sso.sc_ops]
+    sso.LH = sso.H * (-1j*sso.dt )
+    for ops in sso.sops:
+        sso.LH -= ops[0].norm()*0.5*sso.dt
+    sso.ce_ops = [td_Qobj(op) for op in sso.e_ops]
+    sso.cm_ops = [td_Qobj(op) for op in sso.m_ops]
+
+    sso.LH.compile()
+    [[op.compile() for op in ops] for ops in sso.sops]
+    [op.compile() for op in sso.cm_ops]
+    [op.compile() for op in sso.ce_ops]
+
+    res = _sesolve_generic(sso, sso.options, sso.progress_bar)
+
+    if e_ops_dict:
+        res.expect = {e: res.expect[n]
+                      for n, e in enumerate(e_ops_dict.keys())}
+
+    return res
+
+
+def general_stochastic(state0, times, d1, d2, e_ops=[],
+               _safe_mode=True, len_d2=1, args={}, **kwargs):
+    """
+    Solve stochastic general equation. Dispatch to specific solvers
+    depending on the value of the `solver` keyword argument.
+
+    Parameters
+    ----------
+
+    state0 : :class:`qutip.Qobj`
+        Initial state vector (ket) or density matrix as a vector.
+
+    times : *list* / *array*
+        List of times for :math:`t`. Must be uniformly spaced.
+
+    d1 : function, callable class
+        Function representing the deterministic evolution of the system.
+
+        def d1(time (double), state (as a np.array vector)):
+            return 1d np.array
+
+    d2 : function, callable class
+        Function representing the stochastic evolution of the system.
+
+        def d2(time (double), state (as a np.array vector)):
+            return 2d np.array (N_sc_ops, len(state0))
+
+    len_d2 : int
+        Number of output vector produced by d2
+
+    e_ops : list of :class:`qutip.Qobj`
+        single operator or list of operators for which to evaluate
+        expectation values.
+        Must be a superoperator if the state vector is a density matrix.
+
+    kwargs : *dictionary*
+        Optional keyword arguments. See
+        :class:`qutip.stochastic.StochasticSolverOptions`.
+
+    Returns
+    -------
+
+    output: :class:`qutip.solver.SolverResult`
+        An instance of the class :class:`qutip.solver.SolverResult`.
+    """
+
+    if isinstance(e_ops, dict):
+        e_ops_dict = e_ops
+        e_ops = [e for e in e_ops.values()]
+    else:
+        e_ops_dict = None
+
+    if not "solver" in kwargs:
+        kwargs["solver"] = 50
+
+    sso = StochasticSolverOptions(H=None, state0=state0, times=times,
+                                  e_ops=e_ops, args=args, **kwargs)
+    if sso.solver_code not in [50, 100, 150]:
+        raise Exception("Only Euler, platen, platen15 can be " +
+                        "used for the general stochastic solver")
+
+    sso.me = False
+    sso.d1 = d1
+    sso.d2 = d2
+    if _safe_mode:
+        l_vec = sso.rho0.shape[0]
+        try:
+            out_d1 = d1(0., sso.rho0)
+        except Exception as e:
+            raise Exception("d1(0., mat2vec(state0.full()).ravel()) failed:\n"+\
+                            e)
+        except:
+            raise Exception("d1(0., mat2vec(state0.full()).ravel()) failed")
+        try:
+            out_d2 = d2(0., sso.rho0)
+        except Exception as e:
+            raise Exception("d2(0., mat2vec(state0.full()).ravel()) failed:\n"+\
+                            str(e))
+        except:
+            raise Exception("d2(0., mat2vec(state0.full()).ravel()) failed")
+        if out_d1.shape[0] != l_vec or len(out_d1.shape) != 1:
+            raise Exception("d1 must return an 1d numpy array with "+\
+                            "the same number of element than the " +\
+                            "initial state as a vector")
+        if len(out_d2.shape) != 2 and out_d2.shape[1] != l_vec and \
+            out_d2.shape[0] != len_d2:
+            raise Exception("d2 must return an 2d numpy array with the shape "+\
+                            "(l2_len, len(mat2vec(state0.full()).ravel()) )")
+        if out_d1.dtype != np.dtype('complex128') or \
+           out_d2.dtype != np.dtype('complex128') :
+            raise Exception("d1 and d2 must return complex numpy array")
+        for op in sso.e_ops:
+            shape_op = op.shape
+            if sso.me:
+                if shape_op[0]**2 != l_vec or shape_op[1]**2 != l_vec:
+                    raise Exception("The size of the e_ops does not fit the intial state")
+            else:
+                if shape_op[0] != l_vec or shape_op[1] != l_vec:
+                    raise Exception("The size of the e_ops does not fit the intial state")
+
+
+    if sso.store_measurement:
+        raise Exception("General stochastic solver cannot store measurement")
+    sso.m_ops = []
+    sso.cm_ops = []
+    sso.dW_factors = [1.] * len_d2
+    sso.sops = [None] * len_d2
+    sso.ce_ops = [td_Qobj(op) for op in sso.e_ops]
+    [op.compile() for op in sso.ce_ops]
+
+    sso.solver_obj = generic
+    sso.solver_name = "general_stochastic_solver_" + sso.solver
+
+    ssolver = generic()
+    ssolver.set_data(sso)
+    ssolver.set_solver(sso)
+
+    res = _sesolve_generic(sso, sso.options, sso.progress_bar)
+
+    if e_ops_dict:
+        res.expect = {e: res.expect[n]
+                      for n, e in enumerate(e_ops_dict.keys())}
+
+    return res
+
+
+def _safety_checks(sso):
+    l_vec = sso.rho0.shape[0]
+    if sso.H.cte.issuper:
+        if not sso.me:
+            raise
+        shape_op = sso.H.cte.shape
+        if shape_op[0] != l_vec or shape_op[1] != l_vec:
+            raise Exception("The size of the hamiltonian does not fit the intial state")
+    else:
+        shape_op = sso.H.cte.shape
+        if sso.me:
+            if shape_op[0]**2 != l_vec or shape_op[1]**2 != l_vec:
+                raise Exception("The size of the hamiltonian does not fit the intial state")
+        else:
+            if shape_op[0] != l_vec or shape_op[1] != l_vec:
+                raise Exception("The size of the hamiltonian does not fit the intial state")
+
+    for op in sso.sc_ops:
+        if op.cte.issuper:
+            if not sso.me:
+                raise
+            shape_op = op.cte.shape
+            if shape_op[0] != l_vec or shape_op[1] != l_vec:
+                raise Exception("The size of the sc_ops does not fit the intial state")
+        else:
+            shape_op = op.cte.shape
+            if sso.me:
+                if shape_op[0]**2 != l_vec or shape_op[1]**2 != l_vec:
+                    raise Exception("The size of the sc_ops does not fit the intial state")
+            else:
+                if shape_op[0] != l_vec or shape_op[1] != l_vec:
+                    raise Exception("The size of the sc_ops does not fit the intial state")
+
+    for op in sso.c_ops:
+        if op.cte.issuper:
+            if not sso.me:
+                raise
+            shape_op = op.cte.shape
+            if shape_op[0] != l_vec or shape_op[1] != l_vec:
+                raise Exception("The size of the c_ops does not fit the intial state")
+        else:
+            shape_op = op.cte.shape
+            if sso.me:
+                if shape_op[0]**2 != l_vec or shape_op[1]**2 != l_vec:
+                    raise Exception("The size of the c_ops does not fit the intial state")
+            else:
+                if shape_op[0] != l_vec or shape_op[1] != l_vec:
+                    raise Exception("The size of the c_ops does not fit the intial state")
+
+    for op in sso.e_ops:
+        shape_op = op.shape
+        if sso.me:
+            if shape_op[0]**2 != l_vec or shape_op[1]**2 != l_vec:
+                raise Exception("The size of the e_ops does not fit the intial state")
+        else:
+            if shape_op[0] != l_vec or shape_op[1] != l_vec:
+                raise Exception("The size of the e_ops does not fit the intial state")
+
+    if sso.m_ops is not None:
+        for op in sso.m_ops:
+            shape_op = op.shape
+            if sso.me:
+                if shape_op[0]**2 != l_vec or shape_op[1]**2 != l_vec:
+                    raise Exception("The size of the m_ops does not fit the intial state")
+            else:
+                if shape_op[0] != l_vec or shape_op[1] != l_vec:
+                    raise Exception("The size of the m_ops does not fit the intial state")
+
+def _sesolve_generic(sso, options, progress_bar):
+    """
+    Internal function. See smesolve.   Not Good yet ------------------------------------------
+    """
+    data = Result()
+    data.times = sso.times
+    data.expect = np.zeros((len(sso.e_ops), len(sso.times)), dtype=complex)
+    data.ss = np.zeros((len(sso.e_ops), len(sso.times)), dtype=complex)
+    data.measurement = []
+    data.solver = sso.solver_name
+
+    nt = sso.ntraj
+    task = _single_trajectory
+    map_kwargs = {'progress_bar': sso.progress_bar}
+    map_kwargs.update(sso.map_kwargs)
+    task_args = (sso,)
+    task_kwargs = {}
+
+    results = sso.map_func(task, list(range(sso.ntraj)),
+                           task_args, task_kwargs, **map_kwargs)
+    noise = []
+    for result in results:
+        states_list, dW, m, expect, ss = result
+        data.states.append(states_list)
+        noise.append(dW)
+        data.measurement.append(m)
+        data.expect += expect
+        data.ss += ss
+    data.noise = np.stack(noise)
+
+    # average density matrices
+    if options.average_states and np.any(data.states):
+        data.states = [sum([data.states[mm][n] for mm in range(nt)]).unit()
+                       for n in range(len(data.times))]
+
+    # average
+    data.expect = data.expect / nt
+
+    # standard error
+    if nt > 1:
+        data.se = (data.ss - nt * (data.expect ** 2)) / (nt * (nt - 1))
+    else:
+        data.se = None
+
+    # convert complex data to real if hermitian
+    data.expect = [np.real(data.expect[n, :])
+                   if e.isherm else data.expect[n, :]
+                   for n, e in enumerate(sso.e_ops)]
+
+    return data
+
+
+def _single_trajectory(i, sso):
+    ssolver = sso.solver_obj()
+    ssolver.set_data(sso)
+    ssolver.set_solver(sso)
+    result = ssolver.cy_sesolve_single_trajectory(i, sso)
+    return result
+
+
+
+# The code for ssepdpsolve have been moved to the file pdpsolve.
+# The call is still in stochastic for consistance.
 def ssepdpsolve(H, psi0, times, c_ops, e_ops, **kwargs):
     """
     A stochastic (piecewse deterministic process) PDP solver for wavefunction
@@ -637,26 +1093,10 @@ def ssepdpsolve(H, psi0, times, c_ops, e_ops, **kwargs):
         An instance of the class :class:`qutip.solver.SolverResult`.
 
     """
-    if debug:
-        logger.debug(inspect.stack()[0][3])
+    return main_ssepdpsolve(H, psi0, times, c_ops, e_ops, **kwargs)
 
-    if isinstance(e_ops, dict):
-        e_ops_dict = e_ops
-        e_ops = [e for e in e_ops.values()]
-    else:
-        e_ops_dict = None
-
-    sso = StochasticSolverOptions(H=H, state0=psi0, times=times, c_ops=c_ops,
-                                  e_ops=e_ops, **kwargs)
-
-    res = _ssepdpsolve_generic(sso, sso.options, sso.progress_bar)
-
-    if e_ops_dict:
-        res.expect = {e: res.expect[n]
-                      for n, e in enumerate(e_ops_dict.keys())}
-    return res
-
-
+# The code for smepdpsolve have been moved to the file pdpsolve.
+# The call is still in stochastic for consistance.
 def smepdpsolve(H, rho0, times, c_ops, e_ops, **kwargs):
     """
     A stochastic (piecewse deterministic process) PDP solver for density matrix
@@ -700,1451 +1140,4 @@ def smepdpsolve(H, rho0, times, c_ops, e_ops, **kwargs):
         An instance of the class :class:`qutip.solver.SolverResult`.
 
     """
-    if debug:
-        logger.debug(inspect.stack()[0][3])
-
-    if isinstance(e_ops, dict):
-        e_ops_dict = e_ops
-        e_ops = [e for e in e_ops.values()]
-    else:
-        e_ops_dict = None
-
-    sso = StochasticSolverOptions(H=H, state0=rho0, times=times, c_ops=c_ops,
-                                  e_ops=e_ops, **kwargs)
-
-    res = _smepdpsolve_generic(sso, sso.options, sso.progress_bar)
-
-    if e_ops_dict:
-        res.expect = {e: res.expect[n]
-                      for n, e in enumerate(e_ops_dict.keys())}
-    return res
-
-
-# -----------------------------------------------------------------------------
-# Generic parameterized stochastic Schrodinger equation solver
-#
-def _ssesolve_generic(sso, options, progress_bar):
-    """
-    Internal function for carrying out a sse integration. Used by ssesolve.
-    """
-    if debug:
-        logger.debug(inspect.stack()[0][3])
-
-    sso.N_store = len(sso.times)
-    sso.N_substeps = sso.nsubsteps
-    sso.dt = (sso.times[1] - sso.times[0]) / sso.N_substeps
-    nt = sso.ntraj
-
-    data = Result()
-    data.solver = "ssesolve"
-    data.times = sso.times
-    data.expect = np.zeros((len(sso.e_ops), sso.N_store), dtype=complex)
-    data.ss = np.zeros((len(sso.e_ops), sso.N_store), dtype=complex)
-    data.noise = []
-    data.measurement = []
-
-    # pre-compute collapse operator combinations that are commonly needed
-    # when evaluating the RHS of stochastic Schrodinger equations
-    sso.A_ops = sso.generate_A_ops(sso.sc_ops, sso.H)
-
-    map_kwargs = {'progress_bar': progress_bar}
-    map_kwargs.update(sso.map_kwargs)
-
-    task = _ssesolve_single_trajectory
-    task_args = (sso,)
-    task_kwargs = {}
-
-    results = sso.map_func(task, list(range(sso.ntraj)),
-                           task_args, task_kwargs, **map_kwargs)
-
-    for result in results:
-        states_list, dW, m, expect, ss = result
-        data.states.append(states_list)
-        data.noise.append(dW)
-        data.measurement.append(m)
-        data.expect += expect
-        data.ss += ss
-
-    # average density matrices
-    if options.average_states and np.any(data.states):
-        data.states = [sum([ket2dm(data.states[mm][n])
-                            for mm in range(nt)]).unit()
-                       for n in range(len(data.times))]
-
-    # average
-    data.expect = data.expect / nt
-
-    # standard error
-    if nt > 1:
-        data.se = (data.ss - nt * (data.expect ** 2)) / (nt * (nt - 1))
-    else:
-        data.se = None
-
-    # convert complex data to real if hermitian
-    data.expect = [np.real(data.expect[n, :])
-                   if e.isherm else data.expect[n, :]
-                   for n, e in enumerate(sso.e_ops)]
-
-    return data
-
-
-def _ssesolve_single_trajectory(n, sso):
-    """
-    Internal function. See ssesolve.
-    """
-    dt = sso.dt
-    times = sso.times
-    d1, d2 = sso.d1, sso.d2
-    d2_len = sso.d2_len
-    e_ops = sso.e_ops
-    H_data = sso.H.data
-    A_ops = sso.A_ops
-
-    expect = np.zeros((len(sso.e_ops), sso.N_store), dtype=complex)
-    ss = np.zeros((len(sso.e_ops), sso.N_store), dtype=complex)
-
-    psi_t = sso.state0.full().ravel()
-    dims = sso.state0.dims
-
-    # reseed the random number generator so that forked
-    # processes do not get the same sequence of random numbers
-    np.random.seed((n+1) * np.random.randint(0, 4294967295 // (sso.ntraj+1)))
-
-    if sso.noise is None:
-        if sso.homogeneous:
-            if sso.distribution == 'normal':
-                dW = np.sqrt(dt) * \
-                    np.random.randn(len(A_ops), sso.N_store, sso.N_substeps,
-                                    d2_len)
-            else:
-                raise TypeError('Unsupported increment distribution for ' +
-                                'homogeneous process.')
-        else:
-            if sso.distribution != 'poisson':
-                raise TypeError('Unsupported increment distribution for ' +
-                                'inhomogeneous process.')
-
-            dW = np.zeros((len(A_ops), sso.N_store, sso.N_substeps, d2_len))
-    else:
-        dW = sso.noise[n]
-
-    states_list = []
-    measurements = np.zeros((len(times), len(sso.m_ops), d2_len),
-                            dtype=complex)
-
-    for t_idx, t in enumerate(times):
-
-        if e_ops:
-            for e_idx, e in enumerate(e_ops):
-                s = cy_expect_psi_csr(e.data.data,
-                                      e.data.indices,
-                                      e.data.indptr, psi_t, 0)
-                expect[e_idx, t_idx] += s
-                ss[e_idx, t_idx] += s ** 2
-        else:
-            states_list.append(Qobj(psi_t, dims=dims))
-
-        for j in range(sso.N_substeps):
-
-            if sso.noise is None and not sso.homogeneous:
-                for a_idx, A in enumerate(A_ops):
-                    # dw_expect = norm(spmv(A[0], psi_t)) ** 2 * dt
-                    dw_expect = cy_expect_psi_csr(A[3].data,
-                                                  A[3].indices,
-                                                  A[3].indptr, psi_t, 1) * dt
-                    dW[a_idx, t_idx, j, :] = np.random.poisson(dw_expect,
-                                                               d2_len)
-
-            psi_t = sso.rhs(H_data, psi_t, t + dt * j,
-                            A_ops, dt, dW[:, t_idx, j, :], d1, d2, sso.args)
-
-            # optionally renormalize the wave function
-            if sso.normalize:
-                psi_t /= norm(psi_t)
-
-        if sso.store_measurement:
-            for m_idx, m in enumerate(sso.m_ops):
-                for dW_idx, dW_factor in enumerate(sso.dW_factors):
-                    if m[dW_idx]:
-                        m_data = m[dW_idx].data
-                        m_expt = cy_expect_psi_csr(m_data.data,
-                                                   m_data.indices,
-                                                   m_data.indptr,
-                                                   psi_t, 0)
-                    else:
-                        m_expt = 0
-                    mm = (m_expt + dW_factor *
-                          dW[m_idx, t_idx, :, dW_idx].sum() /
-                          (dt * sso.N_substeps))
-                    measurements[t_idx, m_idx, dW_idx] = mm
-
-    if d2_len == 1:
-        measurements = measurements.squeeze(axis=(2))
-
-    return states_list, dW, measurements, expect, ss
-
-
-# -----------------------------------------------------------------------------
-# Generic parameterized stochastic master equation solver
-#
-def _smesolve_generic(sso, options, progress_bar):
-    """
-    Internal function. See smesolve.
-    """
-    if debug:
-        logger.debug(inspect.stack()[0][3])
-
-    sso.N_store = len(sso.times)
-    sso.N_substeps = sso.nsubsteps
-    sso.dt = (sso.times[1] - sso.times[0]) / sso.N_substeps
-    nt = sso.ntraj
-
-    data = Result()
-    data.solver = "smesolve"
-    data.times = sso.times
-    data.expect = np.zeros((len(sso.e_ops), sso.N_store), dtype=complex)
-    data.ss = np.zeros((len(sso.e_ops), sso.N_store), dtype=complex)
-    data.noise = []
-    data.measurement = []
-
-    # Liouvillian for the deterministic part.
-    # needs to be modified for TD systems
-    sso.L = liouvillian(sso.H, sso.c_ops)
-
-    # pre-compute suporoperator operator combinations that are commonly needed
-    # when evaluating the RHS of stochastic master equations
-    sso.A_ops = sso.generate_A_ops(sso.sc_ops, sso.L.data, sso.dt)
-
-    # use .data instead of Qobj ?
-    sso.s_e_ops = [spre(e) for e in sso.e_ops]
-
-    if sso.m_ops:
-        sso.s_m_ops = [[spre(m) if m else None for m in m_op]
-                       for m_op in sso.m_ops]
-    else:
-        sso.s_m_ops = [[spre(c) for _ in range(sso.d2_len)]
-                       for c in sso.sc_ops]
-
-    map_kwargs = {'progress_bar': progress_bar}
-    map_kwargs.update(sso.map_kwargs)
-
-    task = _smesolve_single_trajectory
-    task_args = (sso,)
-    task_kwargs = {}
-
-    results = sso.map_func(task, list(range(sso.ntraj)),
-                           task_args, task_kwargs, **map_kwargs)
-
-    for result in results:
-        states_list, dW, m, expect, ss = result
-        data.states.append(states_list)
-        data.noise.append(dW)
-        data.measurement.append(m)
-        data.expect += expect
-        data.ss += ss
-
-    # average density matrices
-    if options.average_states and np.any(data.states):
-        data.states = [sum([data.states[mm][n] for mm in range(nt)]).unit()
-                       for n in range(len(data.times))]
-
-    # average
-    data.expect = data.expect / nt
-
-    # standard error
-    if nt > 1:
-        data.se = (data.ss - nt * (data.expect ** 2)) / (nt * (nt - 1))
-    else:
-        data.se = None
-
-    # convert complex data to real if hermitian
-    data.expect = [np.real(data.expect[n, :])
-                   if e.isherm else data.expect[n, :]
-                   for n, e in enumerate(sso.e_ops)]
-
-    return data
-
-
-def _smesolve_single_trajectory(n, sso):
-    """
-    Internal function. See smesolve.
-    """
-    dt = sso.dt
-    times = sso.times
-    d1, d2 = sso.d1, sso.d2
-    d2_len = sso.d2_len
-    L_data = sso.L.data
-    N_substeps = sso.N_substeps
-    N_store = sso.N_store
-    A_ops = sso.A_ops
-
-    rho_t = mat2vec(sso.state0.full()).ravel()
-    dims = sso.state0.dims
-
-    expect = np.zeros((len(sso.e_ops), sso.N_store), dtype=complex)
-    ss = np.zeros((len(sso.e_ops), sso.N_store), dtype=complex)
-
-    # reseed the random number generator so that forked
-    # processes do not get the same sequence of random numbers
-    np.random.seed((n+1) * np.random.randint(0, 4294967295 // (sso.ntraj+1)))
-
-    if sso.noise is None:
-        if sso.generate_noise:
-            dW = sso.generate_noise(len(A_ops), N_store, N_substeps,
-                                    sso.d2_len, dt)
-        elif sso.homogeneous:
-            if sso.distribution == 'normal':
-                dW = np.sqrt(dt) * np.random.randn(len(A_ops), N_store,
-                                                   N_substeps, d2_len)
-            else:
-                raise TypeError('Unsupported increment distribution for ' +
-                                'homogeneous process.')
-        else:
-            if sso.distribution != 'poisson':
-                raise TypeError('Unsupported increment distribution for ' +
-                                'inhomogeneous process.')
-
-            dW = np.zeros((len(A_ops), N_store, N_substeps, d2_len))
-    else:
-        dW = sso.noise[n]
-
-    states_list = []
-    measurements = np.zeros((len(times), len(sso.s_m_ops), d2_len),
-                            dtype=complex)
-
-    for t_idx, t in enumerate(times):
-
-        if sso.s_e_ops:
-            for e_idx, e in enumerate(sso.s_e_ops):
-                s = cy_expect_rho_vec(e.data, rho_t, 0)
-                expect[e_idx, t_idx] += s
-                ss[e_idx, t_idx] += s ** 2
-
-        if sso.store_states or not sso.s_e_ops:
-            states_list.append(Qobj(vec2mat(rho_t), dims=dims))
-
-        rho_prev = np.copy(rho_t)
-
-        for j in range(N_substeps):
-
-            if sso.noise is None and not sso.homogeneous:
-                for a_idx, A in enumerate(A_ops):
-                    dw_expect = cy_expect_rho_vec(A[4], rho_t, 1) * dt
-                    if dw_expect > 0:
-                        dW[a_idx, t_idx, j, :] = np.random.poisson(dw_expect,
-                                                                   d2_len)
-                    else:
-                        dW[a_idx, t_idx, j, :] = np.zeros(d2_len)
-
-            rho_t = sso.rhs(L_data, rho_t, t + dt * j,
-                            A_ops, dt, dW[:, t_idx, j, :], d1, d2, sso.args)
-
-        if sso.store_measurement:
-            for m_idx, m in enumerate(sso.s_m_ops):
-                for dW_idx, dW_factor in enumerate(sso.dW_factors):
-                    if m[dW_idx]:
-                        m_expt = cy_expect_rho_vec(m[dW_idx].data, rho_prev, 0)
-                    else:
-                        m_expt = 0
-                    measurements[t_idx, m_idx, dW_idx] = m_expt + dW_factor * \
-                        dW[m_idx, t_idx, :, dW_idx].sum() / (dt * N_substeps)
-
-    if d2_len == 1:
-        measurements = measurements.squeeze(axis=(2))
-
-    return states_list, dW, measurements, expect, ss
-
-
-# -----------------------------------------------------------------------------
-# Generic parameterized stochastic SE PDP solver
-#
-def _ssepdpsolve_generic(sso, options, progress_bar):
-    """
-    For internal use. See ssepdpsolve.
-    """
-    if debug:
-        logger.debug(inspect.stack()[0][3])
-
-    N_store = len(sso.times)
-    N_substeps = sso.nsubsteps
-    dt = (sso.times[1] - sso.times[0]) / N_substeps
-    nt = sso.ntraj
-
-    data = Result()
-    data.solver = "sepdpsolve"
-    data.times = sso.tlist
-    data.expect = np.zeros((len(sso.e_ops), N_store), dtype=complex)
-    data.ss = np.zeros((len(sso.e_ops), N_store), dtype=complex)
-    data.jump_times = []
-    data.jump_op_idx = []
-
-    # effective hamiltonian for deterministic part
-    Heff = sso.H
-    for c in sso.c_ops:
-        Heff += -0.5j * c.dag() * c
-
-    progress_bar.start(sso.ntraj)
-    for n in range(sso.ntraj):
-        progress_bar.update(n)
-        psi_t = sso.state0.full().ravel()
-
-        states_list, jump_times, jump_op_idx = \
-            _ssepdpsolve_single_trajectory(data, Heff, dt, sso.times,
-                                           N_store, N_substeps,
-                                           psi_t, sso.state0.dims,
-                                           sso.c_ops, sso.e_ops)
-
-        data.states.append(states_list)
-        data.jump_times.append(jump_times)
-        data.jump_op_idx.append(jump_op_idx)
-
-    progress_bar.finished()
-
-    # average density matrices
-    if options.average_states and np.any(data.states):
-        data.states = [sum([data.states[m][n] for m in range(nt)]).unit()
-                       for n in range(len(data.times))]
-
-    # average
-    data.expect = data.expect / nt
-
-    # standard error
-    if nt > 1:
-        data.se = (data.ss - nt * (data.expect ** 2)) / (nt * (nt - 1))
-    else:
-        data.se = None
-
-    # convert complex data to real if hermitian
-    data.expect = [np.real(data.expect[n, :])
-                   if e.isherm else data.expect[n, :]
-                   for n, e in enumerate(sso.e_ops)]
-
-    return data
-
-
-def _ssepdpsolve_single_trajectory(data, Heff, dt, times, N_store, N_substeps,
-                                   psi_t, dims, c_ops, e_ops):
-    """
-    Internal function. See ssepdpsolve.
-    """
-    states_list = []
-
-    phi_t = np.copy(psi_t)
-
-    prng = RandomState()  # todo: seed it
-    r_jump, r_op = prng.rand(2)
-
-    jump_times = []
-    jump_op_idx = []
-
-    for t_idx, t in enumerate(times):
-
-        if e_ops:
-            for e_idx, e in enumerate(e_ops):
-                s = cy_expect_psi_csr(
-                    e.data.data, e.data.indices, e.data.indptr, psi_t, 0)
-                data.expect[e_idx, t_idx] += s
-                data.ss[e_idx, t_idx] += s ** 2
-        else:
-            states_list.append(Qobj(psi_t, dims=dims))
-
-        for j in range(N_substeps):
-
-            if norm(phi_t) ** 2 < r_jump:
-                # jump occurs
-                p = np.array([norm(c.data * psi_t) ** 2 for c in c_ops])
-                p = np.cumsum(p / np.sum(p))
-                n = np.where(p >= r_op)[0][0]
-
-                # apply jump
-                psi_t = c_ops[n].data * psi_t
-                psi_t /= norm(psi_t)
-                phi_t = np.copy(psi_t)
-
-                # store info about jump
-                jump_times.append(times[t_idx] + dt * j)
-                jump_op_idx.append(n)
-
-                # get new random numbers for next jump
-                r_jump, r_op = prng.rand(2)
-
-            # deterministic evolution wihtout correction for norm decay
-            dphi_t = (-1.0j * dt) * (Heff.data * phi_t)
-
-            # deterministic evolution with correction for norm decay
-            dpsi_t = (-1.0j * dt) * (Heff.data * psi_t)
-            A = 0.5 * np.sum([norm(c.data * psi_t) ** 2 for c in c_ops])
-            dpsi_t += dt * A * psi_t
-
-            # increment wavefunctions
-            phi_t += dphi_t
-            psi_t += dpsi_t
-
-            # ensure that normalized wavefunction remains normalized
-            # this allows larger time step than otherwise would be possible
-            psi_t /= norm(psi_t)
-
-    return states_list, jump_times, jump_op_idx
-
-
-# -----------------------------------------------------------------------------
-# Generic parameterized stochastic ME PDP solver
-#
-def _smepdpsolve_generic(sso, options, progress_bar):
-    """
-    For internal use. See smepdpsolve.
-    """
-    if debug:
-        logger.debug(inspect.stack()[0][3])
-
-    N_store = len(sso.times)
-    N_substeps = sso.nsubsteps
-    dt = (sso.times[1] - sso.times[0]) / N_substeps
-    nt = sso.ntraj
-
-    data = Result()
-    data.solver = "smepdpsolve"
-    data.times = sso.times
-    data.expect = np.zeros((len(sso.e_ops), N_store), dtype=complex)
-    data.jump_times = []
-    data.jump_op_idx = []
-
-    # Liouvillian for the deterministic part.
-    # needs to be modified for TD systems
-    L = liouvillian(sso.H, sso.c_ops)
-
-    progress_bar.start(sso.ntraj)
-
-    for n in range(sso.ntraj):
-        progress_bar.update(n)
-        rho_t = mat2vec(sso.rho0.full()).ravel()
-
-        states_list, jump_times, jump_op_idx = \
-            _smepdpsolve_single_trajectory(data, L, dt, sso.times,
-                                           N_store, N_substeps,
-                                           rho_t, sso.rho0.dims,
-                                           sso.c_ops, sso.e_ops)
-
-        data.states.append(states_list)
-        data.jump_times.append(jump_times)
-        data.jump_op_idx.append(jump_op_idx)
-
-    progress_bar.finished()
-
-    # average density matrices
-    if options.average_states and np.any(data.states):
-        data.states = [sum([data.states[m][n] for m in range(nt)]).unit()
-                       for n in range(len(data.times))]
-
-    # average
-    data.expect = data.expect / sso.ntraj
-
-    # standard error
-    if nt > 1:
-        data.se = (data.ss - nt * (data.expect ** 2)) / (nt * (nt - 1))
-    else:
-        data.se = None
-
-    return data
-
-
-def _smepdpsolve_single_trajectory(data, L, dt, times, N_store, N_substeps,
-                                   rho_t, dims, c_ops, e_ops):
-    """
-    Internal function. See smepdpsolve.
-    """
-    states_list = []
-
-    rho_t = np.copy(rho_t)
-    sigma_t = np.copy(rho_t)
-
-    prng = RandomState()  # todo: seed it
-    r_jump, r_op = prng.rand(2)
-
-    jump_times = []
-    jump_op_idx = []
-
-    for t_idx, t in enumerate(times):
-
-        if e_ops:
-            for e_idx, e in enumerate(e_ops):
-                data.expect[e_idx, t_idx] += expect_rho_vec(e, rho_t)
-        else:
-            states_list.append(Qobj(vec2mat(rho_t), dims=dims))
-
-        for j in range(N_substeps):
-
-            if sigma_t.norm() < r_jump:
-                # jump occurs
-                p = np.array([expect(c.dag() * c, rho_t) for c in c_ops])
-                p = np.cumsum(p / np.sum(p))
-                n = np.where(p >= r_op)[0][0]
-
-                # apply jump
-                rho_t = c_ops[n] * rho_t * c_ops[n].dag()
-                rho_t /= expect(c_ops[n].dag() * c_ops[n], rho_t)
-                sigma_t = np.copy(rho_t)
-
-                # store info about jump
-                jump_times.append(times[t_idx] + dt * j)
-                jump_op_idx.append(n)
-
-                # get new random numbers for next jump
-                r_jump, r_op = prng.rand(2)
-
-            # deterministic evolution wihtout correction for norm decay
-            dsigma_t = spmv(L.data, sigma_t) * dt
-
-            # deterministic evolution with correction for norm decay
-            drho_t = spmv(L.data, rho_t) * dt
-
-            rho_t += drho_t
-
-            # increment density matrices
-            sigma_t += dsigma_t
-            rho_t += drho_t
-
-    return states_list, jump_times, jump_op_idx
-
-
-# -----------------------------------------------------------------------------
-# Helper-functions for stochastic DE
-#
-# d1 = deterministic part of the contribution to the DE RHS function, to be
-#      multiplied by the increament dt
-#
-# d1 = stochastic part of the contribution to the DE RHS function, to be
-#      multiplied by the increament dW
-#
-
-
-#
-# For SSE
-#
-
-# Function sigurature:
-#
-# def d(A, psi):
-#
-#     psi = wave function at the current time step
-#
-#     A[0] = c
-#     A[1] = c + c.dag()
-#     A[2] = c - c.dag()
-#     A[3] = c.dag() * c
-#
-#     where c is a collapse operator. The combinations of c's stored in A are
-#     precomputed before the time-evolution is started to avoid repeated
-#     computations.
-
-
-def _generate_psi_A_ops(sc_ops, H):
-    """
-    pre-compute superoperator operator combinations that are commonly needed
-    when evaluating the RHS of stochastic schrodinger equations
-    """
-
-    A_ops = []
-    for c_idx, c in enumerate(sc_ops):
-        A_ops.append([c.data,
-                      (c + c.dag()).data,
-                      (c - c.dag()).data,
-                      (c.dag() * c).data])
-
-    return A_ops
-
-
-def d1_psi_homodyne(t, psi, A, args):
-    """
-    OK
-    Need to cythonize
-
-    .. math::
-
-        D_1(C, \psi) = \\frac{1}{2}(\\langle C + C^\\dagger\\rangle\\C psi -
-        C^\\dagger C\\psi - \\frac{1}{4}\\langle C + C^\\dagger\\rangle^2\\psi)
-
-    """
-
-    e1 = cy_expect_psi_csr(A[1].data, A[1].indices, A[1].indptr, psi, 0)
-    return 0.5 * (e1 * spmv(A[0], psi) -
-                  spmv(A[3], psi) -
-                  0.25 * e1 ** 2 * psi)
-
-
-def d2_psi_homodyne(t, psi, A, args):
-    """
-    OK
-    Need to cythonize
-
-    .. math::
-
-        D_2(\psi, t) = (C - \\frac{1}{2}\\langle C + C^\\dagger\\rangle)\\psi
-
-    """
-
-    e1 = cy_expect_psi_csr(A[1].data, A[1].indices, A[1].indptr, psi, 0)
-    return [spmv(A[0], psi) - 0.5 * e1 * psi]
-
-
-def d1_psi_heterodyne(t, psi, A, args):
-    """
-    Need to cythonize
-
-    .. math::
-
-        D_1(\psi, t) = -\\frac{1}{2}(C^\\dagger C -
-        \\langle C^\\dagger \\rangle C +
-        \\frac{1}{2}\\langle C \\rangle\\langle C^\\dagger \\rangle))\psi
-
-    """
-    e_C = cy_expect_psi_csr(A[0].data, A[0].indices, A[0].indptr, psi, 0)
-    B = A[0].T.conj()
-    e_Cd = cy_expect_psi_csr(B.data, B.indices, B.indptr, psi, 0)
-
-    return (-0.5 * spmv(A[3], psi) +
-            0.5 * e_Cd * spmv(A[0], psi) -
-            0.25 * e_C * e_Cd * psi)
-
-
-def d2_psi_heterodyne(t, psi, A, args):
-    """
-    Need to cythonize
-
-        X = \\frac{1}{2}(C + C^\\dagger)
-
-        Y = \\frac{1}{2}(C - C^\\dagger)
-
-        D_{2,1}(\psi, t) = \\sqrt(1/2) (C - \\langle X \\rangle) \\psi
-
-        D_{2,2}(\psi, t) = -i\\sqrt(1/2) (C - \\langle Y \\rangle) \\psi
-
-    """
-
-    X = 0.5 * cy_expect_psi_csr(A[1].data, A[1].indices, A[1].indptr, psi, 0)
-    Y = 0.5 * cy_expect_psi_csr(A[2].data, A[2].indices, A[2].indptr, psi, 0)
-
-    d2_1 = np.sqrt(0.5) * (spmv(A[0], psi) - X * psi)
-    d2_2 = -1.0j * np.sqrt(0.5) * (spmv(A[0], psi) - Y * psi)
-
-    return [d2_1, d2_2]
-
-
-def d1_psi_photocurrent(t, psi, A, args):
-    """
-    Need to cythonize.
-
-    Note: requires poisson increments
-
-    .. math::
-
-        D_1(\psi, t) = - \\frac{1}{2}(C^\dagger C \psi - ||C\psi||^2 \psi)
-
-    """
-    return (-0.5 * (spmv(A[3], psi)
-            - norm(spmv(A[0], psi)) ** 2 * psi))
-
-
-def d2_psi_photocurrent(t, psi, A, args):
-    """
-    Need to cythonize
-
-    Note: requires poisson increments
-
-    .. math::
-
-        D_2(\psi, t) = C\psi / ||C\psi|| - \psi
-
-    """
-    psi_1 = spmv(A[0], psi)
-    n1 = norm(psi_1)
-    if n1 != 0:
-        return [psi_1 / n1 - psi]
-    else:
-        return [- psi]
-
-
-#
-# For SME
-#
-
-# def d(A, rho_vec):
-#
-#     rho = density operator in vector form at the current time stemp
-#
-#     A[_idx_A_L] = spre(a) = A_L
-#     A[_idx_A_R] = spost(a) = A_R
-#     A[_idx_Ad_L] = spre(a.dag()) = Ad_L
-#     A[_idx_Ad_R] = spost(a.dag()) = Ad_R
-#     A[_idx_AdA_L] = spre(a.dag() * a) = (Ad A)_L
-#     A[_idx_AdA_R] = spost(a.dag() * a) = (Ad A)_R
-#     A[_idx_A_LxAd_R] = (spre(a) * spost(a.dag()) = A_L * Ad_R
-#     A[_idx_LD] = lindblad_dissipator(a)
-
-_idx_A_L = 0
-_idx_A_R = 1
-_idx_Ad_L = 2
-_idx_Ad_R = 3
-_idx_AdA_L = 4
-_idx_AdA_R = 5
-_idx_A_LxAd_R = 6
-_idx_LD = 7
-
-
-def _generate_rho_A_ops(sc, L, dt):
-    """
-    pre-compute superoperator operator combinations that are commonly needed
-    when evaluating the RHS of stochastic master equations
-    """
-    out = []
-    for c_idx, c in enumerate(sc):
-        n = c.dag() * c
-        out.append([spre(c).data,
-                    spost(c).data,
-                    spre(c.dag()).data,
-                    spost(c.dag()).data,
-                    spre(n).data,
-                    spost(n).data,
-                    (spre(c) * spost(c.dag())).data,
-                    lindblad_dissipator(c, data_only=True)])
-
-    return out
-
-
-def _generate_A_ops_Euler(sc, L, dt):
-    """
-    combine precomputed operators in one long operator for the Euler method
-    """
-    A_len = len(sc)
-    out = []
-    out += [spre(c).data + spost(c.dag()).data for c in sc]
-    out += [(L + np.sum(
-        [lindblad_dissipator(c, data_only=True) for c in sc], axis=0)) * dt]
-    out1 = [[sp.vstack(out).tocsr(), sc[0].shape[0]]]
-    # the following hack is required for compatibility with old A_ops
-    out1 += [[] for n in range(A_len - 1)]
-
-    # XXX: fix this!
-    out1[0][0].indices = np.array(out1[0][0].indices, dtype=np.int32)
-    out1[0][0].indptr = np.array(out1[0][0].indptr, dtype=np.int32)
-
-    return out1
-
-
-def _generate_A_ops_Milstein(sc, L, dt):
-    """
-    combine precomputed operators in one long operator for the Milstein method
-    with commuting stochastic jump operators.
-    """
-    A_len = len(sc)
-    temp = [spre(c).data + spost(c.dag()).data for c in sc]
-    out = []
-    out += temp
-    out += [temp[n] * temp[n] for n in range(A_len)]
-    out += [temp[n] * temp[m] for (n, m) in np.ndindex(A_len, A_len) if n > m]
-    out += [(L + np.sum(
-        [lindblad_dissipator(c, data_only=True) for c in sc], axis=0)) * dt]
-    out1 = [[sp.vstack(out).tocsr(), sc[0].shape[0]]]
-    # the following hack is required for compatibility with old A_ops
-    out1 += [[] for n in range(A_len - 1)]
-
-    # XXX: fix this!
-    out1[0][0].indices = np.array(out1[0][0].indices, dtype=np.int32)
-    out1[0][0].indptr = np.array(out1[0][0].indptr, dtype=np.int32)
-
-    return out1
-
-
-def _generate_A_ops_simple(sc, L, dt):
-    """
-    pre-compute superoperator operator combinations that are commonly needed
-    when evaluating the RHS of stochastic master equations
-    """
-
-    A_len = len(sc)
-    temp = [spre(c).data + spost(c.dag()).data for c in sc]
-    tempL = (L + np.sum([lindblad_dissipator(c, data_only=True) for c in sc], axis=0)) # Lagrangian
-
-    out = []
-    out += temp
-    out += [tempL]
-    
-    out1 = [out]
-    # the following hack is required for compatibility with old A_ops
-    out1 += [[] for n in range(A_len - 1)]
-
-    return out1
-    
-    
-def _generate_A_ops_implicit(sc, L, dt):
-    """
-    pre-compute superoperator operator combinations that are commonly needed
-    when evaluating the RHS of stochastic master equations
-    """
-
-    A_len = len(sc)
-    temp = [spre(c).data + spost(c.dag()).data for c in sc]
-    tempL = (L + np.sum([lindblad_dissipator(c, data_only=True) for c in sc], axis=0)) # Lagrangian
-
-    out = []
-    out += temp
-    out += [sp.eye(L.shape[0], format='csr') - 0.5*dt*tempL]
-    out += [tempL]
-    
-    out1 = [out]
-    # the following hack is required for compatibility with old A_ops
-    out1 += [[] for n in range(A_len - 1)]
-
-    return out1
-
-
-def _generate_noise_Milstein(sc_len, N_store, N_substeps, d2_len, dt):
-    """
-    generate noise terms for the fast Milstein scheme
-    """
-    dW_temp = np.sqrt(dt) * np.random.randn(sc_len, N_store, N_substeps, 1)
-    if sc_len == 1:
-        noise = np.vstack([dW_temp, 0.5 * (dW_temp * dW_temp - dt *
-                          np.ones((sc_len, N_store, N_substeps, 1)))])
-    else:
-        noise = np.vstack(
-            [dW_temp,
-             0.5 * (dW_temp * dW_temp -
-                    dt * np.ones((sc_len, N_store, N_substeps, 1)))] +
-            [[dW_temp[n] * dW_temp[m]
-              for (n, m) in np.ndindex(sc_len, sc_len) if n > m]])
-
-    return noise
-
-def _generate_noise_Taylor_15(sc_len, N_store, N_substeps, d2_len, dt):
-    """
-    generate noise terms for the strong Taylor 1.5 scheme
-    """
-    U1 = np.random.randn(sc_len, N_store, N_substeps, 1) 
-    U2 = np.random.randn(sc_len, N_store, N_substeps, 1) 
-    dW = U1 * np.sqrt(dt) 
-    dZ = 0.5 * dt**(3./2) * (U1 + 1./np.sqrt(3) * U2) 
-
-    if sc_len == 1:
-        noise = np.vstack([ dW, 0.5 * (dW * dW - dt), dZ, dW * dt - dZ, 0.5 * (1./3. * dW**2 - dt) * dW ])                    
-    
-    elif sc_len == 2:
-        noise = np.vstack([ dW, 0.5 * (dW**2 - dt), dZ, dW * dt - dZ, 0.5 * (1./3. * dW**2 - dt) * dW] 
-                    + [[dW[n] * dW[m] for (n, m) in np.ndindex(sc_len, sc_len) if n < m]]  # Milstein
-                    + [[0.5 * dW[n] * (dW[m]**2 - dt) for (n, m) in np.ndindex(sc_len, sc_len) if n != m]])
-
-    #else:
-        #noise = np.vstack([ dW, 0.5 * (dW**2 - dt), dZ, dW * dt - dZ, 0.5 * (1./3. * dW**2 - dt) * dW] 
-                    #+ [[dW[n] * dW[m] for (n, m) in np.ndindex(sc_len, sc_len) if n > m]]  # Milstein
-                    #+ [[0.5 * dW[n] * (dW[m]**2 - dt) for (n, m) in np.ndindex(sc_len, sc_len) if n != m]]
-                    #+ [[dW[n] * dW[m] * dW[k] for (n, m, k) in np.ndindex(sc_len, sc_len, sc_len) if n>m>k]])  
-    else:
-        raise Exception("too many stochastic operators")
-
-    return noise
-
-
-def sop_H(A, rho_vec):
-    """
-    Evaluate the superoperator
-
-    H[a] rho = a rho + rho a^\dagger - Tr[a rho + rho a^\dagger] rho
-            -> (A_L + Ad_R) rho_vec - E[(A_L + Ad_R) rho_vec] rho_vec
-
-    Need to cythonize, add A_L + Ad_R to precomputed operators
-    """
-    M = A[0] + A[3]
-
-    e1 = cy_expect_rho_vec(M, rho_vec, 0)
-    return spmv(M, rho_vec) - e1 * rho_vec
-
-
-def sop_G(A, rho_vec):
-    """
-    Evaluate the superoperator
-
-    G[a] rho = a rho a^\dagger / Tr[a rho a^\dagger] - rho
-            -> A_L Ad_R rho_vec / Tr[A_L Ad_R rho_vec] - rho_vec
-
-    Need to cythonize, add A_L + Ad_R to precomputed operators
-    """
-
-    e1 = cy_expect_rho_vec(A[6], rho_vec, 0)
-
-    if e1 > 1e-15:
-        return spmv(A[6], rho_vec) / e1 - rho_vec
-    else:
-        return -rho_vec
-
-
-def d1_rho_homodyne(t, rho_vec, A, args):
-    """
-    D1[a] rho = lindblad_dissipator(a) * rho
-
-    Need to cythonize
-    """
-    return spmv(A[7], rho_vec)
-
-
-def d2_rho_homodyne(t, rho_vec, A, args):
-    """
-    D2[a] rho = a rho + rho a^\dagger - Tr[a rho + rho a^\dagger]
-              = (A_L + Ad_R) rho_vec - E[(A_L + Ad_R) rho_vec]
-
-    Need to cythonize, add A_L + Ad_R to precomputed operators
-    """
-    M = A[0] + A[3]
-
-    e1 = cy_expect_rho_vec(M, rho_vec, 0)
-    return [spmv(M, rho_vec) - e1 * rho_vec]
-
-
-def d1_rho_heterodyne(t, rho_vec, A, args):
-    """
-    Need to cythonize, docstrings
-    """
-    return spmv(A[7], rho_vec)
-
-
-def d2_rho_heterodyne(t, rho_vec, A, args):
-    """
-    Need to cythonize, docstrings
-    """
-    M = A[0] + A[3]
-    e1 = cy_expect_rho_vec(M, rho_vec, 0)
-    d1 = spmv(M, rho_vec) - e1 * rho_vec
-    M = A[0] - A[3]
-    e1 = cy_expect_rho_vec(M, rho_vec, 0)
-    d2 = spmv(M, rho_vec) - e1 * rho_vec
-    return [1.0 / np.sqrt(2) * d1, -1.0j / np.sqrt(2) * d2]
-
-
-def d1_rho_photocurrent(t, rho_vec, A, args):
-    """
-    Need to cythonize, add (AdA)_L + AdA_R to precomputed operators
-    """
-    n_sum = A[4] + A[5]
-    e1 = cy_expect_rho_vec(n_sum, rho_vec, 0)
-    return 0.5 * (e1 * rho_vec - spmv(n_sum, rho_vec))
-
-
-def d2_rho_photocurrent(t, rho_vec, A, args):
-    """
-    Need to cythonize, add (AdA)_L + AdA_R to precomputed operators
-    """
-    e1 = cy_expect_rho_vec(A[6], rho_vec, 0)
-    if e1.real > 1e-15:
-        return [spmv(A[6], rho_vec) / e1 - rho_vec]
-    else:
-        return [-rho_vec]
-
-
-# -----------------------------------------------------------------------------
-# Deterministic part of the rho/psi update functions. TODO: Make these
-# compatible with qutip's time-dependent hamiltonian and collapse operators
-#
-def _rhs_psi_deterministic(H, psi_t, t, dt, args):
-    """
-    Deterministic contribution to the density matrix change
-    """
-    dpsi_t = (-1.0j * dt) * (H * psi_t)
-
-    return dpsi_t
-
-
-def _rhs_rho_deterministic(L, rho_t, t, dt, args):
-    """
-    Deterministic contribution to the density matrix change
-    """
-    drho_t = spmv(L, rho_t) * dt
-
-    return drho_t
-
-
-# -----------------------------------------------------------------------------
-# Euler-Maruyama rhs functions for the stochastic Schrodinger and master
-# equations
-#
-
-def _rhs_psi_euler_maruyama(H, psi_t, t, A_ops, dt, dW, d1, d2, args):
-    """
-    Euler-Maruyama rhs function for wave function solver.
-    """
-    dW_len = len(dW[0, :])
-    dpsi_t = _rhs_psi_deterministic(H, psi_t, t, dt, args)
-
-    for a_idx, A in enumerate(A_ops):
-        d2_vec = d2(t, psi_t, A, args)
-        dpsi_t += d1(t, psi_t, A, args) * dt + \
-            np.sum([d2_vec[n] * dW[a_idx, n]
-                    for n in range(dW_len) if dW[a_idx, n] != 0], axis=0)
-
-    return psi_t + dpsi_t
-
-
-def _rhs_rho_euler_maruyama(L, rho_t, t, A_ops, dt, dW, d1, d2, args):
-    """
-    Euler-Maruyama rhs function for density matrix solver.
-    """
-    dW_len = len(dW[0, :])
-
-    drho_t = _rhs_rho_deterministic(L, rho_t, t, dt, args)
-
-    for a_idx, A in enumerate(A_ops):
-        d2_vec = d2(t, rho_t, A, args)
-        drho_t += d1(t, rho_t, A, args) * dt
-        drho_t += np.sum([d2_vec[n] * dW[a_idx, n]
-                          for n in range(dW_len) if dW[a_idx, n] != 0], axis=0)
-
-    return rho_t + drho_t
-
-
-def _rhs_rho_euler_homodyne_fast(L, rho_t, t, A, dt, ddW, d1, d2, args):
-    """
-    Fast Euler-Maruyama for homodyne detection.
-    """
-
-    dW = ddW[:, 0]
-
-    d_vec = spmv(A[0][0], rho_t).reshape(-1, len(rho_t))
-    e = d_vec[:-1].reshape(-1, A[0][1], A[0][1]).trace(axis1=1, axis2=2)
-
-    drho_t = d_vec[-1]
-    drho_t += np.dot(dW, d_vec[:-1])
-    drho_t += (1.0 - np.inner(np.real(e), dW)) * rho_t
-    return drho_t
-
-
-# -----------------------------------------------------------------------------
-# Platen method
-#
-def _rhs_psi_platen(H, psi_t, t, A_ops, dt, dW, d1, d2, args):
-    """
-    TODO: support multiple stochastic increments
-
-    .. note::
-
-        Experimental.
-
-    """
-
-    sqrt_dt = np.sqrt(dt)
-
-    dpsi_t = _rhs_psi_deterministic(H, psi_t, t, dt, args)
-
-    for a_idx, A in enumerate(A_ops):
-        # XXX: This needs to be revised now that
-        # dpsi_t is the change for all stochastic collapse operators
-
-        # TODO: needs to be updated to support mutiple Weiner increments
-        dpsi_t_H = (-1.0j * dt) * spmv(H, psi_t)
-
-        psi_t_1 = (psi_t + dpsi_t_H +
-                   d1(A, psi_t) * dt +
-                   d2(A, psi_t)[0] * dW[a_idx, 0])
-        psi_t_p = (psi_t + dpsi_t_H +
-                   d1(A, psi_t) * dt +
-                   d2(A, psi_t)[0] * sqrt_dt)
-        psi_t_m = (psi_t + dpsi_t_H +
-                   d1(A, psi_t) * dt -
-                   d2(A, psi_t)[0] * sqrt_dt)
-
-        dpsi_t += (
-            0.50 * (d1(A, psi_t_1) + d1(A, psi_t)) * dt +
-            0.25 * (d2(A, psi_t_p)[0] + d2(A, psi_t_m)[0] +
-                    2 * d2(A, psi_t)[0]) * dW[a_idx, 0] +
-            0.25 * (d2(A, psi_t_p)[0] - d2(A, psi_t_m)[0]) *
-            (dW[a_idx, 0] ** 2 - dt) / sqrt_dt
-            )
-
-    return dpsi_t
-
-
-# -----------------------------------------------------------------------------
-# Milstein rhs functions for the stochastic master equation
-#
-def _rhs_rho_milstein_homodyne_single(L, rho_t, t, A_ops, dt, dW, d1, d2,
-                                      args):
-    """
-    .. note::
-
-        Experimental.
-        Milstein scheme for homodyne detection with single jump operator.
-
-    """
-    A = A_ops[0]
-    M = A[0] + A[3]
-    e1 = cy_expect_rho_vec(M, rho_t, 0)
-
-    d2_vec = spmv(M, rho_t)
-    d2_vec2 = spmv(M, d2_vec)
-    e2 = cy_expect_rho_vec(M, d2_vec, 0)
-
-    drho_t = _rhs_rho_deterministic(L, rho_t, t, dt, args)
-    drho_t += spmv(A[7], rho_t) * dt
-    drho_t += (d2_vec - e1 * rho_t) * dW[0, 0]
-    drho_t += 0.5 * (d2_vec2 - 2 * e1 * d2_vec + (-e2 + 2 * e1 * e1) *
-                     rho_t) * (dW[0, 0] * dW[0, 0] - dt)
-    return rho_t + drho_t
-
-
-def _rhs_rho_milstein_homodyne(L, rho_t, t, A_ops, dt, dW, d1, d2, args):
-    """
-    .. note::
-
-        Experimental.
-        Milstein scheme for homodyne detection.
-        This implementation works for commuting stochastic jump operators.
-        TODO: optimizations: do calculation for n>m only
-
-    """
-    A_len = len(A_ops)
-
-    M = np.array([A_ops[n][0] + A_ops[n][3] for n in range(A_len)])
-    e1 = np.array([cy_expect_rho_vec(M[n], rho_t, 0) for n in range(A_len)])
-
-    d1_vec = np.sum([spmv(A_ops[n][7], rho_t)
-                     for n in range(A_len)], axis=0)
-
-    d2_vec = np.array([spmv(M[n], rho_t)
-                       for n in range(A_len)])
-
-    # This calculation is suboptimal. We need only values for m>n in case of
-    # commuting jump operators.
-    d2_vec2 = np.array([[spmv(M[n], d2_vec[m])
-                         for m in range(A_len)] for n in range(A_len)])
-    e2 = np.array([[cy_expect_rho_vec(M[n], d2_vec[m], 0)
-                    for m in range(A_len)] for n in range(A_len)])
-
-    drho_t = _rhs_rho_deterministic(L, rho_t, t, dt, args)
-    drho_t += d1_vec * dt
-    drho_t += np.sum([(d2_vec[n] - e1[n] * rho_t) * dW[n, 0]
-                      for n in range(A_len)], axis=0)
-    drho_t += 0.5 * np.sum(
-        [(d2_vec2[n, n] - 2.0 * e1[n] * d2_vec[n] +
-         (-e2[n, n] + 2.0 * e1[n] * e1[n]) * rho_t) * (dW[n, 0]*dW[n, 0] - dt)
-         for n in range(A_len)], axis=0)
-
-    # This calculation is suboptimal. We need only values for m>n in case of
-    # commuting jump operators.
-    drho_t += 0.5 * np.sum(
-        [(d2_vec2[n, m] - e1[m] * d2_vec[n] - e1[n] * d2_vec[m] +
-         (-e2[n, m] + 2.0 * e1[n] * e1[m]) * rho_t) * (dW[n, 0] * dW[m, 0])
-         for (n, m) in np.ndindex(A_len, A_len) if n != m], axis=0)
-
-    return rho_t + drho_t
-
-
-def _rhs_rho_milstein_homodyne_single_fast(L, rho_t, t, A, dt, ddW, d1, d2,
-                                           args):
-    """
-    fast Milstein for homodyne detection with 1 stochastic operator
-    """
-    dW = np.copy(ddW[:, 0])
-
-    d_vec = spmv(A[0][0], rho_t).reshape(-1, len(rho_t))
-    e = np.real(
-        d_vec[:-1].reshape(-1, A[0][1], A[0][1]).trace(axis1=1, axis2=2))
-
-    e[1] -= 2.0 * e[0] * e[0]
-
-    drho_t = - np.inner(e, dW) * rho_t
-    dW[0] -= 2.0 * e[0] * dW[1]
-
-    drho_t += d_vec[-1]
-    drho_t += np.dot(dW, d_vec[:-1])
-
-    return rho_t + drho_t
-
-
-def _rhs_rho_milstein_homodyne_two_fast(L, rho_t, t, A, dt, ddW, d1, d2, args):
-    """
-    fast Milstein for homodyne detection with 2 stochastic operators
-    """
-    dW = np.copy(ddW[:, 0])
-
-    d_vec = spmv(A[0][0], rho_t).reshape(-1, len(rho_t))
-    e = np.real(
-        d_vec[:-1].reshape(-1, A[0][1], A[0][1]).trace(axis1=1, axis2=2))
-    d_vec[-2] -= np.dot(e[:2][::-1], d_vec[:2])
-
-    e[2:4] -= 2.0 * e[:2] * e[:2]
-    e[4] -= 2.0 * e[1] * e[0]
-
-    drho_t = - np.inner(e, dW) * rho_t
-    dW[:2] -= 2.0 * e[:2] * dW[2:4]
-
-    drho_t += d_vec[-1]
-    drho_t += np.dot(dW, d_vec[:-1])
-
-    return rho_t + drho_t
-
-
-def _rhs_rho_milstein_homodyne_fast(L, rho_t, t, A, dt, ddW, d1, d2, args):
-    """
-    fast Milstein for homodyne detection with >2 stochastic operators
-    """
-    dW = np.copy(ddW[:, 0])
-    sc_len = len(A)
-    sc2_len = 2 * sc_len
-
-    d_vec = spmv(A[0][0], rho_t).reshape(-1, len(rho_t))
-    e = np.real(d_vec[:-1].reshape(
-        -1, A[0][1], A[0][1]).trace(axis1=1, axis2=2))
-    d_vec[sc2_len:-1] -= np.array(
-        [e[m] * d_vec[n] + e[n] * d_vec[m]
-         for (n, m) in np.ndindex(sc_len, sc_len) if n > m])
-
-    e[sc_len:sc2_len] -= 2.0 * e[:sc_len] * e[:sc_len]
-    e[sc2_len:] -= 2.0 * np.array(
-        [e[n] * e[m] for (n, m) in np.ndindex(sc_len, sc_len) if n > m])
-
-    drho_t = - np.inner(e, dW) * rho_t
-    dW[:sc_len] -= 2.0 * e[:sc_len] * dW[sc_len:sc2_len]
-
-    drho_t += d_vec[-1]
-    drho_t += np.dot(dW, d_vec[:-1])
-
-    return rho_t + drho_t
-
-
-def _rhs_rho_taylor_15_one(L, rho_t, t, A, dt, ddW, d1, d2,
-                                           args):
-    """
-    strong order 1.5 Tylor scheme for homodyne detection with 1 stochastic operator
-    """
-
-    dW = ddW[:, 0]
-    A = A[0]
-
-    #reusable operators and traces
-    a = A[-1] * rho_t
-    e0 = cy_expect_rho_vec(A[0], rho_t, 1)
-    b = A[0] * rho_t - e0 * rho_t
-    TrAb = cy_expect_rho_vec(A[0], b, 1)
-    Lb = A[0] * b - TrAb * rho_t - e0 * b
-    TrALb = cy_expect_rho_vec(A[0], Lb, 1)
-    TrAa = cy_expect_rho_vec(A[0], a, 1)
-
-    drho_t = a * dt
-    drho_t += b * dW[0]
-    drho_t += Lb * dW[1] # Milstein term
-
-    # new terms: 
-    drho_t += A[-1] * b * dW[2]
-    drho_t += (A[0] * a - TrAa * rho_t - e0 * a - TrAb * b) * dW[3]
-    drho_t += A[-1] * a * (0.5 * dt*dt)
-    drho_t += (A[0] * Lb - TrALb * rho_t - (2 * TrAb) * b - e0 * Lb) * dW[4] 
-        
-    return rho_t + drho_t
-
-#include _rhs_rho_Taylor_15_two#
-
-def _rhs_rho_milstein_implicit(L, rho_t, t, A, dt, ddW, d1, d2, args):
-    """
-    Drift implicit Milstein (theta = 1/2, eta = 0)
-    Wang, X., Gan, S., & Wang, D. (2012). 
-    A family of fully implicit Milstein methods for stiff stochastic differential 
-    equations with multiplicative noise. 
-    BIT Numerical Mathematics, 52(3), 741–772.
-    """
-    
-    dW = ddW[:, 0]
-    A = A[0]
-    
-
-    #reusable operators and traces
-    a = A[-1] * rho_t * (0.5 * dt)
-    e0 = cy_expect_rho_vec(A[0], rho_t, 1)
-    b = A[0] * rho_t - e0 * rho_t
-    TrAb = cy_expect_rho_vec(A[0], b, 1)
-
-    drho_t = b * dW[0] 
-    drho_t += a
-    drho_t += (A[0] * b - TrAb * rho_t - e0 * b) * dW[1] # Milstein term
-    drho_t += rho_t
-
-    v, check = sp.linalg.bicgstab(A[-2], drho_t, x0 = drho_t + a, tol=args['tol'])
-
-    return v
-    
-def _rhs_rho_taylor_15_implicit(L, rho_t, t, A, dt, ddW, d1, d2, args):
-    """
-    Drift implicit Taylor 1.5 (alpha = 1/2, beta = doesn't matter)
-    Chaptert 12.2 Eq. (2.18) in Numerical Solution of Stochastic Differential Equations
-    By Peter E. Kloeden, Eckhard Platen
-    """
-    
-    dW = ddW[:, 0]
-    A = A[0]
-
-    #reusable operators and traces
-    a = A[-1] * rho_t
-    e0 = cy_expect_rho_vec(A[0], rho_t, 1)
-    b = A[0] * rho_t - e0 * rho_t
-    TrAb = cy_expect_rho_vec(A[0], b, 1)
-    Lb = A[0] * b - TrAb * rho_t - e0 * b
-    TrALb = cy_expect_rho_vec(A[0], Lb, 1)
-    TrAa = cy_expect_rho_vec(A[0], a, 1)
-
-    drho_t = b * dW[0] 
-    drho_t += Lb * dW[1] # Milstein term
-    xx0 = (drho_t + a * dt) + rho_t #starting vector for the linear solver (Milstein prediction)
-    drho_t += (0.5 * dt) * a
-
-    # new terms: 
-    drho_t += A[-1] * b * (dW[2] - 0.5*dW[0]*dt)
-    drho_t += (A[0] * a - TrAa * rho_t - e0 * a - TrAb * b) * dW[3]
-
-    drho_t += (A[0] * Lb - TrALb * rho_t - (2 * TrAb) * b - e0 * Lb) * dW[4]
-    drho_t += rho_t
-
-    v, check = sp.linalg.bicgstab(A[-2], drho_t, x0 = xx0, tol=args['tol'])
-
-    return v
-    
-def _rhs_rho_pred_corr_homodyne_single(L, rho_t, t, A, dt, ddW, d1, d2,
-                                           args):
-    """
-    1/2 predictor-corrector scheme for homodyne detection with 1 stochastic operator
-    """
-    dW = ddW[:, 0]
-    
-    #predictor
-
-    d_vec = (A[0][0] * rho_t).reshape(-1, len(rho_t))
-    e = np.real(
-        d_vec[:-1].reshape(-1, A[0][1], A[0][1]).trace(axis1=1, axis2=2))
-
-    a_pred = np.copy(d_vec[-1])
-    b_pred = - e[0] * rho_t
-    b_pred += d_vec[0]
-
-    pred_rho_t = np.copy(a_pred)
-    pred_rho_t += b_pred * dW[0]
-    pred_rho_t += rho_t
-
-    a_pred -= ((d_vec[1] - e[1] * rho_t) - (2.0 * e[0]) * b_pred) * (0.5 * dt)
-    
-    #corrector
-
-    d_vec = (A[0][0] * pred_rho_t).reshape(-1, len(rho_t))
-    e = np.real(
-        d_vec[:-1].reshape(-1, A[0][1], A[0][1]).trace(axis1=1, axis2=2))
-
-    a_corr = d_vec[-1]
-    b_corr = - e[0] * pred_rho_t
-    b_corr += d_vec[0]
-
-    a_corr -= ((d_vec[1] - e[1] * pred_rho_t) - (2.0 * e[0]) * b_corr) * (0.5 * dt)
-    a_corr += a_pred
-    a_corr *= 0.5
-
-    b_corr += b_pred
-    b_corr *= 0.5 * dW[0]
-
-    corr_rho_t = a_corr
-    corr_rho_t += b_corr
-    corr_rho_t += rho_t
-
-    return corr_rho_t
+    return main_smepdpsolve(H, rho0, times, c_ops, e_ops, **kwargs)

--- a/qutip/superoperator.py
+++ b/qutip/superoperator.py
@@ -45,20 +45,6 @@ from qutip.cy.spmath import zcsr_kron
 from functools import partial
 
 
-"""def td_liouvillian(H, c_ops=[], chi=None, args={}, tlist=None, raw_str=False):
-    print("Old method")
-    h = td_Qobj(H, args=args, tlist=tlist, raw_str=raw_str)
-    co = []
-    for c in c_ops:
-        co.append(td_Qobj(c, args=args, tlist=tlist, raw_str=raw_str))
-    return liouvillian(h, co, chi=chi)
-
-def td_lindblad_dissipator(a, args={}, tlist=None, raw_str=False):
-    print("Old method")
-    return lindblad_dissipator(td_Qobj(a, args=args, tlist=tlist, raw_str=raw_str))
-"""
-
-
 def liouvillian(H, c_ops=[], data_only=False, chi=None):
     """Assembles the Liouvillian superoperator from a Hamiltonian
     and a ``list`` of collapse operators. Like liouvillian, but with an

--- a/qutip/superoperator.py
+++ b/qutip/superoperator.py
@@ -38,9 +38,26 @@ __all__ = ['liouvillian', 'liouvillian_ref', 'lindblad_dissipator',
 import scipy.sparse as sp
 import numpy as np
 from qutip.qobj import Qobj
+from qutip.td_qobj import td_Qobj
 from qutip.fastsparse import fast_csr_matrix, fast_identity
 from qutip.sparse import sp_reshape
 from qutip.cy.spmath import zcsr_kron
+from functools import partial
+
+
+"""def td_liouvillian(H, c_ops=[], chi=None, args={}, tlist=None, raw_str=False):
+    print("Old method")
+    h = td_Qobj(H, args=args, tlist=tlist, raw_str=raw_str)
+    co = []
+    for c in c_ops:
+        co.append(td_Qobj(c, args=args, tlist=tlist, raw_str=raw_str))
+    return liouvillian(h, co, chi=chi)
+
+def td_lindblad_dissipator(a, args={}, tlist=None, raw_str=False):
+    print("Old method")
+    return lindblad_dissipator(td_Qobj(a, args=args, tlist=tlist, raw_str=raw_str))
+"""
+
 
 def liouvillian(H, c_ops=[], data_only=False, chi=None):
     """Assembles the Liouvillian superoperator from a Hamiltonian
@@ -62,23 +79,32 @@ def liouvillian(H, c_ops=[], data_only=False, chi=None):
         Liouvillian superoperator.
 
     """
-
+    if isinstance(c_ops, (Qobj, td_Qobj)):
+        c_ops = [c_ops]
     if chi and len(chi) != len(c_ops):
         raise ValueError('chi must be a list with same length as c_ops')
 
+    h = None
     if H is not None:
-        if H.isoper:
-            op_dims = H.dims
-            op_shape = H.shape
-        elif H.issuper:
-            op_dims = H.dims[0]
+        if isinstance(H, td_Qobj):
+            h = H.cte
+        else:
+            h = H
+        if h.isoper:
+            op_dims = h.dims
+            op_shape = h.shape
+        elif h.issuper:
+            op_dims = h.dims[0]
             op_shape = [np.prod(op_dims[0]), np.prod(op_dims[0])]
         else:
             raise TypeError("Invalid type for Hamiltonian.")
     else:
         # no hamiltonian given, pick system size from a collapse operator
         if isinstance(c_ops, list) and len(c_ops) > 0:
-            c = c_ops[0]
+            if isinstance(c_ops[0], td_Qobj):
+                c = c_ops[0].cte
+            else:
+                c = c_ops[0]
             if c.isoper:
                 op_dims = c.dims
                 op_shape = c.shape
@@ -95,7 +121,18 @@ def liouvillian(H, c_ops=[], data_only=False, chi=None):
 
     spI = fast_identity(op_shape[0])
 
-    if H:
+    td = False
+    L = None
+    if isinstance(H, td_Qobj):
+        td = True
+        def H2L(H):
+            if H.isoper:
+                return -1.0j * (spre(H) - spost(H))
+            else:
+                return H
+        L = H.apply(H2L)
+        data = L.cte.data
+    elif isinstance(H, Qobj):
         if H.isoper:
             Ht = H.data.T
             data = -1j * zcsr_kron(spI, H.data)
@@ -105,12 +142,26 @@ def liouvillian(H, c_ops=[], data_only=False, chi=None):
     else:
         data = fast_csr_matrix(shape=(sop_shape[0], sop_shape[1]))
 
+    td_c_ops = []
     for idx, c_op in enumerate(c_ops):
-        if c_op.issuper:
-            data = data + c_op.data
+        if isinstance(c_op, td_Qobj):
+            td = True
+            if c_op.const:
+                c_ = c_op.cte
+            elif chi:
+                td_c_ops.append(lindblad_dissipator(c_op, chi=chi[idx]))
+                continue
+            else:
+                td_c_ops.append(lindblad_dissipator(c_op))
+                continue
         else:
-            cd = c_op.data.H
-            c = c_op.data
+            c_ = c_op
+
+        if c_.issuper:
+            data = data + c_.data
+        else:
+            cd = c_.data.H
+            c = c_.data
             if chi:
                 data = data + np.exp(1j * chi[idx]) * \
                                 zcsr_kron(c.conj(), c)
@@ -121,13 +172,26 @@ def liouvillian(H, c_ops=[], data_only=False, chi=None):
             data = data - 0.5 * zcsr_kron(spI, cdc)
             data = data - 0.5 * zcsr_kron(cdct, spI)
 
-    if data_only:
-        return data
+    if not td:
+        if data_only:
+            return data
+        else:
+            L = Qobj()
+            L.dims = sop_dims
+            L.data = data
+            L.superrep = 'super'
+            return L
     else:
-        L = Qobj()
-        L.dims = sop_dims
-        L.data = data
-        L.superrep = 'super'
+        if not L:
+            l = Qobj()
+            l.dims = sop_dims
+            l.data = data
+            l.superrep = 'super'
+            L = td_Qobj(l)
+        else:
+            L.cte.data = data
+        for c_op in td_c_ops:
+            L += c_op
         return L
 
 
@@ -161,7 +225,7 @@ def liouvillian_ref(H, c_ops=[]):
     return L
 
 
-def lindblad_dissipator(a, b=None, data_only=False):
+def lindblad_dissipator(a, b=None, data_only=False, chi=None):
     """
     Lindblad dissipator (generalized) for a single pair of collapse operators
     (a, b), or for a single collapse operator (a) when b is not specified:
@@ -173,25 +237,65 @@ def lindblad_dissipator(a, b=None, data_only=False):
 
     Parameters
     ----------
-    a : qobj
+    a : qobj, td_qobj
         Left part of collapse operator.
 
-    b : qobj (optional)
+    b : qobj (optional), td_qobj
         Right part of collapse operator. If not specified, b defaults to a.
 
     Returns
     -------
-    D : qobj
+    D : qobj, td_qobj
         Lindblad dissipator superoperator.
     """
-
     if b is None:
-        b = a
+        if isinstance(a, td_Qobj):
+            if not a.N_obj == 1:
+                raise Exception("Single collapse operator as a Td_Qobj " +\
+                                "must be composed of only 1 Qobj")
+            else:
+                def partial_lindblad_dissipator(A):
+                    return lindblad_dissipator(A, chi=chi)
+                return a.apply(partial_lindblad_dissipator)._f_norm2()
+        else:
+            b = a
 
-    ad_b = a.dag() * b
-    D = spre(a) * spost(b.dag()) - 0.5 * spre(ad_b) - 0.5 * spost(ad_b)
+    td = False
+    #colapse constant td_Qobj
+    if isinstance(a, td_Qobj) and a.const:
+        a = a.cte
+        td = True
+    if isinstance(b, td_Qobj) and b.const:
+        b = b.cte
+        td = True
 
-    return D.data if data_only else D
+    if isinstance(a, td_Qobj):
+        if isinstance(b, td_Qobj):
+            # No td coeff crossterm
+            raise NotImplementedError("lindblad_dissipator do not support 2 td_Qobj")
+        else:
+            def partial_lindblad_dissipator(A):
+                return lindblad_dissipator(A, b, chi=chi)
+            return a.apply(partial_lindblad_dissipator)
+
+    elif isinstance(b, td_Qobj):
+        def partial_lindblad_dissipator(B):
+            return lindblad_dissipator(a, B, chi=chi)
+        return b.apply(partial_lindblad_dissipator)
+
+    else:
+        #both Qobj
+        ad_b = a.dag() * b
+        if chi:
+            D = spre(a) * spost(b.dag()) *np.exp(1j * chi) \
+                - 0.5 * spre(ad_b) - 0.5 * spost(ad_b)
+        else:
+            D = spre(a) * spost(b.dag()) - 0.5 * spre(ad_b) - 0.5 * spost(ad_b)
+        td_Qobj(D) if td else D.data if data_only else D
+        if td:
+            return td_Qobj(D)
+        else:
+            return D.data if data_only else D
 
 
 def operator_to_vector(op):
@@ -199,6 +303,9 @@ def operator_to_vector(op):
     Create a vector representation of a quantum operator given
     the matrix representation.
     """
+    if isinstance(op, td_Qobj):
+        return op.apply(operator_to_vector)
+
     q = Qobj()
     q.dims = [op.dims, [1]]
     q.data = sp_reshape(op.data.T, (np.prod(op.shape), 1))
@@ -210,6 +317,9 @@ def vector_to_operator(op):
     Create a matrix representation given a quantum operator in
     vector form.
     """
+    if isinstance(op, td_Qobj):
+        return op.apply(vector_to_operator)
+
     q = Qobj()
     q.dims = op.dims[0]
     n = int(np.sqrt(op.shape[0]))
@@ -263,6 +373,9 @@ def spost(A):
     super : qobj
         Superoperator formed from input qauntum object.
     """
+    if isinstance(A, td_Qobj):
+        return A.apply(spost)
+
     if not isinstance(A, Qobj):
         raise TypeError('Input is not a quantum object')
 
@@ -271,7 +384,7 @@ def spost(A):
 
     S = Qobj(isherm=A.isherm, superrep='super')
     S.dims = [[A.dims[0], A.dims[1]], [A.dims[0], A.dims[1]]]
-    S.data = zcsr_kron(A.data.T, 
+    S.data = zcsr_kron(A.data.T,
                 fast_identity(np.prod(A.shape[0])))
     return S
 
@@ -289,6 +402,9 @@ def spre(A):
     super :qobj
         Superoperator formed from input quantum object.
     """
+    if isinstance(A, td_Qobj):
+        return A.apply(spre)
+
     if not isinstance(A, Qobj):
         raise TypeError('Input is not a quantum object')
 
@@ -326,8 +442,35 @@ def sprepost(A, B):
     super : Qobj
         Superoperator formed from input quantum objects.
     """
+    # reduce false td
+    td = False
+    if isinstance(A, td_Qobj) and A.const:
+        A = A.cte
+        td = True
+    if isinstance(B, td_Qobj) and B.const:
+        B = B.cte
+        td = True
 
-    dims = [[_drop_projected_dims(A.dims[0]), _drop_projected_dims(B.dims[1])],
-            [_drop_projected_dims(A.dims[1]), _drop_projected_dims(B.dims[0])]]
-    data = zcsr_kron(B.data.T, A.data)
-    return Qobj(data, dims=dims, superrep='super')
+    # A is time-dependent
+    if isinstance(A, td_Qobj):
+        if isinstance(B, td_Qobj):
+            # No td coeff crossterm
+            raise NotImplementedError("sprepost: do not support 2 td_Qobj")
+        else:
+            def partial_sprepost(a):
+                return sprepost(a, B)
+            return A.apply(partial_sprepost)
+
+    elif isinstance(B, td_Qobj):
+        def partial_sprepost(b):
+            return sprepost(A, b)
+        return B.apply(partial_sprepost)
+
+    else:
+        dims = [[_drop_projected_dims(A.dims[0]), _drop_projected_dims(B.dims[1])],
+                [_drop_projected_dims(A.dims[1]), _drop_projected_dims(B.dims[0])]]
+        data = zcsr_kron(B.data.T, A.data)
+        if not td:
+            return Qobj(data, dims=dims, superrep='super')
+        else:
+            return td_Qobj(Qobj(data, dims=dims, superrep='super'))

--- a/qutip/td_qobj.py
+++ b/qutip/td_qobj.py
@@ -1,0 +1,1126 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+"""Time-dependent Quantum Object (Qobj) class.
+"""
+__all__ = ['td_Qobj']#, 'td_liouvillian', 'td_lindblad_dissipator']
+
+from qutip.qobj import Qobj
+from scipy.interpolate import CubicSpline
+from functools import partial, wraps
+from types import FunctionType, BuiltinFunctionType
+import numpy as np
+from numbers import Number
+from qutip.td_qobj_codegen import _compile_str_single, make_united_f_ptr
+from qutip.cy.spmatfuncs import (cy_expect_rho_vec, cy_expect_psi, spmv)
+from qutip.cy.td_qobj_cy import cy_cte_qobj, cy_td_qobj
+import pickle
+
+class td_Qobj:
+    """A class for representing time-dependent quantum objects,
+    such as quantum operators and states.
+
+    The td_Qobj class is a representation of time-dependent Qutip quantum
+    objects (Qobj). This class implements math operations :
+        +,- : td_Qobj, Qobj
+        * : Qobj, C-number
+        / : C-number
+    and some common linear operator/state operations. The td_Qobj
+    are constructed from a nested list of Qobj with their time-dependent
+    coefficients. The time-dependent coefficients are either a funciton, a
+    string or a numpy array.
+
+    For function format, the function signature must be f(t, args).
+    *Examples*
+        def f1_t(t,args):
+            return np.exp(-1j*t*args["w1"])
+
+        def f2_t(t,args):
+            return np.cos(t*args["w2"])
+
+        H = td_Qobj([H0, [H1, f1_t], [H2, f2_t]], args={"w1":1.,"w2":2.})
+
+    For string based, the string must be a compilable python code resulting in
+    a scalar. The following symbols are defined:
+        sin cos tan asin acos atan pi
+        sinh cosh tanh asinh acosh atanh
+        exp log log10 erf sqrt
+        real imag conj abs norm arg proj
+    numpy is also imported as np.
+    *Examples*
+        H = td_Qobj([H0, [H1, 'exp(-1j*w1*t)'], [H2, 'cos(w2*t)']],
+                    args={"w1":1.,"w2":2.})
+
+    For numpy array format, the array must be an 1d of dtype float64 or complex.
+    A list of times (float64) at which the coeffients must be given (tlist).
+    The coeffients array must have the same len as the tlist.
+    The time of the tlist do not need to be equidistant, but must be sorted.
+    *Examples*
+        tlist = np.logspace(-5,0,100)
+        H = td_Qobj([H0, [H1, np.exp(-1j*tlist)], [H2, np.cos(2.*tlist)]],
+                    tlist=tlist)
+
+    Mixing the formats is possible, but not recommended.
+
+    Parameters
+    ----------
+    td_Qobj(Q_object=[], args={}, tlist=None, raw_str=False)
+    Q_object : array_like
+        Data for vector/matrix representation of the quantum object.
+    args : dictionary that contain the arguments for
+    tlist : array_like
+        List of times at which the numpy-array coefficients are applied. Times
+        must be equidistant and start from 0.
+    raw_str : delay the compilation of str based coefficient until the "compile"
+        method is called.
+
+
+    Attributes
+    ----------
+    cte : Qobj
+        Constant part of the td_Qobj
+    ops : list
+        List of Qobj and the coefficients.
+        [(Qobj, coefficient as a function, original coefficient,
+            type, local arguments ), ... ]
+        type :
+            1: function
+            2: string
+            3: np.array
+    args : map
+        arguments of the coefficients
+    tlist : array_like
+        List of times at which the numpy-array coefficients are applied.
+
+    compiled : int
+        Has the cython version of the td_Qobj been created
+    compiled_Qobj : cy_qobj (cy_cte_qobj or cy_td_qobj)
+        Cython version of the td_Qobj
+    dummy_cte : bool
+        is self.cte a dummy Qobj
+    const : bool
+        Indicates if quantum object is Constant
+    raw_str : bool
+        compile the str coefficient only at the cration of the cy_qobj
+    fast : bool
+        Use a cython function for the coefficient of the cy_qobj? (str/array)
+    N_obj : int
+        number of Qobj in the td_Qobj : len(ops) + (1 if not dummy_cte)
+
+
+    Methods
+    -------
+    copy() :
+        Create copy of Qobj
+    arguments(new_args):
+        Update the args of the object
+
+    Math:
+        +/- td_Qobj, Qobj, scalar:
+            Addition is possible between td_Qobj and with Qobj or scalar
+        -:
+            Negation operator
+        * Qobj, scalar:
+            Product is possible with Qobj or scalar
+        / scalar:
+            It is possible to divide by scalar only
+    conj()
+        Return the conjugate of quantum object.
+    dag()
+        Return the adjoint (dagger) of quantum object.
+    trans()
+        Return the transpose of quantum object.
+    norm()
+        Return self.dag() * self.
+        Only possible if N_obj == 1
+    permute(order)
+        Returns composite qobj with indices reordered.
+    ptrace(sel)
+        Returns quantum object for selected dimensions after performing
+        partial trace.
+    apply(f, *args, **kw_args)
+        Apply the function f to every Qobj. f(Qobj) -> Qobj
+        Return a modified td_Qobj and let the original one untouched
+    apply_decorator(decorator, *args, str_mod=None,
+                    inplace_np=False, **kw_args):
+        Apply the decorator to each function of the ops.
+        The *args and **kw_args are passed to the decorator.
+        new_coeff_function = decorator(coeff_function, *args, **kw_args)
+        str_mod : list of 2 elements
+            replace the string : str_mod[0] + original_string + str_mod[1]
+            *exemple: str_mod = ["exp(",")"]
+        inplace_np:
+            Change the numpy array instead of applying the decorator to the
+            function reading the array. Some decorators create incorrect array.
+            Transformations f'(t) = f(g(t)) create a missmatch between the array
+            and the associated time list.
+    tidyup(atol=1e-12)
+        Removes small elements from quantum object.
+    compress():
+        Merge ops which are based on the same quantum object and coeff type.
+
+    compile():
+        Create the associated cython object for faster usage.
+    __call__(t):
+        Return the Qobj at time t.
+        *Faster after compilation
+    with_args(t, new_args):
+        Return the Qobj at time t with the new_args instead of the original
+        arguments. Do not change the args of the object.
+    with_state(t, psi, args={}):
+        Allow to use function coefficients that use states:
+            "def coeff(t,psi,args):" instead of "def coeff(t,args):"
+        Return the Qobj at time t, with the new_args if defined.
+        *Mixing both definition types of coeff will make the td_Qobj crach on
+            call
+    rhs(t, psi):
+        Apply the quantum object (if operator, no check) to psi.
+        More generaly, return the product of the object at t with psi.
+        *Faster after compilation
+    expect(t, psi, herm=False):
+        Calculates the expectation value for the quantum object (if operator,
+            no check) and state psi.
+        Return only the real part if herm.
+        *Faster after compilation
+    get_compiled_call, get_rhs_func, get_expect_func:
+        Compile and return the corresponding function of the cython object.
+        Was useful before the python function was set to call the cython version
+            after compilation.
+    to_list():
+        Return the time-dependent quantum object as a list
+    """
+
+    def __init__(self, Q_object=[], args={}, tlist=None, raw_str=False):
+        if isinstance(Q_object, td_Qobj):
+            self._inplace_copy(Q_object)
+            if args:
+                self.arguments(args)
+            return
+
+        self.const = False
+        self.dummy_cte = False
+        self.args = args
+        self.cte = None
+        self.tlist = tlist
+        self.fast = True
+        self.compiled = False
+        self.compiled_Qobj = None
+        self.compiled_ptr = None
+        self.raw_str = raw_str
+
+        if isinstance(Q_object, list) and len(Q_object) == 2:
+            if isinstance(Q_object[0], Qobj) and not isinstance(Q_object[1],
+                                                                (Qobj, list)):
+                # The format is [Qobj, f/str]
+                Q_object = [Q_object]
+
+        op_type = self._td_format_check_single(Q_object, tlist)
+        self.ops = []
+
+        if isinstance(op_type, int):
+            if op_type == 0:
+                self.cte = Q_object
+                self.const = True
+            elif op_type == 1:
+                raise Exception("The Qobj must not already be a function")
+            elif op_type == -1:
+                pass
+
+        else:
+            compile_list = []
+            compile_count = 0
+            for type_, op in zip(op_type, Q_object):
+                if type_ == 0:
+                    if self.cte is None:
+                        self.cte = op
+                    else:
+                        self.cte += op
+                elif type_ == 1:
+                    self.ops.append([op[0], op[1], op[1], 1, args])
+                    self.fast = False
+                elif type_ == 2:
+                    local_args = {}
+                    for i in args:
+                        if i in op[1]:
+                            local_args[i] = args[i]
+                    self.ops.append([op[0], _dummy, op[1], 2, local_args])
+                    compile_list.append((op[1], local_args, compile_count))
+                    compile_count += 1
+                elif type_ == 3:
+                    l = len(self.ops)
+                    N = len(self.tlist)
+                    dt = self.tlist[-1] / (N - 1)
+                    self.ops.append([op[0], CubicSpline(tlist, op[1]),
+                                     op[1].copy(), 3, None])
+
+                else:
+                    raise Exception("Should never be here")
+
+            if compile_count and not self.raw_str:
+                str_funcs = _compile_str_single(compile_list)
+                count = 0
+                for op in self.ops:
+                    if op[3] == 2:
+                        op[1] = str_funcs[count]
+                        count += 1
+
+            if not self.cte:
+                self.cte = self.ops[0][0]
+                for op in self.ops[1:]:
+                    self.cte += op[0]
+                self.cte *= 0.
+                self.dummy_cte = True
+
+            if not self.ops:
+                self.const = True
+        self.N_obj = (len(self.ops) if self.dummy_cte else len(self.ops) + 1)
+
+    def _td_format_check_single(self, Q_object, tlist=None):
+        op_type = []
+
+        if isinstance(Q_object, Qobj):
+            op_type = 0
+        elif isinstance(Q_object, (FunctionType,
+                                   BuiltinFunctionType, partial)):
+            op_type = 1
+        elif isinstance(Q_object, list):
+            if (len(Q_object) == 0):
+                op_type = -1
+            for op_k in Q_object:
+                if isinstance(op_k, Qobj):
+                    op_type.append(0)
+                elif isinstance(op_k, list):
+                    if not isinstance(op_k[0], Qobj):
+                        raise TypeError("Incorrect Q_object specification")
+                    elif len(op_k) == 2:
+                        if isinstance(op_k[1], (FunctionType,
+                                                BuiltinFunctionType, partial)):
+                            op_type.append(1)
+                        elif isinstance(op_k[1], str):
+                            op_type.append(2)
+                        elif isinstance(op_k[1], np.ndarray):
+                            if not isinstance(tlist, np.ndarray) or not \
+                                        len(op_k[1]) == len(tlist):
+                                raise TypeError("Time list do not match")
+                            op_type.append(3)
+                        elif isinstance(op_k[1], CubicSpline):
+                            raise NotImplementedError(
+                                    "Cubic_Spline not supported")
+                        #    h_obj.append(k)
+                        else:
+                            raise TypeError("Incorrect Q_object specification")
+                    else:
+                        raise TypeError("Incorrect Q_object specification")
+        else:
+            raise TypeError("Incorrect Q_object specification")
+        return op_type
+
+    def __call__(self, t, data=False):
+        if not isinstance(t, (int, float)):
+            raise TypeError("the time need to be a real scalar")
+        if self.compiled:
+            return self.compiled_Qobj.call(t, data)
+        if data:
+            op_t = self.cte.data.copy()
+            for part in self.ops:
+                if part[3] == 1:  # func: f(t,args)
+                    op_t += part[0].data * part[1](t, part[4])
+                elif part[3] == 2:  # str: f(t,w=2)
+                    op_t += part[0].data * part[1](t, **part[4])
+                elif part[3] == 3:  # numpy: _interpolate(t,arr,N,dt)
+                    op_t += part[0].data * part[1](np.array([t]))[0]
+        else:
+            op_t = self.cte.copy()
+            for part in self.ops:
+                if part[3] == 1:  # func: f(t,args)
+                    op_t += part[0] * part[1](t, part[4])
+                elif part[3] == 2:  # str: f(t,w=2)
+                    op_t += part[0] * part[1](t, **part[4])
+                elif part[3] == 3:  # numpy: _interpolate(t,arr,N,dt)
+                    op_t += part[0] * part[1](np.array([t]))[0]
+        return op_t
+
+    def with_args(self, t, args, data=False):
+        if not isinstance(t, (int, float)):
+            raise TypeError("the time need to be a real scalar")
+        if not isinstance(args, dict):
+            raise TypeError("The new args must be in a dict")
+        coeff = np.zeros(len(self.ops), dtype=complex)
+        new_args = self.args.copy()
+        new_args.update(args)
+        if self.compiled:
+            for i, part in enumerate(self.ops):
+                if part[3] == 1:  # func: f(t,args)
+                    coeff[i] = part[1](t, new_args)
+                elif part[3] == 2:  # str: f(t,w=2)
+                    part_args = part[4].copy()
+                    for pa in part_args:
+                        if pa in args:
+                            part_args[pa] = new_args[pa]
+                    coeff[i] = part[1](t, **part_args)
+                elif part[3] == 3:  # numpy: _interpolate(t,arr,N,dt)
+                    coeff[i] = part[1](np.array([t]))[0]
+            op_t = self.compiled_Qobj.call_with_coeff(t, coeff, data=data)
+        elif data:
+            op_t = self.cte.data.copy()
+            for part in self.ops:
+                if part[3] == 1:
+                    op_t += part[0].data * part[1](t, new_args)
+                elif part[3] == 2:
+                    part_args = part[4].copy()
+                    for pa in part_args:
+                        if pa in args:
+                            part_args[pa] = new_args[pa]
+                    op_t += part[0].data * part[1](t, **part_args)
+                elif part[3] == 3:
+                    op_t += part[0].data * part[1](np.array([t]))[0]
+        else:
+            op_t = self.cte.copy()
+            for part in self.ops:
+                if part[3] == 1:
+                    op_t += part[0] * part[1](t, new_args)
+                elif part[3] == 2:
+                    part_args = part[4].copy()
+                    for pa in part_args:
+                        if pa in args:
+                            part_args[pa] = new_args[pa]
+                    op_t += part[0] * part[1](t, **part_args)
+                elif part[3] == 3:
+                    op_t += part[0] * part[1](np.array([t]))[0]
+        return op_t
+
+    def with_state(self, t, psi, args={}, data=False):
+        if not isinstance(t, (int, float)):
+            raise TypeError("the time need to be a real scalar")
+        if not isinstance(args, dict):
+            raise TypeError("The new args must be in a dict")
+        if self.compiled == 3:
+            coeff = np.zeros(len(self.ops), dtype=complex)
+            if args:
+                new_args = self.args.copy()
+                new_args.update(args)
+                for i, part in enumerate(self.ops):
+                    coeff[i] = part[1](t, psi, new_args)
+            else:
+                for i, part in enumerate(self.ops):
+                    coeff[i] = part[1](t, psi, part[4])
+            op_t = self.compiled_Qobj.call_with_coeff(t, coeff, data=data)
+        elif self.compiled:
+            coeff = np.zeros(len(self.ops), dtype=complex)
+            if args:
+                new_args = self.args.copy()
+                new_args.update(args)
+                for i, part in enumerate(self.ops):
+                    if part[3] == 1:  # func: f(t, psi, args)
+                        coeff[i] = part[1](t, psi, new_args)
+                    elif part[3] == 2:  # str: f(t,w=2)
+                        part_args = part[4].copy()
+                        for pa in part_args:
+                            if pa in new_args:
+                                part_args[pa] = new_args[pa]
+                        coeff[i] = part[1](t, **part_args)
+                    elif part[3] == 3:  # numpy: scipy's cubic spline
+                        coeff[i] = part[1](np.array([t]))[0]
+            else:
+                for i, part in enumerate(self.ops):
+                    if part[3] == 1:
+                        coeff[i] = part[1](t, psi, part[4])
+                    elif part[3] == 2:
+                        coeff[i] = part[1](t, **part[4])
+                    elif part[3] == 3:
+                        coeff[i] = part[1](np.array([t]))[0]
+            op_t = self.compiled_Qobj.call_with_coeff(t, coeff, data=data)
+        elif args:
+            new_args = self.args.copy()
+            new_args.update(args)
+            if data:
+                op_t = self.cte.data.copy()
+                for part in self.ops:
+                    if part[3] == 1:
+                        op_t += part[0].data * part[1](t, psi, new_args)
+                    elif part[3] == 2:
+                        part_args = part[4].copy()
+                        for pa in part_args:
+                            if pa in args:
+                                part_args[pa] = args[pa]
+                        op_t += part[0].data * part[1](t, **part_args)
+                    elif part[3] == 3:
+                        op_t += part[0].data * part[1](np.array([t]))[0]
+            else:
+                op_t = self.cte.copy()
+                for part in self.ops:
+                    if part[3] == 1:
+                        op_t += part[0] * part[1](t, psi, new_args)
+                    elif part[3] == 2:
+                        part_args = part[4].copy()
+                        for pa in part_args:
+                            if pa in args:
+                                part_args[pa] = args[pa]
+                        op_t += part[0] * part[1](t, **part_args)
+                    elif part[3] == 3:
+                        op_t += part[0] * part[1](np.array([t]))[0]
+        else:
+            if data:
+                op_t = self.cte.data.copy()
+                for part in self.ops:
+                    if part[3] == 1:
+                        op_t += part[0].data * part[1](t, psi, part[4])
+                    elif part[3] == 2:
+                        op_t += part[0].data * part[1](t, **part[4])
+                    elif part[3] == 3:
+                        op_t += part[0].data * part[1](np.array([t]))[0]
+            else:
+                op_t = self.cte.copy()
+                for part in self.ops:
+                    if part[3] == 1:
+                        op_t += part[0] * part[1](t, psi, part[4])
+                    elif part[3] == 2:
+                        op_t += part[0] * part[1](t, **part[4])
+                    elif part[3] == 3:
+                        op_t += part[0] * part[1](np.array([t]))[0]
+        return op_t
+
+    def copy(self):
+        new = td_Qobj(self.cte.copy())
+        new.const = self.const
+        new.args = self.args.copy()
+        new.tlist = self.tlist
+        new.dummy_cte = self.dummy_cte
+        new.N_obj = self.N_obj
+        new.fast = self.fast
+        new.raw_str = self.raw_str
+        new.compiled = False
+        new.compiled_Qobj = None
+        new.compiled_ptr = None
+        new.coeff_get = None
+
+        for l, op in enumerate(self.ops):
+            new.ops.append([None, None, None, None, None])
+            new.ops[l][0] = op[0].copy()
+            new.ops[l][3] = op[3]
+            new.ops[l][1] = op[1]
+            if new.ops[l][3] in [1, 2]:
+                new.ops[l][2] = op[2]
+                new.ops[l][4] = op[4].copy()
+            elif new.ops[l][3] == 3:
+                new.ops[l][2] = op[2].copy()
+                new.ops[l][4] = None
+
+        return new
+
+    def _inplace_copy(self, other):
+        self.cte = other.cte
+        self.const = other.const
+        self.args = other.args.copy()
+        self.tlist = other.tlist
+        self.dummy_cte = other.dummy_cte
+        self.N_obj = other.N_obj
+        self.fast = other.fast
+        self.raw_str = other.raw_str
+        self.compiled = False
+        self.compiled_Qobj = None
+        self.compiled_ptr = None
+        self.coeff_get = None
+        self.ops = []
+
+        for l, op in enumerate(other.ops):
+            self.ops.append([None, None, None, None, None])
+            self.ops[l][0] = op[0].copy()
+            self.ops[l][3] = op[3]
+            self.ops[l][1] = op[1]
+            if self.ops[l][3] in [1, 2]:
+                self.ops[l][2] = op[2]
+                self.ops[l][4] = op[4].copy()
+            elif self.ops[l][3] == 3:
+                self.ops[l][2] = op[2].copy()
+                self.ops[l][4] = None
+
+    def arguments(self, args):
+        if not isinstance(args, dict):
+            raise TypeError("The new args must be in a dict")
+        self.args.update(args)
+        if self.compiled == 2:
+            self.coeff_get(True).set_args(self.args)
+        for op in self.ops:
+            if op[3] == 1:
+                op[4] = self.args
+            elif op[3] == 2:
+                local_args = {}
+                for i in self.args:
+                    if i in op[2]:
+                        local_args[i] = self.args[i]
+                op[4] = local_args
+
+    def to_list(self):
+        list_Qobj = []
+        if not self.dummy_cte:
+            list_Qobj.append(self.cte)
+        for op in self.ops:
+            if op[3] == 1:
+                list_Qobj.append([op[0], op[1]])
+            else:
+                list_Qobj.append([op[0], op[2]])
+        return list_Qobj
+
+    # Math function
+    def __add__(self, other):
+        res = self.copy()
+        res += other
+        return res
+
+    def __radd__(self, other):
+        res = self.copy()
+        res += other
+        return res
+
+    def __iadd__(self, other):
+        if isinstance(other, td_Qobj):
+            self.cte += other.cte
+            l = len(self.ops)
+            for op in other.ops:
+                self.ops.append([None, None, None, None, None])
+                self.ops[l][0] = op[0].copy()
+                self.ops[l][3] = op[3]
+                self.ops[l][1] = op[1]
+                if self.ops[l][3] in [1, 2]:
+                    self.ops[l][2] = op[2]
+                    self.ops[l][4] = op[4].copy()
+                elif self.ops[l][3] == 3:
+                    self.ops[l][2] = op[2].copy()
+                    self.ops[l][4] = None
+                l += 1
+            self.args.update(**other.args)
+            self.const = self.const and other.const
+            self.dummy_cte = self.dummy_cte and other.dummy_cte
+            self.fast = self.fast and other.fast
+            self.raw_str = self.raw_str and other.raw_str
+            self.compiled = False
+            self.compiled_Qobj = None
+            self.compiled_ptr = None
+            self.coeff_get = None
+
+            if self.tlist is None:
+                self.tlist = other.tlist
+            else:
+                if other.tlist is None:
+                    pass
+                elif len(other.tlist) != len(self.tlist) or \
+                        other.tlist[-1] != self.tlist[-1]:
+                    raise Exception("tlist are not compatible")
+        else:
+            self.cte += other
+            self.dummy_cte = False
+
+        self.N_obj = (len(self.ops) if self.dummy_cte else len(self.ops) + 1)
+        return self
+
+    def __sub__(self, other):
+        res = self.copy()
+        res -= other
+        return res
+
+    def __rsub__(self, other):
+        res = -self.copy()
+        res += other
+        return res
+
+    def __isub__(self, other):
+        self += (-other)
+        return self
+
+    def __mul__(self, other):
+        res = self.copy()
+        res *= other
+        return res
+
+    def __rmul__(self, other):
+        res = self.copy()
+        if isinstance(other, Qobj):
+            res.cte = other * res.cte
+            for op in res.ops:
+                op[0] = other * op[0]
+            return res
+        else:
+            res *= other
+            return res
+
+    def __imul__(self, other):
+        if isinstance(other, Qobj) or isinstance(other, Number):
+            self.cte *= other
+            for op in self.ops:
+                op[0] *= other
+        elif isinstance(other, td_Qobj):
+            if other.const:
+                self.cte *= other.cte
+                for op in self.ops:
+                    op[0] *= other.cte
+            elif self.const:
+                cte = self.cte.copy()
+                self = other.copy()
+                self.cte *= cte
+                for op in self.ops:
+                    op[0] *= cte
+            else:
+                raise Exception("When multiplying td_qobj, one " +
+                                "of them must be constant")
+        else:
+            raise TypeError("td_qobj can only be multiplied" +
+                            " with Qobj or numbers")
+        return self
+
+    def __div__(self, other):
+        if isinstance(other, (int, float, complex,
+                              np.integer, np.floating, np.complexfloating)):
+            res = self.copy()
+            res *= other**(-1)
+            return res
+        else:
+            raise TypeError('Incompatible object for division')
+
+    def __idiv__(self, other):
+        if isinstance(other, (int, float, complex,
+                              np.integer, np.floating, np.complexfloating)):
+            self *= other**(-1)
+        else:
+            raise TypeError('Incompatible object for division')
+        return self
+
+    def __truediv__(self, other):
+        return self.__div__(other)
+
+    def __neg__(self):
+        res = self.copy()
+        res.cte = (-res.cte)
+        for op in res.ops:
+            op[0] = -op[0]
+        return res
+
+    # Transformations
+    def trans(self):
+        res = self.copy()
+        res.cte = res.cte.trans()
+        for op in res.ops:
+            op[0] = op[0].trans()
+        return res
+
+    def conj(self):
+        res = self.copy()
+        res.cte = res.cte.conj()
+        for op in res.ops:
+            op[0] = op[0].conj()
+        res._f_conj()
+        return res
+
+    def dag(self):
+        res = self.copy()
+        res.cte = res.cte.dag()
+        for op in res.ops:
+            op[0] = op[0].dag()
+        res._f_conj()
+        return res
+
+    # When name fixed, put in stochastic/ mcsolve
+    def norm(self):
+        """return a.dag * a """
+        if not self.N_obj == 1:
+            raise NotImplementedError("Only possible with one composing Qobj")
+        res = self.copy()
+        res.cte = res.cte.dag() * res.cte
+        for op in res.ops:
+            op[0] = op[0].dag() * op[0]
+        res._f_norm2()
+        return res
+
+    # Unitary function of Qobj
+    def tidyup(self, atol=1e-12):
+        self.cte = self.cte.tidyup(atol)
+        for op in self.ops:
+            op[0] = op[0].tidyup(atol)
+        return self
+
+    def compress(self):
+        sets = []
+        for i, op1 in enumerate(self.ops):
+            already_matched = False
+            for _set in sets:
+                already_matched = already_matched or i in _set
+            if not already_matched:
+                this_set = [i]
+                for j, op2 in enumerate(self.ops[i+1:]):
+                    if op1[0] == op2[0] and op1[3] == op2[3]:
+                        this_set.append(j+i+1)
+                sets.append(this_set)
+        if len(self.ops) != len(sets):
+            # found 2 td part with the same Qobj
+            self.compiled = False
+            self.compiled_Qobj = None
+            self.compiled_ptr = None
+            self.coeff_get = None
+            new_ops = []
+            for _set in sets:
+                if len(_set) == 1:
+                    new_ops.append(self.ops[_set[0]])
+                elif self.ops[_set[0]][3] == 1:
+                    new_fs = [self.ops[_set[0]][1]]
+                    new_args = self.ops[_set[0]][4].copy()
+                    for i in _set[1:]:
+                        new_fs += [self.ops[i][1]]
+                        new_args.update(self.ops[i][4])
+                    new_op = [self.ops[_set[0]][0], None, new_fs, 1, new_args]
+                    def _new_f(t, *args):
+                        return sum((f(t, *args) for f in new_fs))
+                    new_op[1] = _new_f
+                    new_ops.append(new_op)
+
+                elif self.ops[_set[0]][3] == 2:
+                    new_op = self.ops[_set[0]]
+                    new_str = self.ops[_set[0]][2]
+                    for i in _set[1:]:
+                        if self.ops[i][4]:
+                            new_op[4].update(self.ops[i][4])
+                        new_str = "(" + new_str + ") + (" + \
+                                  self.ops[i][2] + ")"
+                    if self.raw_str:
+                        new_op[1] = _dummy
+                    else:
+                        new_op[1] = \
+                            _compile_str_single([[new_str, new_op[4], 0]])[0]
+                    new_op[2] = new_str
+                    new_ops.append(new_op)
+                elif self.ops[_set[0]][3] == 3:
+                    new_op = self.ops[_set[0]]
+                    new_array = (self.ops[_set[0]][2]).copy()
+                    for i in _set[1:]:
+                        new_array += self.ops[i][2]
+                    new_op[2] = new_array
+                    new_op[1] = CubicSpline(self.tlist, new_array)
+                    new_op[4] = None
+                    new_ops.append(new_op)
+            self.ops = new_ops
+
+    def permute(self, order):
+        res = self.copy()
+        res.cte = res.cte.permute(order)
+        for op in res.ops:
+            op[0] = op[0].permute(order)
+        return res
+
+    def ptrace(self, sel):
+        res = self.copy()
+        res.cte = res.cte.ptrace(sel)
+        for op in res.ops:
+            op[0] = op[0].ptrace(sel)
+        return res
+
+    # function to apply custom transformations
+    def apply(self, function, *args, **kw_args):
+        self.compiled = False
+        res = self.copy()
+        cte_res = function(res.cte, *args, **kw_args)
+        if not isinstance(cte_res, Qobj):
+            raise TypeError("The function must return a Qobj")
+        res.cte = cte_res
+        for op in res.ops:
+            op[0] = function(op[0], *args, **kw_args)
+        return res
+
+    def apply_decorator(self, function, *args, **kw_args):
+        if "str_mod" in kw_args:
+            str_mod = kw_args["str_mod"]
+            del kw_args["str_mod"]
+        else:
+            str_mod = None
+        if "inplace_np" in kw_args:
+            inplace_np  = kw_args["inplace_np"]
+            del kw_args["inplace_np"]
+        else:
+            inplace_np = None
+        self.compiled = False
+        res = self.copy()
+        raw_str = self.raw_str
+        for op in res.ops:
+            if op[3] == 1:
+                op[1] = function(op[1], *args, **kw_args)
+                op[2] = function(op[1], *args, **kw_args)
+            if op[3] == 2:
+                if str_mod is None:
+                    if self.raw_str:
+                        op[1] = _compile_str_single([[op[2], op[4], 0]])[0]
+                        raw_str = False
+                    op[1] = function(op[1], *args, **kw_args)
+                    res.fast = False
+                else:
+                    if not self.raw_str:
+                        op[1] = function(op[1], *args, **kw_args)
+                    op[2] = str_mod[0] + op[2] + str_mod[1]
+            elif op[3] == 3:
+                if inplace_np:
+                    # keep the original function, change the array
+                    def f(a):
+                        return a
+                    ff = function(f, *args, **kw_args)
+                    for i, v in enumerate(op[2]):
+                        op[2][i] = ff(v)
+                    op[1] = CubicSpline(self.tlist, op[2])
+                else:
+                    op[1] = function(op[1], *args, **kw_args)
+                    res.fast = False
+        self.raw_str = raw_str
+        return res
+
+    def _f_norm2(self):
+        for op in self.ops:
+            if op[3] == 1:
+                op[1] = _norm2(op[1])
+                op[2] = op[1]
+            elif op[3] == 2:
+                op[2] = "norm(" + op[2] + ")"
+                if not self.raw_str:
+                    op[1] = _compile_str_single([[op[2], op[4], 0]])[0]
+            elif op[3] == 3:
+                op[2] = np.abs(op[2])**2
+                op[1] = CubicSpline(self.tlist, op[2])
+        return self
+
+    def _f_conj(self):
+        for op in self.ops:
+            if op[3] == 1:
+                op[1] = _conj(op[1])
+                op[2] = op[1]
+            elif op[3] == 2:
+                op[2] = "conj(" + op[2] + ")"
+                if not self.raw_str:
+                    op[1] = _compile_str_single([[op[2], op[4], 0]])[0]
+            elif op[3] == 3:
+                op[2] = np.conj(op[2])
+                op[1] = CubicSpline(self.tlist, op[2])
+        return self
+
+    def get_compiled_call(self):
+        if not self.compiled:
+            self.compile()
+        return self.compiled_Qobj.call
+
+    def get_rhs_func(self):
+        if not self.compiled:
+            self.compile()
+        return self.compiled_Qobj.rhs
+
+    def get_expect_func(self):
+        if not self.compiled:
+            self.compile()
+        return self.compiled_Qobj.expect
+
+    def expect(self, t, vec, herm=0):
+        if not isinstance(t, (int, float)):
+            raise TypeError("The time need to be a real scalar")
+        if isinstance(vec, Qobj):
+            if self.cte.dims[1] != vec.dims[0]:
+                raise Exception("Dimensions do not fit")
+            vec = vec.full().ravel()
+        elif not isinstance(vec, np.ndarray):
+            raise TypeError("The vector must be an array or Qobj")
+        if vec.ndim != 1:
+            raise Exception("The vector must be 1d")
+        if vec.shape[0] != self.cte.shape[1]:
+            raise Exception("The length do not match")
+        if not isinstance(herm, (int, bool)):
+            herm = bool(herm)
+        if self.compiled:
+            return self.compiled_Qobj.expect(t, vec, herm)
+        if self.cte.issuper:
+            return cy_expect_rho_vec(self.__call__(t, data=True), vec, herm)
+        else:
+            return cy_expect_psi(self.__call__(t, data=True), vec, herm)
+
+    def rhs(self, t, vec):
+        if not isinstance(t, (int, float)):
+            raise TypeError("the time need to be a real scalar")
+        if isinstance(vec, Qobj):
+            if self.cte.dims[1] != vec.dims[0]:
+                raise Exception("Dimensions do not fit")
+            vec = vec.full().ravel()
+        elif not isinstance(vec, np.ndarray):
+            raise TypeError("The vector must be an array or Qobj")
+        if vec.ndim != 1:
+            raise Exception("The vector must be 1d")
+        if vec.shape[0] != self.cte.shape[1]:
+            raise Exception("The length do not match")
+        if self.compiled:
+            return self.compiled_Qobj.rhs(t, vec)
+        return spmv(self.__call__(t, data=True), vec)
+
+    def compile(self, code=False):
+        self.tidyup()
+        if self.const:
+            self.compiled_Qobj = cy_cte_qobj()
+            self.compiled_Qobj.set_data(self.cte)
+            self.compiled = 1
+        elif self.fast:
+            self.compiled_Qobj = cy_td_qobj()
+            self.compiled_Qobj.set_data(self.cte, self.ops)
+            if code:
+                self.coeff_get, Code = make_united_f_ptr(self.ops,
+                                                    self.args, self.tlist,
+                                                    True)
+            else:
+                self.coeff_get = make_united_f_ptr(self.ops, self.args,
+                                                          self.tlist, False)
+                Code = None
+            self.compiled_Qobj.set_factor(ptr=self.coeff_get())
+            self.compiled = 2
+            return Code
+        else:
+            self.compiled_Qobj = cy_td_qobj()
+            self.compiled_Qobj.set_data(self.cte, self.ops)
+            self.coeff_get, self.compiled = self._make_united_f_call()
+            self.compiled_Qobj.set_factor(func=self.coeff_get)
+
+    def _make_united_f_call(self):
+        types = [0, 0, 0]
+        for part in self.ops:
+            types[part[3]-1] += 1
+        if sum(types) == 0:
+            if len(self.ops) == 0:
+                raise Exception("No td operator but constant flag missing")
+            else:
+                raise Exception("Type of td_operator not supported")
+        elif types[1] == 0 and types[2] == 0:
+            # Only functions
+            self.funclist = []
+            for part in self.ops:
+                self.funclist.append(part[1])
+            united_f_call = _united_f_caller(self.funclist, self.args)
+            """def united_f_call(t):
+                out = []
+                for func in self.funclist:
+                    out.append(func(t, self.args))
+                return out"""
+            all_function = 3
+        else:
+            # Must be mixed, would be fast otherwise
+            united_f_call  = self._get_coeff
+            """def united_f_call(t):
+                out = []
+                for part in self.ops:
+                    if part[3] == 1:  # func: f(t,args)
+                        out.append(part[1](t, part[4]))
+                    elif part[3] == 2:  # str: f(t,w=2)
+                        if self.raw_str:
+                            # Must compile the str here
+                            part[1] = \
+                                _compile_str_single([[part[2], part[4], 0]])[0]
+                        out.append(part[1](t, **part[4]))
+                    elif part[3] == 3:  # numpy: _interpolate(t,arr,N,dt)
+                        out.append(part[1](np.array([t]))[0])
+                return out"""
+            all_function = 4
+        return united_f_call, all_function
+
+    def _get_coeff(self, t):
+        out = []
+        for part in self.ops:
+            if part[3] == 1:  # func: f(t,args)
+                out.append(part[1](t, part[4]))
+            elif part[3] == 2:  # str: f(t,w=2)
+                if self.raw_str:
+                    # Must compile the str here
+                    part[1] = \
+                        _compile_str_single([[part[2], part[4], 0]])[0]
+                out.append(part[1](t, **part[4]))
+            elif part[3] == 3:  # numpy: _interpolate(t,arr,N,dt)
+                out.append(part[1](np.array([t]))[0])
+        return out
+
+    def __getstate__(self):
+        _dict_ = {key: self.__dict__[key]
+                  for key in self.__dict__ if key is not "compiled_Qobj"}
+        if self.compiled:
+            return (_dict_, self.compiled_Qobj.__getstate__())
+            #return (_dict_, pickle.dumps(self.compiled_Qobj))
+        else:
+            return (_dict_,)
+
+    def __setstate__(self, state):
+        self.__dict__ = state[0]
+        if not self.compiled:
+            self.compiled_Qobj = None
+        elif self.compiled == 1:
+            self.compiled_Qobj = cy_cte_qobj.__new__(cy_cte_qobj)
+            self.compiled_Qobj.__setstate__(state[1])
+            #self.compiled_Qobj = pickle.loads(state[1])
+        elif self.compiled in (2,3,4):
+            self.compiled_Qobj = cy_td_qobj.__new__(cy_td_qobj)
+            self.compiled_Qobj.__setstate__(state[1])
+            #self.compiled_Qobj = pickle.loads(state[1])
+
+
+#Function defined inside another function cannot be pickle,
+#Using class instead
+class _united_f_caller:
+    def __init__(self, funclist, args):
+        self.funclist = funclist
+        self.args = args
+
+    def __call__ (self,t):
+        out = []
+        for func in self.funclist:
+            out.append(func(t, self.args))
+        return out
+
+
+class _compress_f_caller:
+    def __init__(self, funclist):
+        self.funclist = funclist
+
+    def __call__ (self, t, *args):
+        return sum((f(t, *args) for f in self.funclist))
+
+
+def _dummy(t, *args, **kwargs):
+    return 0.
+
+
+class _norm2():
+    def __init__(self, f):
+        self.func = f
+
+    def __call__(self, t, args):
+        return self.func(t, args)*np.conj(self.func(t, args))
+
+
+class _conj():
+    def __init__(self, f):
+        self.func = f
+
+    def __call__(self, t, args):
+        return np.conj(self.func(t, args))

--- a/qutip/td_qobj_codegen.py
+++ b/qutip/td_qobj_codegen.py
@@ -1,0 +1,336 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+import numpy as np
+from qutip.cy.inter import prep_cubic_spline
+
+
+def _compile_str_single(compile_list):
+    import os
+    _cython_path = os.path.dirname(os.path.abspath(__file__)).replace(
+                    "\\", "/")
+    _include_string = "'"+_cython_path + "/cy/complex_math.pxi'"
+
+    all_str = ""
+    for op in compile_list:
+        all_str += op[0]
+    filename = "td_Qobj_"+str(hash(all_str))[1:]
+
+    Code = """
+# This file is generated automatically by QuTiP.
+
+import numpy as np
+cimport numpy as np
+cimport cython
+np.import_array()
+cdef extern from "numpy/arrayobject.h" nogil:
+    void PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
+    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
+from qutip.cy.spmatfuncs cimport spmvpy
+from qutip.cy.math cimport erf
+cdef double pi = 3.14159265358979323
+
+include """+_include_string+"\n"
+
+    for str_coeff in compile_list:
+        Code += _str_2_code(str_coeff)
+
+    file = open(filename+".pyx", "w")
+    file.writelines(Code)
+    file.close()
+    str_func = []
+    for i in range(len(compile_list)):
+        func_name = '_str_factor_' + str(i)
+        import_code = compile('from ' + filename + ' import ' + func_name +
+                              "\nstr_func.append(" + func_name + ")",
+                              '<string>', 'exec')
+        exec(import_code, locals())
+
+    try:
+        os.remove(filename+".pyx")
+    except:
+        pass
+
+    return str_func
+
+
+def _str_2_code(str_coeff):
+
+    func_name = '_str_factor_' + str(str_coeff[2])
+
+    Code = """
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+
+def """ + func_name + "(double t"
+    # used arguments
+    Code += _get_arg_str(str_coeff[1])
+    Code += "):\n"
+    Code += "    return " + str_coeff[0] + "\n"
+
+    return Code
+
+
+def _get_arg_str(args):
+    if len(args) == 0:
+        return ''
+
+    ret = ''
+    for name, value in args.items():
+        if isinstance(value, np.ndarray):
+            ret += ",\n        np.ndarray[np.%s_t, ndim=1] %s" % \
+                (value.dtype.name, name)
+        else:
+            if isinstance(value, (int, np.int32, np.int64)):
+                kind = 'int'
+            elif isinstance(value, (float, np.float32, np.float64)):
+                kind = 'float'
+            elif isinstance(value, (complex, np.complex128)):
+                kind = 'complex'
+            ret += ",\n        " + kind + " " + name
+    return ret
+
+
+def make_united_f_ptr(ops, args, tlist, return_code=False):
+    """Create a cython function which return the coefficients of the
+time-dependent parts of an Qobj.
+string coefficients are compiled
+array_like coefficients become cubic spline (see qutip.cy.inter.pyx)
+
+??? I don't know if it will be useful, but the code is written in a way
+    it would be easy to have different tlist for each array_like coefficients
+    """
+    import os
+    _cython_path = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
+    _include_string = "'"+_cython_path + "/cy/complex_math.pxi'"
+
+    compile_list = []
+    N_np = 0
+    args_np = []
+    spline_list = []
+
+    for op in ops:
+        if op[3] == 2:
+            compile_list.append(op[2])
+        elif op[3] == 3:
+            spline, dt_cte = prep_cubic_spline(op[2], tlist)
+            spline_list.append(spline)
+
+            t_str = "str_tlist_" + str(N_np) +", "
+            y_str = "str_array_" + str(N_np) +", "
+            s_str = "str_spline_" + str(N_np) +", "
+            N_times = str(len(tlist))
+            dt_times = str(tlist[1]-tlist[0])
+            if dt_cte:
+                if isinstance(op[2][0], (float, np.float32, np.float64)):
+                    string = "spline_float_cte_second(t, " + t_str +\
+                             y_str + s_str + N_times + ", " + dt_times + ")"
+                    args_np += [[0,dt_cte]]
+                elif isinstance(op[2][0], (complex, np.complex128)):
+                    string = "spline_complex_cte_second(t, " + t_str +\
+                             y_str + s_str + N_times + ", " + dt_times + ")"
+                    args_np += [[1,dt_cte]]
+            else:
+                if isinstance(op[2][0], (float, np.float32, np.float64)):
+                    string = "spline_float_t_second(t, " + t_str +\
+                             y_str + s_str + N_times + ")"
+                    args_np += [[0,dt_cte]]
+                elif isinstance(op[2][0], (complex, np.complex128)):
+                    string = "spline_complex_t_second(t, " + t_str +\
+                             y_str + s_str + N_times + ")"
+                    args_np += [[1,dt_cte]]
+
+            compile_list.append(string)
+            N_np += 1
+    all_str = "" + str(np.random.random())
+    for op in compile_list:
+        all_str += op[0]
+    filename = "td_Qobj_f_ptr"+str(hash(all_str))[1:]
+
+    code = """
+# This file is generated automatically by QuTiP.
+
+import numpy as np
+cimport numpy as np
+cimport cython
+np.import_array()
+cdef extern from "numpy/arrayobject.h" nogil:
+    void PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
+    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
+from qutip.cy.spmatfuncs cimport spmvpy
+from qutip.cy.inter cimport spline_complex_t_second, spline_complex_cte_second
+from qutip.cy.inter cimport spline_float_t_second, spline_float_cte_second
+from qutip.cy.math cimport erf
+cdef double pi = 3.14159265358979323
+
+cdef extern from "Python.h":
+    object PyLong_FromVoidPtr(void *)
+    void* PyLong_AsVoidPtr(object)
+
+include """ + _include_string + "\n\n"
+
+    code += "cdef class coeff_args:\n"
+    for i, iscplx in enumerate(args_np):
+        if iscplx[0]:
+            code += "    cdef double[::1] str_tlist_" + str(i) + "\n"
+            code += "    cdef complex[::1] str_array_" + str(i) + "\n"
+            code += "    cdef complex[::1] str_spline_" + str(i) + "\n"
+        else:
+            code += "    cdef double[::1] str_tlist_" + str(i) + "\n"
+            code += "    cdef double[::1] str_array_" + str(i) + "\n"
+            code += "    cdef double[::1] str_spline_" + str(i) + "\n"
+
+    for name, value in args.items():
+        if not isinstance(name, str):
+            raise Exception("All arguments key must be string " +
+                            "and valid variables name")
+        if isinstance(value, (int, np.int32, np.int64)):
+            code += "    cdef int " + name + "\n"
+        elif isinstance(value, (float, np.float32, np.float64)):
+            code += "    cdef double " + name + "\n"
+        elif isinstance(value, (complex, np.complex128)):
+            code += "    cdef complex " + name + "\n"
+
+    code += "\n"
+    code += "    def set_array_imag(self, int N, double[::1] tlist, " +\
+            "complex[::1] array, complex[::1] spline):\n"
+    code += "        if N == -1:\n"
+    code += "            pass\n"
+    for i, iscplx in enumerate(args_np):
+        if iscplx[0]:
+            code += "        elif N == " + str(i) + ":\n"
+            code += "            self.str_tlist_" + str(i) + "= tlist\n"
+            code += "            self.str_array_" + str(i) + "= array\n"
+            code += "            self.str_spline_" + str(i) + "= spline\n"
+    code += "        else:\n"
+    code += "            raise Exception('Bad classification imag')\n"
+    code += "\n"
+    code += "    def set_array_real(self, int N, double[::1] tlist, " +\
+            "double[::1] array, double[::1] spline):\n"
+    code += "        if N ==-1:\n"
+    code += "            pass\n"
+    for i, iscplx in enumerate(args_np):
+        if not iscplx[0]:
+            code += "        elif N == " + str(i) + ":\n"
+            code += "            self.str_tlist_" + str(i) + "= tlist\n"
+            code += "            self.str_array_" + str(i) + "= array\n"
+            code += "            self.str_spline_" + str(i) + "= spline\n"
+    code += "        else:\n"
+    code += "            raise Exception('Bad classification real')\n"
+    code += "\n"
+    code += "    def set_args(self, args):\n"
+    if not args:
+        code += "        pass\n"
+    else:
+        for name, value in args.items():
+            code += "        self." + name + " = args['" + name + "']\n"
+    code += "\n"
+    code += "cdef coeff_args np_obj = coeff_args()"
+    code += "\n\n"
+
+    code += "cdef void coeff(double t, complex* out):\n"
+    if N_np:
+        #code += "    cdef int N_times = " + str(len(tlist)) + "\n"
+        #code += "    cdef double dt_times = " + str(tlist[1]-tlist[0]) + "\n"
+        for i, iscplx in enumerate(args_np):
+            if iscplx[0]:
+                code += "    cdef double[::1] str_tlist_" + str(i) +\
+                        "= np_obj.str_tlist_" + str(i) + "\n"
+                code += "    cdef complex[::1] str_array_" + str(i) +\
+                        "= np_obj.str_array_" + str(i) + "\n"
+                code += "    cdef complex[::1] str_spline_" + str(i) +\
+                        "= np_obj.str_spline_" + str(i) + "\n"
+            else:
+                code += "    cdef double[::1] str_tlist_" + str(i) +\
+                        "= np_obj.str_tlist_" + str(i) + "\n"
+                code += "    cdef double[::1] str_array_" + str(i) +\
+                        "= np_obj.str_array_" + str(i) + "\n"
+                code += "    cdef double[::1] str_spline_" + str(i) +\
+                        "= np_obj.str_spline_" + str(i) + "\n"
+    for name, value in args.items():
+        if not isinstance(name, str):
+            raise Exception("All arguments key must be string and" +
+                            " valid variables name")
+        if isinstance(value, (int, np.int32, np.int64)):
+            code += "    cdef int " + name + " = np_obj." + name + "\n"
+        elif isinstance(value, (float, np.float32, np.float64)):
+            code += "    cdef double " + name + " = np_obj." + name + "\n"
+        elif isinstance(value, (complex, np.complex128)):
+            code += "    cdef complex " + name + " = np_obj." + name + "\n"
+    code += "\n"
+    for i, str_coeff in enumerate(compile_list):
+        code += "    out[" + str(i) + "] = " + str_coeff + "\n"
+
+    code += """
+
+def get_ptr(set_np_obj = False):
+    if set_np_obj:
+        return np_obj
+    else:
+        return PyLong_FromVoidPtr(<void*> coeff)
+"""
+
+    file = open(filename+".pyx", "w")
+    file.writelines(code)
+    file.close()
+    compile_f_ptr = []
+
+    import_code = compile('from ' + filename + ' import get_ptr' +
+                          "\ncompile_f_ptr.append(get_ptr)",
+                          '<string>', 'exec')
+    exec(import_code, locals())
+
+    np_obj = compile_f_ptr[0](set_np_obj=True)
+    if N_np:
+        n_op = 0
+        for op in ops:
+            if op[3] == 3:
+                if isinstance(op[2][0], (float, np.float32, np.float64)):
+                    op[4] = spline_list[n_op]
+                    np_obj.set_array_real(n_op, tlist, op[2], spline_list[n_op])
+                elif isinstance(op[2][0], (complex, np.complex128)):
+                    op[4] = spline_list[n_op]
+                    np_obj.set_array_imag(n_op, tlist, op[2], spline_list[n_op])
+                n_op += 1
+    if args:
+        np_obj.set_args(args)
+
+    try:
+        os.remove(filename+".pyx")
+    except:
+        pass
+
+    if return_code:
+        return compile_f_ptr[0], code
+    else:
+        return compile_f_ptr[0]

--- a/qutip/tests/test_stochastic_me.py
+++ b/qutip/tests/test_stochastic_me.py
@@ -34,20 +34,24 @@
 import numpy as np
 from numpy.testing import assert_, run_module_suite
 
-from qutip import (smesolve, mesolve, destroy, coherent, parallel_map, qeye, fock_dm)
+from qutip import (smesolve, mesolve, photocurrentmesolve, liouvillian,
+                   td_Qobj, spre, spost, destroy, coherent, parallel_map,
+                   qeye, fock_dm, general_stochastic, ket2dm)
 
+def f(t, args):
+    return args["a"] * t
 
 def test_smesolve_homodyne_methods():
     "Stochastic: smesolve: homodyne methods with single jump operator"
-    
+
     def arccoth(x):
         return 0.5*np.log((1.+x)/(x-1.))
-    
+
     th = 0.1 # Interaction parameter
     alpha = np.cos(th)
     beta = np.sin(th)
     gamma = 1.
-    
+
     N = 30                 # number of Fock states
     Id = qeye(N)
     a = destroy(N)
@@ -58,10 +62,10 @@ def test_smesolve_homodyne_methods():
     sc_op = [s]
     e_op = [x, x*x]
     rho0 = fock_dm(N,0)      # initial vacuum state
-    
-    T = 6.                   # final time          
+
+    T = 6.                   # final time
     N_store = 200            # number of time steps for which we save the expectation values
-    Nsub = 5
+    Nsub = 10
     tlist = np.linspace(0, T, N_store)
     ddt = (tlist[1]-tlist[0])
 
@@ -70,31 +74,57 @@ def test_smesolve_homodyne_methods():
     A = (gamma**2 + alpha**2 * (beta**2 + 4*gamma) - 2*alpha*beta*gamma)**0.5
     B = arccoth((-4*alpha**2*y0 + alpha*beta - gamma)/A)
     y_an = (alpha*beta - gamma + A / np.tanh(0.5*A*tlist - B))/(4*alpha**2)
-    
+
 
     list_methods_tol = [['euler-maruyama', 2e-2],
-                        ['fast-euler-maruyama', 2e-2],
                         ['pc-euler', 2e-3],
+                        ['pc-euler-2', 2e-3],
+                        ['platen', 1e-3],
                         ['milstein', 1e-3],
-                        ['fast-milstein', 1e-3],
                         ['milstein-imp', 1e-3],
                         ['taylor15', 1e-4],
-                        ['taylor15-imp', 1e-4]
-                        ]
+                        ['taylor15-imp', 1e-4],
+                        ['explicit15', 1e-4]]
     for n_method in list_methods_tol:
         sol = smesolve(H, rho0, tlist, c_op, sc_op, e_op,
                        nsubsteps=Nsub, method='homodyne', solver = n_method[0])
-        sol2 = smesolve(H, rho0, tlist, c_op, sc_op, e_op,
+        sol2 = smesolve(H, rho0, tlist, c_op, sc_op, e_op, store_measurement=0,
                        nsubsteps=Nsub, method='homodyne', solver = n_method[0],
                        noise = sol.noise)
+        sol3 = smesolve(H, rho0, tlist, c_op, sc_op, e_op,
+                        nsubsteps=Nsub*5, method='homodyne',
+                        solver = n_method[0], tol=1e-8)
         err = 1/T * np.sum(np.abs(y_an - (sol.expect[1]-sol.expect[0]*sol.expect[0].conj())))*ddt
+        err3 = 1/T * np.sum(np.abs(y_an - (sol3.expect[1]-sol3.expect[0]*sol3.expect[0].conj())))*ddt
         print(n_method[0], ': deviation =', err, ', tol =', n_method[1])
         assert_(err < n_method[1])
+        assert_(err3 < err) # 5* more substep should decrease the error
         assert_(np.all(sol.noise == sol2.noise))# just to check that noise is not affected by smesolve
         assert_(np.all(sol.expect[0] == sol2.expect[0]))
 
-def test_ssesolve_photocurrent():
-    "Stochastic: smesolve: photo-current"
+    sol = smesolve(H, rho0, tlist[:2], c_op, sc_op, e_op, noise=10, ntraj=2,
+                    nsubsteps=Nsub, method='homodyne', solver='euler',
+                    store_measurement=1)
+    sol2 = smesolve(H, rho0, tlist[:2], c_op, sc_op, e_op, noise=10, ntraj=2,
+                    nsubsteps=Nsub, method='homodyne', solver='euler',
+                    store_measurement=0)
+    sol3 = smesolve(H, rho0, tlist[:2], c_op, sc_op, e_op, noise=11, ntraj=2,
+                    nsubsteps=Nsub, method='homodyne', solver='euler')
+    # sol and sol2 have the same seed, sol3 differ.
+    assert_(np.all(sol.noise == sol2.noise))
+    assert_(np.all(sol.noise != sol3.noise))
+    assert_(not np.all(sol.measurement[0] == 0.+0j))
+    assert_(np.all(sol2.measurement[0] == 0.+0j))
+    sol = smesolve(H, rho0, tlist[:2], c_op, sc_op, e_op, noise=np.array([1,2]),
+                   ntraj=2, nsubsteps=Nsub, method='homodyne', solver='euler')
+    sol2 = smesolve(H, rho0, tlist[:2], c_op, sc_op, e_op, noise=np.array([2,1]),
+                   ntraj=2, nsubsteps=Nsub, method='homodyne', solver='euler')
+    # sol and sol2 have the seed of traj 1 and 2 reversed.
+    assert_(np.all(sol.noise[0,:,:,:] == sol2.noise[1,:,:,:]))
+    assert_(np.all(sol.noise[1,:,:,:] == sol2.noise[0,:,:,:]))
+
+def test_smesolve_photocurrent():
+    "Stochastic: photocurrentmesolve"
     tol = 0.01
 
     N = 4
@@ -103,27 +133,24 @@ def test_ssesolve_photocurrent():
     nsubsteps = 100
     a = destroy(N)
 
-    H = a.dag() * a
+    H = [[a.dag() * a,f]]
     psi0 = coherent(N, 0.5)
-    sc_ops = [np.sqrt(gamma) * a]
+    sc_ops = [np.sqrt(gamma) * a, np.sqrt(gamma) * a * 0.5]
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
 
     times = np.linspace(0, 2.5, 50)
-    res_ref = mesolve(H, psi0, times, sc_ops, e_ops)
-    res = smesolve(H, psi0, times, [], sc_ops, e_ops,
-                   ntraj=ntraj, nsubsteps=nsubsteps,
-                   method='photocurrent', store_measurement=True,
+    res_ref = mesolve(H, psi0, times, sc_ops, e_ops, args={"a":2})
+    res = photocurrentmesolve(H, psi0, times, [], sc_ops, e_ops, args={"a":2},
+                   ntraj=ntraj, nsubsteps=nsubsteps,  store_measurement=True,
                    map_func=parallel_map)
 
     assert_(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
                  for idx in range(len(e_ops))]))
-
     assert_(len(res.measurement) == ntraj)
     assert_(all([m.shape == (len(times), len(sc_ops))
                  for m in res.measurement]))
 
-
-def test_ssesolve_homodyne():
+def test_smesolve_homodyne():
     "Stochastic: smesolve: homodyne"
     tol = 0.01
 
@@ -133,27 +160,34 @@ def test_ssesolve_homodyne():
     nsubsteps = 100
     a = destroy(N)
 
-    H = a.dag() * a
+    H = [[a.dag() * a,f]]
     psi0 = coherent(N, 0.5)
-    sc_ops = [np.sqrt(gamma) * a]
+    sc_ops = [np.sqrt(gamma) * a, np.sqrt(gamma) * a * 0.5]
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
 
     times = np.linspace(0, 2.5, 50)
-    res_ref = mesolve(H, psi0, times, sc_ops, e_ops)
-    res = smesolve(H, psi0, times, [], sc_ops, e_ops,
-                   ntraj=ntraj, nsubsteps=nsubsteps,
-                   method='homodyne', store_measurement=True,
-                   map_func=parallel_map)
+    res_ref = mesolve(H, psi0, times, sc_ops, e_ops, args={"a":2})
+    list_methods_tol = ['euler-maruyama',
+                        'pc-euler',
+                        'pc-euler-2',
+                        'platen',
+                        'milstein',
+                        'milstein-imp',
+                        'taylor15',
+                        'taylor15-imp',
+                        'explicit15']
+    for solver in list_methods_tol:
+        res = smesolve(H, psi0, times, [], sc_ops, e_ops,
+                       ntraj=ntraj, nsubsteps=nsubsteps, args={"a":2},
+                       method='homodyne', store_measurement=True,
+                       solver=solver, map_func=parallel_map)
+        assert_(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
+                     for idx in range(len(e_ops))]))
+        assert_(len(res.measurement) == ntraj)
+        assert_(all([m.shape == (len(times), len(sc_ops))
+                     for m in res.measurement]))
 
-    assert_(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
-                 for idx in range(len(e_ops))]))
-
-    assert_(len(res.measurement) == ntraj)
-    assert_(all([m.shape == (len(times), len(sc_ops))
-                 for m in res.measurement]))
-
-
-def test_ssesolve_heterodyne():
+def test_smesolve_heterodyne():
     "Stochastic: smesolve: heterodyne"
     tol = 0.01
 
@@ -163,25 +197,75 @@ def test_ssesolve_heterodyne():
     nsubsteps = 100
     a = destroy(N)
 
-    H = a.dag() * a
+    H = [[a.dag() * a,f]]
     psi0 = coherent(N, 0.5)
-    sc_ops = [np.sqrt(gamma) * a]
+    sc_ops = [np.sqrt(gamma) * a, np.sqrt(gamma) * a * 0.5]
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
 
     times = np.linspace(0, 2.5, 50)
-    res_ref = mesolve(H, psi0, times, sc_ops, e_ops)
-    res = smesolve(H, psi0, times, [], sc_ops, e_ops,
-                   ntraj=ntraj, nsubsteps=nsubsteps,
-                   method='heterodyne', store_measurement=True,
-                   map_func=parallel_map)
+    res_ref = mesolve(H, psi0, times, sc_ops, e_ops, args={"a":2})
+    list_methods_tol = ['euler-maruyama',
+                        'pc-euler',
+                        'pc-euler-2',
+                        'platen',
+                        'milstein',
+                        'milstein-imp',
+                        'taylor15',
+                        'taylor15-imp',
+                        'explicit15']
+    for solver in list_methods_tol:
+        res = smesolve(H, psi0, times, [], sc_ops, e_ops,
+                       ntraj=ntraj, nsubsteps=nsubsteps, args={"a":2},
+                       method='heterodyne', store_measurement=True,
+                       solver=solver, map_func=parallel_map)
+        assert_(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
+                     for idx in range(len(e_ops))]))
+        assert_(len(res.measurement) == ntraj)
+        assert_(all([m.shape == (len(times), len(sc_ops), 2)
+                     for m in res.measurement]))
 
+def test_general_stochastic():
+    "Stochastic: general_stochastic"
+    "Reproduce smesolve homodyne"
+    tol = 0.015
+    N = 4
+    gamma = 0.25
+    ntraj = 20
+    nsubsteps = 100
+    a = destroy(N)
+
+    H = [[a.dag() * a,f]]
+    psi0 = coherent(N, 0.5)
+    sc_ops = [np.sqrt(gamma) * a, np.sqrt(gamma) * a * 0.5]
+    e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
+
+    L = liouvillian(td_Qobj([[a.dag() * a,f]], args={"a":2}), c_ops = sc_ops)
+    L.compile()
+    sc_opsM = [td_Qobj(spre(op) + spost(op.dag())) for op in sc_ops]
+    [op.compile() for op in sc_opsM]
+    e_opsM = [spre(op) for op in e_ops]
+
+    def d1(t, vec):
+        return L.rhs(t,vec)
+
+    def d2(t, vec):
+        out = []
+        for op in sc_opsM:
+            out.append(op.rhs(t,vec)-op.expect(t,vec)*vec)
+        return np.stack(out)
+
+    times = np.linspace(0, 1.0, 25)
+    res_ref = mesolve(H, psi0, times, sc_ops, e_ops, args={"a":2})
+    list_methods_tol = ['euler-maruyama',
+                        'platen',
+                        'explicit15']
+    for solver in list_methods_tol:
+        res = general_stochastic(ket2dm(psi0),times,d1,d2,len_d2=2, e_ops=e_opsM,
+                                 normalize=False, ntraj=ntraj, nsubsteps=nsubsteps,
+                                 solver=solver)
     assert_(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
                  for idx in range(len(e_ops))]))
-
     assert_(len(res.measurement) == ntraj)
-    assert_(all([m.shape == (len(times), len(sc_ops), 2)
-                 for m in res.measurement]))
-
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_stochastic_se.py
+++ b/qutip/tests/test_stochastic_se.py
@@ -33,11 +33,95 @@
 import numpy as np
 from numpy.testing import assert_,  run_module_suite
 
-from qutip import ssesolve, destroy, coherent, mesolve, parallel_map
+from qutip import (ssesolve, destroy, coherent, mesolve, fock, qeye,
+                   parallel_map, photocurrentsesolve)
+
+def f(t, args):
+    return args["a"] * t
+
+def test_smesolve_homodyne_methods():
+    "Stochastic: smesolve: homodyne methods with single jump operator"
+
+    def arccoth(x):
+        return 0.5*np.log((1.+x)/(x-1.))
+
+    th = 0.1 # Interaction parameter
+    alpha = np.cos(th)
+    beta = np.sin(th)
+    gamma = 1.
+
+    N = 30                 # number of Fock states
+    Id = qeye(N)
+    a = destroy(N)
+    s = 0.5*((alpha+beta)*a + (alpha-beta)*a.dag())
+    x = (a + a.dag()) * 2**-0.5
+    H = Id + gamma * a * a.dag()
+    sc_op = [s]
+    e_op = [x, x*x]
+    rho0 = fock(N,0)      # initial vacuum state
+
+    T = 6.                   # final time
+    N_store = 200            # number of time steps for which we save the expectation values
+    Nsub = 10
+    tlist = np.linspace(0, T, N_store)
+    ddt = (tlist[1]-tlist[0])
+
+    #### No analytic solution for ssesolve, taylor15 with 500 substep
+    sol = ssesolve(H, rho0, tlist, sc_op, e_op,
+                   nsubsteps=1000, method='homodyne', solver='taylor15')
+    y_an = (sol.expect[1]-sol.expect[0]*sol.expect[0].conj())
+
+
+    list_methods_tol = [['euler-maruyama', 3e-2],
+                        ['pc-euler', 5e-3],
+                        ['pc-euler-2', 5e-3],
+                        ['platen', 5e-3],
+                        ['milstein', 5e-3],
+                        ['milstein-imp', 5e-3],
+                        ['taylor15', 5e-4],
+                        ['taylor15-imp', 5e-4],
+                        ['explicit15', 5e-4]]
+    for n_method in list_methods_tol:
+        sol = ssesolve(H, rho0, tlist, sc_op, e_op,
+                       nsubsteps=Nsub, method='homodyne', solver = n_method[0])
+        sol2 = ssesolve(H, rho0, tlist, sc_op, e_op, store_measurement=0,
+                       nsubsteps=Nsub, method='homodyne', solver = n_method[0],
+                       noise = sol.noise)
+        sol3 = ssesolve(H, rho0, tlist, sc_op, e_op,
+                        nsubsteps=Nsub*5, method='homodyne',
+                        solver = n_method[0], tol=1e-8)
+        err = 1/T * np.sum(np.abs(y_an - (sol.expect[1]-sol.expect[0]*sol.expect[0].conj())))*ddt
+        err3 = 1/T * np.sum(np.abs(y_an - (sol3.expect[1]-sol3.expect[0]*sol3.expect[0].conj())))*ddt
+        print(n_method[0], ': deviation =', err, err3,', tol =', n_method[1])
+        assert_(err < n_method[1])
+        assert_(err3 < err) # 5* more substep should decrease the error
+        assert_(np.all(sol.noise == sol2.noise))# just to check that noise is not affected by smesolve
+        assert_(np.all(sol.expect[0] == sol2.expect[0]))
+
+    sol = ssesolve(H, rho0, tlist[:2], sc_op, e_op, noise=10, ntraj=2,
+                    nsubsteps=Nsub, method='homodyne', solver='euler',
+                    store_measurement=1)
+    sol2 = ssesolve(H, rho0, tlist[:2], sc_op, e_op, noise=10, ntraj=2,
+                    nsubsteps=Nsub, method='homodyne', solver='euler',
+                    store_measurement=0)
+    sol3 = ssesolve(H, rho0, tlist[:2], sc_op, e_op, noise=11, ntraj=2,
+                    nsubsteps=Nsub, method='homodyne', solver='euler')
+    # sol and sol2 have the same seed, sol3 differ.
+    assert_(np.all(sol.noise == sol2.noise))
+    assert_(np.all(sol.noise != sol3.noise))
+    assert_(not np.all(sol.measurement[0] == 0.+0j))
+    assert_(np.all(sol2.measurement[0] == 0.+0j))
+    sol = ssesolve(H, rho0, tlist[:2], sc_op, e_op, noise=np.array([1,2]),
+                   ntraj=2, nsubsteps=Nsub, method='homodyne', solver='euler')
+    sol2 = ssesolve(H, rho0, tlist[:2], sc_op, e_op, noise=np.array([2,1]),
+                   ntraj=2, nsubsteps=Nsub, method='homodyne', solver='euler')
+    # sol and sol2 have the seed of traj 1 and 2 reversed.
+    assert_(np.all(sol.noise[0,:,:,:] == sol2.noise[1,:,:,:]))
+    assert_(np.all(sol.noise[1,:,:,:] == sol2.noise[0,:,:,:]))
 
 
 def test_ssesolve_photocurrent():
-    "Stochastic: ssesolve: photo-current"
+    "Stochastic: photocurrentsesolve"
     tol = 0.01
 
     N = 4
@@ -46,17 +130,16 @@ def test_ssesolve_photocurrent():
     nsubsteps = 100
     a = destroy(N)
 
-    H = a.dag() * a
+    H = [[a.dag() * a,f]]
     psi0 = coherent(N, 0.5)
-    sc_ops = [np.sqrt(gamma) * a]
+    sc_ops = [np.sqrt(gamma) * a, np.sqrt(gamma) * a*0.5]
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
 
     times = np.linspace(0, 2.5, 50)
-    res_ref = mesolve(H, psi0, times, sc_ops, e_ops)
-    res = ssesolve(H, psi0, times, sc_ops, e_ops,
-                   ntraj=ntraj, nsubsteps=nsubsteps,
-                   method='photocurrent', store_measurement=True,
-                   map_func=parallel_map)
+    res_ref = mesolve(H, psi0, times, sc_ops, e_ops, args={"a":2})
+    res = photocurrentsesolve(H, psi0, times, sc_ops, e_ops, ntraj=ntraj,
+                              nsubsteps=nsubsteps, store_measurement=True,
+                              map_func=parallel_map, args={"a":2})
 
     assert_(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
                  for idx in range(len(e_ops))]))
@@ -76,17 +159,17 @@ def test_ssesolve_homodyne():
     nsubsteps = 100
     a = destroy(N)
 
-    H = a.dag() * a
+    H = [[a.dag() * a,f]]
     psi0 = coherent(N, 0.5)
-    sc_ops = [np.sqrt(gamma) * a]
+    sc_ops = [np.sqrt(gamma) * a, np.sqrt(gamma) * a*0.5]
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
 
     times = np.linspace(0, 2.5, 50)
-    res_ref = mesolve(H, psi0, times, sc_ops, e_ops)
+    res_ref = mesolve(H, psi0, times, sc_ops, e_ops, args={"a":2})
     res = ssesolve(H, psi0, times, sc_ops, e_ops,
                    ntraj=ntraj, nsubsteps=nsubsteps,
                    method='homodyne', store_measurement=True,
-                   map_func=parallel_map)
+                   map_func=parallel_map, args={"a":2})
 
     assert_(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
                  for idx in range(len(e_ops))]))
@@ -106,17 +189,17 @@ def test_ssesolve_heterodyne():
     nsubsteps = 100
     a = destroy(N)
 
-    H = a.dag() * a
+    H = [[a.dag() * a,f]]
     psi0 = coherent(N, 0.5)
-    sc_ops = [np.sqrt(gamma) * a]
+    sc_ops = [np.sqrt(gamma) * a, np.sqrt(gamma) * a*0.5]
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
 
     times = np.linspace(0, 2.5, 50)
-    res_ref = mesolve(H, psi0, times, sc_ops, e_ops)
+    res_ref = mesolve(H, psi0, times, sc_ops, e_ops, args={"a":2})
     res = ssesolve(H, psi0, times, sc_ops, e_ops,
                    ntraj=ntraj, nsubsteps=nsubsteps,
                    method='heterodyne', store_measurement=True,
-                   map_func=parallel_map)
+                   map_func=parallel_map, args={"a":2})
 
     assert_(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
                  for idx in range(len(e_ops))]))

--- a/qutip/tests/test_superoper.py
+++ b/qutip/tests/test_superoper.py
@@ -39,8 +39,13 @@ import scipy
 from qutip import (rand_dm, rand_unitary, spre, spost, vector_to_operator,
                    operator_to_vector, mat2vec, vec2mat, vec2mat_index,
                    mat2vec_index, tensor, sprepost, to_super, reshuffle,
-                   identity)
-from qutip.superoperator import liouvillian, liouvillian_ref
+                   identity, destroy, create, qeye, td_Qobj)
+from qutip.superoperator import liouvillian, liouvillian_ref, \
+                                lindblad_dissipator
+
+
+def f(t, args):
+    return t*(1-0.5j)
 
 
 class TestMatVec:
@@ -182,6 +187,69 @@ class TestMatVec:
         L2 = liouvillian_ref(H, c_ops)
 
         assert_((L1 - L2).norm('max') < 1e-8)
+
+
+
+class TestSuper_td:
+    """
+    A test class for the QuTiP superoperator functions.
+    """
+
+    def __init__(self):
+        N = 3
+        self.t1 = td_Qobj([qeye(N)*(1.+0.1j),[create(N)*(1.-0.1j),f]])
+        self.t2 = td_Qobj([destroy(N)*(1.-0.2j)])
+        self.t3 = td_Qobj([[destroy(N)*create(N)*(1.+0.2j),f]])
+        self.q1 = qeye(N)*(1.+0.3j)
+        self.q2 = destroy(N)*(1.-0.3j)
+        self.q3 = destroy(N)*create(N)*(1.+0.4j)
+
+    def test_spre_td(self):
+        "Superoperator: spre, time-dependent"
+        assert_(spre(self.t1)(.5) == spre(self.t1(.5)))
+
+    def test_spost_td(self):
+        "Superoperator: spre, time-dependent"
+        assert_(spost(self.t1)(.5) == spost(self.t1(.5)))
+
+    def test_sprepost_td(self):
+        "Superoperator: sprepost, time-dependent"
+        # left td_Qobj
+        assert_(sprepost(self.t1, self.q2)(.5) ==
+                sprepost(self.t1(.5), self.q2))
+        # left td_Qobj
+        assert_(sprepost(self.q2, self.t1)(.5) ==
+                sprepost(self.q2, self.t1(.5)))
+        # left 2 td_Qobj, one cte
+        assert_(sprepost(self.t1, self.t2)(.5) ==
+                sprepost(self.t1(.5), self.t2(.5)))
+
+    def test_operator_vector_td(self):
+        "Superoperator: operator_to_vector, time-dependent"
+        assert_(operator_to_vector(self.t1)(.5) ==
+                operator_to_vector(self.t1(.5)))
+        vec = operator_to_vector(self.t1)
+        assert_(vector_to_operator(vec)(.5) == vector_to_operator(vec(.5)))
+
+    def test_liouvillian_td(self):
+        "Superoperator: liouvillian, time-dependent"
+        assert_(liouvillian(self.t1)(0.5) == liouvillian(self.t1(0.5)))
+        assert_(liouvillian(None, [self.t2])(0.5) ==
+                liouvillian(None, [self.t2(0.5)]))
+        assert_(liouvillian(self.t1, [self.t2, self.q1, self.t3],
+                            chi=[1,2,3])(0.5) ==
+                liouvillian(self.t1(0.5), [self.t2(0.5), self.q1, self.t3(0.5)],
+                            chi=[1,2,3]))
+
+    def test_lindblad_dissipator_td(self):
+        "Superoperator: lindblad_dissipator, time-dependent"
+        assert_(lindblad_dissipator(self.t2)(.5) ==
+                lindblad_dissipator(self.t2(.5)))
+        assert_(lindblad_dissipator(self.t2, self.q1)(.5) ==
+                lindblad_dissipator(self.t2(.5), self.q1))
+        assert_(lindblad_dissipator(self.q1, self.t2)(.5) ==
+                lindblad_dissipator(self.q1, self.t2(.5)))
+
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_td_qobj.py
+++ b/qutip/tests/test_td_qobj.py
@@ -1,0 +1,951 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+
+
+from qutip import *
+import numpy as np
+from numpy.testing import (assert_equal, assert_, assert_almost_equal,
+                            run_module_suite, assert_allclose)
+from functools import partial
+from types import FunctionType, BuiltinFunctionType
+from qutip.cy.spmatfuncs import (cy_expect_rho_vec, cy_expect_psi, spmv)
+
+def _f1(t,args):
+    return np.sin(t*args['w1'])
+
+def _f2(t,args):
+    return np.cos(t*args['w2'])
+
+def _f3(t,args):
+    return np.exp(1j*t*args['w3'])
+
+def _random_td_Qobj(shape=(1,1), ops=[0,0,0], cte=True, tlist=None):
+    """Create a list to make a td_Qobj with up to 3 coefficients"""
+    if tlist is None:
+        tlist = np.linspace(0,1,300)
+
+    Qobj_list = []
+    if cte:
+        Qobj_list.append(Qobj(np.random.random(shape) + \
+                              1j*np.random.random(shape)))
+
+    coeff = [[_f1, "sin(w1*t)", np.sin(tlist)],
+             [_f2, "cos(w2*t)", np.cos(tlist)],
+             [_f3, "exp(w3*t*1j)", np.exp(tlist*1j)]]
+    for i,form in enumerate(ops):
+        if form:
+            Qobj_list.append([Qobj(np.random.random(shape)),coeff[i][form-1]])
+    return Qobj_list
+
+
+def test_td_Qobj_cte_call():
+    "td_Qobj call: cte"
+    N = 5
+    data = np.random.random((N, N))
+    q1 = Qobj(data)
+    td_data = td_Qobj(q1)
+    # Check the constant flag
+    assert_equal(td_data.const, True)
+    # Check that the call return the Qobj
+    assert_equal(td_data(np.random.random()) == q1, True)
+    # Check that the call for the data return the data
+    assert_equal((td_data(np.random.random(),data=True) - data == 0).all(), True)
+
+    # Test another creation format
+    data2 = np.random.random((N, N))
+    q2 = Qobj(data2)
+    td_data2 = td_Qobj([q2])
+    # Check the constant flag
+    assert_equal(td_data2.const, True)
+    # Check that the call return the Qobj
+    assert_equal(td_data2(np.random.random()) == q2, True)
+    # Check that the call for the data return the data
+    assert_equal((td_data2(np.random.random(), data=True) - data2 == 0).all(), True)
+
+
+def test_td_Qobj_func_call():
+    "td_Qobj call: func format"
+    N = 5
+    data1 = np.random.random((N, N))
+    data2 = np.random.random((N, N))
+    data3 = np.random.random((N, N))
+    q1 = Qobj(data1)
+    q2 = Qobj(data2)
+    q3 = Qobj(data3)
+    args={"w1":1, "w2":2}
+    td_data = td_Qobj([q1, [q2,_f1], [q3,_f2]], args=args)
+    # Check the constant flag
+    assert_equal(td_data.const, False)
+    t = np.random.random()
+    q_at_t = q1 + np.sin(t*args['w1']) * q2 + np.cos(t*args['w2']) * q3
+    # Check that the call return the Qobj
+    assert_equal(td_data(t) == q_at_t, True)
+    data_at_t = data1 + np.sin(t*args['w1']) * data2 + np.cos(t*args['w2']) * data3
+    # Check that the call for the data return the data
+    assert_allclose(td_data(t, data=True).todense(), data_at_t)
+
+    # test another init format
+    td_data2 = td_Qobj([q1,_f1], args=args)
+    # Check the constant flag
+    assert_equal(td_data.const, False)
+    t = np.random.random()
+    q_at_t = q1 * np.sin(t*args['w1'])
+    # Check that the call return the Qobj
+    assert_equal(td_data2(t) == q_at_t, True)
+
+
+def test_td_Qobj_str_call():
+    "td_Qobj call: str format"
+    N = 5
+    data1 = np.random.random((N, N))
+    data2 = np.random.random((N, N))
+    data3 = np.random.random((N, N))
+    q1 = Qobj(data1)
+    q2 = Qobj(data2)
+    q3 = Qobj(data3)
+    args={"w1":1, "w2":2}
+    td_data = td_Qobj([q1,[q2,'sin(t*w1)'],[q3,'cos(t*w2)']], args=args)
+    # Check the constant flag
+    assert_equal(td_data.const, False)
+    t = np.random.random()
+    q_at_t = q1 + np.sin(t*args['w1']) * q2 + np.cos(t*args['w2']) * q3
+    # Check that the call return the Qobj
+    assert_equal(td_data(t) == q_at_t, True)
+    data_at_t = data1 + np.sin(t*args['w1']) * data2 + np.cos(t*args['w2']) * data3
+    # Check that the call for the data return the data
+    assert_allclose(td_data(t,data=True).todense(), data_at_t)
+
+    # test another init format
+    td_data2 = td_Qobj([q1,'sin(t*w1)'], args=args)
+    t = np.random.random()
+    q_at_t = q1 * np.sin(t*args['w1'])
+    # Check that the call return the Qobj
+    assert_equal(td_data2(t) == q_at_t, True)
+
+
+def test_td_Qobj_array_call():
+    "td_Qobj call: array format"
+    N = 5
+    tlist = np.linspace(0,1,300)
+    tlistlog = np.logspace(-3,0,600)
+    data1 = np.random.random((N, N))
+    data2 = np.random.random((N, N))
+    data3 = np.random.random((N, N))
+    q1 = Qobj(data1)
+    q2 = Qobj(data2)
+    q3 = Qobj(data3)
+    td_data = td_Qobj([q1,[q2,np.sin(tlist)],[q3,np.cos(2*tlist)]], tlist=tlist)
+    # Check the constant flag
+    assert_equal(td_data.const, False)
+    t = np.random.random() *.99 + 0.01
+    q_at_t = q1 + np.sin(t) * q2 + np.cos(t*2) * q3
+    # Check that the call return the Qobj
+    assert_allclose(td_data(t,data=1).todense() , q_at_t.data.todense())
+    data_at_t = data1 + np.sin(t) * data2 + np.cos(t*2) * data3
+    # Check that the call for the data return the data
+    assert_allclose(td_data(t,data=True).todense(), data_at_t)
+
+    #test for non-linear tlist
+    td_data = td_Qobj([q1,[q2,np.sin(tlistlog)],[q3,np.cos(2*tlistlog)]], tlist=tlistlog)
+    t = np.random.random()
+    data_at_t = data1 + np.sin(t) * data2 + np.cos(t*2) * data3
+    # Check that the call for the data return the data
+    assert_allclose(np.array(td_data(t,data=True).todense()), data_at_t, rtol=3e-7)
+
+
+def test_td_Qobj_mixed_call():
+    "td_Qobj call: mixed format"
+    N = 5
+    tlist = np.linspace(0,1,300)
+    data1 = np.random.random((N, N))
+    data2 = np.random.random((N, N))
+    data3 = np.random.random((N, N))
+    data4 = np.random.random((N, N))
+    q1 = Qobj(data1)
+    q2 = Qobj(data2)
+    q3 = Qobj(data3)
+    q4 = Qobj(data4)
+    args={"w1":1, "w2":2}
+    td_data = td_Qobj([q1, [q2,_f1], [q3,"cos(w2*t)"],
+                      [q4,np.exp(3*tlist)]], tlist=tlist, args=args)
+    t = np.random.random()
+    data_at_t = data1 + np.sin(t) * data2 + np.cos(t*2) * data3 +\
+                np.exp(t*3) * data4
+    # Check that the call for the data return the data
+    assert_allclose(td_data(t,data=True).todense(), data_at_t)
+
+
+def test_td_Qobj_copy():
+    "td_Qobj copy"
+    tlist = np.linspace(0,1,300)
+    td_obj_1 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    t = np.random.random()
+    td_obj_copy = td_obj_1.copy()
+    #Check that the copy is independent
+    assert_equal(td_obj_1 is td_obj_copy, False)
+    #Check that the copy has the same data
+    assert_equal(td_obj_1(t) == td_obj_copy(t), True)
+    td_obj_copy = td_Qobj(td_obj_1)
+    #Check that the copy is independent
+    assert_equal(td_obj_1 is td_obj_copy, False)
+    #Check that the copy has the same data
+    assert_equal(td_obj_1(t) == td_obj_copy(t), True)
+
+
+def test_td_Qobj_to_list():
+    "td_Qobj to_list"
+    td_as_list_1 = _random_td_Qobj((5,5), [0,2,3], tlist=np.linspace(0,1,100))
+    td_as_list_2 = _random_td_Qobj((5,5), [1,0,0], tlist=np.linspace(0,1,100))
+    args={"w1":1, "w2":2}
+    td_obj_1 = td_Qobj(td_as_list_1, args=args, tlist=np.linspace(0,1,100))
+    td_obj_2 = td_Qobj(td_as_list_2, args=args, tlist=np.linspace(0,1,100))
+    td_as_list_back = (td_obj_1 + td_obj_2).to_list()
+
+    all_match = True
+    for part in td_as_list_back:
+        if isinstance(part, Qobj):
+            all_match = all_match and td_as_list_1[0] + td_as_list_2[0] == part
+        elif isinstance(part[1], (FunctionType, BuiltinFunctionType, partial)):
+            all_match = all_match and td_as_list_2[1][1] == part[1]
+            all_match = all_match and td_as_list_2[1][0] == part[0]
+        elif isinstance(part[1], str):
+            all_match = all_match and td_as_list_1[1][1] == part[1]
+            all_match = all_match and td_as_list_1[1][0] == part[0]
+        elif isinstance(part[1], np.ndarray):
+            all_match = all_match and (td_as_list_1[2][1] == part[1]).all()
+            all_match = all_match and td_as_list_1[2][0] == part[0]
+        else:
+            all_match = False
+    # Check that the list get the object back
+    assert_equal(all_match, True)
+
+
+def test_td_Qobj_math_neg():
+    "td_Qobj negation"
+    tlist = np.linspace(0,1,300)
+    td_obj = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_neg = -td_obj
+    t = np.random.random()
+    # check the negation
+    assert_equal(td_obj(t) == -1*td_obj_neg(t), True)
+
+
+def test_td_Qobj_math_add():
+    "td_Qobj addition"
+    tlist = np.linspace(0,1,300)
+    td_obj_1 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_2 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    q1 = Qobj(np.random.random((5,5)))
+    td_obj_sum = td_obj_1 + td_obj_2
+    t = np.random.random()
+    # check the addition td_Qobj + td_Qobj
+    assert_equal(td_obj_sum(t) == td_obj_1(t) + td_obj_2(t), True)
+    td_obj_sum2 = td_obj_1.copy()
+    td_obj_sum2 += td_obj_2
+    # check the inplace addition td_Qobj += td_Qobj
+    assert_equal(td_obj_sum2(t) == td_obj_1(t) + td_obj_2(t), True)
+    td_obj_sum = td_obj_1 + q1
+    t = np.random.random()
+    # check the addition td_Qobj + Qobj
+    assert_equal(td_obj_sum(t) == td_obj_1(t) + q1, True)
+    td_obj_sum = q1 + td_obj_1
+    t = np.random.random()
+    # check the addition Qobj + td_Qobj
+    assert_equal(td_obj_sum(t) == td_obj_1(t) + q1, True)
+    td_obj_sum2 = td_obj_1.copy()
+    td_obj_sum2 += q1
+    # check the inplace addition td_Qobj += Qobj
+    assert_equal(td_obj_sum2(t) == td_obj_1(t) + q1, True)
+    scalar = np.random.random()
+    td_obj_sum = scalar + td_obj_1
+    t = np.random.random()
+    # check the addition td_Qobj + scalar
+    assert_equal(td_obj_sum(t) == td_obj_1(t) + scalar, True)
+    td_obj_sum2 = td_obj_1.copy()
+    td_obj_sum2 += scalar
+    # check the inplace addition td_Qobj += scalar
+    assert_equal(td_obj_sum2(t) == td_obj_1(t) + scalar, True)
+
+
+def test_td_Qobj_math_sub():
+    "td_Qobj subtraction"
+    tlist = np.linspace(0,1,300)
+    td_obj_1 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_2 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    q1 = Qobj(np.random.random((5,5)))
+    td_obj_sum = td_obj_1 - td_obj_2
+    t = np.random.random()
+    # check the subtraction -
+    assert_equal(td_obj_sum(t) == td_obj_1(t) - td_obj_2(t), True)
+    td_obj_sum2 = td_obj_1.copy()
+    td_obj_sum2 -= td_obj_2
+    # check the inplace subtraction -=
+    assert_equal(td_obj_sum2(t) == td_obj_1(t) - td_obj_2(t), True)
+    td_obj_sum = q1 - td_obj_1
+    t = np.random.random()
+    # check the addition td_Qobj - Qobj
+    assert_equal(td_obj_sum(t) == q1 - td_obj_1(t), True)
+    td_obj_sum = td_obj_1 - q1
+    t = np.random.random()
+    # check the addition td_Qobj - Qobj
+    assert_equal(td_obj_sum(t) == td_obj_1(t) - q1, True)
+    td_obj_sum2 = td_obj_1.copy()
+    td_obj_sum2 -= q1
+    # check the inplace addition td_Qobj -= Qobj
+    assert_equal(td_obj_sum2(t) == td_obj_1(t) - q1, True)
+    scalar = np.random.random()
+    td_obj_sum = scalar - td_obj_1
+    t = np.random.random()
+    # check the addition td_Qobj - scalar
+    assert_equal(td_obj_sum(t) == -td_obj_1(t) + scalar, True)
+    td_obj_sum2 = td_obj_1.copy()
+    td_obj_sum2 -= scalar
+    # check the inplace addition td_Qobj -= scalar
+    assert_equal(td_obj_sum2(t) == td_obj_1(t) - scalar, True)
+
+
+def test_td_Qobj_math_mult():
+    "td_Qobj multiplication"
+    tlist = np.linspace(0,1,300)
+    td_obj_1 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    q1 = Qobj(np.random.random((5,5)))
+    td_obj_sum = q1 * td_obj_1
+    t = np.random.random()
+    # check the addition td_Qobj * Qobj
+    assert_equal(td_obj_sum(t) == q1 * td_obj_1(t), True)
+    td_obj_sum = td_obj_1 *q1
+    t = np.random.random()
+    # check the addition td_Qobj * Qobj
+    assert_equal(td_obj_sum(t) == td_obj_1(t) * q1, True)
+    td_obj_sum2 = td_obj_1.copy()
+    td_obj_sum2 *= q1
+    # check the inplace addition td_Qobj *= Qobj
+    assert_equal(td_obj_sum2(t) == td_obj_1(t) * q1, True)
+    scalar = np.random.random()
+    td_obj_sum = scalar * td_obj_1
+    t = np.random.random()
+    # check the addition td_Qobj * scalar
+    assert_equal(td_obj_sum(t) == td_obj_1(t) * scalar, True)
+    td_obj_sum2 = td_obj_1.copy()
+    td_obj_sum2 *= scalar
+    # check the inplace addition td_Qobj *= scalar
+    assert_equal(td_obj_sum2(t) == td_obj_1(t) * scalar, True)
+
+
+def test_td_Qobj_math_div():
+    "td_Qobj division"
+    tlist = np.linspace(0,1,300)
+    td_obj_1 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    scalar = np.random.random()
+    td_obj_sum =  td_obj_1 / scalar
+    t = np.random.random()
+    # check the addition td_Qobj / scalar
+    assert_equal(td_obj_sum(t) == td_obj_1(t) / scalar, True)
+    td_obj_sum2 = td_obj_1.copy()
+    td_obj_sum2 /= scalar
+    # check the inplace addition td_Qobj /= scalar
+    assert_equal(td_obj_sum2(t) == td_obj_1(t) / scalar, True)
+
+
+def test_td_Qobj_trans():
+    "td_Qobj transpose"
+    tlist = np.linspace(0,1,300)
+    td_obj_1 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_trans =  td_obj_1.trans()
+    t = np.random.random()
+    # check the transpose
+    assert_equal(td_obj_trans(t) == td_obj_1(t).trans(), True)
+
+
+def test_td_Qobj_dag():
+    "td_Qobj dag"
+    tlist = np.linspace(0,1,300)
+    td_obj_1 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_dag =  td_obj_1.dag()
+    t = np.random.random()
+    # check the dag
+    assert_equal(td_obj_dag(t) == td_obj_1(t).dag(), True)
+
+
+def test_td_Qobj_conj():
+    "td_Qobj conjugate"
+    tlist = np.linspace(0,1,300)
+    td_obj_1 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_conj =  td_obj_1.conj()
+    t = np.random.random()
+    # check the conjugate
+    assert_equal(td_obj_conj(t) == td_obj_1(t).conj(), True)
+
+
+def test_td_Qobj_norm():
+    "td_Qobj norm: a.dag * a"
+    tlist = np.linspace(0,1,300)
+    args={"w3":1}
+    td_obj_1 = td_Qobj(_random_td_Qobj((5,5), [0,0,1], tlist=tlist, cte=0),
+                       args=args, tlist=tlist)
+    td_obj_2 = td_Qobj(_random_td_Qobj((5,5), [0,0,2], tlist=tlist, cte=0),
+                       args=args, tlist=tlist)
+    td_obj_3 = td_Qobj(_random_td_Qobj((5,5), [0,0,3], tlist=tlist, cte=0),
+                       args=args, tlist=tlist)
+    t = np.random.random()
+    td_obj_norm =  td_obj_1.norm()
+    # check the a.dag * dag, func
+    assert_equal(td_obj_norm(t) == td_obj_1(t).dag() * td_obj_1(t), True)
+    td_obj_norm =  td_obj_2.norm()
+    # check the a.dag * dag, str
+    assert_equal(td_obj_norm(t) == td_obj_2(t).dag() * td_obj_2(t), True)
+    td_obj_norm =  td_obj_3.norm()
+    # check the a.dag * dag, array
+    assert_allclose(td_obj_norm(t,data=True).todense(),
+                    (td_obj_3(t).dag() * td_obj_3(t)).data.todense())
+
+
+def test_td_Qobj_tidyup():
+    "td_Qobj tidyup"
+    tlist = np.linspace(0,1,300)
+    args={"w1":1}
+    td_obj = td_Qobj(_random_td_Qobj((5,5), [1,0,0], tlist=tlist),
+                     args=args, tlist=tlist)
+    td_obj *= 1e-10 * np.random.random()
+    td_obj.tidyup(atol=1e-8)
+    t = np.random.random()
+    # check that the Qobj are cleaned
+    assert_equal(np.max(td_obj(t, data=True)), 0.)
+
+
+def test_td_Qobj_compress():
+    "td_Qobj compress"
+    tlist = np.linspace(0, 1, 300)
+    td_obj_1 = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_2 = (td_obj_1 + td_obj_1)/2.
+    t = np.random.random()
+    td_obj_2.compress()
+    # check that the number of part is decreased
+    assert_equal(len(td_obj_2.to_list()), 4)
+    # check that data is still valid
+    assert_equal(td_obj_2(t) == td_obj_1(t), True)
+
+
+def test_td_Qobj_apply():
+    "td_Qobj apply"
+    def multiply(qobj,b,factor = 3.):
+        return qobj*b*factor
+    tlist = np.linspace(0, 1, 300)
+    td_obj = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                     args={"w1":1, "w2":2}, tlist=tlist)
+    t = np.random.random()
+    # check that the number of part is decreased
+    assert_equal(td_obj.apply(multiply,2)(t) == td_obj(t)*6, True)
+    # check that data is still valid
+    assert_equal(td_obj.apply(multiply,2,factor=2)(t) == td_obj(t)*4, True)
+
+
+def test_td_Qobj_apply_decorator():
+    "td_Qobj apply_decorator"
+    def rescale_time_and_scale(f_original, time_scale, factor=1.):
+        def f(t, *args, **kwargs):
+            return f_original(time_scale*t, *args, **kwargs)*factor
+        return f
+
+    tlist = np.linspace(0, 1, 300)
+    td_obj = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist, cte=False),
+                     args={"w1":1, "w2":2}, tlist=tlist)
+    t = np.random.random() / 2.
+    td_obj_scaled = td_obj.apply_decorator(rescale_time_and_scale,2)
+    # check that the decorated took effect mixed
+    assert_equal(td_obj_scaled(t) == td_obj(2*t), True)
+    def square_f(f_original):
+        def f(t, *args, **kwargs):
+            return f_original(t, *args, **kwargs)**2
+        return f
+
+    td_list = _random_td_Qobj((5,5), [2,0,0], tlist=tlist, cte=False)
+    td_obj_str = td_Qobj(td_list, args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_str_2 = td_obj_str.apply_decorator(square_f, str_mod=["(",")**2"])
+    #Check that it can only be compiled to cython
+    assert_equal(td_obj_str_2.fast, True)
+    assert_equal(td_obj_str_2(t) == td_list[0][0] * np.sin(t)**2, True)
+
+    td_list = _random_td_Qobj((5,5), [3,0,0], tlist=tlist, cte=False)
+    td_obj_array = td_Qobj(td_list, tlist=tlist)
+    td_obj_array_2 = td_obj_array.apply_decorator(square_f, inplace_np=True)
+    #Check that it can only be compiled to cython
+    assert_equal(td_obj_array_2.fast, True)
+    assert_allclose(np.array(td_obj_array_2(t, data=True).todense()),
+                    np.array((td_list[0][0] * np.sin(t)**2).data.todense()),
+                    rtol=3e-7)
+
+
+def test_td_Qobj_compile():
+    "td_Qobj compile"
+    tlist = np.linspace(0, 1, 300)
+    tlistlog = np.logspace(-3, 0, 600)
+    args={"w1":1, "w2":2}
+    td_obj_c = td_Qobj(_random_td_Qobj((5,5), [0,0,0]))
+    td_obj_f = td_Qobj(_random_td_Qobj((5,5), [1,0,0], tlist=tlist),
+                       args=args, tlist=tlist)
+    td_obj_s = td_Qobj(_random_td_Qobj((5,5), [2,0,0], tlist=tlist),
+                       args=args, tlist=tlist)
+    td_obj_a = td_Qobj(_random_td_Qobj((5,5), [3,0,0], tlist=tlist),
+                       args=args, tlist=tlist)
+    td_obj_ca = td_Qobj(_random_td_Qobj((5,5), [0,0,3], tlist=tlistlog),
+                        args=args, tlist=tlistlog)
+    td_obj_sa = td_Qobj(_random_td_Qobj((5,5), [2,3,0], tlist=tlist),
+                       args=args, tlist=tlist)
+    td_obj_m = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args=args, tlist=tlist)
+    t = np.random.random() *.99 + 0.01
+    td_obj_cc = td_obj_c.copy()
+    td_obj_cc.compile()
+    # check if compiled for const format
+    assert_equal(td_obj_cc.compiled != 0, True)
+    # check compiled for const format call
+    assert_equal(td_obj_cc(t) == td_obj_c(t), True)
+    td_obj_fc = td_obj_f.copy()
+    td_obj_fc.compile()
+    # check if compiled for func format
+    assert_equal(td_obj_fc.compiled != 0, True)
+    # check compiled for func format call
+    assert_equal(td_obj_fc(t) == td_obj_f(t), True)
+    td_obj_sc = td_obj_s.copy()
+    td_obj_sc.compile()
+    # check if compiled for str format
+    assert_equal(td_obj_sc.compiled != 0, True)
+    # check compiled for str format call
+    assert_equal(td_obj_sc(t) == td_obj_s(t), True)
+    td_obj_ac = td_obj_a.copy()
+    td_obj_ac.compile()
+    # check if compiled for array format
+    assert_equal(td_obj_ac.compiled != 0, True)
+    # check compiled for array format call
+    assert_allclose(np.array(td_obj_ac(t,data=True).todense()), np.array(td_obj_a(t,data=True).todense()), rtol=3e-07, atol=0)
+    td_obj_cac = td_obj_ca.copy()
+    td_obj_cac.compile()
+    # check if compiled for array format
+    assert_equal(td_obj_cac.compiled != 0, True)
+    # check compiled for array format call
+    assert_allclose(np.array(td_obj_cac(t,data=True).todense()), np.array(td_obj_ca(t,data=True).todense()), rtol=3e-07, atol=0)
+    td_obj_sac = td_obj_sa.copy()
+    td_obj_sac.compile()
+    # check if compiled for mixed array str format
+    assert_equal(td_obj_sac.compiled != 0, True)
+    # check compiled for mixed array str format call
+    assert_allclose(np.array(td_obj_sac(t,data=True).todense()), np.array(td_obj_sa(t,data=True).todense()), rtol=3e-07, atol=0)
+    td_obj_mc = td_obj_m.copy()
+    td_obj_mc.compile()
+    # check if compiled for mixed format
+    assert_equal(td_obj_mc.compiled != 0, True)
+    # check compiled for mixed format call
+    assert_equal(td_obj_mc(t) == td_obj_m(t), True)
+    assert_allclose(np.array(td_obj_ac(t,data=True).todense()), np.array(td_obj_a(t,data=True).todense()), rtol=3e-07, atol=0)
+
+
+def test_td_Qobj_rhs():
+    "td_Qobj rhs"
+    tlist = np.linspace(0,1,300)
+    args={"w1":1, "w2":2}
+    td_obj_c = td_Qobj(_random_td_Qobj((5,5), [0,0,0]))
+    td_obj_f = td_Qobj(_random_td_Qobj((5,5), [1,0,0], tlist=tlist),
+                       args=args, tlist=tlist)
+    td_obj_sa = td_Qobj(_random_td_Qobj((5,5), [2,3,0], tlist=tlist),
+                       args=args, tlist=tlist)
+    td_obj_m = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args=args, tlist=tlist)
+    t = np.random.random()
+    vec = np.arange(5)*.5+.5j
+
+    td_obj_cc = td_obj_c.copy()
+    td_obj_cc.compile()
+    v1 = td_obj_c.rhs(t,vec)
+    v2 = td_obj_cc.rhs(t,vec)
+    v3 = spmv(td_obj_c(t, data=True), vec)
+    # check not compiled rhs const
+    assert_allclose(v1, v3)
+    # check compiled rhs
+    assert_allclose(v3, v2)
+
+    td_obj_fc = td_obj_f.copy()
+    td_obj_fc.compile()
+    v1 = td_obj_f.rhs(t,vec)
+    v2 = td_obj_fc.rhs(t,vec)
+    v3 = spmv(td_obj_f(t, data=True), vec)
+    # check not compiled rhs func
+    assert_allclose(v1, v3)
+    # check compiled rhs func
+    assert_allclose(v3, v2)
+
+    td_obj_sac = td_obj_sa.copy()
+    td_obj_sac.compile()
+    v1 = td_obj_sa.rhs(t,vec)
+    v2 = td_obj_sac.rhs(t,vec)
+    v3 = spmv(td_obj_sa(t, data=True), vec)
+    # check not compiled rhs array str
+    assert_allclose(v1, v3)
+    # check compiled rhs array str
+    assert_allclose(v3, v2)
+
+    td_obj_mc = td_obj_m.copy()
+    td_obj_mc.compile()
+    v1 = td_obj_m.rhs(t,vec)
+    v2 = td_obj_mc.rhs(t,vec)
+    v3 = spmv(td_obj_m(t, data=True), vec)
+    # check not compiled rhs mixed
+    assert_allclose(v1, v3)
+    # check compiled rhs mixed
+    assert_allclose(v3, v2)
+
+
+def test_td_Qobj_expect_psi():
+    "td_Qobj expect psi"
+    tlist = np.linspace(0,1,300)
+    args={"w1":1, "w2":2, "w3":3}
+    td_obj_c = td_Qobj(_random_td_Qobj((5,5), [0,0,0]))
+    td_obj_f = td_Qobj(_random_td_Qobj((5,5), [0,0,1], tlist=tlist),
+                       args=args, tlist=tlist)
+    td_obj_sa = td_Qobj(_random_td_Qobj((5,5), [0,3,2], tlist=tlist),
+                       args=args, tlist=tlist)
+    td_obj_m = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args=args, tlist=tlist)
+    t = np.random.random()
+    vec = np.arange(5)*.5+.5j
+
+    td_obj_cc = td_obj_c.copy()
+    td_obj_cc.compile()
+    v1 = td_obj_c.expect(t, vec, 0)
+    v2 = td_obj_cc.expect(t, vec, 0)
+    v3 = cy_expect_psi(td_obj_c(t, data=True), vec, 0)
+    # check not compiled rhs const
+    assert_allclose(v1, v3)
+    # check compiled rhs
+    assert_allclose(v3, v2)
+
+    td_obj_fc = td_obj_f.copy()
+    td_obj_fc.compile()
+    v1 = td_obj_f.expect(t, vec, 1)
+    v2 = td_obj_fc.expect(t, vec, 1)
+    v3 = cy_expect_psi(td_obj_f(t, data=True), vec, 1)
+    # check not compiled rhs func
+    assert_allclose(v1, v3)
+    # check compiled rhs func
+    assert_allclose(v3, v2)
+
+    td_obj_sac = td_obj_sa.copy()
+    td_obj_sac.compile()
+    v1 = td_obj_sa.expect(t, vec, 0)
+    v2 = td_obj_sac.expect(t, vec, 0)
+    v3 = cy_expect_psi(td_obj_sa(t, data=True), vec, 0)
+    # check not compiled rhs array str
+    assert_allclose(v1, v3)
+    # check compiled rhs array str
+    assert_allclose(v3, v2)
+
+    td_obj_mc = td_obj_m.copy()
+    td_obj_mc.compile()
+    v1 = td_obj_m.expect(t, vec, 1)
+    v2 = td_obj_mc.expect(t ,vec, 1)
+    v3 = cy_expect_psi(td_obj_m(t, data=True), vec, 1)
+    # check not compiled rhs mixed
+    assert_allclose(v1, v3)
+    # check compiled rhs mixed
+    assert_allclose(v3, v2)
+
+
+def test_td_Qobj_expect():
+    "td_Qobj expect rho"
+    tlist = np.linspace(0,1,300)
+    args={"w1":1, "w2":2, "w3":3}
+    data1 = np.random.random((3,3))
+    data2 = np.random.random((3,3))
+    td_obj_sa = td_Qobj(_random_td_Qobj((3,3), [0,3,2], tlist=tlist),
+                       args=args, tlist=tlist)
+    td_obj_m = td_Qobj(_random_td_Qobj((3,3), [1,2,3], tlist=tlist),
+                       args=args, tlist=tlist)
+    t = np.random.random()
+    td_obj_sa = td_obj_sa.apply(spre)
+    td_obj_m = td_obj_m.apply(spre)
+    rho = np.arange(3*3)*0.25+.25j
+    td_obj_sac = td_obj_sa.copy()
+    td_obj_sac.compile()
+    v1 = td_obj_sa.expect(t, rho, 0)
+    v2 = td_obj_sac.expect(t, rho, 0)
+    v3 = cy_expect_rho_vec(td_obj_sa(t, data=True), rho, 0)
+    # check not compiled rhs const
+    assert_allclose(v1, v3)
+    # check compiled rhs
+    assert_allclose(v3, v2)
+
+    td_obj_mc = td_obj_m.copy()
+    td_obj_mc.compile()
+    v1 = td_obj_m.expect(t, rho, 1)
+    v2 = td_obj_mc.expect(t, rho, 1)
+    v3 = cy_expect_rho_vec(td_obj_m(t, data=True), rho, 1)
+    # check not compiled rhs func
+    assert_allclose(v1, v3)
+    # check compiled rhs func
+    assert_allclose(v3, v2)
+
+
+def test_td_Qobj_func_args():
+    "td_Qobj args: func arguments changes"
+    N = 5
+    data1 = np.random.random((N, N))
+    data2 = np.random.random((N, N))
+    data3 = np.random.random((N, N))
+    q1 = Qobj(data1)
+    q2 = Qobj(data2)
+    q3 = Qobj(data3)
+    args={"w1":1, "w2":2}
+    td_data = td_Qobj([q1,[q2,_f1],[q3,_f2]], args=args)
+
+    t = np.random.random()
+    q_at_t = q1 + np.sin(t*args['w1']) * q2 + np.cos(t*10) * q3
+    # Check that the call with custom args
+    assert_equal(td_data.with_args(t,{"w2":10}) == q_at_t, True)
+    t = np.random.random()
+    q_at_t = q1 + np.sin(t*args['w1']) * q2 + np.cos(t*args['w2']) * q3
+    # Check that the with_args call did not change the original args
+    assert_equal(td_data(t) == q_at_t, True)
+
+    new_args={"w1":10}
+    td_data.arguments(new_args)
+    t = np.random.random()
+    q_at_t = q1 + np.sin(t*10) * q2 + np.cos(t*args['w2']) * q3
+    # Check the arguments change
+    assert_equal(td_data(t) == q_at_t, True)
+
+    td_data.compile()
+    new_args={"w1":5}
+    td_data.arguments(new_args)
+    t = np.random.random()
+    q_at_t = q1 + np.sin(t*5) * q2 + np.cos(t*args['w2']) * q3
+    # Check the arguments change after compile
+    assert_equal(td_data(t) == q_at_t, True)
+
+
+def test_td_Qobj_str_args():
+    "td_Qobj args: str arguments changes"
+    N = 5
+    data1 = np.random.random((N, N))
+    data2 = np.random.random((N, N))
+    data3 = np.random.random((N, N))
+    q1 = Qobj(data1)
+    q2 = Qobj(data2)
+    q3 = Qobj(data3)
+    args={"w1":1, "w2":2}
+    td_data = td_Qobj([q1,[q2,"sin(w1*t)"],[q3,"cos(w2*t)"]], args=args)
+
+    t = np.random.random()
+    q_at_t = q1 + np.sin(t*args['w1']) * q2 + np.cos(t*10) * q3
+    # Check that the call with custom args
+    assert_equal(td_data.with_args(t,{"w2":10}) == q_at_t, True)
+    t = np.random.random()
+    q_at_t = q1 + np.sin(t*args['w1']) * q2 + np.cos(t*args['w2']) * q3
+    # Check that the with_args call did not change the original args
+    assert_equal(td_data(t) == q_at_t, True)
+
+    new_args={"w1":10}
+    td_data.arguments(new_args)
+    t = np.random.random()
+    q_at_t = q1 + np.sin(t*10) * q2 + np.cos(t*args['w2']) * q3
+    # Check the arguments change
+    assert_equal(td_data(t) == q_at_t, True)
+
+    td_data.compile()
+    new_args={"w1":5}
+    td_data.arguments(new_args)
+    t = np.random.random()
+    q_at_t = q1 + np.sin(t*5) * q2 + np.cos(t*args['w2']) * q3
+    # Check the arguments change after compile
+    assert_equal(td_data(t) == q_at_t, True)
+
+
+def test_td_Qobj_mixed_args():
+    "td_Qobj args: mixed arguments changes"
+    N = 5
+    tlist = np.linspace(0,1,300)
+    data1 = np.random.random((N, N))
+    data2 = np.random.random((N, N))
+    data3 = np.random.random((N, N))
+    data4 = np.random.random((N, N))
+    q1 = Qobj(data1)
+    q2 = Qobj(data2)
+    q3 = Qobj(data3)
+    q4 = Qobj(data4)
+    args={"w1":1, "w2":2}
+    td_data = td_Qobj([q1, [q2,_f1], [q3,"cos(w2*t)"],
+                      [q4,np.exp(3*tlist)]], tlist=tlist, args=args)
+
+    t = np.random.random()
+    data_at_t = data1 + np.sin(t*args['w1']) * data2 +\
+             np.cos(t*10) * data3 + np.exp(3*t) * data4
+    # Check that the call with custom args
+    assert_allclose(np.array(td_data.with_args(t,{"w2":10},data=True).todense()), data_at_t)
+
+    t = np.random.random()
+    data_at_t = data1 + np.sin(t*10) * data2 +\
+             np.cos(t*args['w2']) * data3 + np.exp(3*t) * data4
+    # Check that the call with custom args
+    assert_allclose(np.array(td_data.with_args(t,{"w1":10},data=True).todense()), data_at_t)
+
+    t = np.random.random()
+    data_at_t = data1 + np.sin(t*args['w1']) * data2 +\
+             np.cos(t*args['w2']) * data3 + np.exp(3*t) * data4
+    # Check that the with_args call did not change the original args
+    assert_allclose(np.array(td_data(t,data=True).todense()), data_at_t)
+
+    new_args={"w1":10, "w2":7}
+    td_data.arguments(new_args)
+    t = np.random.random()
+    data_at_t = data1 + np.sin(t*10) * data2 + np.cos(t*7) * data3 + np.exp(3*t) * data4
+    # Check the arguments change
+    assert_allclose(np.array(td_data(t,data=True).todense()), data_at_t)
+
+    td_data.compile()
+    new_args={"w1":3, "w2":5}
+    td_data.arguments(new_args)
+    t = np.random.random()
+    data_at_t = data1 + np.sin(t*3) * data2 + np.cos(t*5) * data3 + np.exp(3*t) * data4
+    # Check the arguments change after compile
+    assert_allclose(np.array(td_data(t,data=True).todense()), data_at_t)
+
+
+def test_td_Qobj_with_state():
+    "td_Qobj args: with_state"
+    def coeff_state(t,psi,args):
+        return np.mean(psi) * args["w1"]
+    N = 5
+    tlist = np.linspace(0,1,300)
+    data1 = np.random.random((N, N))
+    data2 = np.random.random((N, N))
+    data3 = np.random.random((N, N))
+    data4 = np.random.random((N, N))
+    q1 = Qobj(data1)
+    q2 = Qobj(data2)
+    q3 = Qobj(data3)
+    q4 = Qobj(data4)
+    args={"w1":1}
+    new_args={"w1":10}
+    td_data = td_Qobj([q1,[q2,coeff_state]], args=args)
+    vec = np.arange(N)*.5+.5j
+
+    t = np.random.random()
+    q_at_t = q1 + np.mean(vec) * args["w1"] * q2
+    q_at_t_new = q1 + np.mean(vec) * new_args["w1"] * q2
+
+    # Check that the with_state call
+    assert_equal(td_data.with_state(t,vec) == q_at_t, True)
+    assert_allclose(np.array(td_data.with_state(t, vec).data.todense()), np.array(q_at_t.data.todense()))
+    # Check that the with_state call with custom args
+    assert_equal(td_data.with_state(t, vec, new_args) == q_at_t_new, True)
+    assert_allclose(np.array(td_data.with_state(t, vec, new_args).data.todense()), np.array(q_at_t_new.data.todense()))
+
+    td_data.compile()
+    # Check that the with_state call compiled
+    assert_equal(td_data.with_state(t,vec) == q_at_t, True)
+    assert_allclose(np.array(td_data.with_state(t, vec).data.todense()), np.array(q_at_t.data.todense()))
+    # Check that the with_state call with custom args compiled
+    assert_equal(td_data.with_state(t, vec, new_args) == q_at_t_new, True)
+    assert_allclose(np.array(td_data.with_state(t, vec, new_args).data.todense()), np.array(q_at_t_new.data.todense()))
+
+    args={"w1":1, "w2":2}
+    new_args={"w2":10}
+    t = np.random.random()
+    td_data = td_Qobj([q1, [q2,coeff_state], [q3,"cos(w2*t)"],
+                      [q4,np.exp(3*tlist)]], tlist=tlist, args=args)
+    data_at_t = data1 + np.mean(vec) * args["w1"] * data2 +\
+             np.cos(t*args["w2"]) * data3 + np.exp(3*t) * data4
+    data_at_t_args = data1 + np.mean(vec) * args["w1"] * data2 +\
+             np.cos(t*new_args["w2"]) * data3 + np.exp(3*t) * data4
+
+    # Check that the with_state call for mixed format
+    assert_allclose(np.array(td_data.with_state(t, vec, data=True).todense()), data_at_t)
+    assert_allclose(np.array(td_data.with_state(t, vec).data.todense()), data_at_t)
+    assert_allclose(np.array(td_data.with_state(t, vec, new_args,data=True).todense()), data_at_t_args)
+    assert_allclose(np.array(td_data.with_state(t, vec, new_args).data.todense()), data_at_t_args)
+
+    td_data.compile()
+    # Check that the with_state call for mixed format and compiled
+    assert_allclose(np.array(td_data.with_state(t, vec, data=True).todense()), data_at_t)
+    assert_allclose(np.array(td_data.with_state(t, vec).data.todense()), data_at_t)
+    assert_allclose(np.array(td_data.with_state(t, vec, new_args,data=True).todense()), data_at_t_args)
+    assert_allclose(np.array(td_data.with_state(t, vec, new_args).data.todense()), data_at_t_args)
+
+
+def test_td_Qobj_pickle_cy_td_Qobj():
+    "td_Qobj pickle"
+    #used in parallel_map
+    import pickle
+    tlist = np.linspace(0,1,300)
+    args={"w1":1, "w2":2}
+    t = np.random.random()
+
+    td_obj_c = td_Qobj(_random_td_Qobj((5,5), [0,0,0]))
+    td_obj_c.compile()
+    pickled = pickle.dumps(td_obj_c)
+    td_pick = pickle.loads(pickled)
+    # Check for const case
+    assert_equal(td_obj_c(t) == td_pick(t), True)
+
+    td_obj_sa = td_Qobj(_random_td_Qobj((5,5), [2,3,0], tlist=tlist),
+                       args=args, tlist=tlist)
+    td_obj_sa.compile()
+    td_obj_m = td_Qobj(_random_td_Qobj((5,5), [1,2,3], tlist=tlist),
+                       args=args, tlist=tlist)
+
+    pickled = pickle.dumps(td_obj_sa, -1)
+    td_pick = pickle.loads(pickled)
+    # Check for cython compiled coeff
+    assert_equal(td_obj_sa(t) == td_pick(t), True)
+
+    pickled = pickle.dumps(td_obj_m, -1)
+    td_pick = pickle.loads(pickled)
+    # Check for not compiled mix
+    assert_equal(td_obj_m(t) == td_pick(t), True)
+    td_obj_m.compile()
+    pickled = pickle.dumps(td_obj_m, -1)
+    td_pick = pickle.loads(pickled)
+    # Check for ct_td_qobj
+    assert_equal(td_obj_m(t) == td_pick(t), True)

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ write_version_py()
 # Add Cython extensions here
 cy_exts = ['spmatfuncs', 'stochastic', 'sparse_utils', 'graph_utils', 'interpolate',
         'spmath', 'heom', 'math', 'spconvert', 'ptrace', 'testing', 'brtools',
-        'brtools_testing', 'br_tensor']
+        'brtools_testing', 'br_tensor', 'inter', 'td_qobj_cy']
 
 # If on Win and Python version >= 3.5 and not in MSYS2 (i.e. Visual studio compile)
 if (sys.platform == 'win32' and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35
@@ -205,7 +205,7 @@ if "--with-openmp" in sys.argv:
             extra_link_args=[],
             language='c++')
     EXT_MODULES.append(_mod)
-    
+
     # Add brtools_omp
     _mod = Extension('qutip.cy.openmp.br_omp',
             sources = ['qutip/cy/openmp/br_omp.pyx'],
@@ -214,7 +214,7 @@ if "--with-openmp" in sys.argv:
             extra_link_args=[],
             language='c++')
     EXT_MODULES.append(_mod)
-    
+
     # Add omp_sparse_utils
     _mod = Extension('qutip.cy.openmp.omp_sparse_utils',
             sources = ['qutip/cy/openmp/omp_sparse_utils.pyx'],


### PR DESCRIPTION
The stochastic solver have been redone.
smesolve and ssesovle can be used for time dependent systems (H, c_ops and sc_ops).
The available solvers are :  'euler-maruyama', 'pc-euler, 'milstein', 'platen', 'milstein-imp', 'taylor15', 'taylor15-imp', 'explicit15'. All solvers are usable by both ssesolve and smesolve, for time-dependent cases and for both heterodyne and homodyne methods. There is no restriction on the number of sc_ops. The solvers are in cython, making them 2~3 time faster than the previous version, with the exception of the implicit solvers, where the timing is about the same.

The photocurrent method as been moved to it's own functions: photocurrentmesolve and photocurrentsesolve. It can take time-dependent Hamiltonian.

The stochastic (piecewse deterministic process) PDP solvers (ssepdpsolve and smepdpsolve) are untouched.

The previous version of smesolve/ssesolve allowed the user to determine it's own d1 and d2 function. This capacity have been moved to the function general_stochastic. However the function only has access to some solver:  'euler-maruyama', 'platen', 'explicit15'. 

I created a function which list the solvers with the references: stochastic_solver_info()

The convergence of the solvers was tested with a tests similar to https://github.com/qutip/qutip-notebooks/blob/master/development/development-smesolver-new-methods.ipynb . 