### PR TITLE
Some patches for qip.Gate

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -50,22 +50,22 @@ class Gate(object):
     
     Parameters
     ----------
-    name : String
+    name : string
         Gate name.
-    targets : List or Integer
+    targets : list or int
         Gate targets.
-    controls : List or Integer
+    controls : list or int
         Gate controls.
-    arg_value : Float
+    arg_value : float
         Argument value(phi).
-    arg_label : String
+    arg_label : string
         Label for gate representation.
     """
 
     def __init__(self, name, targets=None, controls=None, arg_value=None,
                  arg_label=None):
         """
-        Creates a gate with specified parameters.
+        Create a gate with specified parameters.
         """
         self.name = name
         self.targets = None
@@ -215,18 +215,18 @@ class QubitCircuit(object):
 
         Parameters
         ----------
-        gate: String or `Gate`
+        gate: string or `Gate`
             Gate name. If gate is an instance of `Gate`, parameters are
             unpacked and added.
-        targets: List
+        targets: list
             Gate targets.
-        controls: List
+        controls: list
             Gate controls.
-        arg_value: Float
+        arg_value: float
             Argument value(phi).
-        arg_label: String
+        arg_label: string
             Label for gate representation.
-        index : List
+        index : list
             Positions to add the gate.
         """
         if isinstance(gate, Gate):
@@ -259,17 +259,17 @@ class QubitCircuit(object):
 
         Parameters
         ----------
-        name : String
+        name : string
             Gate name.
-        start : Integer
+        start : int
             Starting location of qubits.
-        end : Integer
+        end : int
             Last qubit for the gate.
-        qubits : List
+        qubits : list
             Specific qubits for applying gates.
-        arg_value : Float
+        arg_value : float
             Argument value(phi).
-        arg_label : String
+        arg_label : string
             Label for gate representation.
         """
         if name not in ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE"]:
@@ -298,7 +298,7 @@ class QubitCircuit(object):
         ----------
         qc : QubitCircuit
             The circuit block to be added to the main circuit.
-        start : Integer
+        start : int
             The qubit on which the first gate is applied.
         """
         if self.N - start < qc.N:
@@ -329,16 +329,16 @@ class QubitCircuit(object):
 
     def remove_gate(self, index=None, end=None, name=None, remove="first"):
         """
-        Removes a gate from a specific index or between two indexes or the
+        Remove a gate from a specific index or between two indexes or the
         first, last or all instances of a particular gate.
 
         Parameters
         ----------
-        index : Integer
+        index : int
             Location of gate to be removed.
-        name : String
+        name : string
             Gate name to be removed.
-        remove : String
+        remove : string
             If first or all gate are to be removed.
         """
         if index is not None and index <= self.N:
@@ -372,12 +372,12 @@ class QubitCircuit(object):
 
     def reverse_circuit(self):
         """
-        Reverses an entire circuit of unitary gates.
+        Reverse an entire circuit of unitary gates.
 
         Returns
         ----------
         qc : QubitCircuit
-            Returns QubitCircuit of resolved gates for the qubit circuit in the
+            Return QubitCircuit of resolved gates for the qubit circuit in the
             reverse order.
 
         """
@@ -402,7 +402,7 @@ class QubitCircuit(object):
         Returns
         -------
         qc : QubitCircuit
-            Returns QubitCircuit of resolved gates for the qubit circuit in the
+            Return QubitCircuit of resolved gates for the qubit circuit in the
             desired basis.
         """
         qc_temp = QubitCircuit(self.N, self.reverse_states)
@@ -831,9 +831,9 @@ class QubitCircuit(object):
         target/s in terms of gates with adjacent interactions.
 
         Returns
-        ----------
+        -------
         qc : QubitCircuit
-            Returns QubitCircuit of the gates for the qubit circuit with the
+            Return QubitCircuit of the gates for the qubit circuit with the
             resolved non-adjacent gates.
 
         """
@@ -914,7 +914,7 @@ class QubitCircuit(object):
         Returns
         -------
         U_list : list
