### PR TITLE
WIP: Hierarchical Equations of Motion (new features and restructuring)

### DIFF
--- a/qutip/nonmarkov/heom.py
+++ b/qutip/nonmarkov/heom.py
@@ -628,9 +628,11 @@ def _pad_csr(A, row_scale, col_scale, insertrow=0, insertcol=0):
     return A
 
 
-class HSolverUnderDampedLorrentzian(HEOMSolver):
+class HSolverUnderdampedBrownian(HEOMSolver):
     """
-    HEOM solver based on the underdamped Lorrentzian spectral density.
+    HEOM solver based on the underdamped Brownian motion spectral density.
+
+    :math:`J(\omega) = \frac{\gamma \lambda^2 \omega}{(\omega^2 - \omega_0^2)^2 + \gamma^2 \omega}`
 
     Attributes
     ----------
@@ -642,8 +644,7 @@ class HSolverUnderDampedLorrentzian(HEOMSolver):
         Can be useful if using SI units for planck and boltzmann.
 
     bnd_cut_approx : bool
-        Use boundary cut off approximation
-        Can be
+        Use boundary cut off approximation.
     """
     def __init__(self, H_sys, coup_op, coup_strength, temperature,
                      N_cut, N_exp, cut_freq, planck=1.0, boltzmann=1.0,
@@ -690,9 +691,9 @@ class HSolverUnderDampedLorrentzian(HEOMSolver):
         pass
 
 
-def underdamped_lorrentzian(w, lam, gamma, w0):
+def underdamped_brownian(w, lam, gamma, w0):
     """
-    Calculates the underdamped lorrentzian spectral density.
+    Calculates the underdamped Brownian motion spectral density.
 
     Parameters
     ----------
@@ -796,3 +797,4 @@ def bath_correlation(spectral_density, tlist,
         corrI.append(quad(integrandI, w_start, w_cutoff, args=(i,))[0])
     corr = (np.array(corrR) + 1j*np.array(corrI))/np.pi
     return corr
+

--- a/qutip/nonmarkov/heom.py
+++ b/qutip/nonmarkov/heom.py
@@ -973,20 +973,13 @@ class HSolverUB(HEOMSolver):
                                                       * np.sqrt((nlabeltemp[kcount]
                                                                  / abs(lam)))
                                                       * (-lam * spost(Q).data)))
-                    if kcount == 1:
+                    elif kcount == 1:
                         Lbig = Lbig + sp.kron(Ltemp, (-1.j
                                                       * np.sqrt((nlabeltemp[kcount]
                                                                  / abs(lam)))
                                                       * (lam * spre(Q).data)))
-
-                    if kcount == 2:
-                        cin = ck2[0]
-                        Lbig = Lbig + sp.kron(Ltemp, (-1.j
-                                                      * np.sqrt((nlabeltemp[kcount]
-                                                                 / abs(cin)))
-                                                      * cin * (spre(Q).data - spost(Q).data)))
-                    if kcount == 3:
-                        cin = ck2[1]
+                    else:
+                        cin = ck2[kcount - 2]
                         Lbig = Lbig + sp.kron(Ltemp, (-1.j
                                                       * np.sqrt((nlabeltemp[kcount]
                                                                  / abs(cin)))
@@ -1007,13 +1000,8 @@ class HSolverUB(HEOMSolver):
                         Lbig = Lbig + sp.kron(Ltemp, -1.j
                                               * np.sqrt((nlabeltemp[kcount] + 1) * ((abs(lam))))
                                               * (spre(Q) - spost(Q)).data)
-                    if kcount == 2:
-                        cin = ck2[0]
-                        Lbig = Lbig + sp.kron(Ltemp, -1.j
-                                              * np.sqrt((nlabeltemp[kcount] + 1) * (abs(cin)))
-                                              * (spre(Q) - spost(Q)).data)
-                    if kcount == 3:
-                        cin = ck2[1]
+                    else:
+                        cin = ck2[kcount - 2]
                         Lbig = Lbig + sp.kron(Ltemp, -1.j
                                               * np.sqrt((nlabeltemp[kcount] + 1) * (abs(cin)))
                                               * (spre(Q) - spost(Q)).data)

--- a/qutip/nonmarkov/heom.py
+++ b/qutip/nonmarkov/heom.py
@@ -135,9 +135,10 @@ class HEOMSolver(object):
     exp_freq : list of complex
         Frequencies for the exponential series terms
     """
+
     def __init__(self):
         raise NotImplementedError("This is a abstract class only. "
-                "Use a subclass, for example HSolverDL")
+                                  "Use a subclass, for example HSolverDL")
 
     def reset(self):
         """
@@ -164,9 +165,9 @@ class HEOMSolver(object):
         self.configured = False
 
     def configure(self, H_sys, coup_op, coup_strength, temperature,
-                     N_cut, N_exp, planck=None, boltzmann=None,
-                     renorm=None, bnd_cut_approx=None,
-                     options=None, progress_bar=None, stats=None):
+                  N_cut, N_exp, planck=None, boltzmann=None,
+                  renorm=None, bnd_cut_approx=None,
+                  options=None, progress_bar=None, stats=None):
         """
         Configure the solver using the passed parameters
         The parameters are described in the class attributes, unless there
@@ -197,18 +198,21 @@ class HEOMSolver(object):
         self.temperature = temperature
         self.N_cut = N_cut
         self.N_exp = N_exp
-        if planck: self.planck = planck
-        if boltzmann: self.boltzmann = boltzmann
-        if isinstance(options, Options): self.options = options
+        if planck:
+            self.planck = planck
+        if boltzmann:
+            self.boltzmann = boltzmann
+        if isinstance(options, Options):
+            self.options = options
         if isinstance(progress_bar, BaseProgressBar):
             self.progress_bar = progress_bar
-        elif progress_bar == True:
+        elif progress_bar:
             self.progress_bar = TextProgressBar()
         elif progress_bar == False:
             self.progress_bar = None
         if isinstance(stats, Stats):
             self.stats = stats
-        elif stats == True:
+        elif stats:
             self.stats = self.create_new_stats()
         elif stats == False:
             self.stats = None
@@ -223,6 +227,7 @@ class HEOMSolver(object):
         stats = Stats(['config', 'run'])
         stats.header = "Hierarchy Solver Stats"
         return stats
+
 
 class HSolverDL(HEOMSolver):
     """
@@ -249,9 +254,9 @@ class HSolverDL(HEOMSolver):
     """
 
     def __init__(self, H_sys, coup_op, coup_strength, temperature,
-                     N_cut, N_exp, cut_freq, planck=1.0, boltzmann=1.0,
-                     renorm=True, bnd_cut_approx=True,
-                     options=None, progress_bar=None, stats=None):
+                 N_cut, N_exp, cut_freq, planck=1.0, boltzmann=1.0,
+                 renorm=True, bnd_cut_approx=True,
+                 options=None, progress_bar=None, stats=None):
 
         self.reset()
 
@@ -263,13 +268,23 @@ class HSolverDL(HEOMSolver):
         self.progress_bar = False
         if progress_bar is None:
             self.progress_bar = BaseProgressBar()
-        elif progress_bar == True:
+        elif progress_bar:
             self.progress_bar = TextProgressBar()
 
         # the other attributes will be set in the configure method
