### PR TITLE
Add user defined gates, MS gate and fix some bugs (replacement)

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -526,12 +526,12 @@ class QubitCircuit(object):
                 if "ISWAP" in basis_2q:  # dealed with separately
                     temp_resolved.append(gate)
                 else:
-                    temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                            gate.targets[1]))
-                    temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                            gate.targets[0]))
-                    temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                            gate.targets[1]))
+                    temp_resolved.append(
+                        Gate("CNOT", gate.targets[0], gate.targets[1]))
+                    temp_resolved.append(
+                        Gate("CNOT", gate.targets[1], gate.targets[0]))
+                    temp_resolved.append(
+                        Gate("CNOT", gate.targets[0], gate.targets[1]))
             elif gate.name == "ISWAP":
                 temp_resolved.append(Gate("CNOT", gate.targets[0],
                                           gate.targets[1]))

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -33,6 +33,9 @@
 
 from collections.abc import Iterable
 import warnings
+import inspect
+
+import numpy as np
 
 import numpy as np
 
@@ -47,7 +50,7 @@ class Gate(object):
     """
     Representation of a quantum gate, with its required parametrs, and target
     and control qubits.
-    
+
     Parameters
     ----------
     name : string
@@ -95,18 +98,18 @@ class Gate(object):
             if self.controls is not None:
                 raise ValueError("Gate %s cannot have a control" % name)
 
-        if name in ["CNOT", "CSIGN", "CRX", "CRY", "CRZ"]:
+        elif name in ["CNOT", "CSIGN", "CRX", "CRY", "CRZ"]:
             if self.targets is None or len(self.targets) != 1:
                 raise ValueError("Gate %s requires one target" % name)
             if self.controls is None or len(self.controls) != 1:
                 raise ValueError("Gate %s requires one control" % name)
 
-        if name in ["SNOT", "RX", "RY", "RZ", "PHASEGATE"]:
+        elif name in ["SNOT", "RX", "RY", "RZ", "PHASEGATE"]:
             if self.controls is not None:
                 raise ValueError("Gate %s does not take controls" % name)
 
-        if name in ["RX", "RY", "RZ", "CPHASE", "SWAPalpha", "PHASEGATE",
-                    "GLOBALPHASE", "CRX", "CRY", "CRZ"]:
+        elif name in ["RX", "RY", "RZ", "CPHASE", "SWAPalpha", "PHASEGATE",
+                            "GLOBALPHASE", "CRX", "CRY", "CRZ"]:
             if arg_value is None:
                 raise ValueError("Gate %s requires an argument value" % name)
 
@@ -169,10 +172,28 @@ class QubitCircuit(object):
     """
     Representation of a quantum program/algorithm, maintaining a sequence
     of gates.
+
+    Parameters
+    ----------
+    N : int
+        Number of qubits in the system.
+    user_gates : dict
+        Define a dictionary of the custom gates. See examples for detail.
+    input_states : list
+        A list of string such as `0`,'+', "A", "Y". Only used for latex.
+
+    Examples
+    --------
+    >>> def user_gate():
+    ...     mat = np.array([[1.,   0],
+    ...                     [0., 1.j]])
+    ...     return Qobj(mat, dims=[[2], [2]])
+    >>> qc.QubitCircuit(2, user_gates={"T":user_gate})
+    >>> qc.add_gate("T", targets=[0])
     """
 
     def __init__(self, N, input_states=None, output_states=None,
-                 reverse_states=True):
+                 reverse_states=True, user_gates=None):
         # number of qubits in the register
         self.N = N
         self.reverse_states = reverse_states
@@ -180,6 +201,15 @@ class QubitCircuit(object):
         self.U_list = []
         self.input_states = [None for i in range(N)]
         self.output_states = [None for i in range(N)]
+        if user_gates is None:
+            self.user_gates = {}
+        else:
+            if isinstance(user_gates, dict):
+                self.user_gates = user_gates
+            else:
+                raise ValueError(
+                    "`user_gate` takes a python dictionary of the form"
+                    "{{str: gate_function}}, not {}".format(user_gates))
 
     def add_state(self, state, targets=None, state_type="input"):
         """
