### PR TITLE
Add quantum Hellinger distance to `qutip.metrics`

### DIFF
--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -291,6 +291,7 @@ def bures_angle(A, B):
 
     return np.arccos(fidelity(A, B))
 
+
 def hellinger_dist(A, B, sparse=False, tol=0):
     """
     Calculates the quantum Hellinger distance between two density matrices.
@@ -342,6 +343,7 @@ def hellinger_dist(A, B, sparse=False, tol=0):
     #instabilities causing np.sum(eigs) slightly (~1e-8) larger than 1
     #when hellinger_dist(A, B) is called for A=B
     return np.sqrt(2.0 * np.maximum(0., (1.0 - np.real(np.sum(eigs)))))
+
 
 def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False):
     """

--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -341,7 +341,7 @@ def hellinger_dist(A, B, sparse=False, tol=0):
     #np.maximum() is to avoid nan appearing sometimes due to numerical
     #instabilities causing np.sum(eigs) slightly (~1e-8) larger than 1
     #when hellinger_dist(A, B) is called for A=B
-    return float(np.sqrt(2.0 * np.maximum(0., (1.0 - np.sum(eigs)))))
+    return np.sqrt(2.0 * np.maximum(0., (1.0 - np.real(np.sum(eigs)))))
 
 def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False):
     """

--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -295,15 +295,19 @@ def bures_angle(A, B):
 def hellinger_dist(A, B, sparse=False, tol=0):
     """
     Calculates the quantum Hellinger distance between two density matrices.
+
+    Formula:
+    hellinger_dist(A, B) = sqrt(2-2*Tr(sqrt(A)*sqrt(B)))
+
     See: D. Spehner, F. Illuminati, M. Orszag, and W. Roga, "Geometric
     measures of quantum correlations with Bures and Hellinger distances"
     arXiv:1611.03449
 
     Parameters
     ----------
-    A : qobj
+    A : :class:`qutip.Qobj`
         Density matrix or state vector.
-    B : qobj
+    B : :class:`qutip.Qobj`
         Density matrix or state vector with same dimensions as A.
     tol : float
         Tolerance used by sparse eigensolver, if used. (0=Machine precision)
@@ -313,7 +317,7 @@ def hellinger_dist(A, B, sparse=False, tol=0):
     Returns
     -------
     hellinger_dist : float
-        Quantum Hellinger distance between A and B.
+        Quantum Hellinger distance between A and B. Ranges from 0 to sqrt(2).
 
     Examples
     --------

--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -37,8 +37,8 @@ This module contains a collection of functions for calculating metrics
 """
 
 __all__ = ['fidelity', 'tracedist', 'bures_dist', 'bures_angle',
-           'hilbert_dist', 'average_gate_fidelity', 'process_fidelity',
-           'unitarity', 'dnorm']
+           'hellinger_dist', 'hilbert_dist', 'average_gate_fidelity',
+           'process_fidelity', 'unitarity', 'dnorm']
 
 import numpy as np
 from scipy import linalg as la
@@ -291,6 +291,57 @@ def bures_angle(A, B):
 
     return np.arccos(fidelity(A, B))
 
+def hellinger_dist(A, B, sparse=False, tol=0):
+    """
+    Calculates the quantum Hellinger distance between two density matrices.
+    See: D. Spehner, F. Illuminati, M. Orszag, and W. Roga, "Geometric
+    measures of quantum correlations with Bures and Hellinger distances"
+    arXiv:1611.03449
+
+    Parameters
+    ----------
+    A : qobj
+        Density matrix or state vector.
+    B : qobj
+        Density matrix or state vector with same dimensions as A.
+    tol : float
+        Tolerance used by sparse eigensolver, if used. (0=Machine precision)
+    sparse : {False, True}
+        Use sparse eigensolver.
+
+    Returns
+    -------
+    hellinger_dist : float
+        Quantum Hellinger distance between A and B.
+
+    Examples
+    --------
+    >>> x=fock_dm(5,3)
+    >>> y=coherent_dm(5,1)
+    >>> hellinger_dist(x,y)
+    1.3725145002591095
+
+    """
+    if A.dims != B.dims:
+        raise TypeError("A and B do not have same dimensions.")
+
+    if A.isket or A.isbra:
+        sqrtmA = ket2dm(A)
+    else:
+        sqrtmA = A.sqrtm(sparse=sparse, tol=tol)
+    if B.isket or B.isbra:
+        sqrtmB = ket2dm(B)
+    else:
+        sqrtmB = B.sqrtm(sparse=sparse, tol=tol)
+
+    product = sqrtmA*sqrtmB
+
+    eigs = sp_eigs(product.data,
+                   isherm=product.isherm, vecs=False, sparse=sparse, tol=tol)
+    #np.maximum() is to avoid nan appearing sometimes due to numerical
+    #instabilities causing np.sum(eigs) slightly (~1e-8) larger than 1
+    #when hellinger_dist(A, B) is called for A=B
+    return float(np.sqrt(2.0 * np.maximum(0., (1.0 - np.sum(eigs)))))
 
 def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False):
     """

--- a/qutip/tests/test_metrics.py
+++ b/qutip/tests/test_metrics.py
@@ -293,7 +293,10 @@ def test_hellinger_monotonicity():
     """
     Metrics: Hellinger dist.: check monotonicity
     w.r.t. tensor product, see. Eq. (45) in
-    arXiv:1611.03449v2
+    arXiv:1611.03449v2:
+    hellinger_dist(rhoA \otimes rhoB, sigmaA \otimes sigmaB)>=
+    hellinger_dist(rhoA, sigmaA)
+    with equality iff sigmaB=rhoB
     """
     for _ in range(10):
         rhoA = rand_dm(8, 0.5)


### PR DESCRIPTION
This PR suggests enhancing the `qutip.metrics` module by adding a new distance b/w quantum states: the quantum Hellinger distance (QHD), implemented as new function `qutip.metrics.hellinger_dist()`. Excellent description is provided for example in:
_Geometric measures of quantum correlations with Bures and Hellinger distances_, D. Spehner, F. Illuminati, M. Orszag, W. Roga, https://arxiv.org/abs/1611.03449

Albeit a bit less popular than already implemented Bures and trace distances, the QHD is actively studied, eg:
https://arxiv.org/abs/1903.10455
https://arxiv.org/abs/1806.10814
https://arxiv.org/abs/1510.06995

The PR contains tests of properties of the QHD as outlined in arXiv:1611.03449

I am of course keen on performing additional tests, code refactoring, documentation of this feature etc.