### PR TITLE
dynamic args

### DIFF
--- a/qutip/cy/cqobjevo.pxd
+++ b/qutip/cy/cqobjevo.pxd
@@ -41,6 +41,7 @@ cdef class CQobjEvo:
     cdef object dims
     cdef int super
     cdef int num_ops
+    cdef int dyn_args
 
     #cdef void (*factor_ptr)(double, complex*)
     cdef object factor_func
@@ -51,13 +52,17 @@ cdef class CQobjEvo:
     cdef complex* coeff_ptr
 
     cdef void _factor(self, double t)
+    cdef void _factor_dyn(self, double t, complex* state, int[::1] state)
     cdef void _mul_vec(self, double t, complex* vec, complex* out)
     cdef void _mul_matf(self, double t, complex* mat, complex* out,
                     int nrow, int ncols)
     cdef void _mul_matc(self, double t, complex* mat, complex* out,
                     int nrow, int ncols)
-    cdef complex _expect(self, double t, complex* vec, int isherm)
-    cdef complex _expect_super(self, double t, complex* rho, int isherm)
+
+    cpdef complex expect(self, double t, complex[::1] vec)
+    cdef complex _expect(self, double t, complex* vec)
+    cdef complex _expect_super(self, double t, complex* rho)
+    cdef complex _overlapse(self, double t, complex* oper)
 
 
 cdef class CQobjCte(CQobjEvo):
@@ -77,9 +82,6 @@ cdef class CQobjEvoTd(CQobjEvo):
     cdef CSR_Matrix cte
     cdef CSR_Matrix ** ops
     cdef long[::1] sum_elem
-
-
-    cdef void _factor(self, double t)
     cdef void _call_core(self, CSR_Matrix * out, complex* coeff)
 
 
@@ -98,7 +100,6 @@ cdef class CQobjEvoTdDense(CQobjEvo):
 
 cdef class CQobjEvoTdMatched(CQobjEvo):
     cdef int nnz
-
     # data as array
     cdef int[::1] indptr
     cdef int[::1] indices

--- a/qutip/cy/cqobjevo_factor.pxd
+++ b/qutip/cy/cqobjevo_factor.pxd
@@ -1,9 +1,23 @@
 #!python
 #cython: language_level=3
+cimport numpy as np
+
+cdef np.ndarray[complex, ndim=1] zptr2array1d(complex* ptr, int N)
+
+cdef np.ndarray[complex, ndim=2] zptr2array2d(complex* ptr, int R, int C)
+
+cdef np.ndarray[int, ndim=1] iprt2array(int* ptr, int N)
 
 cdef class CoeffFunc:
-    cdef int num_ops
+    cdef dict _args
+    cdef int _num_ops
     cdef void _call_core(self, double t, complex* coeff)
+    cdef void _dyn_args(self, double t, complex* state, int[::1] shape)
 
 cdef class StrCoeff(CoeffFunc):
-    cdef object args
+    cdef list _dyn_args_list
+    cdef int _num_expect
+    cdef int[2] _mat_shape
+    cdef list _expect_op
+    cdef complex[::1] _expect_vec
+    cdef complex[::1] _vec

--- a/qutip/cy/cqobjevo_factor.pyx
+++ b/qutip/cy/cqobjevo_factor.pyx
@@ -41,6 +41,8 @@ from qutip.cy.inter import _prep_cubic_spline
 from qutip.cy.inter cimport (_spline_complex_cte_second,
                              _spline_complex_t_second)
 from qutip.cy.interpolate cimport (interp, zinterp)
+from qutip.cy.cqobjevo cimport CQobjEvo
+
 include "complex_math.pxi"
 
 """
@@ -49,13 +51,30 @@ By using inheritance, it is possible to 'cimport' coefficient compiled at
 runtime. Pure array based, (inter.pyx or interpolate.pyx) are defined here.
 str inherite from StrCoeff and just add the _call_core method.
 """
+
+cdef np.ndarray[complex, ndim=1] zptr2array1d(complex* ptr, int N):
+    cdef np.npy_intp Ns[1]
+    Ns[0] = N
+    return np.PyArray_SimpleNewFromData(1, Ns, np.NPY_COMPLEX128, ptr)
+
+cdef np.ndarray[complex, ndim=2] zptr2array2d(complex* ptr, int R, int C):
+    cdef np.npy_intp Ns[2]
+    Ns[0] = R
+    Ns[1] = C
+    return np.PyArray_SimpleNewFromData(2, Ns, np.NPY_COMPLEX128, ptr)
+
+cdef np.ndarray[int, ndim=1] iprt2array(int* ptr, int N):
+    cdef np.npy_intp Ns[1]
+    Ns[0] = N
+    return np.PyArray_SimpleNewFromData(1, Ns, np.NPY_INT32, ptr)
+
 cdef class CoeffFunc:
     def __init__(self, ops, args, tlist):
-        pass
+        self._args = {}
 
     def __call__(self, double t, args={}):
         cdef np.ndarray[ndim=1, dtype=complex] coeff = \