-            Returns list of unitary matrices for the qubit circuit.
+            Return list of unitary matrices for the qubit circuit.
 
         """
         self.U_list = []

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -81,12 +81,12 @@ class Gate(object):
         else:
             self.controls = controls
 
-        if isinstance(self.targets, Iterable):
-            if not all([isinstance(input, np.int) for input in self.targets]):
-                raise ValueError("Index of target qubit must be an integer")
-        if isinstance(self.controls, Iterable):
-            if not all([isinstance(input, np.int) for input in self.controls]):
-                raise ValueError("Index of control qubit must be an integer")
+        for ind_list in [self.targets, self.controls]:
+            if isinstance(ind_list, Iterable):
+                all_integer = all(
+                    [isinstance(ind, np.int) for ind in ind_list])
+                if not all_integer:
+                    raise ValueError("Index of a qubit must be an integer")
 
         if name in ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
                     "SWAPalpha"]:

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -31,8 +31,10 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-import numpy as np
+from collections.abc import Iterable
 import warnings
+
+import numpy as np
 
 from qutip.qip.circuit_latex import _latex_compile
 from qutip.qip.gates import *
@@ -50,9 +52,9 @@ class Gate(object):
     ----------
     name : String
         Gate name.
-    targets : List
+    targets : List or Integer
         Gate targets.
-    controls : List
+    controls : List or Integer
         Gate controls.
     arg_value : Float
         Argument value(phi).
@@ -69,19 +71,26 @@ class Gate(object):
         self.targets = None
         self.controls = None
 
-        if not isinstance(targets, list) and targets is not None:
+        if not isinstance(targets, Iterable) and targets is not None:
             self.targets = [targets]
         else:
             self.targets = targets
 
-        if not isinstance(controls, list) and controls is not None:
+        if not isinstance(controls, Iterable) and controls is not None:
             self.controls = [controls]
         else:
             self.controls = controls
 
+        if isinstance(self.targets, Iterable):
+            if not any([isinstance(input,np.int) for input in self.targets]):
+                raise ValueError("Index of target qubit must be an integer")
+        if isinstance(self.controls, Iterable):
+            if not any([isinstance(input,np.int) for input in self.controls]):
+                raise ValueError("Index of control qubit must be an integer")
+
         if name in ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
                     "SWAPalpha"]:
-            if len(self.targets) != 2:
+            if (self.targets is None) or (len(self.targets) != 2):
                 raise ValueError("Gate %s requires two targets" % name)
             if self.controls is not None:
                 raise ValueError("Gate %s cannot have a control" % name)

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -82,10 +82,10 @@ class Gate(object):
             self.controls = controls
 
         if isinstance(self.targets, Iterable):
-            if not all([isinstance(input,np.int) for input in self.targets]):
+            if not all([isinstance(input, np.int) for input in self.targets]):
                 raise ValueError("Index of target qubit must be an integer")
         if isinstance(self.controls, Iterable):
-            if not all([isinstance(input,np.int) for input in self.controls]):
+            if not all([isinstance(input, np.int) for input in self.controls]):
                 raise ValueError("Index of control qubit must be an integer")
 
         if name in ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -45,25 +45,25 @@ class Gate(object):
     """
     Representation of a quantum gate, with its required parametrs, and target
     and control qubits.
+    
+    Parameters
+    ----------
+    name : String
+        Gate name.
+    targets : List
+        Gate targets.
+    controls : List
+        Gate controls.
+    arg_value : Float
+        Argument value(phi).
+    arg_label : String
+        Label for gate representation.
     """
 
     def __init__(self, name, targets=None, controls=None, arg_value=None,
                  arg_label=None):
         """
         Creates a gate with specified parameters.
-
-        Parameters
-        ----------
-        name : String
-            Gate name.
-        targets : List
-            Gate targets.
-        controls : List
-            Gate controls.
-        arg_value : Float
-            Argument value(phi).
-        arg_label : String
-            Label for gate representation.
         """
         self.name = name
         self.targets = None

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -79,9 +79,6 @@ class Gate(object):
         else:
             self.controls = controls
 
-        self.arg_value = arg_value
-        self.arg_label = arg_label
-
         if name in ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
                     "SWAPalpha"]:
             if len(self.targets) != 2:

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -82,10 +82,10 @@ class Gate(object):
             self.controls = controls
 
         if isinstance(self.targets, Iterable):
-            if not any([isinstance(input,np.int) for input in self.targets]):
+            if not all([isinstance(input,np.int) for input in self.targets]):
                 raise ValueError("Index of target qubit must be an integer")
         if isinstance(self.controls, Iterable):
-            if not any([isinstance(input,np.int) for input in self.controls]):
+            if not all([isinstance(input,np.int) for input in self.controls]):
                 raise ValueError("Index of control qubit must be an integer")
 
         if name in ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",

--- a/qutip/qip/models/circuitprocessor.py
+++ b/qutip/qip/models/circuitprocessor.py
@@ -68,7 +68,7 @@ class CircuitProcessor(object):
         qc: QubitCircuit
             The optimal circuit representation.
         """
-        raise NotImplemented("Use the function in the sub-class")
+        raise NotImplementedError("Use the function in the sub-class")
 
     def adjacent_gates(self, qc, setup):
         """
@@ -88,7 +88,7 @@ class CircuitProcessor(object):
         qc: QubitCircuit
             The resolved circuit representation.
         """
-        raise NotImplemented("Use the function in the sub-class")
+        raise NotImplementedError("Use the function in the sub-class")
 
     def load_circuit(self, qc):
         """
@@ -100,14 +100,14 @@ class CircuitProcessor(object):
         qc: QubitCircuit
             Takes the quantum circuit to be implemented.
         """
-        raise NotImplemented("Use the function in the sub-class")
+        raise NotImplementedError("Use the function in the sub-class")
 
     def get_ops_and_u(self):
         """
         Returns the Hamiltonian operators and corresponding values by stacking
         them together.
         """
-        raise NotImplemented("Use the function in the sub-class")
+        raise NotImplementedError("Use the function in the sub-class")
 
     def get_ops_labels(self):
         """


### PR DESCRIPTION
Some small changes:

1. remove repetitive assignments of `self.arg_value` and` self.arg_label`
2. move the description to the definition of class so the document will show it
3. raise the corresponding error if targets is None while required or not an integer, e.g `Gate("SWAP")` or `Gate("SWAP", [0.5, 2])`