### PR TITLE
Fixed bug that stopped simdiag working for python3

### DIFF
--- a/qutip/simdiag.py
+++ b/qutip/simdiag.py
@@ -80,7 +80,7 @@ def simdiag(ops, evals=True):
 
     A = ops[0]
     eigvals, eigvecs = la.eig(A.full())
-    zipped = zip(-eigvals, range(len(eigvals)))
+    zipped = list(zip(-eigvals, range(len(eigvals))))
     zipped.sort()
     ds, perm = zip(*zipped)
     ds = -np.real(np.array(ds))
@@ -127,7 +127,7 @@ def degen(tol, in_vecs, ops):
     A = ops[0]
     vecs = np.column_stack(in_vecs)
     eigvals, eigvecs = la.eig(np.dot(vecs.conj().T, A.data.dot(vecs)))
-    zipped = zip(-eigvals, range(len(eigvals)))
+    zipped = list(zip(-eigvals, range(len(eigvals))))
     zipped.sort()
     ds, perm = zip(*zipped)
     ds = -np.real(np.array(ds))


### PR DESCRIPTION
Code that fails with the current version of qutip  when using for python3 is listed below. 
This code runs for both python2 and python3 with the change suggested.
 
=======================================
import qutip as q

#consider two coupled spin L and S
Lval = 1
Sval = 0.5

[Lx,Ly,Lz] = map(lambda x: q.tensor(x, q.qeye(2*Sval+1)),q.jmat(Lval))
[Sx,Sy,Sz] = map(lambda x: q.tensor(q.qeye(2*Lval+1), x),q.jmat(Sval))

Jx = Lx + Sx
Jy = Ly + Sy
Jz = Lz + Sz

Lsq = Lx*Lx + Ly*Ly + Lz*Lz
Ssq = Sx*Sx + Sy*Sy + Sz*Sz
Jsq = Jx*Jx + Jy*Jy + Jz*Jz

q.simdiag([Lsq,Ssq,Jsq,Jz])


===========================================================