### PR TITLE
Added options auto_tidyup_dims to disable deletion of 1 dim Systems after multiplication

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -488,8 +488,8 @@ class Qobj(object):
                 out.dims = dims
                 if settings.auto_tidyup: out.tidyup()
                 if (settings.auto_tidyup_dims 
-                        and not isinstance(dims[0][0], list) and
-                        not isinstance(dims[1][0], list)):
+                        and not isinstance(dims[0][0], list)
+                        and not isinstance(dims[1][0], list)):
                     # If neither left or right is a superoperator,
                     # we should implicitly partial trace over
                     # matching dimensions of 1.

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -487,7 +487,7 @@ class Qobj(object):
                 dims = [self.dims[0], other.dims[1]]
                 out.dims = dims
                 if settings.auto_tidyup: out.tidyup()
-                if (not isinstance(dims[0][0], list) and
+                if (settings.auto_tidyup_dims and not isinstance(dims[0][0], list) and
                         not isinstance(dims[1][0], list)):
                     # If neither left or right is a superoperator,
                     # we should implicitly partial trace over

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -487,7 +487,8 @@ class Qobj(object):
                 dims = [self.dims[0], other.dims[1]]
                 out.dims = dims
                 if settings.auto_tidyup: out.tidyup()
-                if (settings.auto_tidyup_dims and not isinstance(dims[0][0], list) and
+                if (settings.auto_tidyup_dims 
+                        and not isinstance(dims[0][0], list) and
                         not isinstance(dims[1][0], list)):
                     # If neither left or right is a superoperator,
                     # we should implicitly partial trace over

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -37,6 +37,8 @@ tidyup functionality, etc.
 from __future__ import absolute_import
 # use auto tidyup
 auto_tidyup = True
+# use auto tidyup dims on multiplication
+auto_tidyup_dims = True
 # detect hermiticity
 auto_herm = True
 # general absolute tolerance


### PR DESCRIPTION
In the multiplication is a mechanism deleting 1 dimensional Systems. This can lead to problems on Systems having multiple one dimensional Subsystems. Examples are in #823.

Because I coundn't figure out in which cases this deleting mechanism needed, I didn't want to remove it, but provide an option to disable it.


Signed-off-by: Arne Hamann <kontakt+github@arne.email>