### PR TITLE
Fixed stochastic._rhs_psi_platen.

### DIFF
--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -2152,7 +2152,7 @@ def _rhs_rho_pred_corr_homodyne_single(L, rho_t, t, A, dt, ddW, d1, d2,
     """
     dW = ddW[:, 0]
 
-    #predictor
+    #predictor:
 
     d_vec = (A[0][0] * rho_t).reshape(-1, len(rho_t))
     e = np.real(


### PR DESCRIPTION
I noticed that stochastic._rhs_psi_platen wasn't working so I fixed it. Now ssesolve can be used with the platen solver for multiple stochastic collapse operators with both homodyne and heterodyne methods. 

Basically I have written down equation 1.3 from chapter 15.1 of Numerical solution of stochastic differential equations by Kloeden and Platen.