@@ -326,6 +356,10 @@ class QubitCircuit(object):
                               [gate.targets[0] + start,
                                gate.targets[1] + start],
                               gate.controls + start, None, None)
+            elif gate.name in self.user_gates:
+                self.add_gate(
+                              gate.name, targets=gate.targets,
+                              arg_value=gate.arg_value)
 
     def remove_gate(self, index=None, end=None, name=None, remove="first"):
         """
@@ -408,34 +442,29 @@ class QubitCircuit(object):
         qc_temp = QubitCircuit(self.N, self.reverse_states)
         temp_resolved = []
 
-        basis_1q = []
-        basis_2q = None
-
         basis_1q_valid = ["RX", "RY", "RZ"]
         basis_2q_valid = ["CNOT", "CSIGN", "ISWAP", "SQRTSWAP", "SQRTISWAP"]
 
         if isinstance(basis, list):
+            basis_1q = []
+            basis_2q = []
             for gate in basis:
-                if gate not in (basis_1q_valid + basis_2q_valid):
-                    raise ValueError("%s is not a valid basis gate" % gate)
-
                 if gate in basis_2q_valid:
-                    if basis_2q is not None:
-                        raise ValueError("At most one two-qubit gate allowed")
-                    basis_2q = gate
-
-                else:
+                    basis_2q.append(gate)
+                elif gate in basis_1q_valid:
                     basis_1q.append(gate)
-
+                else:
+                    raise NotImplementedError(
+                        "%s is not a valid basis gate" % gate)
             if len(basis_1q) == 1:
                 raise ValueError("Not sufficient single-qubit gates in basis")
             elif len(basis_1q) == 0:
                 basis_1q = ["RX", "RY", "RZ"]
 
-        else:
+        else:  # only one 2q gate is given as basis
             basis_1q = ["RX", "RY", "RZ"]
             if basis in basis_2q_valid:
-                basis_2q = basis
+                basis_2q = [basis]
             else:
                 raise ValueError("%s is not a valid two-qubit basis gate"
                                  % basis)
@@ -469,11 +498,13 @@ class QubitCircuit(object):
                                           arg_label=gate.arg_label))
                 temp_resolved.append(Gate("RZ", gate.targets, None,
                                           gate.arg_value, gate.arg_label))
+            elif gate.name in basis_2q:  # ignore all gate in 2q basis
+                temp_resolved.append(gate)
             elif gate.name == "CPHASE":
                 raise NotImplementedError("Cannot be resolved in this basis")
             elif gate.name == "CNOT":
                 temp_resolved.append(gate)
-            elif gate.name == "CSIGN" and basis_2q is not "CSIGN":
+            elif gate.name == "CSIGN":
                 temp_resolved.append(Gate("RY", gate.targets, None,
                                           arg_value=np.pi / 2,
                                           arg_label=r"\pi/2"))
@@ -491,14 +522,17 @@ class QubitCircuit(object):
                 raise NotImplementedError("Cannot be resolved in this basis")
             elif gate.name == "SWAPalpha":
                 raise NotImplementedError("Cannot be resolved in this basis")
-            elif gate.name == "SWAP" and basis_2q is not "ISWAP":
-                temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                          gate.targets[1]))
-                temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                          gate.targets[0]))
-                temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                          gate.targets[1]))
-            elif gate.name == "ISWAP" and basis_2q is not "ISWAP":
+            elif gate.name == "SWAP":
+                if "ISWAP" in basis_2q:  # dealed with separately
+                    temp_resolved.append(gate)
+                else:
+                    temp_resolved.append(Gate("CNOT", gate.targets[0],
+                                            gate.targets[1]))
+                    temp_resolved.append(Gate("CNOT", gate.targets[1],
+                                            gate.targets[0]))
+                    temp_resolved.append(Gate("CNOT", gate.targets[0],
+                                            gate.targets[1]))
+            elif gate.name == "ISWAP":
                 temp_resolved.append(Gate("CNOT", gate.targets[0],
                                           gate.targets[1]))
                 temp_resolved.append(Gate("CNOT", gate.targets[1],
@@ -528,11 +562,9 @@ class QubitCircuit(object):
                 temp_resolved.append(Gate("GLOBALPHASE", None, None,
                                           arg_value=np.pi / 2,
                                           arg_label=r"\pi/2"))
-            elif gate.name == "SQRTSWAP" and basis_2q not in ["SQRTSWAP",
-                                                              "ISWAP"]:
+            elif gate.name == "SQRTSWAP":
                 raise NotImplementedError("Cannot be resolved in this basis")
-            elif gate.name == "SQRTISWAP" and basis_2q not in ["SQRTISWAP",
-                                                               "ISWAP"]:
+            elif gate.name == "SQRTISWAP":
                 raise NotImplementedError("Cannot be resolved in this basis")
             elif gate.name == "FREDKIN":
                 temp_resolved.append(Gate("CNOT", gate.targets[0],
@@ -663,9 +695,11 @@ class QubitCircuit(object):
                                           gate.controls,
                                           gate.arg_value, gate.arg_label))
             else:
-                temp_resolved.append(gate)
+                raise NotImplementedError(
+                    "Gate {} "
+                    "cannot be resolved.".format(gate.name))
 
-        if basis_2q == "CSIGN":
+        if "CSIGN" in basis_2q:
             for gate in temp_resolved:
                 if gate.name == "CNOT":
                     qc_temp.gates.append(Gate("RY", gate.targets, None,
@@ -678,7 +712,7 @@ class QubitCircuit(object):
                                               arg_label=r"\pi/2"))
                 else:
                     qc_temp.gates.append(gate)
-        elif basis_2q == "ISWAP":
+        elif "ISWAP" in basis_2q:
             for gate in temp_resolved:
                 if gate.name == "CNOT":
                     qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
@@ -725,7 +759,7 @@ class QubitCircuit(object):
                                               arg_label=r"-\pi/2"))
                 else:
                     qc_temp.gates.append(gate)
-        elif basis_2q == "SQRTSWAP":
+        elif "SQRTSWAP" in basis_2q:
             for gate in temp_resolved:
                 if gate.name == "CNOT":
                     qc_temp.gates.append(Gate("RY", gate.targets, None,
@@ -751,7 +785,7 @@ class QubitCircuit(object):
                                               arg_label=r"-\pi/2"))
                 else:
                     qc_temp.gates.append(gate)
-        elif basis_2q == "SQRTISWAP":
+        elif "SQRTISWAP" in basis_2q:
             for gate in temp_resolved:
                 if gate.name == "CNOT":
                     qc_temp.gates.append(Gate("RY", gate.controls, None,
@@ -837,7 +871,7 @@ class QubitCircuit(object):
             resolved non-adjacent gates.
 
         """