-        self.configure(H_sys, coup_op, coup_strength, temperature,
-                     N_cut, N_exp, cut_freq, planck=planck, boltzmann=boltzmann,
-                     renorm=renorm, bnd_cut_approx=bnd_cut_approx, stats=stats)
+        self.configure(
+            H_sys,
+            coup_op,
+            coup_strength,
+            temperature,
+            N_cut,
+            N_exp,
+            cut_freq,
+            planck=planck,
+            boltzmann=boltzmann,
+            renorm=renorm,
+            bnd_cut_approx=bnd_cut_approx,
+            stats=stats)
 
     def reset(self):
         """
@@ -281,22 +296,33 @@ class HSolverDL(HEOMSolver):
         self.bnd_cut_approx = False
 
     def configure(self, H_sys, coup_op, coup_strength, temperature,
-                     N_cut, N_exp, cut_freq, planck=None, boltzmann=None,
-                     renorm=None, bnd_cut_approx=None,
-                     options=None, progress_bar=None, stats=None):
+                  N_cut, N_exp, cut_freq, planck=None, boltzmann=None,
+                  renorm=None, bnd_cut_approx=None,
+                  options=None, progress_bar=None, stats=None):
         """
         Calls configure from :class:`HEOMSolver` and sets any attributes
         that are specific to this subclass
         """
         start_config = timeit.default_timer()
 
-        HEOMSolver.configure(self, H_sys, coup_op, coup_strength,
-                    temperature, N_cut, N_exp,
-                    planck=planck, boltzmann=boltzmann,
-                    options=options, progress_bar=progress_bar, stats=stats)
+        HEOMSolver.configure(
+            self,
+            H_sys,
+            coup_op,
+            coup_strength,
+            temperature,
+            N_cut,
+            N_exp,
+            planck=planck,
+            boltzmann=boltzmann,
+            options=options,
+            progress_bar=progress_bar,
+            stats=stats)
         self.cut_freq = cut_freq
-        if renorm is not None: self.renorm = renorm
-        if bnd_cut_approx is not None: self.bnd_cut_approx = bnd_cut_approx
+        if renorm is not None:
+            self.renorm = renorm
+        if bnd_cut_approx is not None:
+            self.bnd_cut_approx = bnd_cut_approx
 
         # Load local values for optional parameters
         # Constants and Hamiltonian.
@@ -304,7 +330,6 @@ class HSolverDL(HEOMSolver):
         options = self.options
         progress_bar = self.progress_bar
         stats = self.stats
-
 
         if stats:
             ss_conf = stats.sections.get('config')
@@ -324,37 +349,39 @@ class HSolverDL(HEOMSolver):
         sup_dim = N_temp**2
         unit_sys = qeye(N_temp)
 
-
         # Use shorthands (mainly as in referenced PRL)
         lam0 = self.coup_strength
         gam = self.cut_freq
         N_c = self.N_cut
         N_m = self.N_exp
-        Q = coup_op # Q as shorthand for coupling operator
-        beta = 1.0/(self.boltzmann*self.temperature)
+        Q = coup_op  # Q as shorthand for coupling operator
+        beta = 1.0 / (self.boltzmann * self.temperature)
 
         # Ntot is the total number of ancillary elements in the hierarchy
         # Ntot = factorial(N_c + N_m) / (factorial(N_c)*factorial(N_m))
         # Turns out to be the same as nstates from state_number_enumerate
-        N_he, he2idx, idx2he = enr_state_dictionaries([N_c + 1]*N_m , N_c)
+        N_he, he2idx, idx2he = enr_state_dictionaries([N_c + 1] * N_m, N_c)
 
         unit_helems = fast_identity(N_he)
         if self.bnd_cut_approx:
             # the Tanimura boundary cut off operator
             if stats:
                 stats.add_message('options', 'boundary cutoff approx', ss_conf)
-            op = -2*spre(Q)*spost(Q.dag()) + spre(Q.dag()*Q) + spost(Q.dag()*Q)
+            op = -2 * spre(Q) * spost(Q.dag()) + \
+                spre(Q.dag() * Q) + spost(Q.dag() * Q)
 
-            approx_factr = ((2*lam0 / (beta*gam*hbar)) - 1j*lam0) / hbar
+            approx_factr = (
+                (2 * lam0 / (beta * gam * hbar)) - 1j * lam0) / hbar
             for k in range(N_m):
                 approx_factr -= (c[k] / nu[k])
-            L_bnd = -approx_factr*op.data
+            L_bnd = -approx_factr * op.data
             L_helems = zcsr_kron(unit_helems, L_bnd)
         else:
-            L_helems = fast_csr_matrix(shape=(N_he*sup_dim, N_he*sup_dim))
+            L_helems = fast_csr_matrix(shape=(N_he * sup_dim, N_he * sup_dim))
 
         # Build the hierarchy element interaction matrix
-        if stats: start_helem_constr = timeit.default_timer()
+        if stats:
+            start_helem_constr = timeit.default_timer()
 
         unit_sup = spre(unit_sys).data
         spreQ = spre(Q).data
@@ -370,9 +397,9 @@ class HSolverDL(HEOMSolver):
             # coeff for diagonal elements
             sum_n_m_freq = 0.0
             for k in range(N_m):
-                sum_n_m_freq += he_state[k]*nu[k]
+                sum_n_m_freq += he_state[k] * nu[k]
 
-            op = -sum_n_m_freq*unit_sup
+            op = -sum_n_m_freq * unit_sup
             L_he = cy_pad_csr(op, N_he, N_he, he_idx, he_idx)
             L_helems += L_he
 
@@ -387,11 +414,11 @@ class HSolverDL(HEOMSolver):
                     he_state_neigh[k] = n_k - 1
                     he_idx_neigh = he2idx[tuple(he_state_neigh)]
 
-                    op = c[k]*spreQ - np.conj(c[k])*spostQ
+                    op = c[k] * spreQ - np.conj(c[k]) * spostQ
                     if renorm:
-                        op = -1j*norm_minus[n_k, k]*op
+                        op = -1j * norm_minus[n_k, k] * op
                     else:
-                        op = -1j*n_k*op
+                        op = -1j * n_k * op
 
                     L_he = cy_pad_csr(op, N_he, N_he, he_idx, he_idx_neigh)
                     L_helems += L_he
@@ -407,9 +434,9 @@ class HSolverDL(HEOMSolver):
 
                     op = commQ
                     if renorm:
-                        op = -1j*norm_plus[n_k, k]*op
+                        op = -1j * norm_plus[n_k, k] * op
                     else:
-                        op = -1j*op
+                        op = -1j * op
 
                     L_he = cy_pad_csr(op, N_he, N_he, he_idx, he_idx_neigh)
                     L_helems += L_he
@@ -420,14 +447,14 @@ class HSolverDL(HEOMSolver):
         if stats:
             stats.add_timing('hierarchy contruct',
                              timeit.default_timer() - start_helem_constr,
-                            ss_conf)
+                             ss_conf)
             stats.add_count('Num hierarchy elements', N_he, ss_conf)
             stats.add_count('Num he interactions', N_he_interact, ss_conf)
 
         # Setup Liouvillian
-        if stats: 
+        if stats:
             start_louvillian = timeit.default_timer()
-        
+
         H_he = zcsr_kron(unit_helems, liouvillian(H_sys).data)
 
         L_helems += H_he
@@ -435,9 +462,10 @@ class HSolverDL(HEOMSolver):
         if stats:
             stats.add_timing('Liouvillian contruct',
                              timeit.default_timer() - start_louvillian,
-                            ss_conf)
+                             ss_conf)
 
-        if stats: start_integ_conf = timeit.default_timer()
+        if stats:
+            start_integ_conf = timeit.default_timer()
 
         r = scipy.integrate.ode(cy_ode_rhs)
 
@@ -451,7 +479,7 @@ class HSolverDL(HEOMSolver):
             time_now = timeit.default_timer()
             stats.add_timing('Liouvillian contruct',
                              time_now - start_integ_conf,
-                            ss_conf)
+                             ss_conf)
             if ss_conf.total_time is None:
                 ss_conf.total_time = time_now - start_config
             else:
@@ -503,10 +531,11 @@ class HSolverDL(HEOMSolver):
         output.times = tlist
         output.states = []
 
-        if stats: start_init = timeit.default_timer()
+        if stats:
+            start_init = timeit.default_timer()
         output.states.append(Qobj(rho0))
-        rho0_flat = rho0.full().ravel('F') # Using 'F' effectively transposes
-        rho0_he = np.zeros([sup_dim*self._N_he], dtype=complex)
+        rho0_flat = rho0.full().ravel('F')  # Using 'F' effectively transposes
+        rho0_he = np.zeros([sup_dim * self._N_he], dtype=complex)
         rho0_he[:sup_dim] = rho0_flat
         r.set_initial_value(rho0_he, tlist[0])
 
@@ -549,19 +578,19 @@ class HSolverDL(HEOMSolver):
         lam0 = self.coup_strength
         gam = self.cut_freq
         hbar = self.planck
-        beta = 1.0/(self.boltzmann*self.temperature)
+        beta = 1.0 / (self.boltzmann * self.temperature)
         N_m = self.N_exp
 
-        g = 2*np.pi / (beta*hbar)
+        g = 2 * np.pi / (beta * hbar)
         for k in range(N_m):
             if k == 0:
                 nu.append(gam)
-                c.append(lam0*gam*
-                    (1.0/np.tan(gam*hbar*beta/2.0) - 1j) / hbar)
+                c.append(lam0 * gam *
+                         (1.0 / np.tan(gam * hbar * beta / 2.0) - 1j) / hbar)
             else:
-                nu.append(k*g)
-                c.append(4*lam0*gam*nu[k] /
-                      ((nu[k]**2 - gam**2)*beta*hbar**2))
+                nu.append(k * g)
+                c.append(4 * lam0 * gam * nu[k] /
+                         ((nu[k]**2 - gam**2) * beta * hbar**2))
 
         self.exp_coeff = c
         self.exp_freq = nu
@@ -579,12 +608,12 @@ class HSolverDL(HEOMSolver):
         N_m = self.N_exp
         N_c = self.N_cut
 
-        norm_plus = np.empty((N_c+1, N_m))
-        norm_minus = np.empty((N_c+1, N_m))
+        norm_plus = np.empty((N_c + 1, N_m))
+        norm_minus = np.empty((N_c + 1, N_m))
         for k in range(N_m):
-            for n in range(N_c+1):
-                norm_plus[n, k] = np.sqrt(abs(c[k])*(n + 1))
-                norm_minus[n, k] = np.sqrt(float(n)/abs(c[k]))
+            for n in range(N_c + 1):
+                norm_plus[n, k] = np.sqrt(abs(c[k]) * (n + 1))
+                norm_minus[n, k] = np.sqrt(float(n) / abs(c[k]))
 
         return norm_plus, norm_minus
 
@@ -605,32 +634,32 @@ def _pad_csr(A, row_scale, col_scale, insertrow=0, insertcol=0):
     # after much searching most threads suggest directly addressing
     # the underlying arrays, as done here.
     # This certainly proved more efficient than other methods such as stacking
-    #TODO: Perhaps cythonize and move to spmatfuncs
+    # TODO: Perhaps cythonize and move to spmatfuncs
 
     if not isinstance(A, sp.csr_matrix):
         raise TypeError("First parameter must be a csr matrix")
     nrowin = A.shape[0]
     ncolin = A.shape[1]
-    nrowout = nrowin*row_scale
-    ncolout = ncolin*col_scale
+    nrowout = nrowin * row_scale
+    ncolout = ncolin * col_scale
 
     A._shape = (nrowout, ncolout)
     if insertcol == 0:
         pass
     elif insertcol > 0 and insertcol < col_scale:
-        A.indices = A.indices + insertcol*ncolin
+        A.indices = A.indices + insertcol * ncolin
     else:
         raise ValueError("insertcol must be >= 0 and < col_scale")
 
     if insertrow == 0:
-        A.indptr = np.concatenate((A.indptr,
-                        np.array([A.indptr[-1]]*(row_scale-1)*nrowin)))
-    elif insertrow == row_scale-1:
-        A.indptr = np.concatenate((np.array([0]*(row_scale - 1)*nrowin),
+        A.indptr = np.concatenate(
+            (A.indptr, np.array([A.indptr[-1]] * (row_scale - 1) * nrowin)))
+    elif insertrow == row_scale - 1:
+        A.indptr = np.concatenate((np.array([0] * (row_scale - 1) * nrowin),
                                    A.indptr))
     elif insertrow > 0 and insertrow < row_scale - 1:
-         A.indptr = np.concatenate((np.array([0]*insertrow*nrowin), A.indptr,
-                np.array([A.indptr[-1]]*(row_scale - insertrow - 1)*nrowin)))
+        A.indptr = np.concatenate((np.array([0] * insertrow * nrowin), A.indptr, np.array(
+            [A.indptr[-1]] * (row_scale - insertrow - 1) * nrowin)))
     else:
         raise ValueError("insertrow must be >= 0 and < row_scale")
 
@@ -705,7 +734,7 @@ def _heom_number_enumerate(dims, excitations=None, state=None, idx=0):
             yield np.array(state)
         else:
             yield tuple(state)
-            
+
     else:
         for n in range(dims[idx]):
             state[idx] = n
@@ -717,7 +746,8 @@ class HSolverUnderdampedBrownian(HEOMSolver):
     """
     HEOM solver based on the underdamped Brownian motion spectral density.
 
