### PR TITLE
Gates can be added to specified position in a QubitCircuit

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -220,6 +220,8 @@ class QubitCircuit(object):
             Argument value(phi).
         arg_label: String
             Label for gate representation.
+        index : List
+            Positions to add the gate.
         """
         if isinstance(gate, Gate):
             name = gate.name
@@ -237,8 +239,10 @@ class QubitCircuit(object):
 
         else:
             for position in index:
-                self.gates.insert(position, Gate(name, targets=targets, controls=controls,
-                                                 arg_value=arg_value, arg_label=arg_label))
+                self.gates.insert(position, Gate(name, targets=targets,
+                                                 controls=controls,
+                                                 arg_value=arg_value,
+                                                 arg_label=arg_label))
 
     def add_1q_gate(self, name, start=0, end=None, qubits=None,
                     arg_value=None, arg_label=None):

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -203,7 +203,7 @@ class QubitCircuit(object):
                 self.output_states[i] = state
 
     def add_gate(self, gate, targets=None, controls=None, arg_value=None,
-                 arg_label=None):
+                 arg_label=None, index=None):
         """
         Adds a gate with specified parameters to the circuit.
 
@@ -230,8 +230,15 @@ class QubitCircuit(object):
 
         else:
             name = gate
-        self.gates.append(Gate(name, targets=targets, controls=controls,
-                               arg_value=arg_value, arg_label=arg_label))
+
+        if index is None:
+            self.gates.append(Gate(name, targets=targets, controls=controls,
+                                   arg_value=arg_value, arg_label=arg_label))
+
+        else:
+            for position in index:
+                self.gates.insert(position, Gate(name, targets=targets, controls=controls,
+                                                 arg_value=arg_value, arg_label=arg_label))
 
     def add_1q_gate(self, name, start=0, end=None, qubits=None,
                     arg_value=None, arg_label=None):

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -147,6 +147,9 @@ class TestQubitCircuit:
         test_gate = Gate("RZ", targets=[1], arg_value = 1.570796,
                          arg_label="P")
         qc.add_gate(test_gate)
+        qc.add_gate("TOFFOLI", controls=[0, 1], targets=[2])
+        qc.add_gate("SNOT", targets=[3])
+        qc.add_gate(test_gate, index = [3])
 
         # Test explicit gate addition
         assert_(qc.gates[0].name == "CNOT")
@@ -157,6 +160,11 @@ class TestQubitCircuit:
         assert_(qc.gates[1].name == test_gate.name)
         assert_(qc.gates[1].targets == test_gate.targets)
         assert_(qc.gates[1].controls == test_gate.controls)
+
+        # Test specified position gate addition
+        assert_(qc.gates[3].name == test_gate.name)
+        assert_(qc.gates[3].targets == test_gate.targets)
+        assert_(qc.gates[3].controls == test_gate.controls)
 
     def test_add_state(self):
         """


### PR DESCRIPTION
This enables QubitCircuit.add_gate() to insert some gate in the middle of the circuit. This should address issue #615 .