### PR TITLE
ENH: Attribution in about

### DIFF
--- a/qutip/about.py
+++ b/qutip/about.py
@@ -53,11 +53,14 @@ def about():
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")
-    print("Copyright (c) 2011 and later.")
-    print(("A. J. Pitchford, P. D. Nation, "
-            "R. J. Johansson, A. Grimsmo, "
-            "C. Granade, N. Shammah, S. Ahmed, "
-            "N. Lambert, and E. Giguere"))
+    print("Copyright (c) QuTiP team 2011 and later.")
+    print("Original developers: R. J. Johansson & P. D. Nation")
+    print("Current admin team: Alexander Pitchford, Paul D. Nation, "
+            "Nathan Shammah, Shahnawaz Ahmed, "
+            "Neill Lambert, and Éric Giguère")
+    print("Project Manager: Franco Nori.")
+    print("Currently developed through wide collaboration. "
+          "See https://github.com/qutip for details.")
     print("")
     print("QuTiP Version:      %s" % qutip.__version__)
     print("Numpy Version:      %s" % numpy.__version__)

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -53,11 +53,12 @@ def about():
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")
+    print("================================")
     print("Copyright (c) QuTiP team 2011 and later.")
-    print("Original developers: R. J. Johansson & P. D. Nation")
+    print("Original developers: R. J. Johansson & P. D. Nation.")
     print("Current admin team: Alexander Pitchford, Paul D. Nation, "
             "Nathan Shammah, Shahnawaz Ahmed, "
-            "Neill Lambert, and Éric Giguère")
+            "Neill Lambert, and Éric Giguère.")
     print("Project Manager: Franco Nori.")
     print("Currently developed through wide collaboration. "
           "See https://github.com/qutip for details.")

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -58,7 +58,7 @@ def about():
     print("Original developers: R. J. Johansson & P. D. Nation.")
     print("Current admin team: Alexander Pitchford, Paul D. Nation, "
             "Nathan Shammah, Shahnawaz Ahmed, "
-            "Neill Lambert, and Éric Giguère.")
+            "Neill Lambert, and Eric Giguère.")
     print("Project Manager: Franco Nori.")
     print("Currently developed through wide collaboration. "
           "See https://github.com/qutip for details.")


### PR DESCRIPTION
QuTiP team members split into groupings based on role
reference to Github for list of contributors