-        temp = QubitCircuit(self.N, self.reverse_states)
+        temp = QubitCircuit(self.N, reverse_states=self.reverse_states)
         swap_gates = ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
                       "SWAPalpha"]
 
@@ -902,7 +936,9 @@ class QubitCircuit(object):
                     i += 1
 
             else:
-                temp.gates.append(gate)
+                raise NotImplementedError(
+                    "`adjacent_gates` is not defined for "
+                    "gate {}.".format(gate.name))
 
         return temp
 
@@ -933,7 +969,7 @@ class QubitCircuit(object):
             elif gate.name == "PHASEGATE":
                 self.U_list.append(phasegate(gate.arg_value, self.N,
                                              gate.targets[0]))
-            if gate.name == "CRX":
+            elif gate.name == "CRX":
                 self.U_list.append(controlled_gate(rx(gate.arg_value),
                                                    N=self.N,
                                                    control=gate.controls[0],
@@ -978,6 +1014,25 @@ class QubitCircuit(object):
                                            gate.targets[0]))
             elif gate.name == "GLOBALPHASE":
                 self.U_list.append(globalphase(gate.arg_value, self.N))
+            elif gate.name in self.user_gates:
+                if gate.controls is not None:
+                    raise ValueError(
+                        "A user defined gate {} takes only  "
+                        "`targets` variable.".format(gate.name))
+                func = self.user_gates[gate.name]
+                para_num = len(inspect.getfullargspec(func)[0])
+                if para_num == 0:
+                    oper = func()
+                elif para_num == 1:
+                    oper = func(gate.arg_value)
+                else:
+                    raise ValueError(
+                        "gate function takes at most one parameters.")
+                self.U_list.append(expand_oper(oper, self.N, gate.targets))
+
+            else:
+                raise NotImplementedError(
+                    "{} gate is an unknown gate.".format(gate.name))
 
         return self.U_list
 
