### PR TITLE
change to fit with cython0.29

### DIFF
--- a/qutip/control/cy_grape.pyx
+++ b/qutip/control/cy_grape.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.

--- a/qutip/cy/brtools.pxd
+++ b/qutip/cy/brtools.pxd
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 cimport numpy as np
@@ -37,36 +39,36 @@ ctypedef complex (*spec_func)(double, double)
 
 cdef complex[::1,:] farray_alloc(int nrows)
 
-cpdef void dense_add_mult(complex[::1,:] A, complex[::1,:] B, 
+cpdef void dense_add_mult(complex[::1,:] A, complex[::1,:] B,
                   double complex alpha) nogil
 
-cdef void ZHEEVR(complex[::1,:] H, double * eigvals, 
+cdef void ZHEEVR(complex[::1,:] H, double * eigvals,
                 complex[::1,:] Z, int nrows)
 
 cdef complex[::1,:] dense_to_eigbasis(complex[::1,:] A, complex[::1,:] evecs,
                                     unsigned int nrows, double atol)
 
-cdef void diag_liou_mult(double * diags, double complex * vec, 
+cdef void diag_liou_mult(double * diags, double complex * vec,
                         double complex * out, unsigned int nrows) nogil
 
-cdef double complex * vec_to_eigbasis(complex[::1] vec, complex[::1,:] evecs, 
+cdef double complex * vec_to_eigbasis(complex[::1] vec, complex[::1,:] evecs,
                                     unsigned int nrows)
-                                    
-cdef np.ndarray[complex, ndim=1, mode='c'] vec_to_fockbasis(double complex * eig_vec, 
-                                                complex[::1,:] evecs, 
+
+cdef np.ndarray[complex, ndim=1, mode='c'] vec_to_fockbasis(double complex * eig_vec,
+                                                complex[::1,:] evecs,
                                                 unsigned int nrows)
-                                                
-cdef void cop_super_mult(complex[::1,:] cop, complex[::1,:] evecs,  double complex * vec, 
-                    double complex alpha, 
-                    double complex * out, 
+
+cdef void cop_super_mult(complex[::1,:] cop, complex[::1,:] evecs,  double complex * vec,
+                    double complex alpha,
+                    double complex * out,
                     unsigned int nrows,
                     double atol)
 
-cdef void vec2mat_index(int nrows, int index, int[2] out) nogil                   
-                    
-cdef double skew_and_dwmin(double * evals, double[:,::1] skew, 
+cdef void vec2mat_index(int nrows, int index, int[2] out) nogil
+
+cdef double skew_and_dwmin(double * evals, double[:,::1] skew,
                                 unsigned int nrows) nogil
-                                
+
 
 cdef void br_term_mult(double t, complex[::1,:] A, complex[::1,:] evecs,
                 double[:,::1] skew, double dw_min, spec_func spectral,

--- a/qutip/cy/brtools.pyx
+++ b/qutip/cy/brtools.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
@@ -32,7 +34,7 @@
 ###############################################################################
 from scipy.linalg.cython_lapack cimport zheevr
 from scipy.linalg.cython_blas cimport zgemm, zgemv, zaxpy
-from qutip.cy.spmath cimport (_zcsr_kron_core, _zcsr_kron, 
+from qutip.cy.spmath cimport (_zcsr_kron_core, _zcsr_kron,
                     _zcsr_add, _zcsr_transpose, _zcsr_adjoint,
                     _zcsr_mult)
 from qutip.cy.spconvert cimport fdense2D_to_CSR
@@ -54,14 +56,14 @@ cdef extern from "<complex>" namespace "std" nogil:
 @cython.wraparound(False)
 cdef complex[::1,:] farray_alloc(int nrows):
     """
-    Allocate a complex zero array in fortran-order for a 
+    Allocate a complex zero array in fortran-order for a
     square matrix.
-    
+
     Parameters
     ----------
     nrows : int
         Number of rows and columns in the matrix.
-        
+
     Returns
     -------
     fview : memview
@@ -75,14 +77,14 @@ cdef complex[::1,:] farray_alloc(int nrows):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef void dense_add_mult(complex[::1,:] A, 
-                  complex[::1,:] B, 
+cpdef void dense_add_mult(complex[::1,:] A,
+                  complex[::1,:] B,
                   double complex alpha) nogil:
     """
     Performs the dense matrix multiplication A = A + (alpha*B)
     where A and B are complex 2D square matrices,
     and alpha is a complex coefficient.
-    
+
     Parameters
     ----------
     A : ndarray
@@ -91,7 +93,7 @@ cpdef void dense_add_mult(complex[::1,:] A,
         Complex matrix in f-order.
     alpha : complex
         Coefficient in front of B.
-    
+
     """
     cdef int nrows2 = A.shape[0]**2
     cdef int inc = 1
@@ -100,12 +102,12 @@ cpdef void dense_add_mult(complex[::1,:] A,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void ZHEEVR(complex[::1,:] H, double * eigvals, 
+cdef void ZHEEVR(complex[::1,:] H, double * eigvals,
                     complex[::1,:] Z, int nrows):
     """
     Computes the eigenvalues and vectors of a dense Hermitian matrix.
     Eigenvectors are returned in Z.
-    
+
     Parameters
     ----------
     H : array_like
@@ -120,7 +122,7 @@ cdef void ZHEEVR(complex[::1,:] H, double * eigvals,
     cdef char jobz = b'V'
     cdef char rnge = b'A'
     cdef char uplo = b'L'
-    cdef double vl=1, vu=1, abstol=0 
+    cdef double vl=1, vu=1, abstol=0
     cdef int il=1, iu=1
     cdef int lwork = 18 * nrows
     cdef int lrwork = 24*nrows, liwork = 10*nrows
@@ -130,7 +132,7 @@ cdef void ZHEEVR(complex[::1,:] H, double * eigvals,
     cdef complex * work = <complex *>PyDataMem_NEW(lwork * sizeof(complex))
     cdef double * rwork = <double *>PyDataMem_NEW((24*nrows) * sizeof(double))
     cdef int * iwork = <int *>PyDataMem_NEW((10*nrows) * sizeof(int))
-    
+
     zheevr(&jobz, &rnge, &uplo, &nrows, &H[0,0], &nrows, &vl, &vu, &il, &iu, &abstol,
            &M, eigvals, &Z[0,0], &nrows, isuppz, work, &lwork,
           rwork, &lrwork, iwork, &liwork, &info)
@@ -144,7 +146,7 @@ cdef void ZHEEVR(complex[::1,:] H, double * eigvals,
         else:
             raise Exception("Algorithm failed to converge")
 
-            
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def liou_from_diag_ham(double[::1] diags):
@@ -155,7 +157,7 @@ def liou_from_diag_ham(double[::1] diags):
     cdef unsigned int idx, nnz = 0
     cdef size_t ii, jj
     cdef double complex val1, val2, ans
-    
+
     ptr[0] = 0
     for ii in range(nrows):
         val1 = 1j*diags[ii]
@@ -172,16 +174,16 @@ def liou_from_diag_ham(double[::1] diags):
                 ptr[idx+jj] = nnz
     return fast_csr_matrix((data[:nnz],ind[:nnz],ptr), shape=(nrows**2,nrows**2))
 
-    
-    
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void diag_liou_mult(double * diags, double complex * vec, 
+cdef void diag_liou_mult(double * diags, double complex * vec,
                         double complex * out, unsigned int nrows) nogil:
     """
-    Multiplies a Liouvillian constructed from a diagonal Hamiltonian 
+    Multiplies a Liouvillian constructed from a diagonal Hamiltonian
     onto a vectorized density matrix.
-    
+
     Parameters
     ----------
     diags : double ptr
@@ -196,14 +198,14 @@ cdef void diag_liou_mult(double * diags, double complex * vec,
     cdef unsigned int nnz = 0
     cdef size_t ii, jj
     cdef double complex val, ans
-    
+
     for ii in range(nrows):
         val = 1j*diags[ii]
         for jj in range(nrows):
             ans = val - 1j*diags[jj]
             out[nnz] += ans*vec[nnz]
             nnz += 1
-    
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -229,15 +231,15 @@ cdef double complex * ZGEMM(double complex * A, double complex * B,
         tB = b'C'
     else:
         raise Exception('Invalid transB value.')
-    
+
     zgemm(&tA, &tB, &Arows, &Bcols, &Brows, &alpha, A, &Arows, B, &Brows, &beta, C, &Arows)
     return C
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void ZGEMV(double complex * A, double complex * vec, 
+cdef void ZGEMV(double complex * A, double complex * vec,
                         double complex * out,
-                       int Arows, int Acols, int transA = 0, 
+                       int Arows, int Acols, int transA = 0,
                        double complex alpha=1, double complex beta=1):
     cdef char tA
     cdef int idx = 1, idy = 1
@@ -259,7 +261,7 @@ cdef complex[::1,:] dense_to_eigbasis(complex[::1,:] A, complex[::1,:] evecs,
                                     unsigned int nrows,
                                     double atol):
     cdef int kk
-    cdef double complex * temp1 = ZGEMM(&A[0,0], &evecs[0,0], 
+    cdef double complex * temp1 = ZGEMM(&A[0,0], &evecs[0,0],
                                        nrows, nrows, nrows, nrows, 0, 0)
     cdef double complex * eig_mat = ZGEMM(&evecs[0,0], temp1,
                                        nrows, nrows, nrows, nrows, 2, 0)
@@ -277,27 +279,27 @@ cdef complex[::1,:] dense_to_eigbasis(complex[::1,:] A, complex[::1,:] evecs,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef double complex * vec_to_eigbasis(complex[::1] vec, complex[::1,:] evecs, 
+cdef double complex * vec_to_eigbasis(complex[::1] vec, complex[::1,:] evecs,
                                     unsigned int nrows):
-    
-    cdef size_t ii, jj 
-    cdef double complex * temp1 = ZGEMM(&vec[0], &evecs[0,0], 
+
+    cdef size_t ii, jj
+    cdef double complex * temp1 = ZGEMM(&vec[0], &evecs[0,0],
                                        nrows, nrows, nrows, nrows, 0, 0)
     cdef double complex * eig_vec = ZGEMM(&evecs[0,0], temp1,
                                        nrows, nrows, nrows, nrows, 2, 0)
     PyDataMem_FREE(temp1)
     return eig_vec
- 
- 
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef np.ndarray[complex, ndim=1, mode='c'] vec_to_fockbasis(double complex * eig_vec, 
-                                                complex[::1,:] evecs, 
+cdef np.ndarray[complex, ndim=1, mode='c'] vec_to_fockbasis(double complex * eig_vec,
+                                                complex[::1,:] evecs,
                                                 unsigned int nrows):
 
-    cdef size_t ii, jj 
+    cdef size_t ii, jj
     cdef np.npy_intp nrows2 = nrows**2
-    cdef double complex * temp1 = ZGEMM(&eig_vec[0], &evecs[0,0], 
+    cdef double complex * temp1 = ZGEMM(&eig_vec[0], &evecs[0,0],
                                        nrows, nrows, nrows, nrows, 0, 2)
     cdef double complex * fock_vec = ZGEMM(&evecs[0,0], temp1,
                                        nrows, nrows, nrows, nrows, 0, 0)
@@ -306,17 +308,17 @@ cdef np.ndarray[complex, ndim=1, mode='c'] vec_to_fockbasis(double complex * eig
                 np.PyArray_SimpleNewFromData(1, &nrows2, np.NPY_COMPLEX128, fock_vec)
     PyArray_ENABLEFLAGS(out, np.NPY_OWNDATA)
     return out
- 
-            
+
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef cop_super_term(complex[::1,:] cop, complex[::1,:] evecs, 
+cpdef cop_super_term(complex[::1,:] cop, complex[::1,:] evecs,
                      double complex alpha, unsigned int nrows,
                      double atol):
     cdef size_t kk
     cdef CSR_Matrix mat1, mat2, mat3, mat4, mat5
-    
+
     cdef complex[::1,:] cop_eig = dense_to_eigbasis(cop, evecs, nrows, atol)
 
     fdense2D_to_CSR(cop_eig, &mat1, nrows, nrows)
@@ -326,20 +328,20 @@ cpdef cop_super_term(complex[::1,:] cop, complex[::1,:] evecs,
 
     #Free data associated with cop_eig as it is no longer needed.
     PyDataMem_FREE(&cop_eig[0,0])
-    
+
     #create temp array of conj data for cop_eig_sparse
     cdef complex * conj_data = <complex *>PyDataMem_NEW(mat1.nnz * sizeof(complex))
     for kk in range(mat1.nnz):
         conj_data[kk] = conj(mat1.data[kk])
 
-    
+
     #mat2 holds data for kron(cop.dag(), c)
     init_CSR(&mat2, mat1.nnz**2, mat1.nrows**2, mat1.ncols**2)
     _zcsr_kron_core(conj_data, mat1.indices, mat1.indptr,
                    mat1.data, mat1.indices, mat1.indptr,
                    &mat2,
-                   mat1.nrows, mat1.nrows, mat1.ncols)            
-    
+                   mat1.nrows, mat1.nrows, mat1.ncols)
+
     #Free temp conj_data array
     PyDataMem_FREE(conj_data)
     #Create identity in mat3
@@ -369,15 +371,15 @@ cpdef cop_super_term(complex[::1,:] cop, complex[::1,:] evecs,
     free_CSR(&mat4)
     free_CSR(&mat2)
     return CSR_to_scipy(&mat1)
-    
-    
-    
+
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void cop_super_mult(complex[::1,:] cop, complex[::1,:] evecs, 
+cdef void cop_super_mult(complex[::1,:] cop, complex[::1,:] evecs,
                      double complex * vec,
-                     double complex alpha, 
-                     double complex * out, 
+                     double complex alpha,
+                     double complex * out,
                      unsigned int nrows,
                      double atol):
     cdef size_t kk
@@ -387,7 +389,7 @@ cdef void cop_super_mult(complex[::1,:] cop, complex[::1,:] evecs,
 
     #Mat1 holds cop_eig in CSR format
     fdense2D_to_CSR(cop_eig, &mat1, nrows, nrows)
-    
+
     #Multiply by alpha for time-dependence
     for kk in range(mat1.nnz):
         mat1.data[kk] *= alpha
@@ -405,72 +407,72 @@ cdef void cop_super_mult(complex[::1,:] cop, complex[::1,:] evecs,
     _zcsr_kron_core(conj_data, mat1.indices, mat1.indptr,
                    mat1.data, mat1.indices, mat1.indptr,
                    &mat2,
-                   mat1.nrows, mat1.nrows, mat1.ncols)            
-    
+                   mat1.nrows, mat1.nrows, mat1.ncols)
+
     #Do spmv with kron(cop.dag(), c)
     spmvpy(mat2.data,mat2.indices,mat2.indptr,
         &vec[0], 1, out, nrows**2)
-    
+
     #Free temp conj_data array
     PyDataMem_FREE(conj_data)
     #Free mat2
     free_CSR(&mat2)
-    
+
     #Create identity in mat3
     identity_CSR(&mat3, nrows)
-    
+
     #Take adjoint of cop (mat1) -> mat2
     _zcsr_adjoint(&mat1, &mat2)
-    
+
     #multiply cop.dag() * c (cdc) -> mat4
     _zcsr_mult(&mat2, &mat1, &mat4)
-    
+
     #Free mat1 and mat2
     free_CSR(&mat1)
     free_CSR(&mat2)
-    
+
     # kron(eye, cdc) -> mat1
     _zcsr_kron(&mat3, &mat4, &mat1)
-    
+
     #Do spmv with -0.5*kron(eye, cdc)
     spmvpy(mat1.data,mat1.indices,mat1.indptr,
         vec, -0.5, &out[0], nrows**2)
-    
+
     #Free mat1 (mat1 and mat2 are currently free)
     free_CSR(&mat1)
-    
+
     #Take traspose of cdc (mat4) -> mat1
     _zcsr_transpose(&mat4, &mat1)
-    
+
     #Free mat4 (mat2 and mat4 currently free)
     free_CSR(&mat4)
-    
+
     # kron(cdct, eye) -> mat2
     _zcsr_kron(&mat1, &mat3, &mat2)
-    
+
     #Do spmv with -0.5*kron(cdct, eye)
     spmvpy(mat2.data,mat2.indices,mat2.indptr,
         vec, -0.5, &out[0], nrows**2)
-    
+
     #Free mat1, mat2, and mat3
     free_CSR(&mat1)
     free_CSR(&mat2)
     free_CSR(&mat3)
-    
+
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef inline void vec2mat_index(int nrows, int index, int[2] out) nogil:                       
+cdef inline void vec2mat_index(int nrows, int index, int[2] out) nogil:
     out[1] = index // nrows
-    out[0] = index - nrows * out[1] 
-    
+    out[0] = index - nrows * out[1]
+
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef double skew_and_dwmin(double * evals, double[:,::1] skew, 
+cdef double skew_and_dwmin(double * evals, double[:,::1] skew,
                                 unsigned int nrows) nogil:
     cdef double diff
     dw_min = DBL_MAX
@@ -482,7 +484,7 @@ cdef double skew_and_dwmin(double * evals, double[:,::1] skew,
             if diff != 0:
                 dw_min = fmin(fabs(diff), dw_min)
     return dw_min
-    
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -491,7 +493,7 @@ cdef void br_term_mult(double t, complex[::1,:] A, complex[::1,:] evecs,
                 double complex * vec, double complex * out,
                 unsigned int nrows, int use_secular, double sec_cutoff,
                 double atol):
-                
+
     cdef size_t kk
     cdef size_t I, J # vector index variables
     cdef int[2] ab, cd #matrix indexing variables
@@ -503,35 +505,35 @@ cdef void br_term_mult(double t, complex[::1,:] A, complex[::1,:] evecs,
     cdef COO_Matrix coo
     cdef CSR_Matrix csr
     cdef complex[:,::1] non_sec_mat
-    
+
     for I in range(nrows**2):
         vec2mat_index(nrows, I, ab)
         for J in range(nrows**2):
             vec2mat_index(nrows, J, cd)
-            
+
             if (not use_secular) or (fabs(skew[ab[0],ab[1]]-skew[cd[0],cd[1]]) < (dw_min * sec_cutoff)):
                 elem = (A_eig[ab[0],cd[0]]*A_eig[cd[1],ab[1]]) * 0.5
                 elem *= (spectral(skew[cd[0],ab[0]],t)+spectral(skew[cd[1],ab[1]],t))
-            
+
                 if (ab[0]==cd[0]):
                     ac_elem = 0
                     for kk in range(nrows):
                         ac_elem += A_eig[cd[1],kk]*A_eig[kk,ab[1]] * spectral(skew[cd[1],kk],t)
                     elem -= 0.5*ac_elem
-                    
+
                 if (ab[1]==cd[1]):
                     bd_elem = 0
                     for kk in range(nrows):
                         bd_elem += A_eig[ab[0],kk]*A_eig[kk,cd[0]] * spectral(skew[cd[0],kk],t)
                     elem -= 0.5*bd_elem
-                    
+
                 if (elem != 0):
                     coo_rows.push_back(I)
                     coo_cols.push_back(J)
                     coo_data.push_back(elem)
-    
+
     PyDataMem_FREE(&A_eig[0,0])
-    
+
     #Number of elements in BR tensor
     nnz = coo_rows.size()
     coo.nnz = nnz
@@ -540,16 +542,16 @@ cdef void br_term_mult(double t, complex[::1,:] A, complex[::1,:] evecs,
     coo.data = coo_data.data()
     coo.nrows = nrows**2
     coo.ncols = nrows**2
-    coo.is_set = 1 
+    coo.is_set = 1
     coo.max_length = nnz
     COO_to_CSR(&csr, &coo)
     spmvpy(csr.data, csr.indices, csr.indptr, vec, 1, out, nrows**2)
     free_CSR(&csr)
- 
- 
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void sparse_ZHEEVR(complex[::1,:] H, double * eigvals, 
+cdef void sparse_ZHEEVR(complex[::1,:] H, double * eigvals,
                     CSR_Matrix * evecs, int nrows, double atol):
     """
     Computes the eigenvalues and vectors of a dense Hermitian matrix.
@@ -570,7 +572,7 @@ cdef void sparse_ZHEEVR(complex[::1,:] H, double * eigvals,
     cdef char jobz = b'V'
     cdef char rnge = b'A'
     cdef char uplo = b'L'
-    cdef double vl=1, vu=1, abstol=0 
+    cdef double vl=1, vu=1, abstol=0
     cdef int il=1, iu=1
     cdef int lwork = 18 * nrows
     cdef int lrwork = 24*nrows, liwork = 10*nrows
@@ -582,7 +584,7 @@ cdef void sparse_ZHEEVR(complex[::1,:] H, double * eigvals,
     cdef int * iwork = <int *>PyDataMem_NEW((10*nrows) * sizeof(int))
     cdef complex[:,::1] cZ = <complex[:nrows, :nrows]><complex *>PyDataMem_NEW(nrows**2 * sizeof(complex))
     cdef complex[::1,:] Z = cZ.T
-    
+
     zheevr(&jobz, &rnge, &uplo, &nrows, &H[0,0], &nrows, &vl, &vu, &il, &iu, &abstol,
            &M, eigvals, &Z[0,0], &nrows, isuppz, work, &lwork,
           rwork, &lrwork, iwork, &liwork, &info)
@@ -601,8 +603,8 @@ cdef void sparse_ZHEEVR(complex[::1,:] H, double * eigvals,
                 Z[ii,jj] = 0
     fdense2D_to_CSR(Z, evecs, nrows, nrows)
     PyDataMem_FREE(&Z[0,0])
-    
- 
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef CSR_Matrix sparse_to_eigbasis(complex[::1] Adata, int[::1] Aind, int[::1] Aptr,
@@ -617,7 +619,7 @@ cdef CSR_Matrix sparse_to_eigbasis(complex[::1] Adata, int[::1] Aind, int[::1] A
     A.max_length = A.nnz
     A.numpy_lock = 1
     A.is_set = 1
-    
+
     _zcsr_mult(&A, evecs, &B)
     _zcsr_adjoint(evecs, &C)
     _zcsr_mult(&C, &B, &A_eig)
@@ -625,6 +627,3 @@ cdef CSR_Matrix sparse_to_eigbasis(complex[::1] Adata, int[::1] Aind, int[::1] A
     free_CSR(&B)
     free_CSR(&C)
     return A_eig
-     
- 
-   

--- a/qutip/cy/brtools_checks.pyx
+++ b/qutip/cy/brtools_checks.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
@@ -34,7 +36,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 import qutip.settings as qset
-from qutip.cy.brtools cimport (ZHEEVR, diag_liou_mult, dense_to_eigbasis, 
+from qutip.cy.brtools cimport (ZHEEVR, diag_liou_mult, dense_to_eigbasis,
                             vec_to_eigbasis, vec_to_fockbasis,
                             cop_super_mult, br_term_mult, skew_and_dwmin)
 
@@ -48,24 +50,24 @@ def _test_zheevr(complex[::1,:] H, double[::1] evals):
 
 
 @cython.boundscheck(False)
-def _test_diag_liou_mult(double[::1] evals, complex[::1] vec, 
+def _test_diag_liou_mult(double[::1] evals, complex[::1] vec,
                             complex[::1] out, int nrows):
     diag_liou_mult(&evals[0], &vec[0], &out[0], nrows)
 
 
 @cython.boundscheck(False)
-def _test_dense_to_eigbasis(complex[::1,:] A, complex[::1,:] evecs, 
+def _test_dense_to_eigbasis(complex[::1,:] A, complex[::1,:] evecs,
                         unsigned int nrows, double atol):
-    cdef complex[::1,:] out = dense_to_eigbasis(A, evecs, nrows, atol) 
+    cdef complex[::1,:] out = dense_to_eigbasis(A, evecs, nrows, atol)
     cdef np.ndarray[complex, ndim=2] mat
-    cdef np.npy_intp dims[2] 
+    cdef np.npy_intp dims[2]
     dims[:] = [A.shape[0], A.shape[1]]
     #We cannot build simple in fortran-order, so build c-order and return transpose
     mat = np.PyArray_SimpleNewFromData(2, <np.npy_intp *>dims, np.NPY_COMPLEX128, &out[0,0])
     PyArray_ENABLEFLAGS(mat, np.NPY_OWNDATA)
     return mat.T
 
-    
+
 @cython.boundscheck(False)
 def _test_vec_to_eigbasis(complex[::1,:] H, complex[::1] vec):
     cdef np.ndarray[complex, ndim=2, mode='fortran'] Z = np.zeros((H.shape[0],H.shape[0]),
@@ -83,7 +85,7 @@ def _test_vec_to_eigbasis(complex[::1,:] H, complex[::1] vec):
 
 @cython.boundscheck(False)
 def _test_eigvec_to_fockbasis(complex[::1] eig_vec, complex[::1,:] evecs, int nrows):
-    cdef np.ndarray[complex, ndim=1, mode='c'] out 
+    cdef np.ndarray[complex, ndim=1, mode='c'] out
     out = vec_to_fockbasis(&eig_vec[0], evecs, nrows)
     return out
 
@@ -95,27 +97,27 @@ def _test_vector_roundtrip(complex[::1,:] H, complex[::1] vec):
     cdef double[::1] evals = np.zeros(H.shape[0],dtype=float)
     ZHEEVR(H, &evals[0], Z, H.shape[0])
     cdef double complex * eig_vec = vec_to_eigbasis(vec, Z, H.shape[0])
-    cdef np.ndarray[complex, ndim=1, mode='c'] out 
+    cdef np.ndarray[complex, ndim=1, mode='c'] out
     out = vec_to_fockbasis(eig_vec, Z, H.shape[0])
     PyDataMem_FREE(eig_vec)
     return out
-    
+
 @cython.boundscheck(False)
-def _cop_super_mult(complex[::1,:] cop, complex[::1,:] evecs, complex[::1] vec, 
-                    double complex alpha, 
-                    complex[::1] out, 
+def _cop_super_mult(complex[::1,:] cop, complex[::1,:] evecs, complex[::1] vec,
+                    double complex alpha,
+                    complex[::1] out,
                     unsigned int nrows,
                     double atol):
-    cop_super_mult(cop, evecs, &vec[0], alpha, &out[0], nrows, atol) 
-    
- 
+    cop_super_mult(cop, evecs, &vec[0], alpha, &out[0], nrows, atol)
+
+
 #Test spectral function
-cdef complex spectral(double w, double t): return 1.0     
+cdef complex spectral(double w, double t): return 1.0
 
 def _test_br_term_mult(double t, complex[::1,:] A, complex[::1, :] evecs,
-            double[::1] evals, complex[::1] vec, complex[::1] out, 
+            double[::1] evals, complex[::1] vec, complex[::1] out,
             int use_secular, double sec_cutoff, double atol):
-            
+
     cdef unsigned int nrows = A.shape[0]
     cdef double * _temp = <double *>PyDataMem_NEW((nrows**2) * sizeof(double))
     cdef double[:,::1] skew = <double[:nrows,:nrows]> _temp
@@ -123,4 +125,3 @@ def _test_br_term_mult(double t, complex[::1,:] A, complex[::1, :] evecs,
     br_term_mult(t, A, evecs, skew, dw_min, spectral, &vec[0], &out[0],
                 nrows, use_secular, sec_cutoff, atol)
     PyDataMem_FREE(&skew[0,0])
-    

--- a/qutip/cy/checks.pyx
+++ b/qutip/cy/checks.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
@@ -44,7 +46,7 @@ def _test_coo2csr_struct(object A):
     cdef CSR_Matrix out
     COO_to_CSR(&out, &mat)
     return CSR_to_scipy(&out)
-    
+
 
 def _test_sorting(object A):
     cdef complex[::1] data = A.data
@@ -52,9 +54,9 @@ def _test_sorting(object A):
     cdef int[::1] ptr = A.indptr
     cdef int nrows = A.shape[0]
     cdef int ncols = A.shape[1]
-    
+
     cdef CSR_Matrix out
-    
+
     out.data = &data[0]
     out.indices = &ind[0]
     out.indptr = &ptr[0]
@@ -63,8 +65,8 @@ def _test_sorting(object A):
     out.is_set = 1
     out.numpy_lock = 0
     sort_indices(&out)
-    
-    
+
+
 def _test_coo2csr_inplace_struct(object A, int sorted = 0):
     cdef complex[::1] data = A.data
     cdef int[::1] rows = A.row
@@ -82,7 +84,7 @@ def _test_coo2csr_inplace_struct(object A, int sorted = 0):
         _data[kk] = data[kk]
         _rows[kk] = rows[kk]
         _cols[kk] = cols[kk]
-    
+
     cdef COO_Matrix mat
     mat.data = _data
     mat.rows = _rows
@@ -93,7 +95,7 @@ def _test_coo2csr_inplace_struct(object A, int sorted = 0):
     mat.max_length = mat.nnz
     mat.is_set = 1
     mat.numpy_lock = 0
-    
+
     cdef CSR_Matrix out
 
     COO_to_CSR_inplace(&out, &mat)
@@ -107,9 +109,3 @@ def _test_csr2coo_struct(object A):
     cdef COO_Matrix out
     CSR_to_COO(&out, &mat)
     return COO_to_scipy(&out)
-    
-    
-    
-    
-    
-        

--- a/qutip/cy/codegen.py
+++ b/qutip/cy/codegen.py
@@ -45,7 +45,7 @@ class Codegen():
     def __init__(self, h_terms=None, h_tdterms=None, h_td_inds=None,
                  args=None, c_terms=None, c_tdterms=[], c_td_inds=None,
                  c_td_splines=[], c_td_spline_flags=[],
-                 type='me', config=None, 
+                 type='me', config=None,
                  use_openmp=False, omp_components=None, omp_threads=None):
         import sys
         import os
@@ -72,7 +72,7 @@ class Codegen():
         self.code = []  # strings to be written to file
         self.level = 0  # indent level
         self.config = config
-        
+
         #openmp settings
         self.use_openmp = use_openmp
         self.omp_components = omp_components
@@ -166,14 +166,14 @@ class Codegen():
                            "complex[::1] data%d," % k +
                            "int[::1] idx%d," % k +
                            "int[::1] ptr%d" % k)
-                           
+
         kk = len(self.h_tdterms)
         for jj in range(len(self.c_td_splines)):
             input_vars += (",\n        " +
                            "complex[::1] data%d," % (jj+kk) +
                            "int[::1] idx%d," % (jj+kk) +
                            "int[::1] ptr%d" % (jj+kk))
-            
+
         if any(self.c_tdterms):
             for k in range(len(self.h_terms),
                            len(self.h_terms) + len(self.c_tdterms)):
@@ -181,7 +181,7 @@ class Codegen():
                                "complex[::1] data%d," % k +
                                "int[::1] idx%d," % k +
                                "int[::1] ptr%d" % k)
-        
+
         #Add array for each Cubic_Spline term
         spline = 0
         for htd in (self.h_tdterms+self.c_td_splines):
@@ -193,7 +193,7 @@ class Codegen():
                     input_vars += (",\n        " +
                                    "complex[::1] spline%d" % spline)
                 spline += 1
-        
+
         input_vars += self._get_arg_str(self.args)
         func_end = "):"
         return [func_name + input_vars + func_end]
@@ -259,7 +259,7 @@ class Codegen():
                     if self.use_openmp and self.omp_components[ht]:
                         str_out = "spmvpy_openmp(&data%s[0], &idx%s[0], &ptr%s[0], &vec[0], 1.0, out, num_rows, %s)" % (
                             ht, ht, ht, self.omp_threads)
-                    else:    
+                    else:
                         str_out = "spmvpy(&data%s[0], &idx%s[0], &ptr%s[0], &vec[0], 1.0, out, num_rows)" % (
                                 ht, ht, ht)
                 else:
@@ -302,7 +302,7 @@ class Codegen():
                         cstr, cstr, cstr, " (" + tdterms[ct] + ")**2")
                 cinds += 1
                 func_vars.append(str_out)
-        
+
         #Collapse operators have cubic spline td-coeffs
         if len(self.c_td_splines) > 0:
             func_vars.append(" ")
@@ -314,7 +314,7 @@ class Codegen():
                 else:
                     interp_str = "zinterp(t, %s, %s, spline%s)" % (S.a, S.b, spline)
                 spline += 1
-                
+
                 #check if need to wrap string with ()**2
                 if c_idx > 0:
                     interp_str = "("+interp_str+")**2"
@@ -326,8 +326,8 @@ class Codegen():
                     str_out = "spmvpy(&data%s[0], &idx%s[0], &ptr%s[0], &vec[0], %s, out, num_rows)" % (
                         c_idx, c_idx, c_idx, interp_str)
                 func_vars.append(str_out)
-                
-        
+
+
         return func_vars
 
     def func_which(self):
@@ -361,7 +361,7 @@ class Codegen():
 cdef np.npy_intp dims = num_rows
     cdef np.ndarray[complex, ndim=1, mode='c'] arr_out = np.PyArray_SimpleNewFromData(1, &dims, np.NPY_COMPLEX128, out)
     PyArray_ENABLEFLAGS(arr_out, np.NPY_OWNDATA)
-    return arr_out   
+    return arr_out
 """
 
     def func_end_real(self):
@@ -376,8 +376,9 @@ def cython_preamble(use_openmp=False):
         openmp_string='from qutip.cy.openmp.parfuncs cimport spmvpy_openmp'
     else:
         openmp_string=''
-    
-    return ["""\
+
+    return ["""#!python
+#cython: language_level=3
 # This file is generated automatically by QuTiP.
 # (C) 2011 and later, QuSTaR
 

--- a/qutip/cy/graph_utils.pyx
+++ b/qutip/cy/graph_utils.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
@@ -70,7 +72,7 @@ cdef int * int_argsort(int * x, int nrows):
     for kk in range(nrows):
         pairs[kk].data = x[kk]
         pairs[kk].idx = kk
-    
+
     sort(pairs.begin(),pairs.end(),cfptr_)
     cdef int * out = <int *>PyDataMem_NEW(nrows *sizeof(int))
     for kk in range(nrows):

--- a/qutip/cy/heom.pyx
+++ b/qutip/cy/heom.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
@@ -47,7 +49,7 @@ def cy_pad_csr(object A, int row_scale, int col_scale, int insertrow=0, int inse
     cdef int[::1] ind = A.indices
     cdef int[::1] ptr_in = A.indptr
     cdef cnp.ndarray[int, ndim=1, mode='c'] ptr_out = np.zeros(nrowout+1,dtype=np.int32)
-    
+
     A._shape = (nrowout, ncolout)
     if insertcol == 0:
         pass
@@ -57,8 +59,8 @@ def cy_pad_csr(object A, int row_scale, int col_scale, int insertrow=0, int inse
             ind[kk] += temp
     else:
         raise ValueError("insertcol must be >= 0 and < col_scale")
-        
-    
+
+
     if insertrow == 0:
         temp = ptr_in[nrowin]
         for kk in range(nrowin):
@@ -70,7 +72,7 @@ def cy_pad_csr(object A, int row_scale, int col_scale, int insertrow=0, int inse
         temp = (row_scale - 1) * nrowin
         for kk in range(temp, nrowout+1):
             ptr_out[kk] = ptr_in[kk-temp]
-    
+
     elif insertrow > 0 and insertrow < row_scale - 1:
         temp = insertrow*nrowin
         for kk in range(temp, temp+nrowin):
@@ -78,10 +80,10 @@ def cy_pad_csr(object A, int row_scale, int col_scale, int insertrow=0, int inse
         temp = kk+1
         temp2 = ptr_in[nrowin]
         for kk in range(temp, nrowout+1):
-            ptr_out[kk] = temp2     
+            ptr_out[kk] = temp2
     else:
         raise ValueError("insertrow must be >= 0 and < row_scale")
 
     A.indptr = ptr_out
-    
+
     return A

--- a/qutip/cy/interpolate.pxd
+++ b/qutip/cy/interpolate.pxd
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 

--- a/qutip/cy/interpolate.pyx
+++ b/qutip/cy/interpolate.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
@@ -60,12 +62,12 @@ cpdef double interp(double x, double a, double b, double[::1] c):
     cdef size_t ii
     cdef double s = 0, _tmp
     cdef double pos = (x-a)/h + 2
-    
+
     for ii in range(l, m+1):
         _tmp = phi(pos - ii)
         if _tmp:
             s += c[ii-1] * _tmp
-    return s    
+    return s
 
 
 @cython.boundscheck(False)
@@ -84,7 +86,7 @@ cpdef complex zinterp(double x, double a, double b, complex[::1] c):
         _tmp = phi(pos - ii)
         if _tmp:
             s += c[ii-1] * _tmp
-    return s  
+    return s
 
 
 @cython.boundscheck(False)
@@ -92,24 +94,24 @@ cpdef complex zinterp(double x, double a, double b, complex[::1] c):
 @cython.cdivision(True)
 def arr_interp(double[::1] x, double a, double b, double[::1] c):
     cdef int lenx = x.shape[0]
-    cdef int lenc = c.shape[0] 
+    cdef int lenc = c.shape[0]
     cdef int n = lenc - 3
     cdef double h = (b-a) / n
     cdef size_t ii, jj
     cdef int l, m
     cdef double pos, _tmp
     cdef cnp.ndarray[double, ndim=1, mode="c"] out = np.zeros(lenx, dtype=float)
-    
+
     for jj in range(lenx):
         l = <int>((x[jj]-a)/h) + 1
         m = <int>(fmin(l+3, n+3))
         pos = (x[jj]-a)/h + 2
-        
+
         for ii in range(l, m+1):
             _tmp = phi(pos - ii)
             if _tmp:
                 out[jj] += c[ii-1] * _tmp
-    
+
     return out
 
 
@@ -118,7 +120,7 @@ def arr_interp(double[::1] x, double a, double b, double[::1] c):
 @cython.cdivision(True)
 def arr_zinterp(double[::1] x, double a, double b, complex[::1] c):
     cdef int lenx = x.shape[0]
-    cdef int lenc = c.shape[0] 
+    cdef int lenc = c.shape[0]
     cdef int n = lenc - 3
     cdef double h = (b-a) / n
     cdef size_t ii, jj
@@ -130,14 +132,10 @@ def arr_zinterp(double[::1] x, double a, double b, complex[::1] c):
         l = <int>((x[jj]-a)/h) + 1
         m = <int>(fmin(l+3, n+3))
         pos = (x[jj]-a)/h + 2
-    
+
         for ii in range(l, m+1):
             _tmp = phi(pos - ii)
             if _tmp:
                 out[jj] = out[jj] + c[ii-1] * _tmp
 
     return out
-
-
-
-

--- a/qutip/cy/math.pxd
+++ b/qutip/cy/math.pxd
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 

--- a/qutip/cy/math.pyx
+++ b/qutip/cy/math.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
@@ -40,35 +42,35 @@ cdef double erf(double x):
     A Cython version of the erf function from the cdflib in SciPy.
     """
     cdef double c = 0.564189583547756
-    
-    cdef double a[5] 
+
+    cdef double a[5]
     a[:] = [0.771058495001320e-4, -0.133733772997339e-2, 0.323076579225834e-1,
                      0.479137145607681e-1, 0.128379167095513]
-    
-    cdef double b[3] 
+
+    cdef double b[3]
     b[:] = [0.301048631703895e-2, 0.538971687740286e-1, .375795757275549]
-    
-    cdef double p[8] 
+
+    cdef double p[8]
     p[:] = [-1.36864857382717e-7, 5.64195517478974e-1, 7.21175825088309,
                      4.31622272220567e1, 1.52989285046940e2, 3.39320816734344e2,
                      4.51918953711873e2, 3.00459261020162e2]
-    
-    cdef double q[8] 
+
+    cdef double q[8]
     q[:]= [1.0, 1.27827273196294e1, 7.70001529352295e1, 2.77585444743988e2,
                      6.38980264465631e2, 9.31354094850610e2, 7.90950925327898e2,
                      3.00459260956983e2]
-    
-    cdef double r[5] 
-    r[:] = [2.10144126479064, 2.62370141675169e1, 2.13688200555087e1, 
+
+    cdef double r[5]
+    r[:] = [2.10144126479064, 2.62370141675169e1, 2.13688200555087e1,
                       4.65807828718470, 2.82094791773523e-1]
-    
-    cdef double s[4] 
+
+    cdef double s[4]
     s[:] = [9.41537750555460e1, 1.87114811799590e2, 9.90191814623914e1,
                      1.80124575948747e1]
-    
+
     cdef double ax = fabs(x)
     cdef double t, x2, top, bot, erf
-    
+
     if ax <= 0.5:
         t = x*x
         top = ((((a[0]*t+a[1])*t+a[2])*t+a[3])*t+a[4]) + 1.0

--- a/qutip/cy/openmp/benchmark.pyx
+++ b/qutip/cy/openmp/benchmark.pyx
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 cimport cython

--- a/qutip/cy/openmp/br_omp.pxd
+++ b/qutip/cy/openmp/br_omp.pxd
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 cimport numpy as cnp
@@ -35,20 +37,20 @@ cimport numpy as cnp
 #Spectral function with signature (w,t)
 ctypedef complex (*spec_func)(double, double)
 
-                                             
-cdef void cop_super_mult_openmp(complex[::1,:] cop, complex[::1,:] evecs,  double complex * vec, 
-                    double complex alpha, 
-                    double complex * out, 
+
+cdef void cop_super_mult_openmp(complex[::1,:] cop, complex[::1,:] evecs,  double complex * vec,
+                    double complex alpha,
+                    double complex * out,
                     unsigned int nrows,
                     unsigned int omp_thresh,
                     unsigned int nthr,
                     double atol)
-                    
+
 
 cdef void br_term_mult_openmp(double t, complex[::1,:] A, complex[::1,:] evecs,
                 double[:,::1] skew, double dw_min, spec_func spectral,
                 double complex * vec, double complex * out,
-                unsigned int nrows, int use_secular, 
+                unsigned int nrows, int use_secular,
                 double sec_cutoff,
                 unsigned int omp_thresh,
                 unsigned int nthr,

--- a/qutip/cy/openmp/omp_sparse_utils.pyx
+++ b/qutip/cy/openmp/omp_sparse_utils.pyx
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 import numpy as np
@@ -52,8 +54,8 @@ cpdef bool omp_tidyup(complex[::1] data, double atol, int nnz, int nthr):
         for kk in prange(nnz, schedule='static'):
             re_flag = 0
             im_flag = 0
-            re = real(data[kk]) 
-            im = imag(data[kk]) 
+            re = real(data[kk])
+            im = imag(data[kk])
             if fabs(re) < atol:
                 re = 0
                 re_flag = 1
@@ -65,16 +67,3 @@ cpdef bool omp_tidyup(complex[::1] data, double atol, int nnz, int nthr):
             if re_flag and im_flag:
                 out_flag = 1
     return out_flag
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/qutip/cy/openmp/parfuncs.pxd
+++ b/qutip/cy/openmp/parfuncs.pxd
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 cimport numpy as cnp

--- a/qutip/cy/openmp/parfuncs.pyx
+++ b/qutip/cy/openmp/parfuncs.pyx
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 import numpy as np
@@ -35,7 +37,7 @@ cimport numpy as cnp
 cimport cython
 
 cdef extern from "src/zspmv_openmp.hpp" nogil:
-    void zspmvpy_openmp(double complex *data, int *ind, int *ptr, double complex *vec, 
+    void zspmvpy_openmp(double complex *data, int *ind, int *ptr, double complex *vec,
                 double complex a, double complex *out, int nrows, int nthr)
 
 
@@ -46,21 +48,21 @@ cpdef cnp.ndarray[complex, ndim=1, mode="c"] spmv_openmp(
         complex[::1] vec,
         unsigned int nthr):
     """
-    Sparse matrix, dense vector multiplication.  
+    Sparse matrix, dense vector multiplication.
     Here the vector is assumed to have one-dimension.
     Matrix must be in CSR format and have complex entries.
-    
+
     Parameters
     ----------
     super_op : csr matrix
     vec : array
         Dense vector for multiplication.  Must be one-dimensional.
-    
+
     Returns
     -------
     out : array
         Returns dense array.
-    
+
     """
     return spmv_csr_openmp(super_op.data, super_op.indices, super_op.indptr, vec, nthr)
 
@@ -70,10 +72,10 @@ cpdef cnp.ndarray[complex, ndim=1, mode="c"] spmv_openmp(
 cpdef cnp.ndarray[complex, ndim=1, mode="c"] spmv_csr_openmp(complex[::1] data,
             int[::1] ind, int[::1] ptr, complex[::1] vec, unsigned int nthr):
     """
-    Sparse matrix, dense vector multiplication.  
+    Sparse matrix, dense vector multiplication.
     Here the vector is assumed to have one-dimension.
     Matrix must be in CSR format and have complex entries.
-    
+
     Parameters
     ----------
     data : array
@@ -84,12 +86,12 @@ cpdef cnp.ndarray[complex, ndim=1, mode="c"] spmv_csr_openmp(complex[::1] data,
         Pointers for sparse matrix data.
     vec : array
         Dense vector for multiplication.  Must be one-dimensional.
-    
+
     Returns
     -------
     out : array
         Returns dense array.
-    
+
     """
     cdef unsigned int num_rows = vec.shape[0]
     cdef cnp.ndarray[complex, ndim=1, mode="c"] out = np.zeros(num_rows, dtype=complex)
@@ -104,7 +106,7 @@ cdef inline void spmvpy_openmp(complex * data, int * ind, int * ptr,
             complex * out,
             unsigned int nrows,
             unsigned int nthr):
-    
+
     zspmvpy_openmp(data, ind, ptr, vec, a, out, nrows, nthr)
 
 
@@ -112,7 +114,7 @@ cdef inline void spmvpy_openmp(complex * data, int * ind, int * ptr,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef cnp.ndarray[complex, ndim=1, mode="c"] cy_ode_rhs_openmp(
-        double t, 
+        double t,
         complex[::1] rho,
         complex[::1] data,
         int[::1] ind,
@@ -130,8 +132,8 @@ cpdef cnp.ndarray[complex, ndim=1, mode="c"] cy_ode_rhs_openmp(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef cnp.ndarray[complex, ndim=1, mode="c"] cy_ode_psi_func_td_openmp(
-        double t, 
-        cnp.ndarray[complex, ndim=1, mode="c"] psi, 
+        double t,
+        cnp.ndarray[complex, ndim=1, mode="c"] psi,
         object H_func,
         object args,
         unsigned int nthr):
@@ -165,16 +167,3 @@ cpdef cnp.ndarray[complex, ndim=1, mode="c"] cy_ode_rho_func_td_openmp(
     cdef object L
     L = L0 + L_func(t, args).data
     return spmv_csr_openmp(L.data, L.indices, L.indptr, rho, nthr)
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/qutip/cy/piqs.pyx
+++ b/qutip/cy/piqs.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
@@ -233,7 +235,7 @@ cpdef list jmm1_dictionary(int N):
 cdef class Dicke(object):
     """
     A faster Cythonized Dicke state class to build the Lindbladian.
-    
+
     Parameters
     ----------
     N: int
@@ -262,7 +264,7 @@ cdef class Dicke(object):
     collective_dephasing: float
         Collective dephasing coefficient.
         default: 0.0
-        
+
     Attributes
     ----------
     N: int

--- a/qutip/cy/sparse_routines.pxi
+++ b/qutip/cy/sparse_routines.pxi
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
@@ -103,11 +105,11 @@ cdef inline int int_min(int a, int b) nogil:
     return b if b < a else a
 
 cdef inline int int_max(int a, int b) nogil:
-    return a if a > b else b 
-    
+    return a if a > b else b
+
 
 @cython.boundscheck(False)
-@cython.wraparound(False)        
+@cython.wraparound(False)
 cdef void init_CSR(CSR_Matrix * mat, int nnz, int nrows, int ncols = 0,
                 int max_length = 0, int init_zeros = 1):
     """
@@ -121,7 +123,7 @@ cdef void init_CSR(CSR_Matrix * mat, int nnz, int nrows, int ncols = 0,
     nnz : int
         Length of data and indices arrays. Also number of nonzero elements
     nrows : int
-        Number of rows in matrix. Also gives length 
+        Number of rows in matrix. Also gives length
         of indptr array (nrows+1).
     ncols : int (default = 0)
         Number of cols in matrix. Default is ncols = nrows.
@@ -157,7 +159,7 @@ cdef void init_CSR(CSR_Matrix * mat, int nnz, int nrows, int ncols = 0,
 
 
 @cython.boundscheck(False)
-@cython.wraparound(False)        
+@cython.wraparound(False)
 cdef void copy_CSR(CSR_Matrix * out, CSR_Matrix * mat):
     """
     Copy a CSR_Matrix.
@@ -176,10 +178,10 @@ cdef void copy_CSR(CSR_Matrix * out, CSR_Matrix * mat):
     for kk in range(mat.nrows+1):
         out.indptr[kk] = mat.indptr[kk]
 
-    
+
 @cython.boundscheck(False)
-@cython.wraparound(False)        
-cdef void init_COO(COO_Matrix * mat, int nnz, int nrows, int ncols = 0, 
+@cython.wraparound(False)
+cdef void init_COO(COO_Matrix * mat, int nnz, int nrows, int ncols = 0,
                 int max_length = 0, int init_zeros = 1):
     """
     Initialize COO_Matrix struct. Matrix is assumed to be square with
@@ -260,10 +262,10 @@ cdef void free_COO(COO_Matrix * mat):
         mat.is_set = 0
     else:
         raise_error_COO(-2)
-    
-    
+
+
 @cython.boundscheck(False)
-@cython.wraparound(False)       
+@cython.wraparound(False)
 cdef void shorten_CSR(CSR_Matrix * mat, int N):
     """
     Shortends the length of CSR data and indices arrays.
@@ -277,7 +279,7 @@ cdef void shorten_CSR(CSR_Matrix * mat, int N):
             raise_error_CSR(-4, mat)
         elif not mat.is_set:
             raise_error_CSR(-3, mat)
-    
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -300,7 +302,7 @@ cdef void expand_CSR(CSR_Matrix * mat, int init_zeros=0):
             if init_zeros == 1:
                 for ii in range(mat.nnz, new_size):
                     mat.data[ii] = 0
-                
+
         new_ind = <int *>PyDataMem_RENEW(mat.indices, new_size * sizeof(int))
         mat.indices = new_ind
         if init_zeros == 1:
@@ -320,7 +322,7 @@ cdef object CSR_to_scipy(CSR_Matrix * mat):
     """
     Converts a CSR_Matrix struct to a SciPy csr_matrix class object.
     The NumPy arrays are generated from the pointers, and the lifetime
-    of the pointer memory is tied to that of the NumPy array 
+    of the pointer memory is tied to that of the NumPy array
     (i.e. automatic garbage cleanup.)
 
     Parameters
@@ -357,7 +359,7 @@ cdef object COO_to_scipy(COO_Matrix * mat):
     """
     Converts a COO_Matrix struct to a SciPy coo_matrix class object.
     The NumPy arrays are generated from the pointers, and the lifetime
-    of the pointer memory is tied to that of the NumPy array 
+    of the pointer memory is tied to that of the NumPy array
     (i.e. automatic garbage cleanup.)
 
     Parameters
@@ -440,7 +442,7 @@ cdef void CSR_to_COO(COO_Matrix * out, CSR_Matrix * mat):
         k2 = mat.indptr[kk]
         for jj in range(k2, k1):
             out.rows[jj] = kk
-            
+
 
 
 @cython.boundscheck(False)
@@ -535,21 +537,21 @@ cdef void sort_indices(CSR_Matrix * mat):
         row_end = mat.indptr[ii+1]
         length = row_end - row_start
         pairs.resize(length)
-    
+
         for jj in range(length):
             pairs[jj].data = mat.data[row_start+jj]
             pairs[jj].ind = mat.indices[row_start+jj]
-        
+
         sort(pairs.begin(),pairs.end(),cfptr_)
-    
+
         for jj in range(length):
             mat.data[row_start+jj] = pairs[jj].data
             mat.indices[row_start+jj] = pairs[jj].ind
-        
-    
+
+
 
 @cython.boundscheck(False)
-@cython.wraparound(False)  
+@cython.wraparound(False)
 cdef CSR_Matrix CSR_from_scipy(object A):
     """
     Converts a SciPy CSR sparse matrix to a
@@ -561,9 +563,9 @@ cdef CSR_Matrix CSR_from_scipy(object A):
     cdef int nrows = A.shape[0]
     cdef int ncols = A.shape[1]
     cdef int nnz = ptr[nrows]
-    
+
     cdef CSR_Matrix mat
-    
+
     mat.data = &data[0]
     mat.indices = &ind[0]
     mat.indptr = &ptr[0]
@@ -573,12 +575,12 @@ cdef CSR_Matrix CSR_from_scipy(object A):
     mat.max_length = nnz
     mat.is_set = 1
     mat.numpy_lock = 1
-    
+
     return mat
-    
+
 
 @cython.boundscheck(False)
-@cython.wraparound(False)  
+@cython.wraparound(False)
 cdef COO_Matrix COO_from_scipy(object A):
     """
     Converts a SciPy COO sparse matrix to a
@@ -590,7 +592,7 @@ cdef COO_Matrix COO_from_scipy(object A):
     cdef int nrows = A.shape[0]
     cdef int ncols = A.shape[1]
     cdef int nnz = data.shape[0]
-    
+
     cdef COO_Matrix mat
     mat.data = &data[0]
     mat.rows = &rows[0]
@@ -601,10 +603,10 @@ cdef COO_Matrix COO_from_scipy(object A):
     mat.max_length = nnz
     mat.is_set = 1
     mat.numpy_lock = 1
-    
+
     return mat
-     
-     
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef void identity_CSR(CSR_Matrix * mat, unsigned int nrows):

--- a/qutip/cy/sparse_structs.pxd
+++ b/qutip/cy/sparse_structs.pxd
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
@@ -52,6 +54,6 @@ cdef struct _coo_mat:
     int is_set
     int max_length
     int numpy_lock
-    
+
 ctypedef _csr_mat CSR_Matrix
 ctypedef _coo_mat COO_Matrix

--- a/qutip/cy/sparse_utils.pyx
+++ b/qutip/cy/sparse_utils.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
@@ -245,13 +247,13 @@ def _sparse_reverse_permute(
 
     return new_data, new_idx, new_ptr
 
-                    
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def _isdiag(int[::1] idx,
         int[::1] ptr,
         int nrows):
-        
+
     cdef int row, num_elems
     for row in range(nrows):
         num_elems = ptr[row+1] - ptr[row]
@@ -265,9 +267,9 @@ def _isdiag(int[::1] idx,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef cnp.ndarray[complex, ndim=1, mode='c'] _csr_get_diag(complex[::1] data, 
+cpdef cnp.ndarray[complex, ndim=1, mode='c'] _csr_get_diag(complex[::1] data,
     int[::1] idx, int[::1] ptr, int k=0):
-    
+
     cdef size_t row, jj
     cdef int num_rows = ptr.shape[0]-1
     cdef int abs_k = abs(k)
@@ -307,7 +309,7 @@ def unit_row_norm(complex[::1] data, int[::1] ptr, int nrows):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef double zcsr_one_norm(complex[::1] data, int[::1] ind, int[::1] ptr,       
+cpdef double zcsr_one_norm(complex[::1] data, int[::1] ind, int[::1] ptr,
                      int nrows, int ncols):
 
     cdef int k
@@ -320,14 +322,14 @@ cpdef double zcsr_one_norm(complex[::1] data, int[::1] ind, int[::1] ptr,
             col_sum[k] += cabs(data[jj])
     for ii in range(ncols):
         if col_sum[ii] > max_col:
-            max_col = col_sum[ii]        
+            max_col = col_sum[ii]
     PyDataMem_FREE(col_sum)
     return max_col
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef double zcsr_inf_norm(complex[::1] data, int[::1] ind, int[::1] ptr,       
+cpdef double zcsr_inf_norm(complex[::1] data, int[::1] ind, int[::1] ptr,
                      int nrows, int ncols):
 
     cdef int k
@@ -339,11 +341,11 @@ cpdef double zcsr_inf_norm(complex[::1] data, int[::1] ind, int[::1] ptr,
             row_sum[ii] += cabs(data[jj])
     for ii in range(nrows):
         if row_sum[ii] > max_row:
-            max_row = row_sum[ii]        
+            max_row = row_sum[ii]
     PyDataMem_FREE(row_sum)
     return max_row
-    
-    
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef bool cy_tidyup(complex[::1] data, double atol, unsigned int nnz):
@@ -364,13 +366,10 @@ cpdef bool cy_tidyup(complex[::1] data, double atol, unsigned int nnz):
         if fabs(im) < atol:
             im = 0
             im_flag = 1
-        
+
         if re_flag or im_flag:
             data[kk] = re + 1j*im
-            
+
         if re_flag and im_flag:
             out_flag = 1
     return out_flag
-        
-        
-        

--- a/qutip/cy/spconvert.pxd
+++ b/qutip/cy/spconvert.pxd
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,20 +20,20 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
 from qutip.cy.sparse_structs cimport CSR_Matrix
 
-cdef void fdense2D_to_CSR(complex[::1, :] mat, CSR_Matrix * out, 
+cdef void fdense2D_to_CSR(complex[::1, :] mat, CSR_Matrix * out,
                                 unsigned int nrows, unsigned int ncols)

--- a/qutip/cy/spconvert.pyx
+++ b/qutip/cy/spconvert.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
@@ -41,8 +43,8 @@ cdef extern from "stdlib.h":
         int quot
         int rem
 
-include "sparse_routines.pxi"    
-    
+include "sparse_routines.pxi"
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def arr_coo2fast(complex[::1] data, int[::1] rows, int[::1] cols, int nrows, int ncols):
@@ -60,18 +62,18 @@ def arr_coo2fast(complex[::1] data, int[::1] rows, int[::1] cols, int nrows, int
     mat.nnz = nnz
     mat.is_set = 1
     mat.max_length = nnz
-    
+
     cdef CSR_Matrix out
     COO_to_CSR(&out, &mat)
     return CSR_to_scipy(&out)
-    
-    
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def dense2D_to_fastcsr_cmode(complex[:, ::1] mat, int nrows, int ncols):
     """
     Converts a dense c-mode complex ndarray to a sparse CSR matrix.
-    
+
     Parameters
     ----------
     mat : ndarray
@@ -80,7 +82,7 @@ def dense2D_to_fastcsr_cmode(complex[:, ::1] mat, int nrows, int ncols):
         Number of rows in matrix.
     ncols : int
         Number of cols in matrix.
-    
+
     Returns
     -------
     out : fast_csr_matrix
@@ -108,7 +110,7 @@ def dense2D_to_fastcsr_cmode(complex[:, ::1] mat, int nrows, int ncols):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void fdense2D_to_CSR(complex[::1, :] mat, CSR_Matrix * out, 
+cdef void fdense2D_to_CSR(complex[::1, :] mat, CSR_Matrix * out,
                                 unsigned int nrows, unsigned int ncols):
     """
     Converts a dense complex ndarray to a CSR matrix struct.
@@ -189,7 +191,7 @@ def dense2D_to_fastcsr_fmode(complex[::1, :] mat, int nrows, int ncols):
 def zcsr_reshape(object A not None, int new_rows, int new_cols):
     """
     Reshapes a complex CSR matrix.
-    
+
     Parameters
     ----------
     A : fast_csr_matrix
@@ -198,12 +200,12 @@ def zcsr_reshape(object A not None, int new_rows, int new_cols):
         Number of rows in reshaped matrix.
     new_cols : int
         Number of cols in reshaped matrix.
-        
+
     Returns
     -------
     out : fast_csr_matrix
         Reshaped CSR matrix.
-        
+
     Notes
     -----
     This routine does not need to make a temp. copy of the matrix.
@@ -214,7 +216,7 @@ def zcsr_reshape(object A not None, int new_rows, int new_cols):
     cdef CSR_Matrix out
     cdef div_t new_inds
     cdef size_t kk
-    
+
     if (mat.nrows * mat.ncols) != (new_rows * new_cols):
         raise Exception('Total size of array must be unchanged.')
 
@@ -225,7 +227,7 @@ def zcsr_reshape(object A not None, int new_rows, int new_cols):
 
     mat.nrows = new_rows
     mat.ncols = new_cols
-    
+
     COO_to_CSR_inplace(&out, &mat)
     sort_indices(&out)
     return CSR_to_scipy(&out)
@@ -237,17 +239,17 @@ def zcsr_reshape(object A not None, int new_rows, int new_cols):
 def cy_index_permute(int [::1] idx_arr,
                      int [::1] dims,
                      int [::1] order):
-    
+
     cdef int ndims = dims.shape[0]
     cdef int ii, n, dim, idx, orderr
-    
+
     #the fastest way to allocate memory for a temporary array
     cdef int * multi_idx = <int*> malloc(sizeof(int) * ndims)
-    
+
     try:
         for ii from 0 <= ii < idx_arr.shape[0]:
             idx = idx_arr[ii]
-            
+
             #First, decompose long index into multi-index
             for n from ndims > n >= 0:
                 dim = dims[n]

--- a/qutip/cy/spmatfuncs.pxd
+++ b/qutip/cy/spmatfuncs.pxd
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
@@ -62,6 +64,6 @@ cpdef cy_expect_psi(object A,
 
 cpdef cy_expect_psi_csr(complex[::1] data,
                         int[::1] ind,
-                        int[::1] ptr, 
+                        int[::1] ptr,
                         complex[::1] vec,
                         bool isherm)

--- a/qutip/cy/spmatfuncs.pyx
+++ b/qutip/cy/spmatfuncs.pyx
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 import numpy as np
@@ -37,7 +39,7 @@ cimport libc.math
 from libcpp cimport bool
 
 cdef extern from "src/zspmv.hpp" nogil:
-    void zspmvpy(double complex *data, int *ind, int *ptr, double complex *vec, 
+    void zspmvpy(double complex *data, int *ind, int *ptr, double complex *vec,
                 double complex a, double complex *out, int nrows)
 
 include "complex_math.pxi"
@@ -48,21 +50,21 @@ cpdef cnp.ndarray[complex, ndim=1, mode="c"] spmv(
         object super_op,
         complex[::1] vec):
     """
-    Sparse matrix, dense vector multiplication.  
+    Sparse matrix, dense vector multiplication.
     Here the vector is assumed to have one-dimension.
     Matrix must be in CSR format and have complex entries.
-    
+
     Parameters
     ----------
     super_op : csr matrix
     vec : array
         Dense vector for multiplication.  Must be one-dimensional.
-    
+
     Returns
     -------
     out : array
         Returns dense array.
-    
+
     """
     return spmv_csr(super_op.data, super_op.indices, super_op.indptr, vec)
 
@@ -72,10 +74,10 @@ cpdef cnp.ndarray[complex, ndim=1, mode="c"] spmv(
 cpdef cnp.ndarray[complex, ndim=1, mode="c"] spmv_csr(complex[::1] data,
             int[::1] ind, int[::1] ptr, complex[::1] vec):
     """
-    Sparse matrix, dense vector multiplication.  
+    Sparse matrix, dense vector multiplication.
     Here the vector is assumed to have one-dimension.
     Matrix must be in CSR format and have complex entries.
-    
+
     Parameters
     ----------
     data : array
@@ -86,12 +88,12 @@ cpdef cnp.ndarray[complex, ndim=1, mode="c"] spmv_csr(complex[::1] data,
         Pointers for sparse matrix data.
     vec : array
         Dense vector for multiplication.  Must be one-dimensional.
-    
+
     Returns
     -------
     out : array
         Returns dense array.
-    
+
     """
     cdef unsigned int num_rows = ptr.shape[0] - 1
     cdef cnp.ndarray[complex, ndim=1, mode="c"] out = np.zeros((num_rows), dtype=np.complex)
@@ -101,10 +103,10 @@ cpdef cnp.ndarray[complex, ndim=1, mode="c"] spmv_csr(complex[::1] data,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def spmvpy_csr(complex[::1] data,
-            int[::1] ind, int[::1] ptr, complex[::1] vec, 
+            int[::1] ind, int[::1] ptr, complex[::1] vec,
             complex alpha, complex[::1] out):
     """
-    Sparse matrix, dense vector multiplication.  
+    Sparse matrix, dense vector multiplication.
     Here the vector is assumed to have one-dimension.
     Matrix must be in CSR format and have complex entries.
 
@@ -135,7 +137,7 @@ cdef inline void spmvpy(complex * data, int * ind, int * ptr,
             complex a,
             complex * out,
             unsigned int nrows):
-    
+
     zspmvpy(data, ind, ptr, vec, a, out, nrows)
 
 
@@ -143,7 +145,7 @@ cdef inline void spmvpy(complex * data, int * ind, int * ptr,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef cnp.ndarray[complex, ndim=1, mode="c"] cy_ode_rhs(
-        double t, 
+        double t,
         complex[::1] rho,
         complex[::1] data,
         int[::1] ind,
@@ -160,8 +162,8 @@ cpdef cnp.ndarray[complex, ndim=1, mode="c"] cy_ode_rhs(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef cnp.ndarray[complex, ndim=1, mode="c"] cy_ode_psi_func_td(
-        double t, 
-        cnp.ndarray[complex, ndim=1, mode="c"] psi, 
+        double t,
+        cnp.ndarray[complex, ndim=1, mode="c"] psi,
         object H_func,
         object args):
 
@@ -223,7 +225,7 @@ cpdef cy_expect_psi(object A, complex[::1] vec, bool isherm):
 @cython.wraparound(False)
 cpdef cy_expect_psi_csr(complex[::1] data,
                         int[::1] ind,
-                        int[::1] ptr, 
+                        int[::1] ptr,
                         complex[::1] vec,
                         bool isherm):
 
@@ -264,7 +266,7 @@ cpdef cy_expect_rho_vec_csr(complex[::1] data,
                              int[::1] ptr,
                              complex[::1] rho_vec,
                              int herm):
-    
+
     cdef size_t row
     cdef int jj,row_start,row_end
     cdef int num_rows = rho_vec.shape[0]
@@ -276,7 +278,7 @@ cpdef cy_expect_rho_vec_csr(complex[::1] data,
         row_end = ptr[row+1]
         for jj from row_start <= jj < row_end:
             dot += data[jj]*rho_vec[idx[jj]]
- 
+
     if herm == 0:
         return dot
     else:
@@ -287,7 +289,7 @@ cpdef cy_expect_rho_vec_csr(complex[::1] data,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef cy_spmm_tr(object op1, object op2, int herm):
-    
+
     cdef size_t row
     cdef complex tr = 0.0
 
@@ -318,7 +320,7 @@ cpdef cy_spmm_tr(object op1, object op2, int herm):
                 if col2 == row:
                     tr += data1[row1_idx] * data2[row2_idx]
                     break
- 
+
     if herm == 0:
         return tr
     else:
@@ -328,11 +330,11 @@ cpdef cy_spmm_tr(object op1, object op2, int herm):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def expect_csr_ket(object A, object B, int isherm):  
+def expect_csr_ket(object A, object B, int isherm):
 
-    cdef complex[::1] Adata = A.data 
+    cdef complex[::1] Adata = A.data
     cdef int[::1] Aind = A.indices
-    cdef int[::1] Aptr = A.indptr 
+    cdef int[::1] Aptr = A.indptr
     cdef complex[::1] Bdata = B.data
     cdef int[::1] Bptr = B.indptr
     cdef int nrows = A.shape[0]
@@ -403,5 +405,5 @@ cpdef double complex zcsr_mat_elem(object A, object left, object right, bool bra
                 if (Rptr[j] - Rptr[j+1]) != 0:
                     row_sum += Adata[jj]*Rdata[Rptr[j]]
             mat_elem += cval*row_sum
-    
+
     return mat_elem

--- a/qutip/cy/spmath.pxd
+++ b/qutip/cy/spmath.pxd
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, The QuTiP Project.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,22 +20,22 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
 from qutip.cy.sparse_structs cimport CSR_Matrix
 
-cdef void _zcsr_add(CSR_Matrix * A, CSR_Matrix * B, 
+cdef void _zcsr_add(CSR_Matrix * A, CSR_Matrix * B,
                     CSR_Matrix * C, double complex alpha)
 
 cdef void _zcsr_mult(CSR_Matrix * A, CSR_Matrix * B, CSR_Matrix * C)
@@ -41,11 +43,11 @@ cdef void _zcsr_mult(CSR_Matrix * A, CSR_Matrix * B, CSR_Matrix * C)
 
 cdef void _zcsr_kron(CSR_Matrix * A, CSR_Matrix * B, CSR_Matrix * C)
 
-cdef void _zcsr_kron_core(double complex * dataA, int * indsA, int * indptrA, 
+cdef void _zcsr_kron_core(double complex * dataA, int * indsA, int * indptrA,
                      double complex * dataB, int * indsB, int * indptrB,
-                     CSR_Matrix * out,       
+                     CSR_Matrix * out,
                      int rowsA, int rowsB, int colsB) nogil
-                     
+
 cdef void _zcsr_transpose(CSR_Matrix * A, CSR_Matrix * B)
-                                  
+
 cdef void _zcsr_adjoint(CSR_Matrix * A, CSR_Matrix * B)

--- a/qutip/cy/stochastic.pyx
+++ b/qutip/cy/stochastic.pyx
@@ -1,13 +1,15 @@
+#!python
+#cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
 #    All rights reserved.
 #
-#    Redistribution and use in source and binary forms, with or without 
-#    modification, are permitted provided that the following conditions are 
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
 #    met:
 #
-#    1. Redistributions of source code must retain the above copyright notice, 
+#    1. Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #
 #    2. Redistributions in binary form must reproduce the above copyright
@@ -18,16 +20,16 @@
 #       of its contributors may be used to endorse or promote products derived
 #       from this software without specific prior written permission.
 #
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 #    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 import numpy as np
@@ -50,7 +52,7 @@ cpdef cnp.ndarray[CTYPE_t, ndim=1] cy_rhs_psi_deterministic(object H,
     Deterministic contribution to the density matrix change; cython
     implementation.
     """
-    cdef cnp.ndarray[CTYPE_t, ndim=1] dpsi_t 
+    cdef cnp.ndarray[CTYPE_t, ndim=1] dpsi_t
 
     dpsi_t = (-1.0j * dt) * spmv_csr(H.data, H.indices, H.indptr, state)
 
@@ -95,7 +97,7 @@ cpdef cy_d2_psi_photocurrent(double t, cnp.ndarray[CTYPE_t, ndim=1] psi,
     """
     Cython version of d2_psi_photocurrent. See d2_psi_photocurrent for docs.
     """
-    cdef cnp.ndarray[CTYPE_t, ndim=1] psi1 
+    cdef cnp.ndarray[CTYPE_t, ndim=1] psi1
 
     psi1 = spmv_csr(A[0].data, A[0].indices, A[0].indptr, psi)
     n1 = np.linalg.norm(psi1)
@@ -155,5 +157,3 @@ cpdef cy_d2_rho_photocurrent(double t, cnp.ndarray[CTYPE_t, ndim=1] rho_vec,
         return [spmv_csr(a.data, a.indices, a.indptr, rho_vec) / e1 - rho_vec]
     else:
         return [- rho_vec]
-
-

--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -37,7 +37,7 @@ import unittest
 from qutip import *
 import qutip.settings as qset
 from qutip.superoperator import mat2vec
-from qutip.cy.brtools_testing import (_test_zheevr, _test_diag_liou_mult,
+from qutip.cy.brtools_checks import (_test_zheevr, _test_diag_liou_mult,
                     _test_dense_to_eigbasis, _test_vec_to_eigbasis,
                     _test_eigvec_to_fockbasis, _test_vector_roundtrip,
                     _cop_super_mult, _test_br_term_mult)
@@ -53,7 +53,7 @@ def test_br_zheevr():
         assert_(np.allclose(ans_vals,eigvals))
         assert_(np.allclose(Z,ans_vecs))
 
-      
+
 def test_br_dense_to_eigbasis():
     "BR Tools : dense operator to eigenbasis"
     N = 10
@@ -169,7 +169,7 @@ def test_br_term_mult():
         evecs = _test_zheevr(Hf, evals)
         _test_br_term_mult(t, A, evecs, evals, vec, out, use_secular, 0.1, atol)
         assert_(np.allclose(ans,out))
-    
+
     #non-secular tests
     for kk in range(10):
         N = 10

--- a/qutip/tests/test_cy_structs.py
+++ b/qutip/tests/test_cy_structs.py
@@ -34,7 +34,7 @@ import numpy as np
 import scipy.sparse as sp
 from qutip import rand_dm
 from qutip.fastsparse import fast_csr_matrix
-from qutip.cy.testing import (_test_sorting, _test_coo2csr_inplace_struct,
+from qutip.cy.checks import (_test_sorting, _test_coo2csr_inplace_struct,
                             _test_csr2coo_struct, _test_coo2csr_struct)
 from qutip.random_objects import rand_jacobi_rotation
 from numpy.testing import assert_equal, assert_, run_module_suite
@@ -70,7 +70,7 @@ def test_indices_sort():
         B.sort_indices()
         _test_sorting(A)
         assert_(np.all(A.data == B.data))
-        assert_(np.all(A.indices == B.indices))   
+        assert_(np.all(A.indices == B.indices))
 
 
 def test_coo2csr_inplace_nosort():
@@ -80,7 +80,7 @@ def test_coo2csr_inplace_nosort():
         B = A.tocoo()
         C = _test_coo2csr_inplace_struct(B, sorted = 0)
         assert_(not (A!=C).data.any())
-        
+
 
 def test_coo2csr_inplace_sort():
     "Cython structs : COO to CSR inplace (sorted)"
@@ -89,8 +89,8 @@ def test_coo2csr_inplace_sort():
         B = A.tocoo()
         C = _test_coo2csr_inplace_struct(B, sorted = 1)
         assert_(not (A!=C).data.any())
-        
-        
+
+
 def test_csr2coo():
     "Cython structs : CSR to COO"
     for k in range(20):
@@ -98,8 +98,8 @@ def test_csr2coo():
         B = A.tocoo()
         C = _test_csr2coo_struct(A)
         assert_(not (B!=C).data.any())
-        
-         
+
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/setup.py
+++ b/setup.py
@@ -147,8 +147,8 @@ write_version_py()
 
 # Add Cython extensions here
 cy_exts = ['spmatfuncs', 'stochastic', 'sparse_utils', 'graph_utils', 'interpolate',
-        'spmath', 'heom', 'math', 'spconvert', 'ptrace', 'testing', 'brtools',
-        'brtools_testing', 'br_tensor', 'piqs']
+        'spmath', 'heom', 'math', 'spconvert', 'ptrace', 'checks', 'brtools',
+        'brtools_checks', 'br_tensor', 'piqs']
 
 # Extra link args
 _link_flags = []
@@ -214,7 +214,7 @@ if "--with-openmp" in sys.argv:
             extra_link_args=_link_flags,
             language='c++')
     EXT_MODULES.append(_mod)
-    
+
     # Add brtools_omp
     _mod = Extension('qutip.cy.openmp.br_omp',
             sources = ['qutip/cy/openmp/br_omp.pyx'],
@@ -223,7 +223,7 @@ if "--with-openmp" in sys.argv:
             extra_link_args=_link_flags,
             language='c++')
     EXT_MODULES.append(_mod)
-    
+
     # Add omp_sparse_utils
     _mod = Extension('qutip.cy.openmp.omp_sparse_utils',
             sources = ['qutip/cy/openmp/omp_sparse_utils.pyx'],


### PR DESCRIPTION
With cython0.29 that came out this weeks there where warning at "cythonization" about language_level. Complied with it by adding `#cython: language_level=3` at the start of every .pyx and .pxd.

Also rename the cy/*testing* files to cy/*checks* since nose detected them as tests to run which caused automated tests to fail.