-                                            np.zeros(self.num_ops, dtype=complex)
+                                            np.zeros(self._num_ops, dtype=complex)
         self._call_core(t, &coeff[0])
         return coeff
 
@@ -65,11 +84,17 @@ cdef class CoeffFunc:
     cdef void _call_core(self, double t, complex* coeff):
         pass
 
+    cdef void _dyn_args(self, double t, complex* state, int[::1] shape):
+        pass
+
     def __getstate__(self):
         pass
 
     def __setstate__(self, state):
         pass
+
+    def get_args(self):
+        return self._args
 
 
 cdef class InterpolateCoeff(CoeffFunc):
@@ -78,34 +103,35 @@ cdef class InterpolateCoeff(CoeffFunc):
 
     def __init__(self, ops, args, tlist):
         cdef int i, j, l
-        self.num_ops = len(ops)
+        self._args = {}
+        self._num_ops = len(ops)
         self.a = ops[0][2].a
         self.b = ops[0][2].b
         l = len(ops[0][2].coeffs)
-        self.c = np.zeros((self.num_ops, l), dtype=complex)
-        for i in range(self.num_ops):
+        self.c = np.zeros((self._num_ops, l), dtype=complex)
+        for i in range(self._num_ops):
             for j in range(l):
                 self.c[i,j] = ops[i][2].coeffs[j]
 
     def __call__(self, t, args={}):
         cdef np.ndarray[ndim=1, dtype=complex] coeff = \
-                                            np.zeros(self.num_ops, dtype=complex)
+                                            np.zeros(self._num_ops, dtype=complex)
         self._call_core(t, &coeff[0])
         return coeff
 
     cdef void _call_core(self, double t, complex* coeff):
         cdef int i
-        for i in range(self.num_ops):
+        for i in range(self._num_ops):
             coeff[i] = zinterp(t, self.a, self.b, self.c[i,:])
 
     def set_args(self, args):
         pass
 
     def __getstate__(self):
-        return (self.num_ops, self.a, self.b, np.array(self.c))
+        return (self._num_ops, self.a, self.b, np.array(self.c))
 
     def __setstate__(self, state):
-        self.num_ops = state[0]
+        self._num_ops = state[0]
         self.a = state[1]
         self.b = state[2]
         self.c = state[3]
@@ -119,14 +145,15 @@ cdef class InterCoeffCte(CoeffFunc):
 
     def __init__(self, ops, args, tlist):
         cdef int i, j
-        self.num_ops = len(ops)
+        self._args = {}
+        self._num_ops = len(ops)
         self.tlist = tlist
         self.n_t = len(tlist)
         self.dt = tlist[1]-tlist[0]
-        self.y = np.zeros((self.num_ops, self.n_t), dtype=complex)
-        self.M = np.zeros((self.num_ops, self.n_t), dtype=complex)
+        self.y = np.zeros((self._num_ops, self.n_t), dtype=complex)
+        self.M = np.zeros((self._num_ops, self.n_t), dtype=complex)
 
-        for i in range(self.num_ops):
+        for i in range(self._num_ops):
             m, cte = _prep_cubic_spline(ops[i][2], tlist)
             if not cte:
                 raise Exception("tlist not sampled uniformly")
@@ -136,7 +163,7 @@ cdef class InterCoeffCte(CoeffFunc):
 
     cdef void _call_core(self, double t, complex* coeff):
         cdef int i
-        for i in range(self.num_ops):
+        for i in range(self._num_ops):
             coeff[i] = _spline_complex_cte_second(t, self.tlist,
                                     self.y[i,:], self.M[i,:], self.n_t, self.dt)
 
@@ -144,11 +171,11 @@ cdef class InterCoeffCte(CoeffFunc):
         pass
 
     def __getstate__(self):
