### PR TITLE
nosetests segmentation fault in Metrics docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installation
 
 For instructions on how to install QuTiP, see:
 
-[http://qutip.org/docs/4.1/installation.html](http://qutip.org/docs/4.1/installation.html)
+[http://qutip.org/docs/latest/installation.html](http://qutip.org/docs/latest/installation.html)
 
 
 Demos

--- a/qutip/tests/test_metrics.py
+++ b/qutip/tests/test_metrics.py
@@ -294,7 +294,7 @@ def test_hellinger_monotonicity():
     Metrics: Hellinger dist.: check monotonicity
     w.r.t. tensor product, see. Eq. (45) in
     arXiv:1611.03449v2:
-    hellinger_dist(rhoA \otimes rhoB, sigmaA \otimes sigmaB)>=
+    hellinger_dist(rhoA*rhoB, sigmaA*sigmaB)>=
     hellinger_dist(rhoA, sigmaA)
     with equality iff sigmaB=rhoB
     """


### PR DESCRIPTION
Fix a docstring error prompting a segmentation fault when run on python 3.7.3 on Mac Mojave. 