@@ -994,10 +1049,11 @@ class QubitCircuit(object):
                     if len(gate.targets) > 1:
                         if gate.name == "SWAP":
                             col.append(r" \qswap \qwx ")
- 
-                        elif ((self.reverse_states and n == max(gate.targets)) or
-                            (not self.reverse_states
-                             and n == min(gate.targets))):
+
+                        elif ((self.reverse_states and
+                                n == max(gate.targets)) or
+                                (not self.reverse_states and
+                                    n == min(gate.targets))):
                             col.append(r" \multigate{%d}{%s} " %
                                        (len(gate.targets) - 1,
                                         _gate_label(gate.name,
@@ -1022,8 +1078,8 @@ class QubitCircuit(object):
 
                 elif (not gate.controls and not gate.targets):
                     # global gate
-                    if ((self.reverse_states and n == self.N - 1)
-                            or (not self.reverse_states and n == 0)):
+                    if ((self.reverse_states and n == self.N - 1) or
+                            (not self.reverse_states and n == 0)):
                         col.append(r" \multigate{%d}{%s} " %
                                    (self.N - 1,
                                     _gate_label(gate.name, gate.arg_label)))

--- a/qutip/qip/models/spinchain.py
+++ b/qutip/qip/models/spinchain.py
@@ -391,7 +391,6 @@ class LinearSpinChain(SpinChain):
         return super(LinearSpinChain, self).adjacent_gates(qc, "linear")
 
 
-
 class CircularSpinChain(SpinChain):
     """
     Representation of the physical implementation of a quantum
@@ -427,4 +426,3 @@ class CircularSpinChain(SpinChain):
 
     def adjacent_gates(self, qc):
         return super(CircularSpinChain, self).adjacent_gates(qc, "circular")
-

--- a/qutip/qip/models/spinchain.py
+++ b/qutip/qip/models/spinchain.py
@@ -383,7 +383,7 @@ class LinearSpinChain(SpinChain):
     def optimize_circuit(self, qc):
         self.qc0 = qc
         self.qc1 = self.adjacent_gates(self.qc0, "linear")
-        self.qc2 = self.qc1.resolve_gates(basis=["ISWAP", "RX", "RZ"])
+        self.qc2 = self.qc1.resolve_gates(basis=["SQRTISWAP","ISWAP", "RX", "RZ"])
         return self.qc2
 
 
@@ -423,5 +423,5 @@ class CircularSpinChain(SpinChain):
     def optimize_circuit(self, qc):
         self.qc0 = qc
         self.qc1 = self.adjacent_gates(self.qc0, "circular")
-        self.qc2 = self.qc1.resolve_gates(basis=["ISWAP", "RX", "RZ"])
+        self.qc2 = self.qc1.resolve_gates(basis=["SQRTISWAP","ISWAP", "RX", "RZ"])
         return self.qc2

--- a/qutip/qip/models/spinchain.py
+++ b/qutip/qip/models/spinchain.py
@@ -360,6 +360,13 @@ class SpinChain(CircuitProcessor):
 
         return qc_t
 
+    def optimize_circuit(self, qc):
+        self.qc0 = qc
+        self.qc1 = self.adjacent_gates(self.qc0)
+        self.qc2 = self.qc1.resolve_gates(
+            basis=["SQRTISWAP", "ISWAP", "RX", "RZ"])
+        return self.qc2
+
 
 class LinearSpinChain(SpinChain):
     """
@@ -380,11 +387,9 @@ class LinearSpinChain(SpinChain):
                 [r"$\sigma_x^%d\sigma_x^{%d} + \sigma_y^%d\sigma_y^{%d}$"
                  % (n, n, n + 1, n + 1) for n in range(self.N - 1)])
 
-    def optimize_circuit(self, qc):
-        self.qc0 = qc
-        self.qc1 = self.adjacent_gates(self.qc0, "linear")
-        self.qc2 = self.qc1.resolve_gates(basis=["SQRTISWAP","ISWAP", "RX", "RZ"])
-        return self.qc2
+    def adjacent_gates(self, qc):
+        return super(LinearSpinChain, self).adjacent_gates(qc, "linear")
+
 
 
 class CircularSpinChain(SpinChain):
@@ -420,8 +425,6 @@ class CircularSpinChain(SpinChain):
                  % (n, n, (n + 1) % self.N, (n + 1) % self.N)
                  for n in range(self.N)])
 
