### PR TITLE
Docstring sigmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installation
 
 For instructions on how to install QuTiP, see:
 
-[http://qutip.org/docs/4.1/installation.html](http://qutip.org/docs/4.1/installation.html)
+[http://qutip.org/docs/latest/installation.html](http://qutip.org/docs/latest/installation.html)
 
 
 Demos

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -266,7 +266,7 @@ def sigmap():
 
     Examples
     --------
-    >>> sigmam()
+    >>> sigmap()
     Quantum object: dims = [[2], [2]], \
 shape = [2, 2], type = oper, isHerm = False
     Qobj data =


### PR DESCRIPTION
Fix typo in docstrings of `sigmap()` referring incorrectly to `sigmam()`.