-    :math:`J(\omega) = \frac{\gamma \lambda^2 \omega}{(\omega^2 - \omega_0^2)^2 + \gamma^2 \omega}`
+    :math:`J(\omega) = \frac{\gamma \lambda^2 \omega}{(\omega^2
+            - \omega_0^2)^2 + \gamma^2 \omega}`
 
     Attributes
     ----------
@@ -731,6 +761,7 @@ class HSolverUnderdampedBrownian(HEOMSolver):
     bnd_cut_approx : bool
         Use boundary cut off approximation.
     """
+
     def __init__(self, H_sys, coup_op, coup_strength, ckA, vkA,
                  ck_corr, vk_corr,
                  temperature, N_cut, N_exp, cut_freq, planck=1.0,
@@ -747,7 +778,7 @@ class HSolverUnderdampedBrownian(HEOMSolver):
         self.progress_bar = False
         if progress_bar is None:
             self.progress_bar = BaseProgressBar()
-        elif progress_bar == True:
+        elif progress_bar:
             self.progress_bar = TextProgressBar()
 
         # the other attributes will be set in the configure method
@@ -806,117 +837,125 @@ class HSolverUnderdampedBrownian(HEOMSolver):
         Nsup = N_temp**2
         unit = qeye(N_temp)
 
-        #Ntot is the total number of ancillary elements in the hierarchy
-        Ntot = int(round(factorial(Nc+N) / (factorial(Nc) * factorial(N))))
-        LD1 = -2.* spre(Q) * spost(Q.dag()) + spre(Q.dag() * Q) + spost(Q.dag() * Q)
+        # Ntot is the total number of ancillary elements in the hierarchy
+        # Ntot = int(round(factorial(Nc + N) / (factorial(Nc) * factorial(N))))
+        Ntot = num_hierarchy(Nc, N)
+        # LD1 = -2.* spre(Q) * spost(Q.dag()) + spre(Q.dag() * Q) + spost(Q.dag() * Q)
+        L12 = 0. * spre(Q)
 
-        c0=ckA[0]
-        pref=0.
-        L12=0.*LD1;
-        
-        #Setup liouvillian
+        # Setup liouvillian
 
         L = liouvillian(H, [L12])
         Ltot = L.data
-        unitthing=sp.identity(Ntot, dtype='complex', format='csr')
-        Lbig = sp.kron(unitthing,Ltot.tocsr())
-        
-        nstates, state2idx, idx2state =_heom_state_dictionaries([Nc+1]*(N),Nc)
-        for nlabelt in _heom_number_enumerate([Nc+1]*(N),Nc):
-            nlabel = list(nlabelt)                    
+        unitthing = sp.identity(Ntot, dtype='complex', format='csr')
+        Lbig = sp.kron(unitthing, Ltot.tocsr())
+
+        nstates, state2idx, idx2state = _heom_state_dictionaries(
+            [Nc + 1] * (N), Nc)
+        for nlabelt in _heom_number_enumerate([Nc + 1] * (N), Nc):
+            nlabel = list(nlabelt)
             ntotalcheck = 0
             for ncheck in range(N):
-                ntotalcheck = ntotalcheck + nlabel[ncheck]                            
+                ntotalcheck = ntotalcheck + nlabel[ncheck]
+
             current_pos = int(round(state2idx[tuple(nlabel)]))
+
             Ltemp = sp.lil_matrix((Ntot, Ntot))
-            Ltemp[current_pos,current_pos] = 1.
+            Ltemp[current_pos, current_pos] = 1.
             Ltemp.tocsr()
-            Lbig = Lbig + sp.kron(Ltemp,(-nlabel[0] * vkA[0] * spre(unit).data))
-            Lbig = Lbig + sp.kron(Ltemp,(-nlabel[1] * vkA[1] * spre(unit).data))
-            #bi-exponential corrections:
-            if N==3:
-                Lbig = Lbig + sp.kron(Ltemp,(-nlabel[2] * vk_corr[0] * spre(unit).data))
-            if N==4:
-                Lbig = Lbig + sp.kron(Ltemp,(-nlabel[2] * vk_corr[0] * spre(unit).data))
-                Lbig = Lbig + sp.kron(Ltemp,(-nlabel[3] * vk_corr[1] * spre(unit).data))
-            
+
+            Lbig = Lbig + sp.kron(Ltemp,
+                                  (-nlabel[0] * vkA[0] * spre(unit).data))
+            Lbig = Lbig + sp.kron(Ltemp,
+                                  (-nlabel[1] * vkA[1] * spre(unit).data))
+            # bi-exponential corrections:
+
+            if N == 3:
+                Lbig = Lbig + sp.kron(Ltemp,
+                                      (-nlabel[2] * vk_corr[0] * spre(unit).data))
+
+            if N == 4:
+                Lbig = Lbig + sp.kron(Ltemp,
+                                      (-nlabel[2] * vk_corr[0] * spre(unit).data))
+                Lbig = Lbig + sp.kron(Ltemp,
+                                      (-nlabel[3] * vk_corr[1] * spre(unit).data))
+
             for kcount in range(N):
-                if nlabel[kcount]>=1:
-                #find the position of the neighbour
+                if nlabel[kcount] >= 1:
+                    # find the position of the neighbour
                     nlabeltemp = copy(nlabel)
-                    nlabel[kcount] = nlabel[kcount] -1
+                    nlabel[kcount] = nlabel[kcount] - 1
                     current_pos2 = int(round(state2idx[tuple(nlabel)]))
-                    Ltemp = sp.lil_matrix(np.zeros((Ntot,Ntot)))
+                    Ltemp = sp.lil_matrix(np.zeros((Ntot, Ntot)))
                     Ltemp[current_pos, current_pos2] = 1
                     Ltemp.tocsr()
-                # renormalized version:    
-                    #ci =  (4 * lam0 * gam * kb * Temperature * kcount
+                # renormalized version:
+                    # ci =  (4 * lam0 * gam * kb * Temperature * kcount
                     #      * gj/((kcount * gj)**2 - gam**2)) / (hbar**2)
-                    if kcount==0:
-                        
-                        c0n=lam
-                        Lbig = Lbig + sp.kron(Ltemp,(-1.j
-                                         * np.sqrt((nlabeltemp[kcount]
-                                            / abs(c0n)))
-                                         * (0.0*spre(Q).data
-                                         - (lam)
-                                         * spost(Q).data)))
-                    if kcount==1:     
-                        cin=lam
-                        ci =  ckA[kcount]
-                        Lbig = Lbig + sp.kron(Ltemp,(-1.j
-                                         * np.sqrt((nlabeltemp[kcount]
-                                            / abs(cin)))
-                                         * ((lam) * spre(Q).data
-                                         - (0.0)
-                                         * spost(Q).data)))
-                        
-                    if kcount==2:     
-                        cin=ck_corr[0]                        
-                        Lbig = Lbig + sp.kron(Ltemp,(-1.j
-                                             * np.sqrt((nlabeltemp[kcount]
-                                                / abs(cin)))
-                                             * cin*(spre(Q).data - spost(Q).data)))
-                    if kcount==3:     
-                        cin=ck_corr[1]                        
-                        Lbig = Lbig + sp.kron(Ltemp,(-1.j
-                                             * np.sqrt((nlabeltemp[kcount]
-                                                / abs(cin)))
-                                             * cin*(spre(Q).data - spost(Q).data)))
+                    if kcount == 0:
+                        c0n = lam
+                        Lbig = Lbig + sp.kron(Ltemp, (-1.j
+                                                      * np.sqrt((nlabeltemp[kcount]
+                                                                 / abs(c0n)))
+                                                      * (0.0 * spre(Q).data
+                                                          - (lam)
+                                                          * spost(Q).data)))
+                    if kcount == 1:
+                        cin = lam
+                        ci = ckA[kcount]
+                        Lbig = Lbig + sp.kron(Ltemp, (-1.j
+                                                      * np.sqrt((nlabeltemp[kcount]
+                                                                 / abs(cin)))
+                                                      * ((lam) * spre(Q).data
+                                                          - (0.0)
+                                                          * spost(Q).data)))
+
+                    if kcount == 2:
+                        cin = ck_corr[0]
+                        Lbig = Lbig + sp.kron(Ltemp, (-1.j
+                                                      * np.sqrt((nlabeltemp[kcount]
+                                                                 / abs(cin)))
+                                                      * cin * (spre(Q).data - spost(Q).data)))
+                    if kcount == 3:
+                        cin = ck_corr[1]
+                        Lbig = Lbig + sp.kron(Ltemp, (-1.j
+                                                      * np.sqrt((nlabeltemp[kcount]
+                                                                 / abs(cin)))
+                                                      * cin * (spre(Q).data - spost(Q).data)))
                     nlabel = copy(nlabeltemp)
 
             for kcount in range(N):
-                if ntotalcheck<=(Nc-1):
+                if ntotalcheck <= (Nc - 1):
                     nlabeltemp = copy(nlabel)
                     nlabel[kcount] = nlabel[kcount] + 1
                     current_pos3 = int(round(state2idx[tuple(nlabel)]))
-                if current_pos3<=(Ntot):
-                    Ltemp = sp.lil_matrix(np.zeros((Ntot,Ntot)))
+                if current_pos3 <= (Ntot):
+                    Ltemp = sp.lil_matrix(np.zeros((Ntot, Ntot)))
                     Ltemp[current_pos, current_pos3] = 1
                     Ltemp.tocsr()
-                #renormalized   
-                    if kcount==0:
-                        c0n=lam
-                        Lbig = Lbig + sp.kron(Ltemp,-1.j
-                                      * np.sqrt((nlabeltemp[kcount]+1)*((abs(c0n))))
-                                      * (spre(Q)- spost(Q)).data)
-                    if kcount==1:
-                        ci =ckA[kcount]
-                        cin=lam
-                        Lbig = Lbig + sp.kron(Ltemp,-1.j
-                                      * np.sqrt((nlabeltemp[kcount]+1)*(abs(cin)))
-                                      * (spre(Q)- spost(Q)).data)
-                    if kcount==2:
-                        cin=ck_corr[0]
-                        Lbig = Lbig + sp.kron(Ltemp,-1.j
-                                      * np.sqrt((nlabeltemp[kcount]+1)*(abs(cin)))
-                                      * (spre(Q)- spost(Q)).data)
-                    if kcount==3:
-                        cin=ck_corr[1]
-                        Lbig = Lbig + sp.kron(Ltemp,-1.j
-                                      * np.sqrt((nlabeltemp[kcount]+1)*(abs(cin)))
-                                      * (spre(Q)- spost(Q)).data)    
-                 
+                # renormalized
+                    if kcount == 0:
+                        c0n = lam
+                        Lbig = Lbig + sp.kron(Ltemp, -1.j
+                                              * np.sqrt((nlabeltemp[kcount] + 1) * ((abs(c0n))))
+                                              * (spre(Q) - spost(Q)).data)
+                    if kcount == 1:
+                        ci = ckA[kcount]
+                        cin = lam
+                        Lbig = Lbig + sp.kron(Ltemp, -1.j
+                                              * np.sqrt((nlabeltemp[kcount] + 1) * (abs(cin)))
+                                              * (spre(Q) - spost(Q)).data)
+                    if kcount == 2:
+                        cin = ck_corr[0]
+                        Lbig = Lbig + sp.kron(Ltemp, -1.j
+                                              * np.sqrt((nlabeltemp[kcount] + 1) * (abs(cin)))
+                                              * (spre(Q) - spost(Q)).data)
+                    if kcount == 3:
+                        cin = ck_corr[1]
+                        Lbig = Lbig + sp.kron(Ltemp, -1.j
+                                              * np.sqrt((nlabeltemp[kcount] + 1) * (abs(cin)))
+                                              * (spre(Q) - spost(Q)).data)
+
                 nlabel = copy(nlabeltemp)
         self.liouvillian = Lbig
         return Lbig
@@ -943,7 +982,7 @@ class HSolverUnderdampedBrownian(HEOMSolver):
         stats = self.stats
         Nc = self.N_cut
         Nk = self.N_exp
-        self._N_he = int(factorial(Nc + Nk)/(factorial(Nc)*factorial(Nk)))
+        self._N_he = num_hierarchy(Nc, Nk)
         start_run = timeit.default_timer()
         r = scipy.integrate.ode(cy_ode_rhs)
         N_temp = 1
@@ -964,10 +1003,11 @@ class HSolverUnderdampedBrownian(HEOMSolver):
         output.times = tlist
         output.states = []
 
-        if stats: start_init = timeit.default_timer()
+        if stats:
+            start_init = timeit.default_timer()
         output.states.append(Qobj(rho0))
-        rho0_flat = rho0.full().ravel('F') # Using 'F' effectively transposes
-        rho0_he = np.zeros([sup_dim*self._N_he], dtype=complex)
+        rho0_flat = rho0.full().ravel('F')  # Using 'F' effectively transposes
+        rho0_he = np.zeros([sup_dim * self._N_he], dtype=complex)
         rho0_he[:sup_dim] = rho0_flat
         r.set_initial_value(rho0_he, tlist[0])
 
@@ -1005,6 +1045,7 @@ def add_at_idx(seq, k, val):
     lst[k] += val
     return tuple(lst)
 
+
 def prevhe(current_he, k, ncut):
     """
     Calculate the previous heirarchy index