-        return (self.num_ops, self.n_t, self.dt, np.array(self.tlist),
+        return (self._num_ops, self.n_t, self.dt, np.array(self.tlist),
                 np.array(self.y), np.array(self.M))
 
     def __setstate__(self, state):
-        self.num_ops = state[0]
+        self._num_ops = state[0]
         self.n_t = state[1]
         self.dt = state[2]
         self.tlist = state[3]
@@ -164,22 +191,23 @@ cdef class InterCoeffT(CoeffFunc):
 
     def __init__(self, ops, args, tlist):
         cdef int i, j
-        self.num_ops = len(ops)
+        self._args = {}
+        self._num_ops = len(ops)
         self.tlist = tlist
         self.n_t = len(tlist)
-        self.y = np.zeros((self.num_ops, self.n_t), dtype=complex)
-        self.M = np.zeros((self.num_ops, self.n_t), dtype=complex)
-        for i in range(self.num_ops):
+        self.y = np.zeros((self._num_ops, self.n_t), dtype=complex)
+        self.M = np.zeros((self._num_ops, self.n_t), dtype=complex)
+        for i in range(self._num_ops):
             m, cte = _prep_cubic_spline(ops[i][2], tlist)
             if cte:
-                print("tlist not uniformly?")
+                print("tlist not uniform?")
             for j in range(self.n_t):
                 self.y[i,j] = ops[i][2][j]
                 self.M[i,j] = m[j]
 
     cdef void _call_core(self, double t, complex* coeff):
         cdef int i
-        for i in range(self.num_ops):
+        for i in range(self._num_ops):
             coeff[i] = _spline_complex_t_second(t, self.tlist,
                                     self.y[i,:], self.M[i,:], self.n_t)
 
@@ -187,11 +215,11 @@ cdef class InterCoeffT(CoeffFunc):
         pass
 
     def __getstate__(self):
-        return (self.num_ops, self.n_t, None, np.array(self.tlist),
+        return (self._num_ops, self.n_t, None, np.array(self.tlist),
                 np.array(self.y), np.array(self.M))
 
     def __setstate__(self, state):
-        self.num_ops = state[0]
+        self._num_ops = state[0]
         self.n_t = state[1]
         self.tlist = state[3]
         self.y = state[4]
@@ -199,28 +227,85 @@ cdef class InterCoeffT(CoeffFunc):
 
 
 cdef class StrCoeff(CoeffFunc):
-    def __init__(self, ops, args, tlist):
-        self.num_ops = len(ops)
-        self.args = args
+    def __init__(self, ops, args, tlist, dyn_args=[]):
+        self._num_ops = len(ops)
+        self._args = args
+        self._dyn_args_list = dyn_args
         self.set_args(args)
+        self._set_dyn_args(dyn_args)
 
-    def __call__(self, double t, args={}):
+    def _set_dyn_args(self, dyn_args):
+        self._num_expect = 0
+        self._expect_op = []
+        expect_def = []
+        self._mat_shape[0] = 0
+        self._mat_shape[1] = 0
+        if dyn_args:
+            for name, what, op in dyn_args:
+                if what == "expect":
+                    self._expect_op.append(op.compiled_qobjevo)
+                    expect_def.append(self._args[name])
+                    self._num_expect += 1
+                elif what == "vec":
+                    self._vec = self._args[name]
+                elif what == "mat":
+                    self._vec = self._args[name].ravel("F")
+                    self._mat_shape[0] = self._args[name].shape[0]
+                    self._mat_shape[1] = self._args[name].shape[0]
+                elif what == "Qobj":
+                    self._vec = self._args[name].full().ravel("F")
+                    self._mat_shape[0] = self._args[name].shape[0]
+                    self._mat_shape[1] = self._args[name].shape[0]
+        self._expect_vec = np.array(expect_def, dtype=complex)
+
+    cdef void _dyn_args(self, double t, complex* state, int[::1] shape):
+        cdef int ii, nn = shape[0] * shape[1]
+        self._vec = <complex[:nn]> state
+        self._mat_shape[0] = shape[0]
+        self._mat_shape[1] = shape[1]
+        cdef CQobjEvo cop
+        for ii in range(self._num_expect):
+            cop = self._expect_op[ii]
+            if cop.shape1 != nn:
+                self._expect_vec[ii] = cop._overlapse(t, state)
+            elif cop.super:
+                self._expect_vec[ii] = cop._expect_super(t, state)
+            else:
+                self._expect_vec[ii] = cop._expect(t, state)
+
+    def __call__(self, double t, args={}, vec=None):
         cdef np.ndarray[ndim=1, dtype=complex] coeff = \
-                                            np.zeros(self.num_ops, dtype=complex)
+                                    np.zeros(self._num_ops, dtype=complex)
+        cdef int[2] shape
+        if vec is not None:
+            if isinstance(vec, np.ndarray):
+                self._vec = vec.ravel("F")
+                shape[0] = vec.shape[0]
+                shape[1] = vec.shape[1]
+            else:
+                full = vec.full()
+                self._vec = full.ravel("F")
+                shape[0] = full.shape[0]
+                shape[1] = full.shape[1]
+            self._dyn_args(t, &self._vec[0], shape)
+
         if args:
             now_args = self.args.copy()
             now_args.update(args)
             self.set_args(now_args)
             self._call_core(t, &coeff[0])
-            self.set_args(self.args)
+            self.set_args(self._args)
         else:
             self._call_core(t, &coeff[0])
+
         return coeff
 
     def __getstate__(self):
-        return (self.num_ops, self.args)
+        return (self._num_ops, self._args, self._dyn_args_list)
 
     def __setstate__(self, state):
-        self.num_ops = state[0]
-        self.args = state[1]
-        self.set_args(self.args)
+        self._num_ops = state[0]
+        self._args = state[1]
+        self._dyn_args_list = state[2]
+        self.set_args(self._args)
+        self._set_dyn_args(self._dyn_args_list)

--- a/qutip/cy/openmp/cqobjevo_omp.pyx
+++ b/qutip/cy/openmp/cqobjevo_omp.pyx
@@ -98,7 +98,7 @@ cdef class CQobjCteOmp(CQobjCte):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef complex _expect(self, double t, complex* vec, int isherm):
+    cdef complex _expect(self, double t, complex* vec):
         cdef complex[::1] y = np.zeros(self.shape0, dtype=complex)
         spmvpy_openmp(self.cte.data, self.cte.indices, self.cte.indptr, vec, 1.,
                &y[0], self.shape0, self.nthr)
@@ -106,10 +106,7 @@ cdef class CQobjCteOmp(CQobjCte):
         cdef complex dot = 0
         for row from 0 <= row < self.shape0:
             dot += conj(vec[row])*y[row]
-        if isherm:
-            return real(dot)
-        else:
-            return dot
+        return dot
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -138,7 +135,10 @@ cdef class CQobjEvoTdOmp(CQobjEvoTd):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef void _mul_vec(self, double t, complex* vec, complex* out):
-        self._factor(t)
+        cdef int[2] shape
+        shape[0] = self.shape1
+        shape[1] = 1
+        self._factor_dyn(t, vec, shape)
         cdef int i
         spmvpy_openmp(self.cte.data, self.cte.indices, self.cte.indptr, vec,
                1., out, self.shape0, self.nthr)
@@ -151,7 +151,10 @@ cdef class CQobjEvoTdOmp(CQobjEvoTd):
     @cython.cdivision(True)
     cdef void _mul_matf(self, double t, complex* mat, complex* out,
                         int nrow, int ncol):
-        self._factor(t)
+        cdef int[2] shape
+        shape[0] = nrow
+        shape[1] = ncol
+        self._factor_dyn(t, mat, shape)
         cdef int i
         _spmmfpy_omp(self.cte.data, self.cte.indices, self.cte.indptr, mat, 1.,
                out, self.shape0, nrow, ncol, self.nthr)
@@ -164,7 +167,10 @@ cdef class CQobjEvoTdOmp(CQobjEvoTd):
     @cython.cdivision(True)
     cdef void _mul_matc(self, double t, complex* mat, complex* out,
                         int nrow, int ncol):
-        self._factor(t)
+        cdef int[2] shape
+        shape[0] = nrow
+        shape[1] = ncol
+        self._factor_dyn(t, mat, shape)
         cdef int i
         _spmmcpy_par(self.cte.data, self.cte.indices, self.cte.indptr, mat, 1.,
                out, self.shape0, nrow, ncol, self.nthr)
@@ -183,7 +189,10 @@ cdef class CQobjEvoTdMatchedOmp(CQobjEvoTdMatched):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef void _mul_vec(self, double t, complex* vec, complex* out):
-        self._factor(t)
+        cdef int[2] shape
+        shape[0] = self.shape1
+        shape[1] = 1
+        self._factor_dyn(t, vec, shape)
         self._call_core(self.data_t, self.coeff_ptr)
         spmvpy_openmp(self.data_ptr, &self.indices[0], &self.indptr[0], vec,
                1., out, self.shape0, self.nthr)
@@ -193,7 +202,10 @@ cdef class CQobjEvoTdMatchedOmp(CQobjEvoTdMatched):
     @cython.cdivision(True)
     cdef void _mul_matf(self, double t, complex* mat, complex* out,
                         int nrow, int ncol):
-        self._factor(t)
+        cdef int[2] shape
+        shape[0] = nrow
+        shape[1] = ncol
+        self._factor_dyn(t, mat, shape)
         self._call_core(self.data_t, self.coeff_ptr)
         _spmmfpy_omp(self.data_ptr, &self.indices[0], &self.indptr[0], mat, 1.,
                out, self.shape0, nrow, ncol, self.nthr)
@@ -203,7 +215,10 @@ cdef class CQobjEvoTdMatchedOmp(CQobjEvoTdMatched):
     @cython.cdivision(True)
     cdef void _mul_matc(self, double t, complex* mat, complex* out,
                         int nrow, int ncol):
-        self._factor(t)
+        cdef int[2] shape
+        shape[0] = nrow
+        shape[1] = ncol
+        self._factor_dyn(t, mat, shape)
         self._call_core(self.data_t, self.coeff_ptr)
         _spmmcpy_par(self.data_ptr, &self.indices[0], &self.indptr[0], mat, 1.,
                out, self.shape0, nrow, ncol, self.nthr)

--- a/qutip/cy/stochastic.pyx
+++ b/qutip/cy/stochastic.pyx
@@ -517,7 +517,7 @@ cdef class StochasticSolver:
         for t_idx, t in enumerate(times):
             if sso.ce_ops:
                 for e_idx, e in enumerate(sso.ce_ops):
-                    s = e.compiled_qobjevo.expect(t, rho_t, 0)
+                    s = e.compiled_qobjevo.expect(t, rho_t)
                     expect[e_idx, t_idx] = s
             if sso.store_states or not sso.ce_ops:
                 if sso.me:
@@ -532,7 +532,7 @@ cdef class StochasticSolver:
 
             if sso.store_measurement:
                 for m_idx, m in enumerate(sso.cm_ops):
-                    m_expt = m.compiled_qobjevo.expect(t, rho_t, 0)
+                    m_expt = m.compiled_qobjevo.expect(t, rho_t)
                     measurements[t_idx, m_idx] = m_expt + self.dW_factor[m_idx] * \
                         sum(noise[t_idx, :, m_idx]) / (self.dt * self.num_substeps)
 
@@ -1269,7 +1269,7 @@ cdef class SSESolver(StochasticSolver):
         _zero(temp)
         for i in range(self.num_ops):
             c_op = self.cpcd_ops[i]
-            e = c_op._expect(t, &vec[0], 0)
+            e = c_op._expect(t, &vec[0])
             _zero(temp)
             c_op = self.c_ops[i]
             c_op._mul_vec(t, &vec[0], &temp[0])
@@ -1287,7 +1287,7 @@ cdef class SSESolver(StochasticSolver):
             c_op = self.c_ops[i]
             c_op._mul_vec(t, &vec[0], &out[i,0])
             c_op = self.cpcd_ops[i]
-            expect = c_op._expect(t, &vec[0], 0)
+            expect = c_op._expect(t, &vec[0])
             _axpy(-0.5*expect,vec,out[i,:])
 
     @cython.boundscheck(False)
@@ -1932,7 +1932,7 @@ cdef class PcSSESolver(StochasticSolver):
         self.d2(t, vec, d2)
         for i in range(self.num_ops):
             c_op = self.cdc_ops[i]
-            expect = c_op.expect(t, vec, 1).real * dt
+            expect = c_op.expect(t, vec).real * dt
             if expect > 0:
               noise[i] = np.random.poisson(expect)
             else:
@@ -1958,7 +1958,7 @@ cdef class PcSSESolver(StochasticSolver):
         self.d2(t, vec, d2)
         for i in range(self.num_ops):
             c_op = self.cdc_ops[i]
-            expect = c_op.expect(t, vec, 1).real * dt
+            expect = c_op.expect(t, vec).real * dt
             if expect > 0:
               noise[i] = np.random.poisson(expect)
             else:
@@ -2037,7 +2037,7 @@ cdef class PcSMESolver(StochasticSolver):
         self.d2(t, vec, d2)
         for i in range(self.num_ops):
             c_op = self.cdcl_ops[i]
-            expect = c_op.expect(t, vec, 1).real * dt
+            expect = c_op.expect(t, vec).real * dt
             if expect > 0:
               noise[i] = np.random.poisson(expect)
             else:
@@ -2062,7 +2062,7 @@ cdef class PcSMESolver(StochasticSolver):
         self.d2(t, vec, d2)
         for i in range(self.num_ops):
             c_op = self.cdcl_ops[i]
-            expect = c_op.expect(t, vec, 1).real * dt
+            expect = c_op.expect(t, vec).real * dt
             if expect > 0:
               noise[i] = np.random.poisson(expect)
             else:
@@ -2158,7 +2158,7 @@ cdef class PmSMESolver(StochasticSolver):
         self.preLH._mul_vec(t, &vec[0], &temp[0])
         for i in range(self.num_ops):
             c_op = self.sops[i]
-            dy[i] = c_op._expect_super(t, &vec[0], 0) + noise[i]
+            dy[i] = c_op._expect_super(t, &vec[0]) + noise[i]
             c_op = self.preops[i]
             _zero(temp2)
             c_op._mul_vec(t, &vec[0], &temp2[0])

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -55,8 +55,8 @@ from qutip.ui.progressbar import BaseProgressBar, TextProgressBar
 
 
 def propagator(H, t, c_op_list=[], args={}, options=None,
-               unitary_mode='batch', parallel=False, 
-               progress_bar=None, _safe_mode=True, 
+               unitary_mode='batch', parallel=False,
+               progress_bar=None, _safe_mode=True,
                **kwargs):
     """
     Calculate the propagator U(t) for the density matrix or wave function such
@@ -86,13 +86,13 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
         with options for the ODE solver.
 
     unitary_mode = str ('batch', 'single')
-        Solve all basis vectors simulaneously ('batch') or individually 
+        Solve all basis vectors simulaneously ('batch') or individually
         ('single').
-    
+
     parallel : bool {False, True}
-        Run the propagator in parallel mode. This will override the 
+        Run the propagator in parallel mode. This will override the
         unitary_mode settings if set to True.
-    
+
     progress_bar: BaseProgressBar
         Optional instance of BaseProgressBar, or a subclass thereof, for
         showing the progress of the simulation. By default no progress bar
@@ -109,7 +109,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
         num_cpus = kwargs['num_cpus']
     else:
         num_cpus = kw['num_cpus']
-    
+
     if progress_bar is None:
         progress_bar = BaseProgressBar()
     elif progress_bar is True:
@@ -127,23 +127,26 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
 
     if _safe_mode:
         _solver_safety_check(H, None, c_ops=c_op_list, e_ops=[], args=args)
-    
+
     td_type = _td_format_check(H, c_op_list, solver='me')
-        
+
     if isinstance(H, (types.FunctionType, types.BuiltinFunctionType,
                       functools.partial)):
         H0 = H(0.0, args)
+        if unitary_mode =='batch':
+            # batch don't work with function Hamiltonian
+            unitary_mode = 'single'
     elif isinstance(H, list):
         H0 = H[0][0] if isinstance(H[0], list) else H[0]
     else:
         H0 = H
-    
+
     if len(c_op_list) == 0 and H0.isoper:
         # calculate propagator for the wave function
 
         N = H0.shape[0]
         dims = H0.dims
-        
+
         if parallel:
             unitary_mode = 'single'
             u = np.zeros([N, N, len(tlist)], dtype=complex)
@@ -152,20 +155,15 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                                   progress_bar=progress_bar, num_cpus=num_cpus)
             for n in range(N):
                 for k, t in enumerate(tlist):
-                    u[:, n, k] = output[n].states[k].full().T 
+                    u[:, n, k] = output[n].states[k].full().T
         else:
             if unitary_mode == 'single':
-                u = np.zeros([N, N, len(tlist)], dtype=complex)
-                progress_bar.start(N)
-                for n in range(0, N):
-                    progress_bar.update(n)
-                    psi0 = basis(N, n)
-                    output = sesolve(H, psi0, tlist, [], args, options,
-                                     _safe_mode=False)
-                    for k, t in enumerate(tlist):
-                        u[:, n, k] = output.states[k].full().T
-                    progress_bar.finished()
-
+                output = sesolve(H, qeye(N), tlist, [], args, options,
+                                 _safe_mode=False)
+                if len(tlist) == 2:
+                    return output.states[-1]
+                else:
+                    return output.states
 
             elif unitary_mode =='batch':
                 u = np.zeros(len(tlist), dtype=object)
@@ -193,7 +191,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
 
             else:
                 raise Exception('Invalid unitary mode.')
-                        
+
 
     elif len(c_op_list) == 0 and H0.issuper:
         # calculate the propagator for the vector representation of the
@@ -202,7 +200,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
         N = H0.shape[0]
         sqrt_N = int(np.sqrt(N))
         dims = H0.dims
-        
+
         u = np.zeros([N, N, len(tlist)], dtype=complex)
 
         if parallel:
@@ -215,18 +213,14 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                 for k, t in enumerate(tlist):
                     u[:, n, k] = mat2vec(output[n].states[k].full()).T
         else:
-            progress_bar.start(N)
-            for n in range(0, N):
-                progress_bar.update(n)
-                col_idx, row_idx = np.unravel_index(n, (sqrt_N, sqrt_N))
-                rho0 = Qobj(sp.csr_matrix(([1], ([row_idx], [col_idx])),
-                                          shape=(sqrt_N,sqrt_N), dtype=complex)
-                            )
-                output = mesolve(H, rho0, tlist, [], [], args, options,
-                                 _safe_mode=False)
-                for k, t in enumerate(tlist):
-                    u[:, n, k] = mat2vec(output.states[k].full()).T
-            progress_bar.finished()
+            rho0 = qeye(N,N)
+            rho0.dims = [[sqrt_N, sqrt_N], [sqrt_N, sqrt_N]]
+            output = mesolve(H, psi0, tlist, [], args, options,
+                             _safe_mode=False)
+            if len(tlist) == 2:
+                return output.states[-1]
+            else:
+                return output.states
 
     else:
         # calculate the propagator for the vector representation of the
@@ -236,7 +230,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
         dims = [H0.dims, H0.dims]
 
         u = np.zeros([N * N, N * N, len(tlist)], dtype=complex)
-        
+
         if parallel:
             output = parallel_map(_parallel_mesolve, range(N * N),
                                   task_args=(
@@ -300,7 +294,7 @@ def propagator_steadystate(U):
     """
 
     evals, evecs = la.eig(U.full())
-    
+
     shifted_vals = np.abs(evals - 1.0)
     ev_idx = np.argmin(shifted_vals)
     ev_min = shifted_vals[ev_idx]
@@ -324,4 +318,3 @@ def _parallel_mesolve(n, N, H, tlist, c_op_list, args, options):
     output = mesolve(H, rho0, tlist, c_op_list, [], args, options,
                      _safe_mode=False)
     return output
-

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -52,9 +52,10 @@ def _compile_str_single(string, args):
 # This file is generated automatically by QuTiP.
 
 import numpy as np
+import scipy.special as spe
 cimport numpy as np
 cimport cython
-from qutip.cy.math cimport erf
+from qutip.cy.math cimport erf, zerf
 cdef double pi = 3.14159265358979323
 include """+_include_string+"""
 
@@ -84,11 +85,11 @@ def f(double t, args):
     return str_func[0], filename
 
 
-def _compiled_coeffs(ops, args, tlist):
+def _compiled_coeffs(ops, args, dyn_args, tlist):
     """Create and import a cython compiled class for coeff that
     need compilation.
     """
-    code = _make_code_4_cimport(ops, args, tlist)
+    code = _make_code_4_cimport(ops, args, dyn_args, tlist)
     filename = "cqobjevo_compiled_coeff_"+str(hash(code))[1:]
 
     file = open(filename+".pyx", "w")
@@ -100,7 +101,7 @@ def _compiled_coeffs(ops, args, tlist):
                           "import_list.append(CompiledStrCoeff)",
                           '<string>', 'exec')
     exec(import_code, locals())
-    coeff_obj = import_list[0](ops, args, tlist)
+    coeff_obj = import_list[0](ops, args, tlist, dyn_args)
 
     try:
         os.remove(filename+".pyx")
@@ -110,7 +111,7 @@ def _compiled_coeffs(ops, args, tlist):
     return coeff_obj, code, filename
 
 
-def _make_code_4_cimport(ops, args, tlist):
+def _make_code_4_cimport(ops, args, dyn_args, tlist):
     """
     Create the code for a CoeffFunc cython class the wraps
     the string coefficients, array_like coefficients and Cubic_Spline.
@@ -125,6 +126,7 @@ def _make_code_4_cimport(ops, args, tlist):
 
 import numpy as np
 cimport numpy as np
+import scipy.special as spe
 cimport cython
 np.import_array()
 cdef extern from "numpy/arrayobject.h" nogil:
@@ -135,7 +137,9 @@ from qutip.cy.inter cimport _spline_complex_t_second, _spline_complex_cte_second
 from qutip.cy.inter cimport _spline_float_t_second, _spline_float_cte_second
 from qutip.cy.interpolate cimport (interp, zinterp)
 from qutip.cy.cqobjevo_factor cimport StrCoeff
-from qutip.cy.math cimport erf
+from qutip.cy.cqobjevo cimport CQobjEvo
+from qutip.cy.math cimport erf, zerf
+from qutip.qobj import Qobj
 cdef double pi = 3.14159265358979323
 
 include """ + _include_string + "\n\n"
@@ -189,7 +193,11 @@ include """ + _include_string + "\n\n"
             N_np += 1
 
     code += "cdef class CompiledStrCoeff(StrCoeff):\n"
-    for name, value in args.items():
+    normal_args = args.copy()
+    for name, _, _ in dyn_args:
+        del normal_args[name]
+
+    for name, value in normal_args.items():
         if not isinstance(name, str):
             raise Exception("All arguments key must be string " +
                             "and valid variables name")
@@ -201,18 +209,20 @@ include """ + _include_string + "\n\n"
             code += "    cdef complex[::1] " + name + "\n"
         elif isinstance(value, (complex, np.complex128)):
             code += "    cdef complex " + name + "\n"
-        else:
+        elif np.isscalar(value):
             code += "    cdef double " + name + "\n"
+        else:
+            code += "    cdef object " + name + "\n"
 
     code += "\n"
-    if args:
+    if normal_args:
         code += "    def set_args(self, args):\n"
-        for name, value in args.items():
+        for name, value in normal_args.items():
             code += "        self." + name + "=args['" + name + "']\n"
         code += "\n"
     code += "    cdef void _call_core(self, double t, complex * coeff):\n"
 
-    for name, value in args.items():
+    for name, value in normal_args.items():
         if isinstance(value, np.ndarray) and \
                 isinstance(value[0], (float, np.float32, np.float64)):
             code += "        cdef double[::1] " + name + " = self." +\
@@ -223,8 +233,26 @@ include """ + _include_string + "\n\n"
                     name + "\n"
         elif isinstance(value, (complex, np.complex128)):
             code += "        cdef complex " + name + " = self." + name + "\n"
-        else:
+        elif np.isscalar(value):
             code += "        cdef double " + name + " = self." + name + "\n"
+        else:
+            code += "        cdef object " + name + " = self." + name + "\n"
+
+    expect_i = 0
+    for name, what, op in dyn_args:
+        if what == "vec":
+            code += "        cdef complex[::1] " + name + " = self._vec\n"
+        if what == "mat":
+            code += "        cdef np.ndarray[complex, ndim=2] " + name + \
+                    " = np.array(self._vec).reshape(" \
+                    "(self._mat_shape[0], self._mat_shape[1]), order='F')\n"
+        if what == "Qobj":
+            code += "        " + name + " = Qobj(np.array(self._vec).reshape(" \
+                    "(self._mat_shape[0], self._mat_shape[1]), order='F'))\n"
+        if what == "expect":
+            code += "        cdef complex " + name + " = self._expect_vec[" \
+                    + str(expect_i) + "]\n"
+            expect_i += 1
 
     code += "\n"
     for i, str_coeff in enumerate(compile_list):

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -109,6 +109,7 @@ def stochastic_solvers():
         Efficient Quantum Filtering for Quantum Feedback Control
         Pierre Rouchon, Jason F. Ralph
         arXiv:1410.5345 [quant-ph]
+        Phys. Rev. A 91, 012118, (2015)
 
     taylor1.5, Order 1.5 strong Taylor scheme:
         Solver with more terms of the Ito-Taylor expansion.

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -105,7 +105,7 @@ def stochastic_solvers():
         Scheme keeping the positivity of the density matrix. (smesolve only)
         -Order strong 1.0?
         -Code: 'rouchon', 'Rouchon'
-        Eq. 4 of arXiv:1410.5345 with eta=1 
+        Eq. 4 of arXiv:1410.5345 with eta=1
         Efficient Quantum Filtering for Quantum Feedback Control
         Pierre Rouchon, Jason F. Ralph
         arXiv:1410.5345 [quant-ph]
@@ -244,7 +244,7 @@ class StochasticSolverOptions:
 
     store_measurement : bool (default False)
         Whether or not to store the measurement results in the
-        :class:`qutip.solver.SolverResult` instance returned by the solver.
+        :class:`qutip.solver.Result` instance returned by the solver.
 
     noise : int, array[int, 1d], array[double, 4d]
         int : seed of the noise
@@ -549,9 +549,9 @@ def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
     Returns
     -------
 
-    output: :class:`qutip.solver.SolverResult`
+    output: :class:`qutip.solver.Result`
 
-        An instance of the class :class:`qutip.solver.SolverResult`.
+        An instance of the class :class:`qutip.solver.Result`.
 
     """
     if "method" in kwargs and kwargs["method"] == "photocurrent":
@@ -677,9 +677,9 @@ def ssesolve(H, psi0, times, sc_ops=[], e_ops=[],
     Returns
     -------
 
-    output: :class:`qutip.solver.SolverResult`
+    output: :class:`qutip.solver.Result`
 
-        An instance of the class :class:`qutip.solver.SolverResult`.
+        An instance of the class :class:`qutip.solver.Result`.
     """
     if "method" in kwargs and kwargs["method"] == "photocurrent":
         print("stochastic solver with photocurrent method has been moved to "
@@ -887,9 +887,9 @@ def photocurrent_mesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
     Returns
     -------
 
-    output: :class:`qutip.solver.SolverResult`
+    output: :class:`qutip.solver.Result`
 
-        An instance of the class :class:`qutip.solver.SolverResult`.
+        An instance of the class :class:`qutip.solver.Result`.
     """
     if isket(rho0):
         rho0 = ket2dm(rho0)
@@ -978,9 +978,9 @@ def photocurrent_sesolve(H, psi0, times, sc_ops=[], e_ops=[],
     Returns
     -------
 
-    output: :class:`qutip.solver.SolverResult`
+    output: :class:`qutip.solver.Result`
 
-        An instance of the class :class:`qutip.solver.SolverResult`.
+        An instance of the class :class:`qutip.solver.Result`.
     """
     if isinstance(e_ops, dict):
         e_ops_dict = e_ops
@@ -1068,8 +1068,8 @@ def general_stochastic(state0, times, d1, d2, e_ops=[], m_ops=[],
     Returns
     -------
 
-    output: :class:`qutip.solver.SolverResult`
-        An instance of the class :class:`qutip.solver.SolverResult`.
+    output: :class:`qutip.solver.Result`
+        An instance of the class :class:`qutip.solver.Result`.
     """
 
     if isinstance(e_ops, dict):
@@ -1352,9 +1352,9 @@ def ssepdpsolve(H, psi0, times, c_ops, e_ops, **kwargs):
     Returns
     -------
 
-    output: :class:`qutip.solver.SolverResult`
+    output: :class:`qutip.solver.Result`
 
-        An instance of the class :class:`qutip.solver.SolverResult`.
+        An instance of the class :class:`qutip.solver.Result`.
 
     """
     return main_ssepdpsolve(H, psi0, times, c_ops, e_ops, **kwargs)
@@ -1400,9 +1400,9 @@ def smepdpsolve(H, rho0, times, c_ops, e_ops, **kwargs):
     Returns
     -------
 
-    output: :class:`qutip.solver.SolverResult`
+    output: :class:`qutip.solver.Result`
 
-        An instance of the class :class:`qutip.solver.SolverResult`.
+        An instance of the class :class:`qutip.solver.Result`.
 
     """
     return main_smepdpsolve(H, rho0, times, c_ops, e_ops, **kwargs)

--- a/qutip/superoperator.py
+++ b/qutip/superoperator.py
@@ -38,7 +38,6 @@ __all__ = ['liouvillian', 'liouvillian_ref', 'lindblad_dissipator',
 import scipy.sparse as sp
 import numpy as np
 from qutip.qobj import Qobj
-from qutip.qobjevo import QobjEvo
 from qutip.fastsparse import fast_csr_matrix, fast_identity
 from qutip.sparse import sp_reshape
 from qutip.cy.spmath import zcsr_kron
@@ -405,3 +404,5 @@ def sprepost(A, B):
                  _drop_projected_dims(B.dims[0])]]
         data = zcsr_kron(B.data.T, A.data)
         return Qobj(data, dims=dims, superrep='super')
+
+from qutip.qobjevo import QobjEvo


### PR DESCRIPTION
This PR is part of  PR #969 , splitting that PR in two parts.

It contains:
- `qobjevo`'s args that update with the state. (replacing rhs_with_state functionality) 
- method `norm` renamed to `_cdc` as it was not used as a norm.
- cython side of expect method no longer take `isherm` as an arguments.
- security check in propagator for `H` as a function with `batch` method.
- `propagator` uses `sesolve` capability to evolve operators.
- floquet now call `sesolve` instead of `mesolve` with no collapse.