### PR TITLE
Bugs leading to error in building the documentation

### DIFF
--- a/qutip/eseries.py
+++ b/qutip/eseries.py
@@ -36,7 +36,6 @@ __all__ = ['eseries', 'esval', 'esspec', 'estidy']
 import numpy as np
 import scipy.sparse as sp
 from qutip.qobj import Qobj
-import qutip as qt
 
 
 class eseries():
@@ -88,7 +87,7 @@ class eseries():
                 q = np.asarray(q, dtype=object)
                 ind = np.shape(q)
                 num = ind[0]  # number of elements in q
-                if any([qt.Qobj(x).shape != qt.Qobj(q[0]).shape for x in q]):
+                if any([Qobj(x).shape != Qobj(q[0]).shape for x in q]):
                     raise TypeError('All amplitudes must have same dimension.')
                 self.ampl = np.array([x for x in q], dtype=object)
                 self.rates = np.zeros(ind)
@@ -111,7 +110,7 @@ class eseries():
                 q = np.asarray(q, dtype=object)
                 ind = np.shape(q)
                 num = ind[0]
-                if any([qt.Qobj(x).shape != qt.Qobj(q[0]).shape for x in q]):
+                if any([Qobj(x).shape != Qobj(q[0]).shape for x in q]):
                     raise TypeError('All amplitudes must have same dimension.')
                 self.ampl = np.array([Qobj(q[x]) for x in range(0, num)],
                                      dtype=object)

--- a/qutip/eseries.py
+++ b/qutip/eseries.py
@@ -36,6 +36,7 @@ __all__ = ['eseries', 'esval', 'esspec', 'estidy']
 import numpy as np
 import scipy.sparse as sp
 from qutip.qobj import Qobj
+import qutip as qt
 
 
 class eseries():

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -730,12 +730,9 @@ def qdiags(diagonals, offsets, dims=None, shape=None):
         Shape of operator.  If omitted, a square operator large enough
         to contain the diagonals is generated.
 
-    See Also
-    --------
-    scipy.sparse.diags for usage information.
-
     Notes
     -----
+    See also `scipy.sparse.diags` for usage information.
     This function requires SciPy 0.11+.
 
     Examples

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -730,9 +730,12 @@ def qdiags(diagonals, offsets, dims=None, shape=None):
         Shape of operator.  If omitted, a square operator large enough
         to contain the diagonals is generated.
 
+    See Also
+    --------
+    scipy.sparse.diags : for usage information.
+
     Notes
     -----
-    See also `scipy.sparse.diags` for usage information.
     This function requires SciPy 0.11+.
 
     Examples


### PR DESCRIPTION
1. `Qobj` is included separately. `qt` is not defined.
2. See Also: `func_a : Function a with its description.` As described in https://numpydoc.readthedocs.io/en/latest/format.html