@@ -1014,6 +1055,7 @@ def prevhe(current_he, k, ncut):
     if nprev[k] < 0:
         return False
     return nprev
+
 
 def nexthe(current_he, k, ncut):
     """
@@ -1025,26 +1067,41 @@ def nexthe(current_he, k, ncut):
         return False
     return nnext
 
-def num_hierarchy(kcut, ncut):
+
+def num_hierarchy(ncut, kcut):
     """
     Get the total number of auxiliary density matrices in the
-    Hierarchy
+    hierarchy.
+
+    Parameters
+    ==========
+    ncut: int
+        The Heirarchy cutoff
+
+    kcut: int
+        The cutoff in the correlation frequencies, i.e., how many
+        total exponents are used.
+
+    Returns
+    =======
+    num_hierarchy: int
+        The total number of auxiliary density matrices in the hierarchy.
     """
-    return int(factorial(ncut + kcut)/(factorial(ncut)*factorial(kcut)))
+    return int(factorial(ncut + kcut) / (factorial(ncut) * factorial(kcut)))
 
 
 class Heom(object):
     """
     The Heom class to tackle Heirarchy.
-    
+
     Parameters
     ==========
     hamiltonian: :class:`qutip.Qobj`
         The system Hamiltonian
-    
+
     coupling: :class:`qutip.Qobj`
         The coupling operator
