### PR TITLE
Purity

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installation
 
 For instructions on how to install QuTiP, see:
 
-[http://qutip.org/docs/4.1/installation.html](http://qutip.org/docs/4.1/installation.html)
+[http://qutip.org/docs/latest/installation.html](http://qutip.org/docs/latest/installation.html)
 
 
 Demos

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1047,7 +1047,7 @@ class Qobj(object):
             For a mixed state, the purity is <1.
 
         """
-        if argg.type == "oper" or argg.type =="ket" or argg.type =="bra":
+        if self.type == "oper" or self.type =="ket" or self.type =="bra":
             raise TypeError('Purity is defined on a density matrix or state only.')
 
         if self.type == "ket" or self.type == "bra":

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1031,8 +1031,7 @@ class Qobj(object):
         Returns
         -------
         trace : float
-            Returns ``real`` if operator is Hermitian, returns ``complex``
-            otherwise.
+            Returns the trace of the quantum object.
 
         """
         return zcsr_trace(self.data, self.isherm)

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1591,7 +1591,7 @@ class Qobj(object):
                 elif other.isoper:
                     return (qutip.states.ket2dm(self).dag() * other).tr()
                 else:
-                    err = 
+                    err = "Can only calculate overlap for state vector Qobjs"
                     raise TypeError(err)
 
             elif self.isket:

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1035,6 +1035,28 @@ class Qobj(object):
 
         """
         return zcsr_trace(self.data, self.isherm)
+    
+    def purity(self):
+        """Purity of a quantum object.
+
+        Returns
+        -------
+        state_purity : float
+            Returns the purity of a quantum object.
+            For a pure state, the purity is 1.
+            For a mixed state, the purity is <1.
+
+        """
+        if argg.type == "oper" or argg.type =="ket" or argg.type =="bra":
+            raise TypeError('Purity is defined on a density matrix or state only.')
+
+        if self.type == "ket" or self.type == "bra":
+            state_purity = (rho*rho.dag()).tr()
+
+        if self.type == "oper":
+            state_purity = (rho*rho).tr()
+
+        return state_purity
 
     def full(self, order='C', squeeze=False):
         """Dense array from quantum object.

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1037,14 +1037,14 @@ class Qobj(object):
         return zcsr_trace(self.data, self.isherm)
     
     def purity(self):
-        """Purity of a quantum object.
+        """Calculate purity of a quantum object.
 
         Returns
         -------
         state_purity : float
             Returns the purity of a quantum object.
             For a pure state, the purity is 1.
-            For a mixed state, the purity is <1.
+            For a mixed state of dimension `d`, 1/d<=purity<1.
 
         """
         rho = self

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1047,13 +1047,14 @@ class Qobj(object):
             For a mixed state, the purity is <1.
 
         """
-        if self.type == "oper" or self.type =="ket" or self.type =="bra":
+        rho = self
+        if (rho.type == "super"):
             raise TypeError('Purity is defined on a density matrix or state only.')
 
-        if self.type == "ket" or self.type == "bra":
+        if rho.type == "ket" or rho.type == "bra":
             state_purity = (rho*rho.dag()).tr()
 
-        if self.type == "oper":
+        if rho.type == "oper":
             state_purity = (rho*rho).tr()
 
         return state_purity

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -502,11 +502,12 @@ class Qobj(object):
                     # to have uneven length (non-square Qobjs).
                     # We use None as padding so that it doesn't match anything,
                     # and will never cause a partial trace on the other side.
-                    mask = [l == r == 1 for l, r in zip_longest(dims[0], dims[1],
+                    mask = [l == r == 1 for l, r in zip_longest(dims[0], 
+                                                                dims[1],
                                                                 fillvalue=None)]
                     # To ensure that there are still any dimensions left, we
-                    # use max() to add a dimensions list of [1] if all matching dims
-                    # are traced out of that side.
+                    # use max() to add a dimensions list of [1] if all matching
+                    # dims are traced out of that side.
                     out.dims = [max([1],
                                     [dim for dim, m in zip(dims[0], mask)
                                     if not m]),
@@ -1049,7 +1050,7 @@ class Qobj(object):
         """
         rho = self
         if (rho.type == "super"):
-            raise TypeError('Purity is defined on a density matrix or state only.')
+            raise TypeError('Purity is defined on a density matrix or state.')
 
         if rho.type == "ket" or rho.type == "bra":
             state_purity = (rho*rho.dag()).tr()
@@ -1543,7 +1544,9 @@ class Qobj(object):
             elif bra.isket and ket.isket:
                 return zcsr_mat_elem(self.data,bra.data,ket.data,0)
             else:
-                raise TypeError("Can only calculate matrix elements for bra and ket vectors.")
+                err = "Can only calculate matrix elements for bra"
+                err += " and ket vectors."
+                raise TypeError(err)
 
     def overlap(self, other):
         """Overlap between two state vectors or two operators.
@@ -1588,7 +1591,8 @@ class Qobj(object):
                 elif other.isoper:
                     return (qutip.states.ket2dm(self).dag() * other).tr()
                 else:
-                    raise TypeError("Can only calculate overlap for state vector Qobjs")
+                    err = 
+                    raise TypeError(err)
 
             elif self.isket:
                 if other.isbra:
@@ -1598,7 +1602,8 @@ class Qobj(object):
                 elif other.isoper:
                     return (qutip.states.ket2dm(self).dag() * other).tr()
                 else:
-                    raise TypeError("Can only calculate overlap for state vector Qobjs")
+                    err = "Can only calculate overlap for state vector Qobjs"
+                    raise TypeError(err)
 
             elif self.isoper:
                 if other.isket or other.isbra:
@@ -1606,7 +1611,8 @@ class Qobj(object):
                 elif other.isoper:
                     return (self.dag() * other).tr()
                 else:
-                    raise TypeError("Can only calculate overlap for state vector Qobjs")
+                    err = "Can only calculate overlap for state vector Qobjs"
+                    raise TypeError(err)
 
 
         raise TypeError("Can only calculate overlap for state vector Qobjs")
@@ -1833,8 +1839,8 @@ class Qobj(object):
         Parameters
         ----------
         B : :class:`qutip.Qobj` or None
-            If B is not None, the diamond distance d(A, B) = dnorm(A - B) between
-            this operator and B is returned instead of the diamond norm.
+            If B is not None, the diamond distance d(A, B) = dnorm(A - B) 
+            between this operator and B is returned instead of the diamond norm.
 
         Returns
         -------
@@ -1872,7 +1878,8 @@ class Qobj(object):
                     else sr.to_choi(self)
                 )
                 # If J isn't hermitian, then that could indicate either
-                # that J is not normal, or is normal, but has complex eigenvalues.
+                # that J is not normal, or is normal,  
+                # but has complex eigenvalues.
                 # In either case, it makes no sense to then demand that the
                 # eigenvalues be non-negative.
                 if not J.isherm:

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -616,7 +616,7 @@ def test_QobjNorm():
     assert_almost_equal(b.norm(), (b*b.dag()).sqrtm().tr().real)
 
 def test_QobjPurity():
-    "Qobj purity"
+    "Tests the purity method of `Qobj`"
     psi = basis(2,1)
     # check purity of pure ket state
     assert_almost_equal(psi.purity(), 1)

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -610,18 +610,18 @@ def test_QobjNorm():
     assert_equal(
         np.abs(A.norm('fro') - la.norm(A.full(), 'fro')) < 1e-12, True)
     # operator trace norm
-    a = rand_herm(10,0.25)
+    a = rand_herm(10, 0.25)
     assert_almost_equal(a.norm(), (a*a.dag()).sqrtm().tr().real)
-    b = rand_herm(10,0.25) - 1j*rand_herm(10,0.25)
+    b = rand_herm(10, 0.25) - 1j*rand_herm(10, 0.25)
     assert_almost_equal(b.norm(), (b*b.dag()).sqrtm().tr().real)
 
 def test_QobjPurity():
     "Tests the purity method of `Qobj`"
-    psi = basis(2,1)
+    psi = basis(2, 1)
     # check purity of pure ket state
     assert_almost_equal(psi.purity(), 1)
     # check purity of pure ket state (superposition)
-    psi2 = basis(2,0)
+    psi2 = basis(2, 0)
     psi_tot = (psi+psi2).unit() 
     assert_almost_equal(psi_tot.purity(), 1)
     # check purity of density matrix of pure state 

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -615,6 +615,21 @@ def test_QobjNorm():
     b = rand_herm(10,0.25) - 1j*rand_herm(10,0.25)
     assert_almost_equal(b.norm(), (b*b.dag()).sqrtm().tr().real)
 
+def test_QobjPurity():
+    "Qobj purity"
+    psi = basis(2,1)
+    # check purity of pure ket state
+    assert_(psi.purity(), 1)
+    # check purity of pure ket state (superposition)
+    psi2 = basis(2,0)
+    psi_tot = (psi+psi2).unit() 
+    assert_(psi_tot.purity(), 1)
+    # check purity of density matrix of pure state 
+    assert_almost_equal(ket2dm(psi_tot).purity(), 1)
+    # check purity of maximally mixed density matrix
+    rho_mixed = (ket2dm(psi)+ket2dm(psi2)).unit() 
+    assert_almost_equal(rho_mixed.purity(), 0.5)
+
 def test_QobjPermute():
     "Qobj permute"
     A = basis(3, 0)

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -619,11 +619,11 @@ def test_QobjPurity():
     "Qobj purity"
     psi = basis(2,1)
     # check purity of pure ket state
-    assert_(psi.purity(), 1)
+    assert_almost_equal(psi.purity(), 1)
     # check purity of pure ket state (superposition)
     psi2 = basis(2,0)
     psi_tot = (psi+psi2).unit() 
-    assert_(psi_tot.purity(), 1)
+    assert_almost_equal(psi_tot.purity(), 1)
     # check purity of density matrix of pure state 
     assert_almost_equal(ket2dm(psi_tot).purity(), 1)
     # check purity of maximally mixed density matrix


### PR DESCRIPTION
Add a simple method onto the Qobj to calculate the purity of a quantum object, `(rho*rho).tr()`.