### PR TITLE
Piqs prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installation
 
 For instructions on how to install QuTiP, see:
 
-[http://qutip.org/docs/4.1/installation.html](http://qutip.org/docs/4.1/installation.html)
+[http://qutip.org/docs/latest/installation.html](http://qutip.org/docs/latest/installation.html)
 
 
 Demos

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -346,53 +346,6 @@ class Dicke(object):
         result = pim.solve(initial_state, tlist, options=None)
         return result
 
-    def prune_eigenstates(self, liouvillian):
-        """Remove spurious eigenvalues and eigenvectors of the Liouvillian.
-
-        Spurious means that the given eigenvector has elements outside of the
-        block-diagonal matrix.
-
-        Parameters
-        ----------
-        liouvillian_eigenstates: list
-            A list with the eigenvalues and eigenvectors of the Liouvillian
-            including spurious ones.
-
-        Returns
-        -------
-        correct_eigenstates: list
-            The list with the correct eigenvalues and eigenvectors of the
-            Liouvillian.
-        """
-        liouvillian_eigenstates = liouvillian.eigenstates()
-        N = self.N
-        block_mat = block_matrix(N)
-        nnz_tuple_bm = [(i, j) for i, j in zip(*block_mat.nonzero())]
-
-        # 0. Create  a copy of the eigenvalues to approximate values
-        eig_val, eig_vec = liouvillian_eigenstates
-        tol = 10
-        eig_val_round = np.round(eig_val, tol)
-
-        # 2. Use 'block_matrix(N)' to remove eigenvectors with matrix
-        # elements
-        # outside of the block matrix.
-        forbidden_eig_index = []
-        for k in range(0, len(eig_vec)):
-            dm = vector_to_operator(eig_vec[k])
-            nnz_tuple = [(i, j) for i, j in zip(*dm.data.nonzero())]
-            for i in nnz_tuple:
-                if i not in nnz_tuple_bm:
-                    if np.round(dm[i], tol) != 0:
-                        forbidden_eig_index.append(k)
-
-        forbidden_eig_index = np.array(list(set(forbidden_eig_index)))
-        # 3. Remove the forbidden eigenvalues and eigenvectors.
-        correct_eig_val = np.delete(eig_val, forbidden_eig_index)
-        correct_eig_vec = np.delete(eig_vec, forbidden_eig_index)
-        correct_eigenstates = correct_eig_val, correct_eig_vec
-        return correct_eigenstates
-
     def c_ops(self):
         """Build collapse operators in the full Hilbert space 2^N.
 

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -1091,43 +1091,6 @@ class TestDicke:
         assert_almost_equal(true_gamma_3, test_gamma_3)
         assert_almost_equal(true_gamma_4, test_gamma_4)
 
-    def test_prune_eigenstates(self):
-        """
-        PIQS: Test the eigenstate pruning
-        """
-        N = 2
-        w0 = 1
-        kappa = 2 * w0
-        gCE = kappa /(N/2)
-        gE = 1
-        gD = 1
-        [jx, jy, jz] = jspin(N)
-        jp, jm = jspin(N, "+"), jspin(N, "-")
-        H = w0 * jx
-
-        ensemble = Dicke(N=N, hamiltonian=H, collective_emission=gCE,
-                         emission=gE, dephasing=gD)
-        liouv = ensemble.liouvillian()
-        pruned_eig_values, pruned_eig_states = ensemble.prune_eigenstates(liouv)
-        estate_last = np.array([[-0.00510544+0.j],
-                                [0.00000000-0.01614514j],
-                                [0.08133350+0.j],
-                                [0.00000000+0.j],
-                                [0.00000000+0.01614514j],
-                                [-0.02588476+0.j],
-                                [0.00000000-0.30050737j],
-                                [0.00000000+0.j],
-                                [0.08133350+0.j],
-                                [0.00000000+0.30050737j],
-                                [-0.61872203+0.j],
-                                [0.00000000+0.j],
-                                [0.00000000+0.j],
-                                [0.00000000+0.j],
-                                [0.00000000+0.j],
-                                [0.64971224+0.j]])
-        assert_array_almost_equal(pruned_eig_states[-1].full(), estate_last)
-
-
 class TestPim:
     """
     Tests for the `qutip.piqs.Pim` class.


### PR DESCRIPTION
Eliminate the function `prune_eigenstates()` as it is not correct. Not affecting any other part of code. 