-    
+
     ck: list
         The list of amplitudes in the expansion of the correlation function
 
@@ -1053,7 +1110,7 @@ class Heom(object):
 
     ncut: int
         The Heirarchy cutoff
-        
+
     kcut: int
         The cutoff in the Matsubara frequencies
 
@@ -1061,22 +1118,25 @@ class Heom(object):
         The cutoff for the maximum absolute value in an auxillary matrix
         which is used to remove it from the heirarchy
     """
+
     def __init__(self, hamiltonian, coupling, ck, vk,
                  ncut, rcut=None, renorm=False, lam=0.):
         self.hamiltonian = hamiltonian
-        self.coupling = coupling    
+        self.coupling = coupling
         self.ck, self.vk = ck, vk
         self.ncut = ncut
         self.renorm = renorm
         self.kcut = len(ck)
-        nhe, he2idx, idx2he =_heom_state_dictionaries([ncut+1]*(len(ck)), ncut)
+        nhe, he2idx, idx2he = _heom_state_dictionaries(
+            [ncut + 1] * (len(ck)), ncut)
         # he2idx, idx2he, nhe = self._initialize_he()
         self.nhe = nhe
         self.he2idx = he2idx
         self.idx2he = idx2he
         self.N = self.hamiltonian.shape[0]
-        
-        total_nhe = int(factorial(self.ncut + self.kcut)/(factorial(self.ncut)*factorial(self.kcut)))
+
+        total_nhe = int(factorial(self.ncut + self.kcut) /
+                        (factorial(self.ncut) * factorial(self.kcut)))
         self.total_nhe = total_nhe
         self.hshape = (total_nhe, self.N**2)
         self.weak_coupling = self.deltak()
@@ -1084,7 +1144,10 @@ class Heom(object):
         self.grad_shape = (self.N**2, self.N**2)
         self.spreQ = spre(coupling).data
         self.spostQ = spost(coupling).data
-        self.L_helems = lil_matrix((total_nhe*self.N**2, total_nhe*self.N**2), dtype=np.complex)
+        self.L_helems = lil_matrix(
+            (total_nhe * self.N**2,
+             total_nhe * self.N**2),
+            dtype=np.complex)
         self.lam = lam
 
     def _initialize_he(self):
@@ -1092,8 +1155,8 @@ class Heom(object):
         Initialize the hierarchy indices
         """
         zeroth = tuple([0 for i in range(self.kcut)])
-        he2idx = {zeroth:0}
-        idx2he = {0:zeroth}
+        he2idx = {zeroth: 0}
+        idx2he = {0: zeroth}
         nhe = 1
         return he2idx, idx2he, nhe
 
@@ -1132,7 +1195,7 @@ class Heom(object):
         else:
             dk = np.sum(np.divide(self.ck[self.kcut:], self.vk[self.kcut:]))
             return dk
-    
+
     def grad_n(self, he_n):
         """
         Get the gradient term for the Hierarchy ADM at
@@ -1142,14 +1205,14 @@ class Heom(object):
         nu = self.vk
         L = self.L.copy()
         gradient_sum = -np.sum(np.multiply(he_n, nu))
-        sum_op = gradient_sum*np.eye(L.shape[0])
+        sum_op = gradient_sum * np.eye(L.shape[0])
         L += sum_op
 
         # Fill in larger L
         nidx = self.he2idx[he_n]
         block = self.N**2
-        pos = int(nidx*(block))
-        self.L_helems[pos:pos+block, pos:pos+block] = L
+        pos = int(nidx * (block))
+        self.L_helems[pos:pos + block, pos:pos + block] = L
 
     def grad_prev(self, he_n, k, prev_he):
         """
@@ -1161,48 +1224,50 @@ class Heom(object):
         spostQ = self.spostQ
         nk = he_n[k]
         norm_prev = nk
-            
+
+        # Normalize
         if k == 0:
-            norm_prev = np.sqrt(float(nk)/abs(self.lam))
-            op1 = -1j*norm_prev*(-self.lam*spostQ)
-        elif k == 1 :
-            norm_prev = np.sqrt(float(nk)/abs(self.lam))
-            op1 = -1j*norm_prev*(self.lam*spreQ)
+            norm_prev = np.sqrt(float(nk) / abs(self.lam))
+            op1 = -1j * norm_prev * (-self.lam * spostQ)
+        elif k == 1:
+            norm_prev = np.sqrt(float(nk) / abs(self.lam))
+            op1 = -1j * norm_prev * (self.lam * spreQ)
         else:
-            norm_prev = np.sqrt(float(nk)/abs(c[k]))
-            op1 = -1j*norm_prev*(c[k]*(spreQ - spostQ))
+            norm_prev = np.sqrt(float(nk) / abs(c[k]))
+            op1 = -1j * norm_prev * (c[k] * (spreQ - spostQ))
 
         # Fill in larger L
         rowidx = self.he2idx[he_n]
         colidx = self.he2idx[prev_he]
         block = self.N**2
-        rowpos = int(rowidx*(block))
-        colpos = int(colidx*(block))
-        self.L_helems[rowpos:rowpos+block, colpos:colpos+block] = op1
+        rowpos = int(rowidx * (block))
+        colpos = int(colidx * (block))
+        self.L_helems[rowpos:rowpos + block, colpos:colpos + block] = op1
 
     def grad_next(self, he_n, k, next_he):
         c = self.ck
         nu = self.vk
         spreQ = self.spreQ
         spostQ = self.spostQ
-        
-        nk = he_n[k]            
-        
+
+        nk = he_n[k]
+
+        # Normalize
         if k < 2:
-            norm_next = np.sqrt(self.lam*(nk + 1))
-            op2 = -1j*norm_next*(spreQ - spostQ)
+            norm_next = np.sqrt(self.lam * (nk + 1))
+            op2 = -1j * norm_next * (spreQ - spostQ)
         else:
-            norm_next = np.sqrt(abs(c[k])*(nk + 1))
-            op2 = -1j*norm_next*(spreQ - spostQ)
+            norm_next = np.sqrt(abs(c[k]) * (nk + 1))
+            op2 = -1j * norm_next * (spreQ - spostQ)
 
         # Fill in larger L
         rowidx = self.he2idx[he_n]
         colidx = self.he2idx[next_he]
         block = self.N**2
-        rowpos = int(rowidx*(block))
-        colpos = int(colidx*(block))
-        self.L_helems[rowpos:rowpos+block, colpos:colpos+block] = op2
-    
+        rowpos = int(rowidx * (block))
+        colpos = int(colidx * (block))
+        self.L_helems[rowpos:rowpos + block, colpos:colpos + block] = op2
+
     def rhs(self, progress=None):
         """
         Make the RHS
@@ -1210,8 +1275,8 @@ class Heom(object):
         while self.nhe < self.total_nhe:
             heidxlist = copy(list(self.idx2he.keys()))
             self.populate(heidxlist)
-        if progress != None:
-            bar = progress(total = self.nhe*self.kcut)
+        if progress is not None:
+            bar = progress(total=self.nhe * self.kcut)
 
         for n in self.idx2he:
             he_n = self.idx2he[n]
@@ -1251,17 +1316,18 @@ class Heom(object):
                          atol=options.atol, rtol=options.rtol,
                          nsteps=options.nsteps, first_step=options.first_step,
                          min_step=options.min_step, max_step=options.max_step)
-                        
+
         r.set_initial_value(rho_he, tlist[0])
         dt = np.diff(tlist)
         n_tsteps = len(tlist)
         if progress:
-            bar = progress(total=n_tsteps-1)
+            bar = progress(total=n_tsteps - 1)
         for t_idx, t in enumerate(tlist):
             if t_idx < n_tsteps - 1:
                 r.integrate(r.t + dt[t_idx])
                 r1 = r.y.reshape(self.hshape)
                 r0 = r1[0].reshape(self.N, self.N).T
                 output.states.append(Qobj(r0))
-                if progress: bar.update()
+                if progress:
+                    bar.update()
         return output

--- a/qutip/nonmarkov/heom.py
+++ b/qutip/nonmarkov/heom.py
@@ -108,7 +108,7 @@ class HEOMSolver(object):
 
     N_exp : int
         Number of exponential terms used to approximate the bath correlation
-        functions
+        functions (Matsubara part)
 
     planck : float
         reduced Planck constant
@@ -827,7 +827,7 @@ class HSolverUB(HEOMSolver):
         Q = self.coup_op
         lam = self.coup_strength
         Nc = self.N_cut
-        N = self.N_exp
+        N = self.N_exp + 2
         #Parameters and hamiltonian
 
         hbar = self.planck
@@ -981,7 +981,7 @@ class HSolverUB(HEOMSolver):
         options = self.options
         stats = self.stats
         Nc = self.N_cut
-        Nk = self.N_exp
+        Nk = self.N_exp + 2
         self._N_he = num_hierarchy(Nc, Nk)
         start_run = timeit.default_timer()
         r = scipy.integrate.ode(cy_ode_rhs)

--- a/qutip/nonmarkov/heom.py
+++ b/qutip/nonmarkov/heom.py
@@ -60,6 +60,10 @@ from qutip.fastsparse import fast_csr_matrix, fast_identity
 from functools import reduce
 from operator import mul
 from scipy.misc import factorial
+from scipy.sparse import lil_matrix
+from scipy.integrate import ode
+
+
 from copy import copy
 
 
@@ -993,109 +997,271 @@ class HSolverUnderdampedBrownian(HEOMSolver):
         return output
 
 
-def underdamped_brownian(w, lam, gamma, w0):
+def add_at_idx(seq, k, val):
     """
