### PR TITLE
sesolve unitary operator evolution

### DIFF
--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -671,18 +671,6 @@ def _ode_psi_func_td_with_state(t, psi, H_func, args):
     H = H_func(t, psi, args)
     return -1j * (H * psi)
 
-def _trace_norm(A):
-    """Trace norm of dense matrix"""
-    return np.abs(np.trace(A.dot(A.conj().T)))
-
-def _get_norm_factor(A, norm_dim_factor):
-    if oper:
-        # return np.sqrt(float(A.shape[0]) / _trace_norm(A))
-        #return float(A.shape[0]) / Qobj(A).norm()
-        return np.sqrt(A.shape[0]) / la_norm(A)
-    else:
-        return norm_dim_factor / la_norm(A)
-
 # -----------------------------------------------------------------------------
 # Solve an ODE which solver parameters already setup (r). Calculate the
 # required expectation values or invoke callback function at each time step.

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -335,7 +335,7 @@ def psi_list_td_with_state(t, psi, H_list_and_args):
 # a constant Hamiltonian.
 #
 def _sesolve_const(H, psi0, tlist, e_ops, args, opt, progress_bar):
-    """!
+    """
     Evolve the wave function using an ODE solver
     """
     if debug:
@@ -522,19 +522,26 @@ def _sesolve_list_str_td(H_list, psi0, tlist, e_ops, args, opt,
 
 # -----------------------------------------------------------------------------
 # Wave function evolution using a ODE solver (unitary quantum evolution), for
-# time dependent hamiltonians
-#
+# time dependent Hamiltonians
 def _sesolve_list_td(H_func, psi0, tlist, e_ops, args, opt, progress_bar):
     """
     Evolve the wave function using an ODE solver with time-dependent
     Hamiltonian.
+    Note: Deprecated method
     """
 
     if debug:
         print(inspect.stack()[0][3])
 
-    if not isket(psi0):
-        raise TypeError("psi0 must be a ket")
+    if psi0.isket:
+        pass
+    elif psi0.isunitary:
+        raise TypeError("The unitary operator evolution is not supported"
+                        " in the list td method.")
+    else:
+        raise TypeError("The unitary solver requires psi0 to be"
+                        " a ket as initial state"
+                        " or a unitary as initial operator.")
 
     #
     # configure time-dependent terms and setup ODE solver
@@ -611,7 +618,7 @@ def _sesolve_list_td(H_func, psi0, tlist, e_ops, args, opt, progress_bar):
 
 # -----------------------------------------------------------------------------
 # Wave function evolution using a ODE solver (unitary quantum evolution), for
-# time dependent hamiltonians
+# time dependent hamiltonians.
 #
 def _sesolve_func_td(H_func, psi0, tlist, e_ops, args, opt, progress_bar):
     """!
@@ -667,7 +674,7 @@ def _sesolve_func_td(H_func, psi0, tlist, e_ops, args, opt, progress_bar):
 
     if oper_evo:
         initial_vector = operator_to_vector(psi0).full().ravel()
-        # Check function returns superoperator
+        # Check that function returns superoperator
         if H_func(0, args).issuper:
             L_func = H_func
         else:

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -70,17 +70,20 @@ def sesolve(H, psi0, tlist, e_ops=[], args={}, options=None,
             progress_bar=None,
             _safe_mode=True):
     """
-    Schrodinger equation evolution of a state vector for a given Hamiltonian.
+    Schrodinger equation evolution of a state vector or unitary matrix
+    for a given Hamiltonian.
 
     Evolve the state vector (`psi0`) using a given
     Hamiltonian (`H`), by integrating the set of ordinary differential
-    equations that define the system.
+    equations that define the system. Alternatively evolve a unitary matrix in
+    solving the Schrodinger operator equation.
 
-    The output is either the state vector at arbitrary points in time
-    (`tlist`), or the expectation values of the supplied operators
+    The output is either the state vector or unitary matrix at arbitrary points
+    in time (`tlist`), or the expectation values of the supplied operators
     (`e_ops`). If e_ops is a callback function, it is invoked for each
     time in `tlist` with time and the state as arguments, and the function
-    does not use any return values.
+    does not use any return values. e_ops cannot be used in conjunction
+    with solving the Schrodinger operator equation
 
     Parameters
     ----------
@@ -90,7 +93,8 @@ def sesolve(H, psi0, tlist, e_ops=[], args={}, options=None,
         Hamiltonians.
 
     psi0 : :class:`qutip.qobj`
-        initial state vector (ket).
+        initial state vector (ket)
+        or initial unitary operator `psi0 = U`
 
     tlist : *list* / *array*
         list of times for :math:`t`.
@@ -98,10 +102,10 @@ def sesolve(H, psi0, tlist, e_ops=[], args={}, options=None,
     e_ops : list of :class:`qutip.qobj` / callback function single
         single operator or list of operators for which to evaluate
         expectation values.
+        Must be empty list operator evolution
 
     args : *dictionary*
-        dictionary of parameters for time-dependent Hamiltonians and
-        collapse operators.
+        dictionary of parameters for time-dependent Hamiltonians
 
     options : :class:`qutip.Qdeoptions`
         with options for the ODE solver.
@@ -124,8 +128,7 @@ def sesolve(H, psi0, tlist, e_ops=[], args={}, options=None,
 
     """
     # check initial state: must be a state vector
-    if not isket(psi0):
-        raise TypeError("The unitary solver requires a ket as initial state")
+
 
     if isinstance(e_ops, Qobj):
         e_ops = [e_ops]