-    def optimize_circuit(self, qc):
-        self.qc0 = qc
-        self.qc1 = self.adjacent_gates(self.qc0, "circular")
-        self.qc2 = self.qc1.resolve_gates(basis=["SQRTISWAP","ISWAP", "RX", "RZ"])
-        return self.qc2
+    def adjacent_gates(self, qc):
+        return super(CircularSpinChain, self).adjacent_gates(qc, "circular")
+

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -33,13 +33,15 @@
 
 import itertools
 import numpy as np
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_, assert_allclose, run_module_suite
 from qutip.states import basis, ket2dm
 from qutip.operators import identity, qeye, sigmax, sigmay, sigmaz
 from qutip.qip import (rx, ry, rz, phasegate, cnot, swap, iswap,
-                       sqrtswap, toffoli, fredkin, gate_expand_3toN, qubit_clifford_group)
-from qutip.random_objects import rand_ket, rand_herm
+                       sqrtswap, toffoli, fredkin, gate_expand_3toN, 
+                       qubit_clifford_group, expand_oper)
+from qutip.random_objects import rand_ket, rand_herm, rand_unitary
 from qutip.tensor import tensor
+from qutip.qobj import Qobj
 
 
 class TestGates:
@@ -74,7 +76,7 @@ class TestGates:
         Returns True if and only if U is proportional to the
         identity.
         """
-        U0 = complex(U[0, 0]) #scipy 1.3 return 0 dims array.
+        U0 = complex(U[0, 0])  # scipy 1.3 return 0 dims array.
         if U0 != 0:
             norm_U = U / U0
             return (qeye(U.dims[0]) - norm_U).norm() <= tol
@@ -282,6 +284,38 @@ class TestGates:
                         o1 = psi_out.overlap(psi_in)
                         o2 = psi_ref_out.overlap(psi_ref_in)
                         assert_(abs(o1 - o2) < 1e-12)
+
+    def test_expand_oper(self):
+        """
+        gate : expand qubits operator to a N qubits system.
+        """
+        # random single qubit gate test, integer as target
+        r = rand_unitary(2)
+        assert(expand_oper(r, 3, 0) == tensor([r, identity(2), identity(2)]))
+        assert(expand_oper(r, 3, 1) == tensor([identity(2), r, identity(2)]))
+        assert(expand_oper(r, 3, 2) == tensor([identity(2), identity(2), r]))
+
+        # random 2qubits gate test, list as target
+        r2 = rand_unitary(4)
+        r2.dims = [[2, 2], [2, 2]]
+        assert(expand_oper(r2, 3, [2, 1]) == tensor(
+            [identity(2), r2.permute([1, 0])]))
+        assert(expand_oper(r2, 3, [0, 1]) == tensor(
+            [r2, identity(2)]))
+        assert(expand_oper(r2, 3, [0, 2]) == tensor(
+            [r2, identity(2)]).permute([0, 2, 1]))
+
+        # cnot expantion, qubit 2 control qubit 0
+        assert(expand_oper(cnot(), 3, [2, 0]) == Qobj([
+            [1., 0., 0., 0., 0., 0., 0., 0.],
+            [0., 0., 0., 0., 0., 1., 0., 0.],
+            [0., 0., 1., 0., 0., 0., 0., 0.],
+            [0., 0., 0., 0., 0., 0., 0., 1.],
+            [0., 0., 0., 0., 1., 0., 0., 0.],
+            [0., 1., 0., 0., 0., 0., 0., 0.],
+            [0., 0., 0., 0., 0., 0., 1., 0.],
+            [0., 0., 0., 1., 0., 0., 0., 0.]],
+            dims=[[2, 2, 2], [2, 2, 2]]))
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -36,8 +36,9 @@ import numpy as np
 from numpy.testing import assert_, assert_allclose, run_module_suite
 from qutip.states import basis, ket2dm
 from qutip.operators import identity, qeye, sigmax, sigmay, sigmaz
-from qutip.qip import (rx, ry, rz, phasegate, cnot, swap, iswap,
-                       sqrtswap, toffoli, fredkin, gate_expand_3toN, 
+from qutip.qip import (rx, ry, rz, phasegate, qrot, cnot, swap, iswap,
+                       sqrtswap, molmer_sorensen,
+                       toffoli, fredkin, gate_expand_3toN, 
                        qubit_clifford_group, expand_oper)
 from qutip.random_objects import rand_ket, rand_herm, rand_unitary
 from qutip.tensor import tensor
@@ -317,6 +318,44 @@ class TestGates:
             [0., 0., 0., 1., 0., 0., 0., 0.]],
             dims=[[2, 2, 2], [2, 2, 2]]))
 
+    def test_molmer_sorensen(self):
+        """
+        gate: test for the molmer_sorensen gate
+        """
+        assert_allclose(
+            molmer_sorensen(np.pi, targets=[0, 1]),
+            Qobj(-1j*np.array(
+                 [[0, 0, 0, 1],
+                  [0, 0, 1, 0],
+                  [0, 1, 0, 0],
+                  [1, 0, 0, 0]]), dims=[[2, 2], [2, 2]]),
+            atol=1e-15)
+        assert_allclose(
+            molmer_sorensen(2*np.pi, targets=[0, 1]),
+            Qobj(-np.array(
+                 [[1, 0, 0, 0],
+                  [0, 1, 0, 0],
+                  [0, 0, 1, 0],
+                  [0, 0, 0, 1]]), dims=[[2, 2], [2, 2]]),
+            atol=1e-15)
+        assert_allclose(
+            molmer_sorensen(np.pi/2, N=4, targets=[1, 2]),
+            tensor([identity(2), molmer_sorensen(np.pi/2), identity(2)])
+        )
+
+    def test_qrot(self):
+        """
+        gate: test for the qubit rotation gate
+        """
+        assert_allclose(qrot(0, 0), identity(2))
+        assert_allclose(
+            qrot(np.pi, np.pi/2),
+            Qobj([[0, -1], [1, 0]]),
+            atol=1e-15)
+        assert_allclose(
+            qrot(np.pi/4., np.pi/3., N=2, target=1),
+            tensor([identity(2), qrot(np.pi/4., np.pi/3.)])
+        )
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This is a fresh PR branching from the current master as a replacement for #1025 
1. `expand_oper`: expand a qubits operator to dim N
2. User-defined gate can be given by a python function. By passing a list of user-defined gate function to the attribute `QubitCircuit.user_gate`,   `QubitCircuit.propagators()` can return the corresponding matrices. Resolve #914 
3. MS gate and physical single qubit rotation. (Is the name `mc_gate `and `qrot `appropriate?) Resolve #819
4. Fix some bugs in resolving circuit gates. Allow more than one 2-qubits gates in the basis. This is actually already required in `spinchain.py` but covered by a bug