-    Calculates the underdamped Brownian motion spectral density.
-
-    Parameters
-    ----------
-    w: np.ndarray
-        A 1D numpy array of frequencies.
-
-    lam: float
-        The coupling strength parameter.
-
-    gamma: float
-        A parameter characterizing the FWHM of the spectral density.
-
-    w0: float
-        The qubit frequency.
-
-    Returns
-    -------
-    spectral_density: np.ndarray
-        The spectral density for specified parameters.
+    Add (subtract) a value in the tuple at position k
     """
-    omega = np.sqrt(w0**2 - (gamma/2)**2)
-    a = omega + 1j*gamma/2.
-    aa = np.conjugate(a)
-    prefactor = (lam**2)*gamma
-    spectral_density = prefactor*(w/((w-a)*(w+a)*(w-aa)*(w+aa)))
-    return spectral_density
+    lst = list(seq)
+    lst[k] += val
+    return tuple(lst)
 
-
-def bath_correlation(spectral_density, tlist,
-                     params, beta, w_cutoff):
+def prevhe(current_he, k, ncut):
     """
-    Calculates the bath correlation function (C) for a specific spectral
-    density (J(w)) for an environment modelled as a bath of harmonic
-    oscillators. If :math: `\beta` is the inverse temperature of the bath
-    then the correlation is:
+    Calculate the previous heirarchy index
+    for the current index `n`.
+    """
+    nprev = add_at_idx(current_he, k, -1)
+    if nprev[k] < 0:
+        return False
+    return nprev
 
-    :math:`C(t) = \frac{1}{\pi} \left[\int_{0}^{\infty} \coth
-    (\beta \omega /2) \cos(\omega t) - i\sin(\omega t) \right]`
+def nexthe(current_he, k, ncut):
+    """
+    Calculate the next heirarchy index
+    for the current index `n`.
+    """
+    nnext = add_at_idx(current_he, k, 1)
+    if sum(nnext) > ncut:
+        return False
+    return nnext
 
-    where :math: `\beta = 1/kT` with T as the bath temperature and k as
-    the Boltzmann's constant.
+def num_hierarchy(kcut, ncut):
+    """
+    Get the total number of auxiliary density matrices in the
+    Hierarchy
+    """
+    return int(factorial(ncut + kcut)/(factorial(ncut)*factorial(kcut)))
 
-    Assumptions:
-        1. The bath is in a thermal state at a given temperature.
-        2. The initial state of the environment is Gaussian.
-        3. Bath operators are in a product state with the system intially.
 
-    The `spectral_density` function is a callable, for example the Ohmic
-    spectral density given as: `ohmic_sd = lambda w, eta: eta*w`
-
+class Heom(object):
+    """
+    The Heom class to tackle Heirarchy.
+    
     Parameters
     ==========
-    spectral_density: callable
-        A function of the form f(w, *params) which calculates the spectral
-        densities for the given parameters, where w are the frequencies.
+    hamiltonian: :class:`qutip.Qobj`
+        The system Hamiltonian
+    
+    coupling: :class:`qutip.Qobj`
+        The coupling operator
+    
+    ck: list
+        The list of amplitudes in the expansion of the correlation function
 
-    tlist : *list* / *array*
-        A 1D array/list of times to calculate the correlation.
+    vk: list
+        The list of frequencies in the expansion of the correlation function
 
-    params: ndarray
-        A 1D array of parameters for the spectral density function.
+    ncut: int
+        The Heirarchy cutoff
+        
+    kcut: int
+        The cutoff in the Matsubara frequencies
 