@@ -137,6 +140,8 @@ def sesolve(H, psi0, tlist, e_ops=[], args={}, options=None,
         e_ops_dict = None
 
     if _safe_mode:
+        if not isket(psi0):
+            raise TypeError("The unitary solver requires a ket as initial state")
         _solver_safety_check(H, psi0, c_ops=[], e_ops=e_ops, args=args)
 
     if progress_bar is None:

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -302,8 +302,7 @@ def psi_list_td_with_state(t, psi, H_list_and_args):
     H = H_list[0][0]
     H_td = H_list[0][1]
     out = np.zeros(psi.shape[0],dtype=complex)
-    spmvpy_csr(H.data, H.indices, H.indptr,
-                psi, H_td(t, args), out)
+    spmvpy_csr(H.data, H.indices, H.indptr, psi, H_td(t, args), out)
     for n in range(1, len(H_list)):
         #
         # args[n][0] = the sparse data for a Qobj in operator form
@@ -385,10 +384,10 @@ def _sesolve_list_str_td(H_list, psi0, tlist, e_ops, args, opt,
 
     if psi0.isket:
         initial_vector = psi0.full().ravel()
-        oper_evo = True
+        oper_evo = False
     elif psi0.isunitary:
         initial_vector = operator_to_vector(psi0).full().ravel()
-        opt.normalize_output = False
+        oper_evo = True
     else:
         raise TypeError("The unitary solver requires psi0 to be"
                         " a ket as initial state"
@@ -509,7 +508,7 @@ def _sesolve_list_str_td(H_list, psi0, tlist, e_ops, args, opt,
 # time dependent hamiltonians
 #
 def _sesolve_list_td(H_func, psi0, tlist, e_ops, args, opt, progress_bar):
-    """!
+    """
     Evolve the wave function using an ODE solver with time-dependent
     Hamiltonian.
     """

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -335,10 +335,10 @@ def _sesolve_const(H, psi0, tlist, e_ops, args, opt, progress_bar):
         #initial_vector = psi0.full().ravel()
         initial_vector = mat2vec(psi0.full()).ravel('F')
         L = -1.0j * H
-        oper_evo = False
     elif psi0.isunitary:
         initial_vector = operator_to_vector(psi0).full().ravel()
         L = -1.0j * spre(H)
+        opt.normalize_output = False
     else:
         raise TypeError("The unitary solver requires psi0 to be"
                         " a ket as initial state"
@@ -357,6 +357,7 @@ def _sesolve_const(H, psi0, tlist, e_ops, args, opt, progress_bar):
                      max_step=opt.max_step)
 
     r.set_initial_value(initial_vector, tlist[0])
+    print("y init: ", r.y)
 
     #
     # call generic ODE code
@@ -680,7 +681,6 @@ def _generic_ode_solve(r, psi0, tlist, e_ops, opt, progress_bar, dims=None):
     else:
         state_norm_func = None
 
-
     #
     # prepare output array
     #
@@ -740,6 +740,7 @@ def _generic_ode_solve(r, psi0, tlist, e_ops, opt, progress_bar, dims=None):
 
         if opt.store_states:
             if output_opers:
+                print("y: ", r.y)
                 output.states.append(Qobj(r.y.reshape([oper_n, oper_n]).T,
                                           dims=dims))
 #                vec = Qobj(r.y)

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -645,7 +645,77 @@ class TestMESolveSuperInit:
 
         fid = self.fidelitycheck(out1, out2, rho0vec)
         assert_(max(abs(1.0-fid)) < me_error, True)
-
+    
+    def test_me_interp1(self):
+        "mesolve: interp time-dependent collapse operator #1"
+        
+        N = 10  # number of basis states to consider
+        kappa = 0.2  # coupling to oscillator
+        tlist = np.linspace(0, 10, 100)
+        a = destroy(N)
+        H = a.dag() * a
+        psi0 = basis(N, 9)  # initial state
+        S = Cubic_Spline(tlist[0],tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
+        c_op_list = [[a, S]]
+        medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+        expt = medata.expect[0]
+        actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
+        avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
+        assert_(avg_diff < 1e-5)
+        
+    def test_me_interp2(self):
+         "mesolve: interp time-dependent collapse operator #2"
+         
+         N = 10  # number of basis states to consider
+         kappa = 0.2  # coupling to oscillator
+         tlist = np.linspace(0, 10, 100)
+         C = Cubic_Spline(tlist[0], tlist[-1], np.ones_like(tlist))
+         S = Cubic_Spline(tlist[0],tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
+         a = destroy(N)
+         H = [[a.dag() * a, C]]
+         psi0 = basis(N, 9)  # initial state
+         c_op_list = [[a, S]]
+         medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+         expt = medata.expect[0]
+         actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
+         avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
+         assert_(avg_diff < 1e-5)
+         
+    def test_me_interp3(self):
+        "mesolve: interp time-dependent collapse operator #3"
+        
+        N = 10  # number of basis states to consider
+        kappa = 0.2  # coupling to oscillator
+        tlist = np.linspace(0, 10, 100)
+        C = Cubic_Spline(tlist[0], tlist[-1], np.ones_like(tlist))
+        S = Cubic_Spline(tlist[0],tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
+        a = destroy(N)
+        H = [a.dag() * a, [a.dag() * a, C]]
+        psi0 = basis(N, 9)  # initial state
+        c_op_list = [[a, S]]
+        medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+        expt = medata.expect[0]
+        actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
+        avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
+        assert_(avg_diff < 1e-5)
+        
+    def test_me_interp4(self):
+        "mesolve: interp time-dependent collapse operator #4"
+        
+        N = 10  # number of basis states to consider
+        kappa = 0.2  # coupling to oscillator
+        tlist = np.linspace(0, 10, 100)
+        C = Cubic_Spline(tlist[0], tlist[-1], np.ones_like(tlist))
+        S = Cubic_Spline(tlist[0],tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
+        a = destroy(N)
+        H = [a.dag() * a, [a.dag() * a, C]]
+        psi0 = basis(N, 9)  # initial state
+        c_op_list = [[a, S],[a, S]]
+        medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+        expt = medata.expect[0]
+        actual_answer = 9.0 * np.exp(-2*kappa * (1.0 - np.exp(-tlist)))
+        avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
+        assert_(avg_diff < 1e-5)
 
 class TestMESolverMisc:
     """

--- a/qutip/tests/test_sesolve.py
+++ b/qutip/tests/test_sesolve.py
@@ -39,6 +39,8 @@ import os
 
 from qutip import sigmax, sigmay, sigmaz, sigmam, qeye
 from qutip import qobj, basis, expect
+from qutip.superoperator import spre
+from qutip.interpolate import Cubic_Spline
 from qutip import sesolve
 from qutip.solver import Options
 
@@ -50,166 +52,285 @@ class TestSESolve:
     A test class for the QuTiP Schrodinger Eq. solver
     """
 
-    def qubit_integrate(self, tlist, psi0, epsilon, delta, e_ops=[]):
+    def check_evolution(self, H, delta, psi0, tlist, analytic_func,
+                        U0=None, td_args={}, tol=5e-3):
+        """
+        Compare integrated evolution with analytical result
+        If U0 is not None then operator evo is checked
+        Otherwise state evo
+        """
 
-        H = epsilon / 2.0 * sigmaz() + delta / 2.0 * sigmax()
+        if U0 is None:
+            output = sesolve(H, psi0, tlist, [sigmax(), sigmay(), sigmaz()],
+                            args=td_args)
+            sx, sy, sz = output.expect[0], output.expect[1], output.expect[2]
+        else:
+            output = sesolve(H, U0, tlist, args=td_args)
+            sx = [expect(sigmax(), U*psi0) for U in output.states]
+            sy = [expect(sigmay(), U*psi0) for U in output.states]
+            sz = [expect(sigmaz(), U*psi0) for U in output.states]
 
-        return sesolve(H, psi0, tlist, e_ops)
+        sx_analytic = np.zeros(np.shape(tlist))
+        sy_analytic = np.array([-np.sin(delta*analytic_func(t, td_args))
+                                for t in tlist])
+        sz_analytic = np.array([np.cos(delta*analytic_func(t, td_args))
+                                for t in tlist])
+
+        assert_(max(abs(sx - sx_analytic)) < tol,
+                msg="expect X not matching analytic")
+        assert_(max(abs(sy - sy_analytic)) < tol,
+                msg="expect Y not matching analytic")
+        assert_(max(abs(sz - sz_analytic)) < tol,
+                msg="expect Z not matching analytic")
 
     def test_01_1_state_with_const_H(self):
         "sesolve: state with const H"
-        tol = 5e-3
-        epsilon = 0.0 * 2 * np.pi   # cavity frequency
-        delta = 1.0 * 2 * np.pi   # atom frequency
+        delta = 1.0 * 2*np.pi   # atom frequency
         psi0 = basis(2, 0)        # initial state
-        tlist = np.linspace(0, 5, 200)
-        e_ops = [sigmax(), sigmay(), sigmaz()]
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
 
-        output = self.qubit_integrate(tlist, psi0, epsilon, delta, e_ops)
-        sx, sy, sz = output.expect[0], output.expect[1], output.expect[2]
+        analytic_func = lambda t, args: t
 
-        sx_analytic = np.zeros(np.shape(tlist))
-        sy_analytic = -np.sin(2 * np.pi * tlist)
-        sz_analytic = np.cos(2 * np.pi * tlist)
-
-        assert_(max(abs(sx - sx_analytic)) < tol,
-                msg="expect X not matching analytic")
-        assert_(max(abs(sy - sy_analytic)) < tol,
-                msg="expect Y not matching analytic")
-        assert_(max(abs(sz - sz_analytic)) < tol,
-                msg="expect Z not matching analytic")
+        self.check_evolution(H1, delta, psi0, tlist, analytic_func)
 
     def test_01_1_unitary_with_const_H(self):
         "sesolve: unitary operator with const H"
-        tol = 5e-3
-        epsilon = 0.0 * 2 * np.pi   # cavity frequency
-        delta = 1.0 * 2 * np.pi   # atom frequency
+        delta = 1.0 * 2*np.pi   # atom frequency
         psi0 = basis(2, 0)        # initial state
         U0 = qeye(2)                # initital operator
-        tlist = np.linspace(0, 5, 200)
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
 
-        output = self.qubit_integrate(tlist, U0, epsilon, delta)
-        sx = [expect(sigmax(), U*psi0) for U in output.states]
-        sy = [expect(sigmay(), U*psi0) for U in output.states]
-        sz = [expect(sigmaz(), U*psi0) for U in output.states]
+        analytic_func = lambda t, args: t
 
-        sx_analytic = np.zeros(np.shape(tlist))
-        sy_analytic = -np.sin(2 * np.pi * tlist)
-        sz_analytic = np.cos(2 * np.pi * tlist)
+        self.check_evolution(H1, delta, psi0, tlist, analytic_func, U0)
 
-        assert_(max(abs(sx - sx_analytic)) < tol,
-                msg="expect X not matching analytic")
-        assert_(max(abs(sy - sy_analytic)) < tol,
-                msg="expect Y not matching analytic")
-        assert_(max(abs(sz - sz_analytic)) < tol,
-                msg="expect Z not matching analytic")
+    def test_02_1_state_with_func_H(self):
+        "sesolve: state with td func H"
+        delta = 1.0 * 2*np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
 
-    def fidelitycheck(self, out1, out2, rho0vec):
-        fid = np.zeros(len(out1.states))
-        for i, E in enumerate(out2.states):
-            rhot = vector_to_operator(E*rho0vec)
-            fid[i] = fidelity(out1.states[i], rhot)
-        return fid
+        alpha = 0.1
+        td_args = {'alpha':alpha}
+        h1_func = lambda t, args: H1*np.exp(-args['alpha']*t)
+        analytic_func = lambda t, args: ((1 - np.exp(-args['alpha']*t))
+                                        /args['alpha'])
 
-    def testMETDDecayAsFuncList(self):
-        "mesolve: time-dependence as function list with super as init cond"
-        me_error = 1e-6
+        self.check_evolution(h1_func, delta, psi0, tlist, analytic_func,
+                             td_args=td_args)
 
-        N = 10  # number of basis states to consider
-        a = destroy(N)
-        H = a.dag() * a
-        psi0 = basis(N, 9)  # initial state
-        rho0vec = operator_to_vector(psi0*psi0.dag())
-        E0 = sprepost(qeye(N), qeye(N))
-        kappa = 0.2  # coupling to oscillator
+    def test_02_2_unitary_with_func_H(self):
+        "sesolve: unitary operator with td func H"
+        delta = 1.0 * 2*np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        U0 = qeye(2)                # initital operator
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
 
-        def sqrt_kappa(t, args):
-            return np.sqrt(kappa * np.exp(-t))
-        c_op_list = [[a, sqrt_kappa]]
-        tlist = np.linspace(0, 10, 100)
-        out1 = mesolve(H, psi0, tlist, c_op_list, [])
-        out2 = mesolve(H, E0, tlist, c_op_list, [])
+        alpha = 0.1
+        td_args = {'alpha':alpha}
+        h1_func = lambda t, args: H1*np.exp(-args['alpha']*t)
+        analytic_func = lambda t, args: ((1 - np.exp(-args['alpha']*t))
+                                        /args['alpha'])
 
-        fid = self.fidelitycheck(out1, out2, rho0vec)
-        assert_(max(abs(1.0-fid)) < me_error, True)
+        self.check_evolution(h1_func, delta, psi0, tlist, analytic_func, U0,
+                             td_args=td_args)
 
-    def testMETDDecayAsStrList(self):
-        "mesolve: time-dependence as string list with super as init cond"
-        me_error = 1e-6
+    def test_02_3_unitary_with_func_super_H(self):
+        "sesolve: unitary operator with superop td func H"
+        delta = 1.0 * 2*np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        U0 = qeye(2)                # initital operator
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
 
-        N = 10  # number of basis states to consider
-        a = destroy(N)
-        H = a.dag() * a
-        psi0 = basis(N, 9)  # initial state
-        rho0vec = operator_to_vector(psi0*psi0.dag())
-        E0 = sprepost(qeye(N), qeye(N))
-        kappa = 0.2  # coupling to oscillator
-        c_op_list = [[a, 'sqrt(k*exp(-t))']]
-        args = {'k': kappa}
-        tlist = np.linspace(0, 10, 100)
-        out1 = mesolve(H, psi0, tlist, c_op_list, [], args=args)
-        out2 = mesolve(H, E0, tlist, c_op_list, [], args=args)
-        fid = self.fidelitycheck(out1, out2, rho0vec)
-        assert_(max(abs(1.0-fid)) < me_error, True)
+        alpha = 0.1
+        td_args = {'alpha':alpha}
+        L1 = spre(H1)
+        l1_func = lambda t, args: L1*np.exp(-args['alpha']*t)
+        analytic_func = lambda t, args: ((1 - np.exp(-args['alpha']*t))
+                                        /args['alpha'])
 
-    def testMETDDecayAsArray(self):
-        "mesolve: time-dependence as array with super as init cond"
-        me_error = 1e-5
+        self.check_evolution(l1_func, delta, psi0, tlist, analytic_func, U0,
+                             td_args)
 
-        N = 10
-        a = destroy(N)
-        H = a.dag() * a
-        psi0 = basis(N, 9)
-        rho0vec = operator_to_vector(psi0*psi0.dag())
-        E0 = sprepost(qeye(N), qeye(N))
-        kappa = 0.2
-        tlist = np.linspace(0, 10, 1000)
-        c_op_list = [[a, np.sqrt(kappa * np.exp(-tlist))]]
-        out1 = mesolve(H, psi0, tlist, c_op_list, [])
-        out2 = mesolve(H, E0, tlist, c_op_list, [])
-        fid = self.fidelitycheck(out1, out2, rho0vec)
-        assert_(max(abs(1.0-fid)) < me_error, True)
+    def test_03_1_state_with_list_func_H(self):
+        "sesolve: state with td list func H"
+        delta = 1.0 * 2*np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
 
-    def testMETDDecayAsFunc(self):
-        "mesolve: time-dependence as function with super as init cond"
+        alpha = 0.1
+        td_args = {'alpha':alpha}
+        h1_coeff = lambda t, args: np.exp(-args['alpha']*t)
+        H = [[H1, h1_coeff]]
+        analytic_func = lambda t, args: ((1 - np.exp(-args['alpha']*t))
+                                        /args['alpha'])
 
-        N = 10  # number of basis states to consider
-        a = destroy(N)
-        H = a.dag() * a
-        rho0 = ket2dm(basis(N, 9))  # initial state
-        rho0vec = operator_to_vector(rho0)
-        E0 = sprepost(qeye(N), qeye(N))
-        kappa = 0.2  # coupling to oscillator
+        self.check_evolution(H, delta, psi0, tlist, analytic_func,
+                             td_args=td_args)
 
-        def Liouvillian_func(t, args):
-            c = np.sqrt(kappa * np.exp(-t))*a
-            data = liouvillian(H, [c])
-            return data
+    def test_03_2_unitary_with_list_func_H(self):
+        "sesolve: unitary operator with td list func H"
+        delta = 1.0 * 2*np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        U0 = qeye(2)                # initital operator
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
 
-        tlist = np.linspace(0, 10, 100)
-        args = {'kappa': kappa}
-        out1 = mesolve(Liouvillian_func, rho0, tlist, [], [], args=args)
-        out2 = mesolve(Liouvillian_func, E0, tlist, [], [], args=args)
+        alpha = 0.1
+        td_args = {'alpha':alpha}
+        h1_coeff = lambda t, args: np.exp(-args['alpha']*t)
+        H = [[H1, h1_coeff]]
+        analytic_func = lambda t, args: ((1 - np.exp(-args['alpha']*t))
+                                        /args['alpha'])
 
-        fid = self.fidelitycheck(out1, out2, rho0vec)
-        assert_(max(abs(1.0-fid)) < me_error, True)
+        self.check_evolution(H, delta, psi0, tlist, analytic_func, U0,
+                             td_args=td_args)
 
-    def test_me_interp1(self):
-        "mesolve: interp time-dependent collapse operator #1"
+    def test_04_1_state_with_list_str_H(self):
+        "sesolve: state with td list str H"
+        delta = 1.0 * 2*np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
 
-        N = 10  # number of basis states to consider
-        kappa = 0.2  # coupling to oscillator
-        tlist = np.linspace(0, 10, 100)
-        a = destroy(N)
-        H = a.dag() * a
-        psi0 = basis(N, 9)  # initial state
-        S = Cubic_Spline(tlist[0],tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
-        c_op_list = [[a, S]]
-        medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
-        expt = medata.expect[0]
-        actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
-        avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-        assert_(avg_diff < 1e-5)
+        alpha = 0.1
+        td_args = {'alpha':alpha}
+        H = [[H1, 'exp(-alpha*t)']]
+        analytic_func = lambda t, args: ((1 - np.exp(-args['alpha']*t))
+                                        /args['alpha'])
+
+        self.check_evolution(H, delta, psi0, tlist, analytic_func,
+                             td_args=td_args)
+
+    def test_04_2_unitary_with_list_func_H(self):
+        "sesolve: unitary operator with td list str H"
+        delta = 1.0 * 2*np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        U0 = qeye(2)                # initital operator
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
+
+        alpha = 0.1
+        td_args = {'alpha':alpha}
+        H = [[H1, 'exp(-alpha*t)']]
+        analytic_func = lambda t, args: ((1 - np.exp(-args['alpha']*t))
+                                        /args['alpha'])
+
+        self.check_evolution(H, delta, psi0, tlist, analytic_func, U0,
+                             td_args=td_args)
+
+#    def fidelitycheck(self, out1, out2, rho0vec):
+#        fid = np.zeros(len(out1.states))
+#        for i, E in enumerate(out2.states):
+#            rhot = vector_to_operator(E*rho0vec)
+#            fid[i] = fidelity(out1.states[i], rhot)
+#        return fid
+#
+#    def testMETDDecayAsFuncList(self):
+#        "mesolve: time-dependence as function list with super as init cond"
+#        me_error = 1e-6
+#
+#        N = 10  # number of basis states to consider
+#        a = destroy(N)
+#        H = a.dag() * a
+#        psi0 = basis(N, 9)  # initial state
+#        rho0vec = operator_to_vector(psi0*psi0.dag())
+#        E0 = sprepost(qeye(N), qeye(N))
+#        kappa = 0.2  # coupling to oscillator
+#
+#        def sqrt_kappa(t, args):
+#            return np.sqrt(kappa * np.exp(-t))
+#        c_op_list = [[a, sqrt_kappa]]
+#        tlist = np.linspace(0, 10, 100)
+#        out1 = mesolve(H, psi0, tlist, c_op_list, [])
+#        out2 = mesolve(H, E0, tlist, c_op_list, [])
+#
+#        fid = self.fidelitycheck(out1, out2, rho0vec)
+#        assert_(max(abs(1.0-fid)) < me_error, True)
+#
+#    def testMETDDecayAsStrList(self):
+#        "mesolve: time-dependence as string list with super as init cond"
+#        me_error = 1e-6
+#
+#        N = 10  # number of basis states to consider
+#        a = destroy(N)
+#        H = a.dag() * a
+#        psi0 = basis(N, 9)  # initial state
+#        rho0vec = operator_to_vector(psi0*psi0.dag())
+#        E0 = sprepost(qeye(N), qeye(N))
+#        kappa = 0.2  # coupling to oscillator
+#        c_op_list = [[a, 'sqrt(k*exp(-t))']]
+#        args = {'k': kappa}
+#        tlist = np.linspace(0, 10, 100)
+#        out1 = mesolve(H, psi0, tlist, c_op_list, [], args=args)
+#        out2 = mesolve(H, E0, tlist, c_op_list, [], args=args)
+#        fid = self.fidelitycheck(out1, out2, rho0vec)
+#        assert_(max(abs(1.0-fid)) < me_error, True)
+#
+#    def testMETDDecayAsArray(self):
+#        "mesolve: time-dependence as array with super as init cond"
+#        me_error = 1e-5
+#
+#        N = 10
+#        a = destroy(N)
+#        H = a.dag() * a
+#        psi0 = basis(N, 9)
+#        rho0vec = operator_to_vector(psi0*psi0.dag())
+#        E0 = sprepost(qeye(N), qeye(N))
+#        kappa = 0.2
+#        tlist = np.linspace(0, 10, 1000)
+#        c_op_list = [[a, np.sqrt(kappa * np.exp(-tlist))]]
+#        out1 = mesolve(H, psi0, tlist, c_op_list, [])
+#        out2 = mesolve(H, E0, tlist, c_op_list, [])
+#        fid = self.fidelitycheck(out1, out2, rho0vec)
+#        assert_(max(abs(1.0-fid)) < me_error, True)
+#
+#    def testMETDDecayAsFunc(self):
+#        "mesolve: time-dependence as function with super as init cond"
+#
+#        N = 10  # number of basis states to consider
+#        a = destroy(N)
+#        H = a.dag() * a
+#        rho0 = ket2dm(basis(N, 9))  # initial state
+#        rho0vec = operator_to_vector(rho0)
+#        E0 = sprepost(qeye(N), qeye(N))
+#        kappa = 0.2  # coupling to oscillator
+#
+#        def Liouvillian_func(t, args):
+#            c = np.sqrt(kappa * np.exp(-t))*a
+#            data = liouvillian(H, [c])
+#            return data
+#
+#        tlist = np.linspace(0, 10, 100)
+#        args = {'kappa': kappa}
+#        out1 = mesolve(Liouvillian_func, rho0, tlist, [], [], args=args)
+#        out2 = mesolve(Liouvillian_func, E0, tlist, [], [], args=args)
+#
+#        fid = self.fidelitycheck(out1, out2, rho0vec)
+#        assert_(max(abs(1.0-fid)) < me_error, True)
+#
+#    def test_me_interp1(self):
+#        "mesolve: interp time-dependent collapse operator #1"
+#
+#        N = 10  # number of basis states to consider
+#        kappa = 0.2  # coupling to oscillator
+#        tlist = np.linspace(0, 10, 100)
+#        a = destroy(N)
+#        H = a.dag() * a
+#        psi0 = basis(N, 9)  # initial state
+#        S = Cubic_Spline(tlist[0], tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
+#        c_op_list = [[a, S]]
+#        medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+#        expt = medata.expect[0]
+#        actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
+#        avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
+#        assert_(avg_diff < 1e-5)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_sesolve.py
+++ b/qutip/tests/test_sesolve.py
@@ -45,7 +45,7 @@ from qutip.solver import Options
 os.environ['QUTIP_GRAPHICS'] = "NO"
 
 
-class TestSchrodingerEqSolve:
+class TestSESolve:
     """
     A test class for the QuTiP Schrodinger Eq. solver
     """
@@ -103,6 +103,113 @@ class TestSchrodingerEqSolve:
                 msg="expect Y not matching analytic")
         assert_(max(abs(sz - sz_analytic)) < tol,
                 msg="expect Z not matching analytic")
+
+    def fidelitycheck(self, out1, out2, rho0vec):
+        fid = np.zeros(len(out1.states))
+        for i, E in enumerate(out2.states):
+            rhot = vector_to_operator(E*rho0vec)
+            fid[i] = fidelity(out1.states[i], rhot)
+        return fid
+
+    def testMETDDecayAsFuncList(self):
+        "mesolve: time-dependence as function list with super as init cond"
+        me_error = 1e-6
+
+        N = 10  # number of basis states to consider
+        a = destroy(N)
+        H = a.dag() * a
+        psi0 = basis(N, 9)  # initial state
+        rho0vec = operator_to_vector(psi0*psi0.dag())
+        E0 = sprepost(qeye(N), qeye(N))
+        kappa = 0.2  # coupling to oscillator
+
+        def sqrt_kappa(t, args):
+            return np.sqrt(kappa * np.exp(-t))
+        c_op_list = [[a, sqrt_kappa]]
+        tlist = np.linspace(0, 10, 100)
+        out1 = mesolve(H, psi0, tlist, c_op_list, [])
+        out2 = mesolve(H, E0, tlist, c_op_list, [])
+
+        fid = self.fidelitycheck(out1, out2, rho0vec)
+        assert_(max(abs(1.0-fid)) < me_error, True)
+
+    def testMETDDecayAsStrList(self):
+        "mesolve: time-dependence as string list with super as init cond"
+        me_error = 1e-6
+
+        N = 10  # number of basis states to consider
+        a = destroy(N)
+        H = a.dag() * a
+        psi0 = basis(N, 9)  # initial state
+        rho0vec = operator_to_vector(psi0*psi0.dag())
+        E0 = sprepost(qeye(N), qeye(N))
+        kappa = 0.2  # coupling to oscillator
+        c_op_list = [[a, 'sqrt(k*exp(-t))']]
+        args = {'k': kappa}
+        tlist = np.linspace(0, 10, 100)
+        out1 = mesolve(H, psi0, tlist, c_op_list, [], args=args)
+        out2 = mesolve(H, E0, tlist, c_op_list, [], args=args)
+        fid = self.fidelitycheck(out1, out2, rho0vec)
+        assert_(max(abs(1.0-fid)) < me_error, True)
+
+    def testMETDDecayAsArray(self):
+        "mesolve: time-dependence as array with super as init cond"
+        me_error = 1e-5
+
+        N = 10
+        a = destroy(N)
+        H = a.dag() * a
+        psi0 = basis(N, 9)
+        rho0vec = operator_to_vector(psi0*psi0.dag())
+        E0 = sprepost(qeye(N), qeye(N))
+        kappa = 0.2
+        tlist = np.linspace(0, 10, 1000)
+        c_op_list = [[a, np.sqrt(kappa * np.exp(-tlist))]]
+        out1 = mesolve(H, psi0, tlist, c_op_list, [])
+        out2 = mesolve(H, E0, tlist, c_op_list, [])
+        fid = self.fidelitycheck(out1, out2, rho0vec)
+        assert_(max(abs(1.0-fid)) < me_error, True)
+
+    def testMETDDecayAsFunc(self):
+        "mesolve: time-dependence as function with super as init cond"
+
+        N = 10  # number of basis states to consider
+        a = destroy(N)
+        H = a.dag() * a
+        rho0 = ket2dm(basis(N, 9))  # initial state
+        rho0vec = operator_to_vector(rho0)
+        E0 = sprepost(qeye(N), qeye(N))
+        kappa = 0.2  # coupling to oscillator
+
+        def Liouvillian_func(t, args):
+            c = np.sqrt(kappa * np.exp(-t))*a
+            data = liouvillian(H, [c])
+            return data
+
+        tlist = np.linspace(0, 10, 100)
+        args = {'kappa': kappa}
+        out1 = mesolve(Liouvillian_func, rho0, tlist, [], [], args=args)
+        out2 = mesolve(Liouvillian_func, E0, tlist, [], [], args=args)
+
+        fid = self.fidelitycheck(out1, out2, rho0vec)
+        assert_(max(abs(1.0-fid)) < me_error, True)
+
+    def test_me_interp1(self):
+        "mesolve: interp time-dependent collapse operator #1"
+
+        N = 10  # number of basis states to consider
+        kappa = 0.2  # coupling to oscillator
+        tlist = np.linspace(0, 10, 100)
+        a = destroy(N)
+        H = a.dag() * a
+        psi0 = basis(N, 9)  # initial state
+        S = Cubic_Spline(tlist[0],tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
+        c_op_list = [[a, S]]
+        medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+        expt = medata.expect[0]
+        actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
+        avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
+        assert_(avg_diff < 1e-5)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_sesolve.py
+++ b/qutip/tests/test_sesolve.py
@@ -225,112 +225,43 @@ class TestSESolve:
         self.check_evolution(H, delta, psi0, tlist, analytic_func, U0,
                              td_args=td_args)
 
-#    def fidelitycheck(self, out1, out2, rho0vec):
-#        fid = np.zeros(len(out1.states))
-#        for i, E in enumerate(out2.states):
-#            rhot = vector_to_operator(E*rho0vec)
-#            fid[i] = fidelity(out1.states[i], rhot)
-#        return fid
-#
-#    def testMETDDecayAsFuncList(self):
-#        "mesolve: time-dependence as function list with super as init cond"
-#        me_error = 1e-6
-#
-#        N = 10  # number of basis states to consider
-#        a = destroy(N)
-#        H = a.dag() * a
-#        psi0 = basis(N, 9)  # initial state
-#        rho0vec = operator_to_vector(psi0*psi0.dag())
-#        E0 = sprepost(qeye(N), qeye(N))
-#        kappa = 0.2  # coupling to oscillator
-#
-#        def sqrt_kappa(t, args):
-#            return np.sqrt(kappa * np.exp(-t))
-#        c_op_list = [[a, sqrt_kappa]]
-#        tlist = np.linspace(0, 10, 100)
-#        out1 = mesolve(H, psi0, tlist, c_op_list, [])
-#        out2 = mesolve(H, E0, tlist, c_op_list, [])
-#
-#        fid = self.fidelitycheck(out1, out2, rho0vec)
-#        assert_(max(abs(1.0-fid)) < me_error, True)
-#
-#    def testMETDDecayAsStrList(self):
-#        "mesolve: time-dependence as string list with super as init cond"
-#        me_error = 1e-6
-#
-#        N = 10  # number of basis states to consider
-#        a = destroy(N)
-#        H = a.dag() * a
-#        psi0 = basis(N, 9)  # initial state
-#        rho0vec = operator_to_vector(psi0*psi0.dag())
-#        E0 = sprepost(qeye(N), qeye(N))
-#        kappa = 0.2  # coupling to oscillator
-#        c_op_list = [[a, 'sqrt(k*exp(-t))']]
-#        args = {'k': kappa}
-#        tlist = np.linspace(0, 10, 100)
-#        out1 = mesolve(H, psi0, tlist, c_op_list, [], args=args)
-#        out2 = mesolve(H, E0, tlist, c_op_list, [], args=args)
-#        fid = self.fidelitycheck(out1, out2, rho0vec)
-#        assert_(max(abs(1.0-fid)) < me_error, True)
-#
-#    def testMETDDecayAsArray(self):
-#        "mesolve: time-dependence as array with super as init cond"
-#        me_error = 1e-5
-#
-#        N = 10
-#        a = destroy(N)
-#        H = a.dag() * a
-#        psi0 = basis(N, 9)
-#        rho0vec = operator_to_vector(psi0*psi0.dag())
-#        E0 = sprepost(qeye(N), qeye(N))
-#        kappa = 0.2
-#        tlist = np.linspace(0, 10, 1000)
-#        c_op_list = [[a, np.sqrt(kappa * np.exp(-tlist))]]
-#        out1 = mesolve(H, psi0, tlist, c_op_list, [])
-#        out2 = mesolve(H, E0, tlist, c_op_list, [])
-#        fid = self.fidelitycheck(out1, out2, rho0vec)
-#        assert_(max(abs(1.0-fid)) < me_error, True)
-#
-#    def testMETDDecayAsFunc(self):
-#        "mesolve: time-dependence as function with super as init cond"
-#
-#        N = 10  # number of basis states to consider
-#        a = destroy(N)
-#        H = a.dag() * a
-#        rho0 = ket2dm(basis(N, 9))  # initial state
-#        rho0vec = operator_to_vector(rho0)
-#        E0 = sprepost(qeye(N), qeye(N))
-#        kappa = 0.2  # coupling to oscillator
-#
-#        def Liouvillian_func(t, args):
-#            c = np.sqrt(kappa * np.exp(-t))*a
-#            data = liouvillian(H, [c])
-#            return data
-#
-#        tlist = np.linspace(0, 10, 100)
-#        args = {'kappa': kappa}
-#        out1 = mesolve(Liouvillian_func, rho0, tlist, [], [], args=args)
-#        out2 = mesolve(Liouvillian_func, E0, tlist, [], [], args=args)
-#
-#        fid = self.fidelitycheck(out1, out2, rho0vec)
-#        assert_(max(abs(1.0-fid)) < me_error, True)
-#
-#    def test_me_interp1(self):
-#        "mesolve: interp time-dependent collapse operator #1"
-#
-#        N = 10  # number of basis states to consider
-#        kappa = 0.2  # coupling to oscillator
-#        tlist = np.linspace(0, 10, 100)
-#        a = destroy(N)
-#        H = a.dag() * a
-#        psi0 = basis(N, 9)  # initial state
-#        S = Cubic_Spline(tlist[0], tlist[-1], np.sqrt(kappa*np.exp(-tlist)))
-#        c_op_list = [[a, S]]
-#        medata = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
-#        expt = medata.expect[0]
-#        actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
-#        avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-#        assert_(avg_diff < 1e-5)
+
+    def test_05_1_state_with_interp_H(self):
+        "sesolve: state with td interp H"
+        delta = 1.0 * 2*np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
+
+        alpha = 0.1
+        td_args = {'alpha':alpha}
+        tcub = np.linspace(0, 20, 50)
+        S = Cubic_Spline(0, 20, np.exp(-alpha*tcub))
+        H = [[H1, S]]
+        analytic_func = lambda t, args: ((1 - np.exp(-args['alpha']*t))
+                                        /args['alpha'])
+
+        self.check_evolution(H, delta, psi0, tlist, analytic_func,
+                             td_args=td_args)
+
+    def test_05_2_unitary_with_interp_H(self):
+        "sesolve: unitary operator with td interp H"
+        delta = 1.0 * 2*np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        U0 = qeye(2)                # initital operator
+        H1 = 0.5*delta*sigmax()      # Hamiltonian operator
+        tlist = np.linspace(0, 20, 200)
+
+        alpha = 0.1
+        td_args = {'alpha':alpha}
+        tcub = np.linspace(0, 20, 50)
+        S = Cubic_Spline(0, 20, np.exp(-alpha*tcub))
+        H = [[H1, S]]
+        analytic_func = lambda t, args: ((1 - np.exp(-args['alpha']*t))
+                                        /args['alpha'])
+
+        self.check_evolution(H, delta, psi0, tlist, analytic_func, U0,
+                             td_args=td_args)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_sesolve.py
+++ b/qutip/tests/test_sesolve.py
@@ -79,5 +79,30 @@ class TestSchrodingerEqSolve:
         assert_(max(abs(sz - sz_analytic)) < tol,
                 msg="expect Z not matching analytic")
 
+    def test_01_1_unitary_with_const_H(self):
+        "sesolve: unitary operator with const H"
+        tol = 5e-3
+        epsilon = 0.0 * 2 * np.pi   # cavity frequency
+        delta = 1.0 * 2 * np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        U0 = qeye(2)                # initital operator
+        tlist = np.linspace(0, 5, 200)
+
+        output = self.qubit_integrate(tlist, U0, epsilon, delta)
+        sx = [expect(sigmax(), U*psi0) for U in output.states]
+        sy = [expect(sigmay(), U*psi0) for U in output.states]
+        sz = [expect(sigmaz(), U*psi0) for U in output.states]
+
+        sx_analytic = np.zeros(np.shape(tlist))
+        sy_analytic = -np.sin(2 * np.pi * tlist)
+        sz_analytic = np.cos(2 * np.pi * tlist)
+
+        assert_(max(abs(sx - sx_analytic)) < tol,
+                msg="expect X not matching analytic")
+        assert_(max(abs(sy - sy_analytic)) < tol,
+                msg="expect Y not matching analytic")
+        assert_(max(abs(sz - sz_analytic)) < tol,
+                msg="expect Z not matching analytic")
+
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_sesolve.py
+++ b/qutip/tests/test_sesolve.py
@@ -1,0 +1,83 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+import numpy as np
+from numpy.testing import assert_, run_module_suite
+
+# disable the progress bar
+import os
+
+from qutip import sigmax, sigmay, sigmaz, sigmam, qeye
+from qutip import qobj, basis, expect
+from qutip import sesolve
+from qutip.solver import Options
+
+os.environ['QUTIP_GRAPHICS'] = "NO"
+
+
+class TestSchrodingerEqSolve:
+    """
+    A test class for the QuTiP Schrodinger Eq. solver
+    """
+
+    def qubit_integrate(self, tlist, psi0, epsilon, delta, e_ops=[]):
+
+        H = epsilon / 2.0 * sigmaz() + delta / 2.0 * sigmax()
+
+        return sesolve(H, psi0, tlist, e_ops)
+
+    def test_01_1_state_with_const_H(self):
+        "sesolve: state with const H"
+        tol = 5e-3
+        epsilon = 0.0 * 2 * np.pi   # cavity frequency
+        delta = 1.0 * 2 * np.pi   # atom frequency
+        psi0 = basis(2, 0)        # initial state
+        tlist = np.linspace(0, 5, 200)
+        e_ops = [sigmax(), sigmay(), sigmaz()]
+
+        output = self.qubit_integrate(tlist, psi0, epsilon, delta, e_ops)
+        sx, sy, sz = output.expect[0], output.expect[1], output.expect[2]
+
+        sx_analytic = np.zeros(np.shape(tlist))
+        sy_analytic = -np.sin(2 * np.pi * tlist)
+        sz_analytic = np.cos(2 * np.pi * tlist)
+
+        assert_(max(abs(sx - sx_analytic)) < tol,
+                msg="expect X not matching analytic")
+        assert_(max(abs(sy - sy_analytic)) < tol,
+                msg="expect Y not matching analytic")
+        assert_(max(abs(sz - sz_analytic)) < tol,
+                msg="expect Z not matching analytic")
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
Can now give unitary operator as initial `psi0` in sesolve. This way we solve the Schrodinger operator equation.
Also added tests for all the sesolve methods.

Kind of a bit of waste of time, as `propagator` does almost exactly the same thing. However, I think it does add a bit of completeness. The tests at least should be valuable