### PR TITLE
Update deprecated usage of Iterable

### DIFF
--- a/qutip/control/optimizer.py
+++ b/qutip/control/optimizer.py
@@ -1067,7 +1067,7 @@ class OptimizerCrab(Optimizer):
         if self.pulse_generator is None:
             pulse_gen_valid = False
             err_msg = "pulse_generator attribute is None"
-        elif not isinstance(self.pulse_generator, collections.Iterable):
+        elif not isinstance(self.pulse_generator, collections.abc.Iterable):
             pulse_gen_valid = False
             err_msg = "pulse_generator is not iterable"
 


### PR DESCRIPTION
I updated the use of Iterable and now there is no warning for it in the tests mentioned in #1003.