-    w_cutoff: float
-        The cutoff value for the angular frequencies
-        for integration.
-
-        In general the intergration is for all values but since at
-        higher frequencies, the spectral density is zero, we set
-        a finite limit to the numerical integration.
-
-    beta: float
-        The inverse temperature of the bath. If the temperature
-        is zero, `beta` goes to infinity and we can replace the coth(x)
-        term in the correlation function's real part with 1.
-        At higher temperatures the coth(x) function behaves poorly at
-        low frequencies.
-
-    Returns
-    =======
-    corr: ndarray
-        A 1D array giving the values of the correlation function for given
-        time.
+    rcut: float
+        The cutoff for the maximum absolute value in an auxillary matrix
+        which is used to remove it from the heirarchy
     """
-    if not callable(spectral_density):
-        raise TypeError("""Spectral density should be a callable function
-            f(w, args)""")
+    def __init__(self, hamiltonian, coupling, ck, vk,
+                 ncut, rcut=None, renorm=False, lam=0.):
+        self.hamiltonian = hamiltonian
+        self.coupling = coupling    
+        self.ck, self.vk = ck, vk
+        self.ncut = ncut
+        self.renorm = renorm
+        self.kcut = len(ck)
+        nhe, he2idx, idx2he =_heom_state_dictionaries([ncut+1]*(len(ck)), ncut)
+        # he2idx, idx2he, nhe = self._initialize_he()
+        self.nhe = nhe
+        self.he2idx = he2idx
+        self.idx2he = idx2he
+        self.N = self.hamiltonian.shape[0]
+        
+        total_nhe = int(factorial(self.ncut + self.kcut)/(factorial(self.ncut)*factorial(self.kcut)))
+        self.total_nhe = total_nhe
+        self.hshape = (total_nhe, self.N**2)
+        self.weak_coupling = self.deltak()
+        self.L = liouvillian(self.hamiltonian, []).data
+        self.grad_shape = (self.N**2, self.N**2)
+        self.spreQ = spre(coupling).data
+        self.spostQ = spost(coupling).data
+        self.L_helems = lil_matrix((total_nhe*self.N**2, total_nhe*self.N**2), dtype=np.complex)
+        self.lam = lam
 
-    corrR = []
-    corrI = []
+    def _initialize_he(self):
+        """
+        Initialize the hierarchy indices
+        """
+        zeroth = tuple([0 for i in range(self.kcut)])
+        he2idx = {zeroth:0}
+        idx2he = {0:zeroth}
+        nhe = 1
+        return he2idx, idx2he, nhe
 
-    coth = lambda x: 1/np.tanh(x)
-    w_start = 0.
+    def populate(self, heidx_list):
+        """
+        Given a Hierarchy index list, populate the graph of next and
+        previous elements
+        """
+        ncut = self.ncut
+        kcut = self.kcut
+        he2idx = self.he2idx
+        idx2he = self.idx2he
+        for heidx in heidx_list:
+            for k in range(self.kcut):
+                he_current = idx2he[heidx]
+                he_next = nexthe(he_current, k, ncut)
+                he_prev = prevhe(he_current, k, ncut)
+                if he_next and (he_next not in he2idx):
+                    he2idx[he_next] = self.nhe
+                    idx2he[self.nhe] = he_next
+                    self.nhe += 1
 
-    integrandR = lambda w, t: np.real(spectral_density(w, *params) \
-        *(coth(beta*(w/2)))*np.cos(w*t))
-    integrandI = lambda w, t: np.real(-spectral_density(w, *params) \
-        *np.sin(w*t))
+                if he_prev and (he_prev not in he2idx):
+                    he2idx[he_prev] = self.nhe
+                    idx2he[self.nhe] = he_prev
+                    self.nhe += 1
 
-    for i in tlist:
-        corrR.append(np.real(quad(integrandR, w_start, w_cutoff, args=(i,))[0]))
-        corrI.append(quad(integrandI, w_start, w_cutoff, args=(i,))[0])
-    corr = (np.array(corrR) + 1j*np.array(corrI))/np.pi
-    return corr
+    def deltak(self):
+        """
+        Calculates the deltak values for those Matsubara terms which are
+        greater than the cutoff set for the exponentials.
+        """
+        # Needs some test or check here
+        if self.kcut >= len(self.vk):
+            return 0
+        else:
+            dk = np.sum(np.divide(self.ck[self.kcut:], self.vk[self.kcut:]))
+            return dk
+    
+    def grad_n(self, he_n):
+        """
+        Get the gradient term for the Hierarchy ADM at
+        level n
+        """
+        c = self.ck
+        nu = self.vk
+        L = self.L.copy()
+        gradient_sum = -np.sum(np.multiply(he_n, nu))
+        sum_op = gradient_sum*np.eye(L.shape[0])
+        L += sum_op
+
+        # Fill in larger L
+        nidx = self.he2idx[he_n]
+        block = self.N**2
+        pos = int(nidx*(block))
+        self.L_helems[pos:pos+block, pos:pos+block] = L
+
+    def grad_prev(self, he_n, k, prev_he):
+        """
+        Get prev gradient
+        """
+        c = self.ck
+        nu = self.vk
+        spreQ = self.spreQ
+        spostQ = self.spostQ
+        nk = he_n[k]
+        norm_prev = nk
+            
+        if k == 0:
+            norm_prev = np.sqrt(float(nk)/abs(self.lam))
+            op1 = -1j*norm_prev*(-self.lam*spostQ)
+        elif k == 1 :
+            norm_prev = np.sqrt(float(nk)/abs(self.lam))
+            op1 = -1j*norm_prev*(self.lam*spreQ)
+        else:
+            norm_prev = np.sqrt(float(nk)/abs(c[k]))
+            op1 = -1j*norm_prev*(c[k]*(spreQ - spostQ))
+
+        # Fill in larger L
+        rowidx = self.he2idx[he_n]
+        colidx = self.he2idx[prev_he]
+        block = self.N**2
+        rowpos = int(rowidx*(block))
+        colpos = int(colidx*(block))
+        self.L_helems[rowpos:rowpos+block, colpos:colpos+block] = op1
+
+    def grad_next(self, he_n, k, next_he):
+        c = self.ck
+        nu = self.vk
+        spreQ = self.spreQ
+        spostQ = self.spostQ
+        
+        nk = he_n[k]            
+        
+        if k < 2:
+            norm_next = np.sqrt(self.lam*(nk + 1))
+            op2 = -1j*norm_next*(spreQ - spostQ)
+        else:
+            norm_next = np.sqrt(abs(c[k])*(nk + 1))
+            op2 = -1j*norm_next*(spreQ - spostQ)
+
+        # Fill in larger L
+        rowidx = self.he2idx[he_n]
+        colidx = self.he2idx[next_he]
+        block = self.N**2
+        rowpos = int(rowidx*(block))
+        colpos = int(colidx*(block))
+        self.L_helems[rowpos:rowpos+block, colpos:colpos+block] = op2
+    
+    def rhs(self, progress=None):
+        """
+        Make the RHS
+        """
+        while self.nhe < self.total_nhe:
+            heidxlist = copy(list(self.idx2he.keys()))
+            self.populate(heidxlist)
+        if progress != None:
+            bar = progress(total = self.nhe*self.kcut)
+
+        for n in self.idx2he:
+            he_n = self.idx2he[n]
+            self.grad_n(he_n)
+            for k in range(self.kcut):
+                next_he = nexthe(he_n, k, self.ncut)
+                prev_he = prevhe(he_n, k, self.ncut)
+                if next_he and (next_he in self.he2idx):
+                    self.grad_next(he_n, k, next_he)
+                if prev_he and (prev_he in self.he2idx):
+                    self.grad_prev(he_n, k, prev_he)
+
+    def run(self, rho0, tlist, options=None, progress=None):
+        """
+        Solve the Hierarchy equations of motion for the given initial
+        density matrix and time.
+        """
+        if options is None:
+            options = Options()
+
+        output = Result()
+        output.solver = "hsolve"
+        output.times = tlist
+        output.states = []
+        output.states.append(Qobj(rho0))
+
+        dt = np.diff(tlist)
+        rho_he = np.zeros(self.hshape, dtype=np.complex)
+        rho_he[0] = rho0.full().ravel("F")
+        rho_he = rho_he.flatten()
+
+        self.rhs()
+        L_helems = self.L_helems.asformat("csr")
+        r = ode(cy_ode_rhs)
+        r.set_f_params(L_helems.data, L_helems.indices, L_helems.indptr)
+        r.set_integrator('zvode', method=options.method, order=options.order,
+                         atol=options.atol, rtol=options.rtol,
+                         nsteps=options.nsteps, first_step=options.first_step,
+                         min_step=options.min_step, max_step=options.max_step)
+                        
+        r.set_initial_value(rho_he, tlist[0])
+        dt = np.diff(tlist)
+        n_tsteps = len(tlist)
+        if progress:
+            bar = progress(total=n_tsteps-1)
+        for t_idx, t in enumerate(tlist):
+            if t_idx < n_tsteps - 1:
+                r.integrate(r.t + dt[t_idx])
+                r1 = r.y.reshape(self.hshape)
+                r0 = r1[0].reshape(self.N, self.N).T
+                output.states.append(Qobj(r0))
+                if progress: bar.update()
+        return output

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -36,7 +36,8 @@ import numpy as np
 
 from qutip import _version2int
 from numpy import trapz, linspace, pi
-from numpy.testing import run_module_suite, assert_
+from numpy.testing import (run_module_suite, assert_,
+                           assert_array_almost_equal, assert_raises)
 import unittest
 import warnings
 
@@ -45,7 +46,7 @@ from qutip import (correlation, destroy, coherent_dm, correlation_2op_2t,
                    spectrum_pi, correlation_ss, spectrum_correlation_fft,
                    spectrum, correlation_3op_2t, mesolve, Options,
                    Cubic_Spline)
-
+from qutip.correlation import bath_correlation, underdamped_brownian 
 # find Cython if it exists
 try:
     import Cython
@@ -664,6 +665,27 @@ def test_fn_list_td_corr():
     )
 
     assert_(abs(g20 - 0.85) < 1e-2)
+
+
+def test_sd_function():
+    """
+    correlation: Test for bath correlation function.
+    """
+    tlist = [0., 0.5, 1., 1.5, 2.]
+    lam, gamma, w0 = 0.4, 0.4, 1.
+    beta = np.inf
+    w_cutoff = 10.
+    corr = bath_correlation(underdamped_brownian, tlist,
+                            [lam, gamma, w0], beta, w_cutoff)
+
+    y = np.array([0.07108, 0.059188-0.03477j, 0.033282-0.055529j,
+                  0.003295-0.060187j, -0.022843-0.050641j])
+
+    assert_array_almost_equal(corr, y)
+
+    sd = np.arange(0, 10, 2)
+    assert_raises(TypeError, bath_correlation, [sd, tlist, [0.1], beta,
+                                                w_cutoff])
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_heom_solver.py
+++ b/qutip/tests/test_heom_solver.py
@@ -172,10 +172,9 @@ def test_heom():
     ck1, vk1 = solver1._calc_nonmatsubara_params(lam, gamma, w0, beta)
     ck2, vk2 = solver1._calc_matsubara_params(lam, gamma, w0, beta, Nexp, tlist)
 
-    solver2 = Heom(Hsys, Q, np.concatenate([ck1, ck2]),
+    solver2 = Heom(Hsys, Q, lam_coeff, np.concatenate([ck1, ck2]),
         np.concatenate([vk1, vk2]),
-        ncut=Nc,
-        lam=lam_coeff)
+        ncut=Nc)
 
     output1 = solver1.run(rho0, tlist)
     result1 = np.real(expect(output1.states, sigmaz()))

--- a/qutip/tests/test_heom_solver.py
+++ b/qutip/tests/test_heom_solver.py
@@ -149,7 +149,7 @@ def test_heom():
     initial_ket = basis(2, 1)
     Nc = 9
     rho0 = initial_ket*initial_ket.dag()
-    Nexp = 4
+    Nexp = 2
     lam, gamma, w0 = 0.2, 0.05, 1.
     omega = np.sqrt(w0**2 - (gamma/2.)**2)
     a = omega + 1j*gamma/2.
@@ -165,7 +165,7 @@ def test_heom():
 
     options = Options(nsteps=1500, store_states=True, atol=1e-12, rtol=1e-12)
     solver1 = HSolverUB(Hsys, Q, lam_renorm,
-        ck1, -vk1, ck_mats, -vk_mats, 0., Nc, 4, 1, options=options)
+        ck1, -vk1, ck_mats, -vk_mats, 0., Nc, Nexp, 1, options=options)
 
     solver2 = Heom(Hsys, Q, np.concatenate([ck1, ck_mats]),
         np.concatenate([-vk1, -vk_mats]), ncut=Nc, lam=lam_renorm)

--- a/qutip/tests/test_heom_solver.py
+++ b/qutip/tests/test_heom_solver.py
@@ -145,6 +145,10 @@ def test_heom():
     Q = sigmax()
     wq = 1.
     wrc = 1.
+    w0 = 1.
+    temp = 1e-6
+    cut_freq = 0.5
+
     Hsys = 0.5*wq*sigmaz()
     initial_ket = basis(2, 1)
     Nc = 9
@@ -164,10 +168,13 @@ def test_heom():
     vk_mats = np.array([-0.34959062, -1.75226554])
 
     options = Options(nsteps=1500, store_states=True, atol=1e-12, rtol=1e-12)
-    solver1 = HSolverUB(Hsys, Q, lam_renorm,
-        ck1, -vk1, ck_mats, -vk_mats, 0., Nc, Nexp, 1, options=options)
+    solver1 = HSolverUB(Hsys, Q, lam_renorm, temp, Nc, Nexp,
+                        cut_freq, cav_freq = w0, cav_broad = gamma,
+                        options=options,
+                        ck2 = ck_mats, vk2 = -vk_mats)
 
-    solver2 = Heom(Hsys, Q, np.concatenate([ck1, ck_mats]),
+    solver2 = Heom(Hsys, Q,
+        np.concatenate([ck1, ck_mats]),
         np.concatenate([-vk1, -vk_mats]), ncut=Nc, lam=lam_renorm)
     tlist = np.linspace(0, 200, 1000)
     output1 = solver1.run(rho0, tlist)

--- a/qutip/tests/test_heom_solver.py
+++ b/qutip/tests/test_heom_solver.py
@@ -47,7 +47,7 @@ from numpy.testing import (
 from scipy.integrate import quad, IntegrationWarning
 from qutip import Qobj, sigmaz, basis, expect
 from qutip.nonmarkov.heom import (HSolverDL, Heom,
-                                  HSolverUnderdampedBrownian)
+                                  HSolverUB)
 from qutip.solver import Options
 import warnings
 from qutip.operators import sigmax, sigmaz
@@ -164,7 +164,7 @@ def test_heom():
     vk_mats = np.array([-0.34959062, -1.75226554])
 
     options = Options(nsteps=1500, store_states=True, atol=1e-12, rtol=1e-12)
-    solver1 = HSolverUnderdampedBrownian(Hsys, Q, lam_renorm,
+    solver1 = HSolverUB(Hsys, Q, lam_renorm,
         ck1, -vk1, ck_mats, -vk_mats, 0., Nc, 4, 1, options=options)
 
     solver2 = Heom(Hsys, Q, np.concatenate([ck1, ck_mats]),

--- a/qutip/tests/test_heom_solver.py
+++ b/qutip/tests/test_heom_solver.py
@@ -42,10 +42,12 @@ import os
 import numpy as np
 from numpy import pi, real, cos, tanh
 from numpy.testing import (
-    assert_, assert_almost_equal, run_module_suite, assert_equal)
+    assert_, assert_almost_equal, run_module_suite, assert_equal,
+    assert_array_almost_equal, assert_raises)
 from scipy.integrate import quad, IntegrationWarning
 from qutip import Qobj, sigmaz, basis, expect
-from qutip.nonmarkov.heom import HSolverDL
+from qutip.nonmarkov.heom import (HSolverDL, underdamped_lorrentzian,
+                                  bath_correlation)
 from qutip.solver import Options
 import warnings
 warnings.simplefilter('ignore', IntegrationWarning)
@@ -132,4 +134,27 @@ class TestHSolver:
         assert_(max_resid < resid_tol, "Max residual {} outside tolerence {}, "
                 "for hsolve with {}".format(max_resid, resid_tol, test_desc))
         
-        
+
+def test_sd_function():
+    """
+    correlation: Test for bath correlation function.
+    """
+    tlist = [0., 0.5, 1., 1.5, 2.]
+    lam, gamma, w0 = 0.4, 0.4, 1.
+    beta = np.inf
+    w_cutoff = 10.
+    corr = bath_correlation(underdamped_lorrentzian, tlist,
+                            [lam, gamma, w0], beta, w_cutoff)
+
+    y = np.array([0.07108, 0.059188-0.03477j, 0.033282-0.055529j,
+                  0.003295-0.060187j, -0.022843-0.050641j])
+
+    assert_array_almost_equal(corr, y)
+
+    sd = np.arange(0, 10, 2)
+    assert_raises(TypeError, bath_correlation, [sd, tlist, [0.1], beta,
+                                                w_cutoff])
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/qutip/tests/test_heom_solver.py
+++ b/qutip/tests/test_heom_solver.py
@@ -173,7 +173,7 @@ def test_heom():
     ck2, vk2 = solver1._calc_matsubara_params(lam, gamma, w0, beta, Nexp, tlist)
 
     solver2 = Heom(Hsys, Q, np.concatenate([ck1, ck2]),
-        np.concatenate([vk1, -vk2]),
+        np.concatenate([vk1, vk2]),
         ncut=Nc,
         lam=lam_coeff)
 

--- a/qutip/tests/test_heom_solver.py
+++ b/qutip/tests/test_heom_solver.py
@@ -46,10 +46,11 @@ from numpy.testing import (
     assert_array_almost_equal, assert_raises)
 from scipy.integrate import quad, IntegrationWarning
 from qutip import Qobj, sigmaz, basis, expect
-from qutip.nonmarkov.heom import (HSolverDL, underdamped_lorrentzian,
+from qutip.nonmarkov.heom import (HSolverDL, underdamped_brownian,
                                   bath_correlation)
 from qutip.solver import Options
 import warnings
+
 warnings.simplefilter('ignore', IntegrationWarning)
     
 class TestHSolver:
@@ -143,7 +144,7 @@ def test_sd_function():
     lam, gamma, w0 = 0.4, 0.4, 1.
     beta = np.inf
     w_cutoff = 10.
-    corr = bath_correlation(underdamped_lorrentzian, tlist,
+    corr = bath_correlation(underdamped_brownian, tlist,
                             [lam, gamma, w0], beta, w_cutoff)
 
     y = np.array([0.07108, 0.059188-0.03477j, 0.033282-0.055529j,


### PR DESCRIPTION
I would like to add the Underdamped Lorentzian spectral density to the HEOM and realised that there should be some discussion on the design.

For this specific PR, I am in two minds: 

A. I follow the previous code and make a `HSolverUnderDampedBrownian` class. This will be quite different from the HSolverDL class as now, we will take the coefficients ck and vk separately for the non-Matsubara part and then the Mastsubara part and combine them to get the RHS instead of computing them from the coupling strength as before.

B. Rewrite a new `Heom` class with the `configure` method taking the ck and vk values and not caring about the spectral density. We add some additional functions to compute the cks and vks based on Drude-Lorrentz, Underdamped Lorrentzian or Ohmic spectral density. We can even do a numerical fitting for the coefficients using the `bath_correlation` function that I added now for any arbitrary spectral density and then feed it to the `configure` method of the new `Heom` class to build the RHS. This is a more generic version of the HEOM which separates the method from specific spectral densities and is close to implementing the following version that is simplified from @nwlambert 's paper :

![screenshot 2019-03-05 14 41 25](https://user-images.githubusercontent.com/6968324/53809476-16468080-3f55-11e9-90bd-50159a075663.png)

I am leaning more towards B and re-structuring the HEOM functions to seperate the SD and the implementation itself. This has some advantages in the future too perhaps if we want to work specificially on the HEOM part without caring about the form of the spectral density.

The second point is:

Most of QuTiP's solvers are function based eg., `mesolve`. In `qutip.piqs` however, we tried to do things with the class called `Dicke`. We defined a `pisolve` method similar in spirit to `mesolve` which takes in an initial state, tlist and computes the evolution. For many sophisticated approaches like `piqs` or `heom`, there needs to be some amount of pre-processing such as computing the Liouvillian/Lindbladian or the levels of the Hierarchy that needs to be done to get the RHS which is solved to get the dynamics. I saw similar approaches in `qutip.pdpsolve` with `StochasticSolverOptions`.

I really like the `HEOMSolver` class defined here and was wondering if we can we have a similar abstract class which can be shared across all future solver methods and not just HEOM or the stochastic solver? I add an example below.

@ajgpitch Does this make sense and should we strive to get some uniform class for all future solvers? 
@nathanshammah @nonhermitian 

```
class Solver(object):
    """
    A super-class specifying the basic methods required in a solver.

    Parameters
    ----------
    name: str
        The name of the specific solver the sub-class represents, eg., `heom`.
        default: None
    """
    def __init__(self, solver=None):
    	self.solver = solver

    def configure(self, *args, **kwargs):
    	"""
    	Configures the solver by computing the necessary objects required
    	to run the `solve` method.
    	"""
    	raise NotImplementedError("This is a abstract class only. "
        "Use a subclass, for example `Dicke.configure`")

    def solve(self, initial_state, tlist, options, *args, **kwargs):
    	"""
    	Runs the solver to compute the evolution using the initial state and tlist.
    	"""
    	raise NotImplementedError("This is a abstract class only. "
        "Use the solve method from a subclass, for example `Dicke.solve`")
```
