### PR TITLE
Recursively add .pyx files in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.md
 include LICENSE.txt
 include requirements.txt
 include qutip.bib
+recursive-include qutip/ *.pyx


### PR DESCRIPTION
This is the update which fixes the inclusion of .pyx files when qutip source distribution is generated by sdist in the presence of MANIFEST.in. More discussions in #894 