### PR TITLE
Entropy vn dicke

### DIFF
--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -58,11 +58,13 @@ from qutip.cy.piqs import (jmm1_dictionary, _num_dicke_states,
                            m_vals, j_vals)
 
 __all__ = ['num_dicke_states','num_dicke_ladders','num_tls','isdiagonal',
-           'mask_dicke_matrix','purity_dicke','expand_dicke_matrix',
-           'entropy_vn_dicke','Dicke','state_degeneracy','m_degeneracy',
-           'ap','am','spin_algebra','jspin','collapse_uncoupled',
-           'dicke_basis','dicke','excited','superradiant','css','ghz',
-           'ground','identity_uncoupled','block_matrix','tau_column','Pim']
+           'mask_dicke_matrix','expand_dicke_matrix',
+           'dicke_trace','purity_dicke','entropy_vn_dicke',
+           'Dicke','state_degeneracy','m_degeneracy',
+            'energy_degeneracy','ap','am','spin_algebra','jspin',
+            'collapse_uncoupled','dicke_basis',
+            'dicke','excited','superradiant','css','ghz','ground',
+            'identity_uncoupled','block_matrix','tau_column','Pim']
 
 # Functions necessary to generate the Lindbladian/Liouvillian
 def num_dicke_states(N):

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -1,6 +1,7 @@
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
-#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson,
+#    and the QuTiP Developers.
 #    All rights reserved.
 #
 #    Redistribution and use in source and binary forms, with or without

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -45,6 +45,7 @@ from decimal import Decimal
 
 import numpy as np
 from scipy.integrate import odeint
+from scipy.sparse.linalg import eigsh
 from scipy import constants
 from scipy.sparse import dok_matrix, block_diag, lil_matrix
 from qutip.solver import Options, Result

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -235,7 +235,7 @@ def purity_dicke(rho):
         j = N/2. - k
         #print(j)
         djn = state_degeneracy(N,j)
-        block_purity.append(purity(Qobj(block/djn))*djn)
+        block_purity.append((Qobj(block/djn)).purity()*djn)
         k = k +1
     
     return sum(block_purity)

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -51,6 +51,7 @@ from qutip.solver import Options, Result
 from qutip import (Qobj, spre, spost, tensor, identity, ket2dm,
                    vector_to_operator)
 from qutip import sigmax, sigmay, sigmaz, sigmap, sigmam
+from qutip import entropy_vn
 from qutip.cy.piqs import Dicke as _Dicke
 from qutip.cy.piqs import (jmm1_dictionary, _num_dicke_states,
                            _num_dicke_ladders, get_blocks, j_min,

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -1392,22 +1392,23 @@ def identity_uncoupled(N):
     identity = Qobj(rho, dims=spins_dims)
     return identity
 
-def block_matrix(N):
+def block_matrix(N,elements="ones"):
     """Construct the block-diagonal matrix for the Dicke basis.
 
     Parameters
     ----------
-    N: int
+    N : int
         Number of two-level systems.
+    elements : str {'ones' (default),'degeneracy'}
 
     Returns
     -------
-    block_matr: ndarray
-        A 2D block-diagonal matrix of ones with dimension (nds,nds),
+    block_matr : ndarray
+        A 2D block-diagonal matrix with dimension (nds,nds),
         where nds is the number of Dicke states for N two-level
-        systems.
+        systems. Filled with ones or the value of degeneracy 
+        at each matrix element.
     """
-    nds = _num_dicke_states(N)
     # create a list with the sizes of the blocks, in order
     blocks_dimensions = int(N/2 + 1 - 0.5*(N % 2))
     blocks_list = [(2 * (i+1 * (N % 2)) + 1*((N+1) % 2))
@@ -1417,7 +1418,12 @@ def block_matrix(N):
     square_blocks = []
     k = 0
     for i in blocks_list:
-        square_blocks.append(np.ones((i, i)))
+        if elements == "ones":
+            square_blocks.append(np.ones((i, i)))
+        elif elements == "degeneracy":
+            j = N/2 - k
+            dj = state_degeneracy(N,j)
+            square_blocks.append(dj*np.ones((i, i)))
         k = k + 1
     return block_diag(square_blocks)
 

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -50,23 +50,51 @@ from scipy.special import entr
 from scipy import constants
 from scipy.sparse import dok_matrix, block_diag, lil_matrix
 from qutip.solver import Options, Result
-from qutip import (Qobj, spre, spost, tensor, identity, ket2dm,
-                   vector_to_operator)
+from qutip import Qobj, spre, spost, tensor, identity, ket2dm, vector_to_operator
 from qutip import sigmax, sigmay, sigmaz, sigmap, sigmam
 from qutip import entropy_vn
 from qutip.cy.piqs import Dicke as _Dicke
-from qutip.cy.piqs import (jmm1_dictionary, _num_dicke_states,
-                           _num_dicke_ladders, get_blocks, j_min,
-                           m_vals, j_vals)
+from qutip.cy.piqs import (
+    jmm1_dictionary,
+    _num_dicke_states,
+    _num_dicke_ladders,
+    get_blocks,
+    j_min,
+    m_vals,
+    j_vals,
+)
 
-__all__ = ['num_dicke_states','num_dicke_ladders','num_tls','isdiagonal',
-           'mask_dicke_matrix','expand_dicke_matrix',
-           'dicke_function_trace','purity_dicke','entropy_vn_dicke',
-           'Dicke','state_degeneracy','m_degeneracy',
-            'energy_degeneracy','ap','am','spin_algebra','jspin',
-            'collapse_uncoupled','dicke_basis',
-            'dicke','excited','superradiant','css','ghz','ground',
-            'identity_uncoupled','block_matrix','tau_column','Pim']
+__all__ = [
+    "num_dicke_states",
+    "num_dicke_ladders",
+    "num_tls",
+    "isdiagonal",
+    "mask_dicke_matrix",
+    "expand_dicke_matrix",
+    "dicke_function_trace",
+    "purity_dicke",
+    "entropy_vn_dicke",
+    "Dicke",
+    "state_degeneracy",
+    "m_degeneracy",
+    "energy_degeneracy",
+    "ap",
+    "am",
+    "spin_algebra",
+    "jspin",
+    "collapse_uncoupled",
+    "dicke_basis",
+    "dicke",
+    "excited",
+    "superradiant",
+    "css",
+    "ghz",
+    "ground",
+    "identity_uncoupled",
+    "block_matrix",
+    "tau_column",
+    "Pim",
+]
 
 # Functions necessary to generate the Lindbladian/Liouvillian
 def num_dicke_states(N):
@@ -83,6 +111,7 @@ def num_dicke_states(N):
         The number of Dicke states.
     """
     return _num_dicke_states(N)
+
 
 def num_dicke_ladders(N):
     """Calculate the total number of ladders in the Dicke space.
@@ -102,6 +131,7 @@ def num_dicke_ladders(N):
     """
     return _num_dicke_ladders(N)
 
+
 def num_tls(nds):
     """Calculate the number of two-level systems.
 
@@ -117,11 +147,12 @@ def num_tls(nds):
     """
     if np.sqrt(nds).is_integer():
         # N is even
-        N = 2*(np.sqrt(nds)-1)
+        N = 2 * (np.sqrt(nds) - 1)
     else:
         # N is odd
-        N = 2*(np.sqrt(nds + 1/4)-1)
+        N = 2 * (np.sqrt(nds + 1 / 4) - 1)
     return int(N)
+
 
 def isdiagonal(mat):
     """
@@ -142,8 +173,9 @@ def isdiagonal(mat):
 
     return np.all(mat == np.diag(np.diagonal(mat)))
 
+
 # nonlinear functions of the density matrix
-def mask_dicke_matrix(rho,blocks='qobj'):
+def mask_dicke_matrix(rho, blocks="qobj"):
     """Create a block-diagonal mask for a matrix in the Dicke basis.
 
     Parameters
@@ -166,24 +198,26 @@ def mask_dicke_matrix(rho,blocks='qobj'):
     N = num_tls(shape_dimension)
     ladders = num_dicke_ladders(N)
     # create a list with the sizes of the blocks, in order
-    blocks_dimensions = int(N/2 + 1 - 0.5*(N % 2))
-    blocks_list = [(2 * (i+1 * (N % 2)) + 1*((N+1) % 2))
-                   for i in range(blocks_dimensions)]
+    blocks_dimensions = int(N / 2 + 1 - 0.5 * (N % 2))
+    blocks_list = [
+        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2)) for i in range(blocks_dimensions)
+    ]
     blocks_list = np.flip(blocks_list, 0)
     # create a list with each block matrix as element
     square_blocks = []
     block_position = 0
     for block_size in blocks_list:
         start_m = block_position
-        end_m = (block_position+block_size)
-        square_block = rho[start_m:end_m,start_m:end_m]
+        end_m = block_position + block_size
+        square_block = rho[start_m:end_m, start_m:end_m]
         block_position = block_position + block_size
         square_blocks.append(square_block)
-        
+
     if blocks == "list":
         return square_blocks
     else:
         return Qobj(block_diag(square_blocks))
+
 
 def dicke_function_trace(f, rho):
     """Calculate the trace of a function on a Dicke density matrix.
@@ -199,9 +233,9 @@ def dicke_function_trace(f, rho):
     -------
     res : float
         Trace of a nonlinear function on `rho`.
-    """    
+    """
     N = num_tls(rho.shape[0])
-    blocks = mask_dicke_matrix(rho,blocks="list")
+    blocks = mask_dicke_matrix(rho, blocks="list")
     block_f = []
     degen_blocks = np.flip(j_vals(N))
     state_degeneracies = []
@@ -212,15 +246,16 @@ def dicke_function_trace(f, rho):
     deg = []
     for i, block in enumerate(blocks):
         dj = state_degeneracies[i]
-        normalized_block = block/dj
+        normalized_block = block / dj
         eigenvals_block = eigsh(normalized_block, return_eigenvectors=False)
         for val in eigenvals_block:
             eigenvals_degeneracy.append(val)
             deg.append(dj)
- 
-    eigenvalue=np.array(eigenvals_degeneracy)
-    function_array = f(eigenvalue)*deg
+
+    eigenvalue = np.array(eigenvals_degeneracy)
+    function_array = f(eigenvalue) * deg
     return sum(function_array)
+
 
 def entropy_vn_dicke(rho):
     """Von Neumann Entropy of a Dicke-basis density matrix.
@@ -242,6 +277,7 @@ def entropy_vn_dicke(rho):
     """
     return dicke_function_trace(entr, rho)
 
+
 def purity_dicke(rho):
     """Calculate purity of a density matrix in the Dicke basis.
     It accounts for the degenerate blocks in the density matrix.
@@ -257,10 +293,11 @@ def purity_dicke(rho):
         The purity of the quantum state. 
         It's 1 for pure states, 0<=purity<1 for mixed states.       
     """
-    f = lambda x: x*x    
+    f = lambda x: x * x
     return dicke_function_trace(f, rho)
 
-def expand_dicke_matrix(rho,blocks='qobj'):
+
+def expand_dicke_matrix(rho, blocks="qobj"):
     """Expand the block-diagonal matrix from the Dicke basis to 2^N.
 
     Parameters
@@ -283,9 +320,10 @@ def expand_dicke_matrix(rho,blocks='qobj'):
     N = num_tls(shape_dimension)
     ladders = num_dicke_ladders(N)
     # create a list with the sizes of the blocks, in order
-    blocks_dimensions = int(N/2 + 1 - 0.5*(N % 2))
-    blocks_list = [(2 * (i+1 * (N % 2)) + 1*((N+1) % 2))
-                   for i in range(blocks_dimensions)]
+    blocks_dimensions = int(N / 2 + 1 - 0.5 * (N % 2))
+    blocks_list = [
+        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2)) for i in range(blocks_dimensions)
+    ]
     blocks_list = np.flip(blocks_list, 0)
     # create a list with each block matrix as element
     square_blocks = []
@@ -293,19 +331,19 @@ def expand_dicke_matrix(rho,blocks='qobj'):
     block_position = 0
     for block_size in blocks_list:
         start_m = block_position
-        end_m = (block_position+block_size)
-        square_block = rho[start_m:end_m,start_m:end_m]
+        end_m = block_position + block_size
+        square_block = rho[start_m:end_m, start_m:end_m]
         block_position = block_position + block_size
-        j = N/2 - k
-        #print(block_size)
-        #print(square_block)
+        j = N / 2 - k
+        # print(block_size)
+        # print(square_block)
         # = block_size-1
-        #print("block_size ",block_size)
-        djn = state_degeneracy(N,j)
-        for block_counter in range(0,djn):
-            square_blocks.append(square_block/djn) # preserve trace
+        # print("block_size ",block_size)
+        djn = state_degeneracy(N, j)
+        for block_counter in range(0, djn):
+            square_blocks.append(square_block / djn)  # preserve trace
         k = k + 1
-    if blocks == 'list':
+    if blocks == "list":
         return square_blocks
     else:
         return Qobj(block_diag(square_blocks))
@@ -405,10 +443,18 @@ class Dicke(object):
         The shape of the Hilbert space in the Dicke or uncoupled basis.
         default: (nds, nds).
     """
-    def __init__(self, N, hamiltonian=None,
-                 emission=0., dephasing=0., pumping=0.,
-                 collective_emission=0., collective_dephasing=0.,
-                 collective_pumping=0.):
+
+    def __init__(
+        self,
+        N,
+        hamiltonian=None,
+        emission=0.0,
+        dephasing=0.0,
+        pumping=0.0,
+        collective_emission=0.0,
+        collective_dephasing=0.0,
+        collective_pumping=0.0,
+    ):
         self.N = N
         self.hamiltonian = hamiltonian
         self.emission = emission
@@ -426,8 +472,9 @@ class Dicke(object):
         string.append("N = {}".format(self.N))
         string.append("Hilbert space dim = {}".format(self.dshape))
         string.append("Number of Dicke states = {}".format(self.nds))
-        string.append("Liouvillian space dim = {}".format((self.nds**2,
-                                                           self.nds**2)))
+        string.append(
+            "Liouvillian space dim = {}".format((self.nds ** 2, self.nds ** 2))
+        )
         if self.emission != 0:
             string.append("emission = {}".format(self.emission))
         if self.dephasing != 0:
@@ -435,14 +482,11 @@ class Dicke(object):
         if self.pumping != 0:
             string.append("pumping = {}".format(self.pumping))
         if self.collective_emission != 0:
-            string.append(
-                "collective_emission = {}".format(self.collective_emission))
+            string.append("collective_emission = {}".format(self.collective_emission))
         if self.collective_dephasing != 0:
-            string.append(
-                "collective_dephasing = {}".format(self.collective_dephasing))
+            string.append("collective_dephasing = {}".format(self.collective_dephasing))
         if self.collective_pumping != 0:
-            string.append(
-                "collective_pumping = {}".format(self.collective_pumping))
+            string.append("collective_pumping = {}".format(self.collective_pumping))
         return "\n".join(string)
 
     def lindbladian(self):
@@ -453,13 +497,15 @@ class Dicke(object):
         lindbladian : :class:`qutip.Qobj`
             The Lindbladian matrix as a `qutip.Qobj`.
         """
-        cythonized_dicke = _Dicke(int(self.N),
-                                  float(self.emission),
-                                  float(self.dephasing),
-                                  float(self.pumping),
-                                  float(self.collective_emission),
-                                  float(self.collective_dephasing),
-                                  float(self.collective_pumping))
+        cythonized_dicke = _Dicke(
+            int(self.N),
+            float(self.emission),
+            float(self.dephasing),
+            float(self.pumping),
+            float(self.collective_emission),
+            float(self.collective_dephasing),
+            float(self.collective_pumping),
+        )
         return cythonized_dicke.lindbladian()
 
     def liouvillian(self):
@@ -476,8 +522,9 @@ class Dicke(object):
 
         else:
             hamiltonian = self.hamiltonian
-            hamiltonian_superoperator = - 1j * \
-                spre(hamiltonian) + 1j * spost(hamiltonian)
+            hamiltonian_superoperator = -1j * spre(hamiltonian) + 1j * spost(
+                hamiltonian
+            )
             liouv = lindblad + hamiltonian_superoperator
         return liouv
 
@@ -519,9 +566,15 @@ class Dicke(object):
             msg = "Initial density matrix should be diagonal."
             raise ValueError(msg)
 
-        pim = Pim(self.N, self.emission, self.dephasing, self.pumping,
-                  self.collective_emission, self.collective_pumping,
-                  self.collective_dephasing)
+        pim = Pim(
+            self.N,
+            self.emission,
+            self.dephasing,
+            self.pumping,
+            self.collective_emission,
+            self.collective_pumping,
+            self.collective_dephasing,
+        )
         result = pim.solve(initial_state, tlist, options=None)
         return result
 
@@ -536,13 +589,15 @@ class Dicke(object):
         ce = self.collective_emission
         cd = self.collective_dephasing
         cp = self.collective_pumping
-        c_ops_list = collapse_uncoupled(N=self.N,
-                                        emission=self.emission,
-                                        dephasing=self.dephasing,
-                                        pumping=self.pumping,
-                                        collective_emission=ce,
-                                        collective_dephasing=cd,
-                                        collective_pumping=cp)
+        c_ops_list = collapse_uncoupled(
+            N=self.N,
+            emission=self.emission,
+            dephasing=self.dephasing,
+            pumping=self.pumping,
+            collective_emission=ce,
+            collective_dephasing=cd,
+            collective_pumping=cp,
+        )
         return c_ops_list
 
     def coefficient_matrix(self):
@@ -555,13 +610,15 @@ class Dicke(object):
             p is the vector of the diagonal matrix elements
             of the density matrix rho in the Dicke basis.
         """
-        diagonal_system = Pim(N=self.N,
-                              emission=self.emission,
-                              dephasing=self.dephasing,
-                              pumping=self.pumping,
-                              collective_emission=self.collective_emission,
-                              collective_dephasing=self.collective_dephasing,
-                              collective_pumping=self.collective_pumping)
+        diagonal_system = Pim(
+            N=self.N,
+            emission=self.emission,
+            dephasing=self.dephasing,
+            pumping=self.pumping,
+            collective_emission=self.collective_emission,
+            collective_dephasing=self.collective_dephasing,
+            collective_pumping=self.collective_pumping,
+        )
         coef_matrix = diagonal_system.coefficient_matrix()
         return coef_matrix
 
@@ -588,10 +645,11 @@ def energy_degeneracy(N, m):
         The energy degeneracy
     """
     numerator = Decimal(factorial(N))
-    d1 = Decimal(factorial(N/2 + m))
-    d2 = Decimal(factorial(N/2 - m))
-    degeneracy = numerator/(d1 * d2)
+    d1 = Decimal(factorial(N / 2 + m))
+    d2 = Decimal(factorial(N / 2 - m))
+    degeneracy = numerator / (d1 * d2)
     return int(degeneracy)
+
 
 def state_degeneracy(N, j):
     """Calculate the degeneracy of the Dicke state.
@@ -616,12 +674,13 @@ def state_degeneracy(N, j):
     """
     if j < 0:
         raise ValueError("j value should be >= 0")
-    numerator = Decimal(factorial(N)) * Decimal(2*j + 1)
-    denominator_1 = Decimal(factorial(N/2 + j + 1))
-    denominator_2 = Decimal(factorial(N/2 - j))
-    degeneracy = numerator/(denominator_1 * denominator_2)
+    numerator = Decimal(factorial(N)) * Decimal(2 * j + 1)
+    denominator_1 = Decimal(factorial(N / 2 + j + 1))
+    denominator_2 = Decimal(factorial(N / 2 - j))
+    degeneracy = numerator / (denominator_1 * denominator_2)
     degeneracy = int(np.round(float(degeneracy)))
     return degeneracy
+
 
 def m_degeneracy(N, m):
     """Calculate the number of Dicke states :math:`|j, m\\rangle` with
@@ -647,8 +706,9 @@ def m_degeneracy(N, m):
         e = "m value is incorrect for this N."
         e += " Minimum m value can be {}".format(-maxj)
         raise ValueError(e)
-    degeneracy = N/2 + 1 - abs(m)
+    degeneracy = N / 2 + 1 - abs(m)
     return int(degeneracy)
+
 
 def ap(j, m):
     """Calculate the coefficient `ap` by applying J_+ |j, m>.
@@ -666,8 +726,9 @@ def ap(j, m):
     a_plus: float
         The value of :math:`a_{+}`.
     """
-    a_plus = np.sqrt((j-m) * (j+m+1))
+    a_plus = np.sqrt((j - m) * (j + m + 1))
     return a_plus
+
 
 def am(j, m):
     """Calculate the operator `am` used later.
@@ -687,8 +748,9 @@ def am(j, m):
     a_minus: float
         The value of :math:`a_{-}`.
     """
-    a_minus = np.sqrt((j+m) * (j-m+1))
+    a_minus = np.sqrt((j + m) * (j - m + 1))
     return a_minus
+
 
 def spin_algebra(N, op=None):
     """Create the list [sx, sy, sz] with the spin operators.
@@ -752,18 +814,19 @@ def spin_algebra(N, op=None):
 
     if not op:
         return spin_operators
-    elif op == 'x':
+    elif op == "x":
         return sx
-    elif op == 'y':
+    elif op == "y":
         return sy
-    elif op == 'z':
+    elif op == "z":
         return sz
-    elif op == '+':
+    elif op == "+":
         return sp
-    elif op == '-':
+    elif op == "-":
         return sm
     else:
-        raise TypeError('Invalid type')
+        raise TypeError("Invalid type")
+
 
 def _jspin_uncoupled(N, op=None):
     """Construct the the collective spin algebra in the uncoupled basis.
@@ -804,18 +867,19 @@ def _jspin_uncoupled(N, op=None):
 
     if not op:
         return collective_operators
-    elif op == 'x':
+    elif op == "x":
         return jx
-    elif op == 'y':
+    elif op == "y":
         return jy
-    elif op == 'z':
+    elif op == "z":
         return jz
-    elif op == '+':
+    elif op == "+":
         return jp
-    elif op == '-':
+    elif op == "-":
         return jm
     else:
-        raise TypeError('Invalid type')
+        raise TypeError("Invalid type")
+
 
 def jspin(N, op=None, basis="dicke"):
     """
@@ -857,18 +921,18 @@ def jspin(N, op=None, basis="dicke"):
 
     for k in range(0, num_ladders):
         j = 0.5 * N - k
-        mmax = int(2*j + 1)
+        mmax = int(2 * j + 1)
         for i in range(0, mmax):
-            m = j-i
+            m = j - i
             jz_operator[s, s] = m
-            if (s+1) in range(0, nds):
-                jp_operator[s, s+1] = ap(j, m-1)
-            if (s-1) in range(0, nds):
-                jm_operator[s, s-1] = am(j, m+1)
-            s = s+1
+            if (s + 1) in range(0, nds):
+                jp_operator[s, s + 1] = ap(j, m - 1)
+            if (s - 1) in range(0, nds):
+                jm_operator[s, s - 1] = am(j, m + 1)
+            s = s + 1
 
-    jx_operator = 1/2 * (jp_operator+jm_operator)
-    jy_operator = 1j/2 * (jm_operator-jp_operator)
+    jx_operator = 1 / 2 * (jp_operator + jm_operator)
+    jy_operator = 1j / 2 * (jm_operator - jp_operator)
     jx = Qobj(jx_operator)
     jy = Qobj(jy_operator)
     jz = Qobj(jz_operator)
@@ -877,22 +941,29 @@ def jspin(N, op=None, basis="dicke"):
 
     if not op:
         return [jx, jy, jz]
-    if op == '+':
+    if op == "+":
         return jp
-    elif op == '-':
+    elif op == "-":
         return jm
-    elif op == 'x':
+    elif op == "x":
         return jx
-    elif op == 'y':
+    elif op == "y":
         return jy
-    elif op == 'z':
+    elif op == "z":
         return jz
     else:
-        raise TypeError('Invalid type')
+        raise TypeError("Invalid type")
 
-def collapse_uncoupled(N, emission=0., dephasing=0., pumping=0.,
-              collective_emission=0., collective_dephasing=0.,
-              collective_pumping=0.):
+
+def collapse_uncoupled(
+    N,
+    emission=0.0,
+    dephasing=0.0,
+    pumping=0.0,
+    collective_emission=0.0,
+    collective_dephasing=0.0,
+    collective_pumping=0.0,
+):
     """
     Create the collapse operators (c_ops) of the Lindbladian in the
     uncoupled basis
@@ -952,8 +1023,7 @@ def collapse_uncoupled(N, emission=0., dephasing=0., pumping=0.,
     [sx, sy, sz] = spin_algebra(N)
     sp, sm = spin_algebra(N, "+"), spin_algebra(N, "-")
     [jx, jy, jz] = jspin(N, basis="uncoupled")
-    jp, jm = (jspin(N, "+", basis = "uncoupled"),
-              jspin(N, "-", basis="uncoupled"))
+    jp, jm = (jspin(N, "+", basis="uncoupled"), jspin(N, "-", basis="uncoupled"))
 
     c_ops = []
 
@@ -979,6 +1049,7 @@ def collapse_uncoupled(N, emission=0., dephasing=0., pumping=0.,
         c_ops.append(np.sqrt(collective_pumping) * jp)
 
     return c_ops
+
 
 # State definitions in the Dicke basis with an option for basis transformation
 def dicke_basis(N, jmm1=None):
@@ -1020,6 +1091,7 @@ def dicke_basis(N, jmm1=None):
         rho[i, k] = jmm1[key]
     return Qobj(rho)
 
+
 def dicke(N, j, m):
     """
     Generate a Dicke state as a pure density matrix in the Dicke basis.
@@ -1052,8 +1124,9 @@ def dicke(N, j, m):
     jmm1_dict = jmm1_dictionary(N)[1]
 
     i, k = jmm1_dict[(j, m, m)]
-    rho[i, k] = 1.
+    rho[i, k] = 1.0
     return Qobj(rho)
+
 
 # Uncoupled states in the full Hilbert space. These are returned with the
 # choice of the keyword argument `basis="uncoupled"` in the state functions.
@@ -1075,8 +1148,9 @@ def _uncoupled_excited(N):
     N = int(N)
     jz = jspin(N, "z", basis="uncoupled")
     en, vn = jz.eigenstates()
-    psi0 = vn[2**N - 1]
+    psi0 = vn[2 ** N - 1]
     return ket2dm(psi0)
+
 
 def _uncoupled_superradiant(N):
     """
@@ -1097,8 +1171,9 @@ def _uncoupled_superradiant(N):
     N = int(N)
     jz = jspin(N, "z", basis="uncoupled")
     en, vn = jz.eigenstates()
-    psi0 = vn[2**N - (N+1)]
+    psi0 = vn[2 ** N - (N + 1)]
     return ket2dm(psi0)
+
 
 def _uncoupled_ground(N):
     """
@@ -1121,6 +1196,7 @@ def _uncoupled_ground(N):
     psi0 = vn[0]
     return ket2dm(psi0)
 
+
 def _uncoupled_ghz(N):
     """
     Generate the density matrix of the GHZ state in the full 2^N
@@ -1137,15 +1213,16 @@ def _uncoupled_ghz(N):
         The density matrix for the GHZ state in the full Hilbert space.
     """
     N = int(N)
-    rho = np.zeros((2**N, 2**N))
-    rho[0, 0] = 1/2
-    rho[2**N - 1, 0] = 1/2
-    rho[0, 2**N - 1] = 1/2
-    rho[2**N - 1, 2**N - 1] = 1/2
+    rho = np.zeros((2 ** N, 2 ** N))
+    rho[0, 0] = 1 / 2
+    rho[2 ** N - 1, 0] = 1 / 2
+    rho[0, 2 ** N - 1] = 1 / 2
+    rho[2 ** N - 1, 2 ** N - 1] = 1 / 2
     spin_dim = [2 for i in range(0, N)]
     spins_dims = list((spin_dim, spin_dim))
     rho = Qobj(rho, dims=spins_dims)
     return rho
+
 
 def _uncoupled_css(N, a, b):
     """
@@ -1192,11 +1269,12 @@ def _uncoupled_css(N, a, b):
     # |+><+| = Prod_(i=1)^N |CSS>_i<CSS|_i
     for i in range(1, N):
         rho[i] = rho[0].permute(b[i])
-    identity_i = Qobj(np.eye(2**N), dims=rho[0].dims, shape=rho[0].shape)
+    identity_i = Qobj(np.eye(2 ** N), dims=rho[0].dims, shape=rho[0].shape)
     rho_tot = identity_i
     for i in range(0, N):
         rho_tot = rho_tot * rho[i]
     return rho_tot
+
 
 def excited(N, basis="dicke"):
     """
@@ -1223,8 +1301,9 @@ def excited(N, basis="dicke"):
         state = _uncoupled_excited(N)
         return state
 
-    jmm1 = {(N/2, N/2, N/2): 1}
+    jmm1 = {(N / 2, N / 2, N / 2): 1}
     return dicke_basis(N, jmm1)
+
 
 def superradiant(N, basis="dicke"):
     """
@@ -1252,14 +1331,14 @@ def superradiant(N, basis="dicke"):
         return state
 
     if N % 2 == 0:
-        jmm1 = {(N/2, 0, 0): 1.}
+        jmm1 = {(N / 2, 0, 0): 1.0}
         return dicke_basis(N, jmm1)
     else:
-        jmm1 = {(N/2, 0.5, 0.5): 1.}
+        jmm1 = {(N / 2, 0.5, 0.5): 1.0}
     return dicke_basis(N, jmm1)
 
-def css(N, x=1/np.sqrt(2), y=1/np.sqrt(2),
-        basis="dicke", coordinates="cartesian"):
+
+def css(N, x=1 / np.sqrt(2), y=1 / np.sqrt(2), basis="dicke", coordinates="cartesian"):
     """
     Generate the density matrix of the Coherent Spin State (CSS).
 
@@ -1307,19 +1386,26 @@ def css(N, x=1/np.sqrt(2), y=1/np.sqrt(2),
     # loop in the allowed matrix elements
     jmm1_dict = jmm1_dictionary(N)[1]
 
-    j = 0.5*N
-    mmax = int(2*j + 1)
+    j = 0.5 * N
+    mmax = int(2 * j + 1)
     for i in range(0, mmax):
-        m = j-i
-        psi_m = np.sqrt(float(energy_degeneracy(N, m))) * \
-            a**(N*0.5 + m) * b**(N*0.5 - m)
+        m = j - i
+        psi_m = (
+            np.sqrt(float(energy_degeneracy(N, m)))
+            * a ** (N * 0.5 + m)
+            * b ** (N * 0.5 - m)
+        )
         for i1 in range(0, mmax):
             m1 = j - i1
             row_column = jmm1_dict[(j, m, m1)]
-            psi_m1 = np.sqrt(float(energy_degeneracy(N, m1))) * \
-                np.conj(a)**(N*0.5 + m1) * np.conj(b)**(N*0.5 - m1)
-            rho[row_column] = psi_m*psi_m1
+            psi_m1 = (
+                np.sqrt(float(energy_degeneracy(N, m1)))
+                * np.conj(a) ** (N * 0.5 + m1)
+                * np.conj(b) ** (N * 0.5 - m1)
+            )
+            rho[row_column] = psi_m * psi_m1
     return Qobj(rho)
+
 
 def ghz(N, basis="dicke"):
     """
@@ -1345,11 +1431,12 @@ def ghz(N, basis="dicke"):
         return _uncoupled_ghz(N)
     nds = _num_dicke_states(N)
     rho = dok_matrix((nds, nds), dtype=np.complex)
-    rho[0, 0] = 1/2
-    rho[N, N] = 1/2
-    rho[N, 0] = 1/2
-    rho[0, N] = 1/2
+    rho[0, 0] = 1 / 2
+    rho[N, N] = 1 / 2
+    rho[N, 0] = 1 / 2
+    rho[0, N] = 1 / 2
     return Qobj(rho)
+
 
 def ground(N, basis="dicke"):
     """
@@ -1380,6 +1467,7 @@ def ground(N, basis="dicke"):
     rho[N, N] = 1
     return Qobj(rho)
 
+
 def identity_uncoupled(N):
     """
     Generate the identity in a :math:`2^N`-dimensional Hilbert space.
@@ -1397,15 +1485,16 @@ def identity_uncoupled(N):
         The identity matrix.
     """
     N = int(N)
-    rho = np.zeros((2**N, 2**N))
-    for i in range(0, 2**N):
+    rho = np.zeros((2 ** N, 2 ** N))
+    for i in range(0, 2 ** N):
         rho[i, i] = 1
     spin_dim = [2 for i in range(0, N)]
     spins_dims = list((spin_dim, spin_dim))
     identity = Qobj(rho, dims=spins_dims)
     return identity
 
-def block_matrix(N,elements="ones"):
+
+def block_matrix(N, elements="ones"):
     """Construct the block-diagonal matrix for the Dicke basis.
 
     Parameters
@@ -1423,9 +1512,10 @@ def block_matrix(N,elements="ones"):
         at each matrix element.
     """
     # create a list with the sizes of the blocks, in order
-    blocks_dimensions = int(N/2 + 1 - 0.5*(N % 2))
-    blocks_list = [(2 * (i+1 * (N % 2)) + 1*((N+1) % 2))
-                   for i in range(blocks_dimensions)]
+    blocks_dimensions = int(N / 2 + 1 - 0.5 * (N % 2))
+    blocks_list = [
+        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2)) for i in range(blocks_dimensions)
+    ]
     blocks_list = np.flip(blocks_list, 0)
     # create a list with each block matrix as element
     square_blocks = []
@@ -1434,11 +1524,12 @@ def block_matrix(N,elements="ones"):
         if elements == "ones":
             square_blocks.append(np.ones((i, i)))
         elif elements == "degeneracy":
-            j = N/2 - k
-            dj = state_degeneracy(N,j)
-            square_blocks.append(dj*np.ones((i, i)))
+            j = N / 2 - k
+            dj = state_degeneracy(N, j)
+            square_blocks.append(dj * np.ones((i, i)))
         k = k + 1
     return block_diag(square_blocks)
+
 
 # ============================================================================
 # Adding a faster version to make a Permutational Invariant matrix
@@ -1462,15 +1553,17 @@ def tau_column(tau, k, j):
     """
     # In the notes, we indexed from k = 1, here we do it from k = 0
     k = k + 1
-    mapping = {"tau3": k-(2 * j + 3),
-               "tau2": k-1,
-               "tau4": k+(2 * j - 1),
-               "tau5": k-(2 * j + 2),
-               "tau1": k,
-               "tau6": k+(2 * j),
-               "tau7": k-(2 * j + 1),
-               "tau8": k+1,
-               "tau9": k+(2 * j + 1)}
+    mapping = {
+        "tau3": k - (2 * j + 3),
+        "tau2": k - 1,
+        "tau4": k + (2 * j - 1),
+        "tau5": k - (2 * j + 2),
+        "tau1": k,
+        "tau6": k + (2 * j),
+        "tau7": k - (2 * j + 1),
+        "tau8": k + 1,
+        "tau9": k + (2 * j + 1),
+    }
     # we need to decrement k again as indexing is from 0
     return int(mapping[tau] - 1)
 
@@ -1546,9 +1639,17 @@ class Pim(object):
         A nested dictionary of the structure {row: {col: val}} which holds
         non zero elements of the matrix M
     """
-    def __init__(self, N, emission=0., dephasing=0, pumping=0,
-                 collective_emission=0, collective_pumping=0,
-                 collective_dephasing=0):
+
+    def __init__(
+        self,
+        N,
+        emission=0.0,
+        dephasing=0,
+        pumping=0,
+        collective_emission=0,
+        collective_pumping=0,
+        collective_dephasing=0,
+    ):
         self.N = N
         self.emission = emission
         self.dephasing = dephasing
@@ -1574,16 +1675,16 @@ class Pim(object):
         cols = 0
 
         if (self.N % 2) == 0:
-            cols = int(self.N/2 + 1)
+            cols = int(self.N / 2 + 1)
         else:
-            cols = int(self.N/2 + 1/2)
+            cols = int(self.N / 2 + 1 / 2)
         if (dicke_row > rows) or (dicke_row < 0):
-            return (False)
-        if (dicke_col > cols) or (dicke_col < 0):
-            return (False)
-        if (dicke_row < int(rows/2)) and (dicke_col > dicke_row):
             return False
-        if (dicke_row >= int(rows/2)) and (rows - dicke_row <= dicke_col):
+        if (dicke_col > cols) or (dicke_col < 0):
+            return False
+        if (dicke_row < int(rows / 2)) and (dicke_col > dicke_row):
+            return False
+        if (dicke_row >= int(rows / 2)) and (rows - dicke_row <= dicke_col):
             return False
         else:
             return True
@@ -1606,16 +1707,25 @@ class Pim(object):
             A dictionary of key, val as {tau: value} consisting of the valid
             taus for this row and column of the Dicke space element.
         """
-        tau_functions = [self.tau3, self.tau2, self.tau4,
-                         self.tau5, self.tau1, self.tau6,
-                         self.tau7, self.tau8, self.tau9]
+        tau_functions = [
+            self.tau3,
+            self.tau2,
+            self.tau4,
+            self.tau5,
+            self.tau1,
+            self.tau6,
+            self.tau7,
+            self.tau8,
+            self.tau9,
+        ]
         N = self.N
         if self.isdicke(dicke_row, dicke_col) is False:
             return False
         # The 3x3 sub matrix surrounding the Dicke space element to
         # run the tau functions
-        indices = [(dicke_row + x, dicke_col + y) for x in range(-1, 2)
-                   for y in range(-1, 2)]
+        indices = [
+            (dicke_row + x, dicke_col + y) for x in range(-1, 2) for y in range(-1, 2)
+        ]
         taus = {}
         for idx, tau in zip(indices, tau_functions):
             if self.isdicke(idx[0], idx[1]):
@@ -1638,9 +1748,9 @@ class Pim(object):
             The j and m values.
         """
         N = self.N
-        j = N/2 - dicke_col
-        m = N/2 - dicke_row
-        return(j, m)
+        j = N / 2 - dicke_col
+        m = N / 2 - dicke_row
+        return (j, m)
 
     def calculate_k(self, dicke_row, dicke_col):
         """
@@ -1660,8 +1770,10 @@ class Pim(object):
         if dicke_row == 0:
             k = dicke_col
         else:
-            k = int(((dicke_col)/2) * (2 * (N + 1) - 2 * (dicke_col - 1)) +
-                                      (dicke_row - (dicke_col)))
+            k = int(
+                ((dicke_col) / 2) * (2 * (N + 1) - 2 * (dicke_col - 1))
+                + (dicke_row - (dicke_col))
+            )
         return k
 
     def coefficient_matrix(self):
@@ -1678,9 +1790,9 @@ class Pim(object):
 
         sparse_M = lil_matrix((nds, nds), dtype=float)
         if (self.N % 2) == 0:
-            cols = int(self.N/2 + 1)
+            cols = int(self.N / 2 + 1)
         else:
-            cols = int(self.N/2 + 1/2)
+            cols = int(self.N / 2 + 1 / 2)
         for (dicke_row, dicke_col) in np.ndindex(rows, cols):
             if self.isdicke(dicke_row, dicke_col):
                 k = int(self.calculate_k(dicke_row, dicke_col))
@@ -1723,13 +1835,13 @@ class Pim(object):
         yCP = self.collective_pumping
         N = float(self.N)
         spontaneous = yS * (1 + j - m) * (j + m)
-        losses = yL * (N/2 + m)
-        pump = yP * (N/2 - m)
+        losses = yL * (N / 2 + m)
+        pump = yP * (N / 2 - m)
         collective_pump = yCP * (1 + j + m) * (j - m)
         if j == 0:
-            dephase = yD * N/4
+            dephase = yD * N / 4
         else:
-            dephase = yD * (N/4 - m**2 * ((1 + N/2)/(2 * j * (j+1))))
+            dephase = yD * (N / 4 - m ** 2 * ((1 + N / 2) / (2 * j * (j + 1))))
         t1 = spontaneous + losses + pump + dephase + collective_pump
         return -t1
 
@@ -1741,7 +1853,7 @@ class Pim(object):
         yL = self.emission
         N = float(self.N)
         spontaneous = yS * (1 + j - m) * (j + m)
-        losses = yL * (((N/2 + 1) * (j - m + 1) * (j + m))/(2 * j * (j+1)))
+        losses = yL * (((N / 2 + 1) * (j - m + 1) * (j + m)) / (2 * j * (j + 1)))
         t2 = spontaneous + losses
         return t2
 
@@ -1751,9 +1863,9 @@ class Pim(object):
         """
         yL = self.emission
         N = float(self.N)
-        num = (j + m - 1) * (j + m) * (j + 1 + N/2)
+        num = (j + m - 1) * (j + m) * (j + 1 + N / 2)
         den = 2 * j * (2 * j + 1)
-        t3 = yL * (num/den)
+        t3 = yL * (num / den)
         return t3
 
     def tau4(self, j, m):
@@ -1762,9 +1874,9 @@ class Pim(object):
         """
         yL = self.emission
         N = float(self.N)
-        num = (j - m + 1) * (j - m + 2) * (N/2 - j)
+        num = (j - m + 1) * (j - m + 2) * (N / 2 - j)
         den = 2 * (j + 1) * (2 * j + 1)
-        t4 = yL * (num/den)
+        t4 = yL * (num / den)
         return t4
 
     def tau5(self, j, m):
@@ -1773,9 +1885,9 @@ class Pim(object):
         """
         yD = self.dephasing
         N = float(self.N)
-        num = (j - m) * (j + m) * (j + 1 + N/2)
+        num = (j - m) * (j + m) * (j + 1 + N / 2)
         den = 2 * j * (2 * j + 1)
-        t5 = yD * (num/den)
+        t5 = yD * (num / den)
         return t5
 
     def tau6(self, j, m):
@@ -1784,9 +1896,9 @@ class Pim(object):
         """
         yD = self.dephasing
         N = float(self.N)
-        num = (j - m + 1) * (j + m + 1) * (N/2 - j)
+        num = (j - m + 1) * (j + m + 1) * (N / 2 - j)
         den = 2 * (j + 1) * (2 * j + 1)
-        t6 = yD * (num/den)
+        t6 = yD * (num / den)
         return t6
 
     def tau7(self, j, m):
@@ -1795,9 +1907,9 @@ class Pim(object):
         """
         yP = self.pumping
         N = float(self.N)
-        num = (j - m - 1) * (j - m) * (j + 1 + N/2)
+        num = (j - m - 1) * (j - m) * (j + 1 + N / 2)
         den = 2 * j * (2 * j + 1)
-        t7 = yP * (float(num)/den)
+        t7 = yP * (float(num) / den)
         return t7
 
     def tau8(self, j, m):
@@ -1808,10 +1920,10 @@ class Pim(object):
         yCP = self.collective_pumping
         N = float(self.N)
 
-        num = (1 + N/2) * (j-m) * (j + m + 1)
-        den = 2 * j * (j+1)
-        pump = yP * (float(num)/den)
-        collective_pump = yCP * (j-m) * (j+m+1)
+        num = (1 + N / 2) * (j - m) * (j + m + 1)
+        den = 2 * j * (j + 1)
+        pump = yP * (float(num) / den)
+        collective_pump = yCP * (j - m) * (j + m + 1)
         t8 = pump + collective_pump
         return t8
 
@@ -1821,7 +1933,7 @@ class Pim(object):
         """
         yP = self.pumping
         N = float(self.N)
-        num = (j+m+1) * (j+m+2) * (N/2 - j)
-        den = 2 * (j+1) * (2*j + 1)
-        t9 = yP * (float(num)/den)
+        num = (j + m + 1) * (j + m + 2) * (N / 2 - j)
+        den = 2 * (j + 1) * (2 * j + 1)
+        t9 = yP * (float(num) / den)
         return t9

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -212,6 +212,7 @@ def dicke_blocks(rho):
 
     return square_blocks
 
+
 def dicke_blocks_full(rho):
     """Give the full (2^N-dimensional) list of blocks for a Dicke-basis matrix.
 
@@ -252,6 +253,7 @@ def dicke_blocks_full(rho):
             full_blocks.append(square_block / djn)  # preserve trace
         k = k + 1
     return full_blocks
+
 
 def dicke_function_trace(f, rho):
     """Calculate the trace of a function on a Dicke density matrix.
@@ -327,6 +329,7 @@ def purity_dicke(rho):
     """
     f = lambda x: x * x
     return dicke_function_trace(f, rho)
+
 
 class Dicke(object):
     """The Dicke class which builds the Lindbladian and Liouvillian matrix.

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -69,8 +69,8 @@ __all__ = [
     "num_dicke_ladders",
     "num_tls",
     "isdiagonal",
-    "mask_dicke_matrix",
-    "expand_dicke_matrix",
+    "dicke_blocks",
+    "dicke_blocks_full",
     "dicke_function_trace",
     "purity_dicke",
     "entropy_vn_dicke",
@@ -175,8 +175,8 @@ def isdiagonal(mat):
 
 
 # nonlinear functions of the density matrix
-def mask_dicke_matrix(rho, blocks="qobj"):
-    """Create a block-diagonal mask for a matrix in the Dicke basis.
+def dicke_blocks(rho):
+    """Create the list of blocks for block-diagonal density matrix in the Dicke basis.
 
     Parameters
     ----------
@@ -184,14 +184,11 @@ def mask_dicke_matrix(rho, blocks="qobj"):
         A 2D block-diagonal matrix of ones with dimension (nds,nds),
         where nds is the number of Dicke states for N two-level
         systems.
-    blocks : string {'qobj','list'}
-        Set how to return the output, either as a Qobj matrix or as list.
 
     Returns
     -------
-    masked_matr: qutip.Qobj (default) or list of np.array ('list')
-        Apply the mask in the block diagonal terms.
-        Gives back a block-diagonal matrix or just the block list. 
+    square_blocks: list of np.array 
+        Give back the blocks list. 
         
     """
     shape_dimension = rho.shape[0]
@@ -213,11 +210,48 @@ def mask_dicke_matrix(rho, blocks="qobj"):
         block_position = block_position + block_size
         square_blocks.append(square_block)
 
-    if blocks == "list":
-        return square_blocks
-    else:
-        return Qobj(block_diag(square_blocks))
+    return square_blocks
 
+def dicke_blocks_full(rho):
+    """Give the full (2^N-dimensional) list of blocks for a Dicke-basis matrix.
+
+    Parameters
+    ----------
+    rho : :class:`qutip.Qobj`
+        A 2D block-diagonal matrix of ones with dimension (nds,nds),
+        where nds is the number of Dicke states for N two-level
+        systems.
+
+    Returns
+    -------
+    full_blocks : list 
+        The list of blocks expanded in the 2^N space for N qubits.
+        
+    """
+    shape_dimension = rho.shape[0]
+    N = num_tls(shape_dimension)
+    ladders = num_dicke_ladders(N)
+    # create a list with the sizes of the blocks, in order
+    blocks_dimensions = int(N / 2 + 1 - 0.5 * (N % 2))
+    blocks_list = [
+        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2)) for i in range(blocks_dimensions)
+    ]
+    blocks_list = np.flip(blocks_list, 0)
+    # create a list with each block matrix as element
+    full_blocks = []
+    k = 0
+    block_position = 0
+    for block_size in blocks_list:
+        start_m = block_position
+        end_m = block_position + block_size
+        square_block = rho[start_m:end_m, start_m:end_m]
+        block_position = block_position + block_size
+        j = N / 2 - k
+        djn = state_degeneracy(N, j)
+        for block_counter in range(0, djn):
+            full_blocks.append(square_block / djn)  # preserve trace
+        k = k + 1
+    return full_blocks
 
 def dicke_function_trace(f, rho):
     """Calculate the trace of a function on a Dicke density matrix.
@@ -235,7 +269,7 @@ def dicke_function_trace(f, rho):
         Trace of a nonlinear function on `rho`.
     """
     N = num_tls(rho.shape[0])
-    blocks = mask_dicke_matrix(rho, blocks="list")
+    blocks = dicke_blocks(rho)
     block_f = []
     degen_blocks = np.flip(j_vals(N))
     state_degeneracies = []
@@ -293,59 +327,6 @@ def purity_dicke(rho):
     """
     f = lambda x: x * x
     return dicke_function_trace(f, rho)
-
-
-def expand_dicke_matrix(rho, blocks="qobj"):
-    """Expand the block-diagonal matrix from the Dicke basis to 2^N.
-
-    Parameters
-    ----------
-    rho : :class:`qutip.Qobj`
-        A 2D block-diagonal matrix of ones with dimension (nds,nds),
-        where nds is the number of Dicke states for N two-level
-        systems.
-    blocks : string. {'qobj' (default), 'list'}
-        Set if return is block-diagonal matrix (or list of blocks).
-
-    Returns
-    -------
-    expanded_matr : :class:`qutip.Qobj` (default) or list (optional)
-        Expanded matrix in the 2^N space. 
-        A 2D block-diagonal matrix (as a Qobj or list of blocks) for rho.
-        
-    """
-    shape_dimension = rho.shape[0]
-    N = num_tls(shape_dimension)
-    ladders = num_dicke_ladders(N)
-    # create a list with the sizes of the blocks, in order
-    blocks_dimensions = int(N / 2 + 1 - 0.5 * (N % 2))
-    blocks_list = [
-        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2)) for i in range(blocks_dimensions)
-    ]
-    blocks_list = np.flip(blocks_list, 0)
-    # create a list with each block matrix as element
-    square_blocks = []
-    k = 0
-    block_position = 0
-    for block_size in blocks_list:
-        start_m = block_position
-        end_m = block_position + block_size
-        square_block = rho[start_m:end_m, start_m:end_m]
-        block_position = block_position + block_size
-        j = N / 2 - k
-        # print(block_size)
-        # print(square_block)
-        # = block_size-1
-        # print("block_size ",block_size)
-        djn = state_degeneracy(N, j)
-        for block_counter in range(0, djn):
-            square_blocks.append(square_block / djn)  # preserve trace
-        k = k + 1
-    if blocks == "list":
-        return square_blocks
-    else:
-        return Qobj(block_diag(square_blocks))
-
 
 class Dicke(object):
     """The Dicke class which builds the Lindbladian and Liouvillian matrix.

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -50,7 +50,15 @@ from scipy.special import entr
 from scipy import constants
 from scipy.sparse import dok_matrix, block_diag, lil_matrix
 from qutip.solver import Options, Result
-from qutip import Qobj, spre, spost, tensor, identity, ket2dm, vector_to_operator
+from qutip import (
+    Qobj,
+    spre,
+    spost,
+    tensor,
+    identity,
+    ket2dm,
+    vector_to_operator,
+)
 from qutip import sigmax, sigmay, sigmaz, sigmap, sigmam
 from qutip import entropy_vn
 from qutip.cy.piqs import Dicke as _Dicke
@@ -197,7 +205,8 @@ def dicke_blocks(rho):
     # create a list with the sizes of the blocks, in order
     blocks_dimensions = int(N / 2 + 1 - 0.5 * (N % 2))
     blocks_list = [
-        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2)) for i in range(blocks_dimensions)
+        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2))
+        for i in range(blocks_dimensions)
     ]
     blocks_list = np.flip(blocks_list, 0)
     # create a list with each block matrix as element
@@ -235,7 +244,8 @@ def dicke_blocks_full(rho):
     # create a list with the sizes of the blocks, in order
     blocks_dimensions = int(N / 2 + 1 - 0.5 * (N % 2))
     blocks_list = [
-        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2)) for i in range(blocks_dimensions)
+        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2))
+        for i in range(blocks_dimensions)
     ]
     blocks_list = np.flip(blocks_list, 0)
     # create a list with each block matrix as element
@@ -464,11 +474,17 @@ class Dicke(object):
         if self.pumping != 0:
             string.append("pumping = {}".format(self.pumping))
         if self.collective_emission != 0:
-            string.append("collective_emission = {}".format(self.collective_emission))
+            string.append(
+                "collective_emission = {}".format(self.collective_emission)
+            )
         if self.collective_dephasing != 0:
-            string.append("collective_dephasing = {}".format(self.collective_dephasing))
+            string.append(
+                "collective_dephasing = {}".format(self.collective_dephasing)
+            )
         if self.collective_pumping != 0:
-            string.append("collective_pumping = {}".format(self.collective_pumping))
+            string.append(
+                "collective_pumping = {}".format(self.collective_pumping)
+            )
         return "\n".join(string)
 
     def lindbladian(self):
@@ -1005,7 +1021,10 @@ def collapse_uncoupled(
     [sx, sy, sz] = spin_algebra(N)
     sp, sm = spin_algebra(N, "+"), spin_algebra(N, "-")
     [jx, jy, jz] = jspin(N, basis="uncoupled")
-    jp, jm = (jspin(N, "+", basis="uncoupled"), jspin(N, "-", basis="uncoupled"))
+    jp, jm = (
+        jspin(N, "+", basis="uncoupled"),
+        jspin(N, "-", basis="uncoupled"),
+    )
 
     c_ops = []
 
@@ -1320,7 +1339,13 @@ def superradiant(N, basis="dicke"):
     return dicke_basis(N, jmm1)
 
 
-def css(N, x=1 / np.sqrt(2), y=1 / np.sqrt(2), basis="dicke", coordinates="cartesian"):
+def css(
+    N,
+    x=1 / np.sqrt(2),
+    y=1 / np.sqrt(2),
+    basis="dicke",
+    coordinates="cartesian",
+):
     """
     Generate the density matrix of the Coherent Spin State (CSS).
 
@@ -1496,7 +1521,8 @@ def block_matrix(N, elements="ones"):
     # create a list with the sizes of the blocks, in order
     blocks_dimensions = int(N / 2 + 1 - 0.5 * (N % 2))
     blocks_list = [
-        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2)) for i in range(blocks_dimensions)
+        (2 * (i + 1 * (N % 2)) + 1 * ((N + 1) % 2))
+        for i in range(blocks_dimensions)
     ]
     blocks_list = np.flip(blocks_list, 0)
     # create a list with each block matrix as element
@@ -1706,7 +1732,9 @@ class Pim(object):
         # The 3x3 sub matrix surrounding the Dicke space element to
         # run the tau functions
         indices = [
-            (dicke_row + x, dicke_col + y) for x in range(-1, 2) for y in range(-1, 2)
+            (dicke_row + x, dicke_col + y)
+            for x in range(-1, 2)
+            for y in range(-1, 2)
         ]
         taus = {}
         for idx, tau in zip(indices, tau_functions):
@@ -1835,7 +1863,9 @@ class Pim(object):
         yL = self.emission
         N = float(self.N)
         spontaneous = yS * (1 + j - m) * (j + m)
-        losses = yL * (((N / 2 + 1) * (j - m + 1) * (j + m)) / (2 * j * (j + 1)))
+        losses = yL * (
+            ((N / 2 + 1) * (j - m + 1) * (j + m)) / (2 * j * (j + 1))
+        )
         t2 = spontaneous + losses
         return t2
 

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -56,6 +56,12 @@ from qutip.cy.piqs import (jmm1_dictionary, _num_dicke_states,
                            _num_dicke_ladders, get_blocks, j_min,
                            m_vals, j_vals)
 
+__all__ = ['num_dicke_states','num_dicke_ladders','num_tls','isdiagonal',
+           'mask_dicke_matrix','purity_dicke','expand_dicke_matrix'
+           'entropy_vn_dicke','Dicke','state_degeneracy','m_degeneracy',
+           'ap','am','spin_algebra','jspin','collapse_uncoupled',
+           'dicke_basis','dicke','excited','superradiant','css','ghz',
+           'ground','identity_uncoupled','block_matrix','tau_column','Pim']
 
 # Functions necessary to generate the Lindbladian/Liouvillian
 def num_dicke_states(N):

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -57,7 +57,7 @@ from qutip.cy.piqs import (jmm1_dictionary, _num_dicke_states,
                            m_vals, j_vals)
 
 __all__ = ['num_dicke_states','num_dicke_ladders','num_tls','isdiagonal',
-           'mask_dicke_matrix','purity_dicke','expand_dicke_matrix'
+           'mask_dicke_matrix','purity_dicke','expand_dicke_matrix',
            'entropy_vn_dicke','Dicke','state_degeneracy','m_degeneracy',
            'ap','am','spin_algebra','jspin','collapse_uncoupled',
            'dicke_basis','dicke','excited','superradiant','css','ghz',

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -36,6 +36,7 @@
 This module calculates the Liouvillian for the dynamics of ensembles of
 identical two-level systems (TLS) in the presence of local and collective
 processes by exploiting permutational symmetry and using the Dicke basis.
+It also allows to characterize nonlinear functions of the density matrix.
 """
 
 # Authors: Nathan Shammah, Shahnawaz Ahmed
@@ -196,9 +197,9 @@ def dicke_blocks(rho):
 
     Returns
     -------
-    square_blocks: list of np.array 
-        Give back the blocks list. 
-        
+    square_blocks: list of np.array
+        Give back the blocks list.
+
     """
     shape_dimension = rho.shape[0]
     N = num_tls(shape_dimension)
@@ -235,9 +236,9 @@ def dicke_blocks_full(rho):
 
     Returns
     -------
-    full_blocks : list 
+    full_blocks : list
         The list of blocks expanded in the 2^N space for N qubits.
-        
+
     """
     shape_dimension = rho.shape[0]
     N = num_tls(shape_dimension)
@@ -271,9 +272,9 @@ def dicke_function_trace(f, rho):
     Parameters
     ----------
     f : function
-        A Taylor-expandable function of `rho`. 
-    
-    rho : :class:`qutip.Qobj` 
+        A Taylor-expandable function of `rho`.
+
+    rho : :class:`qutip.Qobj`
         A density matrix in the Dicke basis.
 
     Returns
@@ -318,7 +319,7 @@ def entropy_vn_dicke(rho):
     -------
     entropy_dm: float
         Entropy. Use degeneracy to multiply each block.
-        
+
     """
     return dicke_function_trace(entr, rho)
 
@@ -335,8 +336,8 @@ def purity_dicke(rho):
     Returns
     -------
     purity : float
-        The purity of the quantum state. 
-        It's 1 for pure states, 0<=purity<1 for mixed states.       
+        The purity of the quantum state.
+        It's 1 for pure states, 0<=purity<1 for mixed states.
     """
     f = lambda x: x * x
     return dicke_function_trace(f, rho)
@@ -1516,7 +1517,7 @@ def block_matrix(N, elements="ones"):
     block_matr : ndarray
         A 2D block-diagonal matrix with dimension (nds,nds),
         where nds is the number of Dicke states for N two-level
-        systems. Filled with ones or the value of degeneracy 
+        systems. Filled with ones or the value of degeneracy
         at each matrix element.
     """
     # create a list with the sizes of the blocks, in order

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -266,8 +266,6 @@ def entropy_vn_dicke(rho):
         A 2D block-diagonal matrix of ones with dimension (nds,nds),
         where nds is the number of Dicke states for N two-level
         systems.
-    blocks : string {'qobj','list'}
-        Set how to return the output. 
 
     Returns
     -------
@@ -311,9 +309,9 @@ def expand_dicke_matrix(rho, blocks="qobj"):
 
     Returns
     -------
-    expanded_matr : :class:`qutip.Qobj` (default) or list
+    expanded_matr : :class:`qutip.Qobj` (default) or list (optional)
         Expanded matrix in the 2^N space. 
-        A 2D block-diagonal matrix (or list of blocks) for rho.
+        A 2D block-diagonal matrix (as a Qobj or list of blocks) for rho.
         
     """
     shape_dimension = rho.shape[0]

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -258,7 +258,7 @@ def purity_dicke(rho):
         It's 1 for pure states, 0<=purity<1 for mixed states.       
     """
     f = lambda x: x*x    
-    return dicke_function_trace(rho)
+    return dicke_function_trace(f, rho)
 
 def expand_dicke_matrix(rho,blocks='qobj'):
     """Expand the block-diagonal matrix from the Dicke basis to 2^N.

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -46,6 +46,7 @@ from decimal import Decimal
 import numpy as np
 from scipy.integrate import odeint
 from scipy.sparse.linalg import eigsh
+from scipy.special import entr
 from scipy import constants
 from scipy.sparse import dok_matrix, block_diag, lil_matrix
 from qutip.solver import Options, Result
@@ -239,8 +240,7 @@ def entropy_vn_dicke(rho):
         Entropy. Use degeneracy to multiply each block.
         
     """
-    f = lambda x: -x*np.log(x)
-    return dicke_function_trace(f, rho)
+    return dicke_function_trace(f=entr, rho)
 
 def purity_dicke(rho):
     """Calculate purity of a density matrix in the Dicke basis.

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -240,7 +240,7 @@ def entropy_vn_dicke(rho):
         Entropy. Use degeneracy to multiply each block.
         
     """
-    return dicke_function_trace(f=entr, rho)
+    return dicke_function_trace(entr, rho)
 
 def purity_dicke(rho):
     """Calculate purity of a density matrix in the Dicke basis.

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -78,7 +78,9 @@ class TestDicke:
         """
         N_list = [1, 2, 3, 4, 5, 6, 9, 10, 20, 100, 123]
         dicke_states = [num_dicke_states(i) for i in N_list]
-        assert_array_equal(dicke_states, [2, 4, 6, 9, 12, 16, 30, 36, 121, 2601, 3906])
+        assert_array_equal(
+            dicke_states, [2, 4, 6, 9, 12, 16, 30, 36, 121, 2601, 3906]
+        )
         N = -1
         assert_raises(ValueError, num_dicke_states, N)
         N = 0.2
@@ -252,7 +254,8 @@ class TestDicke:
 
         blocks = get_blocks(N)
         calculated_indices = [
-            get_index(N, jmm1[0], jmm1[1], jmm1[2], blocks) for jmm1 in jmm1_list
+            get_index(N, jmm1[0], jmm1[1], jmm1[2], blocks)
+            for jmm1 in jmm1_list
         ]
         assert_array_almost_equal(calculated_indices, indices)
         N = 2
@@ -282,7 +285,8 @@ class TestDicke:
             (3, 3),
         ]
         calculated_indices = [
-            get_index(N, jmm1[0], jmm1[1], jmm1[2], blocks) for jmm1 in jmm1_list
+            get_index(N, jmm1[0], jmm1[1], jmm1[2], blocks)
+            for jmm1 in jmm1_list
         ]
         assert_array_almost_equal(calculated_indices, indices)
         N = 3
@@ -318,7 +322,8 @@ class TestDicke:
         ]
 
         calculated_indices = [
-            get_index(N, jmm1[0], jmm1[1], jmm1[2], blocks) for jmm1 in jmm1_list
+            get_index(N, jmm1[0], jmm1[1], jmm1[2], blocks)
+            for jmm1 in jmm1_list
         ]
         assert_array_almost_equal(calculated_indices, indices)
 
@@ -449,7 +454,9 @@ class TestDicke:
         Ldata[2] = [0, 0, -0.9, 0]
         Ldata[3] = [0.6, 0, 0, -0.6]
 
-        lindbladian_correct = Qobj(Ldata, dims=[[[2], [2]], [[2], [2]]], shape=(4, 4))
+        lindbladian_correct = Qobj(
+            Ldata, dims=[[[2], [2]], [[2], [2]]], shape=(4, 4)
+        )
         assert_array_almost_equal(lindbladian.data.toarray(), Ldata)
         N = 2
         gCE = 0.5
@@ -475,7 +482,12 @@ class TestDicke:
         Ldata[1, 1], Ldata[1, 6] = -2, 1.1
         Ldata[2, 2] = -2.2999999999999998
         Ldata[4, 4], Ldata[4, 9] = -2, 1.1
-        Ldata[5, 0], Ldata[5, 5], Ldata[5, 10], Ldata[5, 15] = (1.1, -2.25, 1.1, 0.05)
+        Ldata[5, 0], Ldata[5, 5], Ldata[5, 10], Ldata[5, 15] = (
+            1.1,
+            -2.25,
+            1.1,
+            0.05,
+        )
         Ldata[6, 1], Ldata[6, 6] = 1.1, -2
         Ldata[8, 8] = -2.2999999999999998
         Ldata[9, 4], Ldata[9, 9] = 1.1, -2
@@ -486,7 +498,9 @@ class TestDicke:
             0.1,
             -0.25,
         )
-        lindbladian_correct = Qobj(Ldata, dims=[[[4], [4]], [[4], [4]]], shape=(16, 16))
+        lindbladian_correct = Qobj(
+            Ldata, dims=[[[4], [4]], [[4], [4]]], shape=(16, 16)
+        )
         assert_array_almost_equal(lindbladian.data.toarray(), Ldata)
 
     def test_gamma(self):
@@ -528,7 +542,17 @@ class TestDicke:
             model.gamma8((2, -1, -1)),
             model.gamma9((1, -1, -1)),
         ]
-        tau_real = [2.0, 8.0, 0.333333, 1.5, -19.5, 0.666667, 2.0, 8.0, 0.333333]
+        tau_real = [
+            2.0,
+            8.0,
+            0.333333,
+            1.5,
+            -19.5,
+            0.666667,
+            2.0,
+            8.0,
+            0.333333,
+        ]
         assert_array_almost_equal(tau_calculated, tau_real)
 
     def test_jspin(self):
@@ -992,7 +1016,9 @@ class TestDicke:
         """
         test_identity = identity_uncoupled(4)
         assert_equal(test_identity.dims, [[2, 2, 2, 2], [2, 2, 2, 2]])
-        assert_array_equal(np.diag(test_identity.full()), np.ones(16, np.complex))
+        assert_array_equal(
+            np.diag(test_identity.full()), np.ones(16, np.complex)
+        )
 
     def test_css(self):
         """
@@ -1144,7 +1170,9 @@ class TestDicke:
         )
         test_liouvillian = test_piqs.liouvillian()
         test_hamiltonian = test_piqs.hamiltonian
-        assert_array_almost_equal(test_liouvillian.full(), true_liouvillian.full())
+        assert_array_almost_equal(
+            test_liouvillian.full(), true_liouvillian.full()
+        )
         assert_array_almost_equal(test_hamiltonian.full(), true_H.full())
         assert_array_equal(test_liouvillian.dims, test_liouvillian.dims)
 
@@ -1426,7 +1454,17 @@ class TestPim:
             model.tau8(2, -1),
             model.tau9(1, -1),
         ]
-        tau_real = [2.0, 8.0, 0.333333, 1.5, -19.5, 0.666667, 2.0, 8.0, 0.333333]
+        tau_real = [
+            2.0,
+            8.0,
+            0.333333,
+            1.5,
+            -19.5,
+            0.666667,
+            2.0,
+            8.0,
+            0.333333,
+        ]
         assert_array_almost_equal(tau_calculated, tau_real)
 
     def test_isdicke(self):
@@ -1483,7 +1521,12 @@ class TestPim:
         test_matrix = ensemble.coefficient_matrix().todense()
         ensemble2 = Dicke(N, emission=1)
         test_matrix2 = ensemble.coefficient_matrix().todense()
-        true_matrix = [[-2, 0, 0, 0], [1, -1, 0, 0], [0, 1, 0, 1.0], [1, 0, 0, -1.0]]
+        true_matrix = [
+            [-2, 0, 0, 0],
+            [1, -1, 0, 0],
+            [0, 1, 0, 1.0],
+            [1, 0, 0, -1.0],
+        ]
 
         assert_array_almost_equal(test_matrix, true_matrix)
         assert_array_almost_equal(test_matrix2, true_matrix)
@@ -1504,14 +1547,20 @@ class TestPim:
         non_diag_initial_state = ghz(4)
         tlist = np.linspace(0, 10, 100)
 
-        assert_raises(ValueError, non_diag_system.pisolve, diag_initial_state, tlist)
+        assert_raises(
+            ValueError, non_diag_system.pisolve, diag_initial_state, tlist
+        )
         assert_raises(
             ValueError, non_diag_system.pisolve, non_diag_initial_state, tlist
         )
-        assert_raises(ValueError, diag_system.pisolve, non_diag_initial_state, tlist)
+        assert_raises(
+            ValueError, diag_system.pisolve, non_diag_initial_state, tlist
+        )
 
         non_dicke_initial_state = excited(4, basis="uncoupled")
-        assert_raises(ValueError, diag_system.pisolve, non_dicke_initial_state, tlist)
+        assert_raises(
+            ValueError, diag_system.pisolve, non_dicke_initial_state, tlist
+        )
 
         # no Hamiltonian
         no_hamiltonian_system = Dicke(4, emission=0.1)

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -158,6 +158,7 @@ class TestDicke:
         """
         PIQS: Test the `dicke_function_trace` function.
         """
+        ## test for N odd
         N = 3
         # test trace
         rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
@@ -173,9 +174,10 @@ class TestDicke:
         test_val3 = dicke_function_trace(f,rho_mixed)
         true_val3 = (expand_dicke_matrix(rho_mixed)**3).tr()
         assert_almost_equal(test_val3,true_val3)
+        ## test for N even
         N = 4
         # test trace
-        rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
+        rho_mixed = (excited(N)+dicke(N,0,0)).unit()
         f = lambda x:x
         test_val = dicke_function_trace(f,rho_mixed)
         true_val = (expand_dicke_matrix(rho_mixed)).tr()

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -128,6 +128,52 @@ class TestDicke:
         for (i, j) in zip(m_real, m_calc):
             assert_array_equal(i, j)
 
+    def test_mask_dicke_matrix(self):
+        """
+        PIQS: Test the `mask_dicke_matrix` function.
+        """
+        # test 1
+        # mixed state with non-symmetrical block matrix elements
+        N = 3
+        true_matrix = (excited(N)+dicke(N,0.5,0.5)).unit()
+        test_matrix = mask_dicke_matrix(true_matrix)
+        assert_(test_matrix == true_matrix)
+        # test 2
+        # all elements in block-diagonal matrix
+        N = 4
+        true_matrix = Qobj(block_matrix(N)).unit()
+        test_matrix = mask_dicke_matrix(true_matrix)
+        assert_(test_matrix == true_matrix)
+        
+    def test_expand_dicke_matrix(self):
+        """
+        PIQS: Test the `expand_dicke_matrix` function.
+        """
+        test_matrix = expand_dicke_matrix(excited(3))
+        true_expanded = np.zeros((8,8))
+        true_expanded[0,0] = 1.
+        assert_(test_matrix == Qobj(true_expanded))
+        
+    def test_entropy_vn_dicke(self):
+        """
+        PIQS: Test the `entropy_vn_dicke` function.
+        """
+        N = 3
+        rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
+        test_val = entropy_vn_dicke(rho_mixed)
+        true_val = entropy_vn(expand_dicke_matrix(rho_mixed))
+        assert_(test_val == true_val)
+
+    def test_purity_dicke(self):
+        """
+        PIQS: Test the `purity_dicke` function.
+        """
+        N = 3
+        rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
+        test_val = purity_dicke(rho_mixed)
+        true_val = (expand_dicke_matrix(rho_mixed)).purity()
+        assert_(test_val == true_val)
+
     def test_get_index(self):
         """
         PIQS: Test the index fetching function for given j, m, m1 value.

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -56,7 +56,7 @@ if sys.version_info[0] < 3:
 
 class TestDicke:
     """
-    Tests for `qutip.piqs.Dicke` class.
+    Tests for `qutip.piqs.Dicke` class and auxiliary functions.
     """
 
     def test_num_dicke_states(self):

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -34,14 +34,27 @@
 Tests for Permutational Invariant Quantum solver (PIQS).
 """
 import numpy as np
-from numpy.testing import (assert_, run_module_suite, assert_raises,
-                           assert_array_equal, assert_array_almost_equal,
-                           assert_almost_equal, assert_equal)
+from numpy.testing import (
+    assert_,
+    run_module_suite,
+    assert_raises,
+    assert_array_equal,
+    assert_array_almost_equal,
+    assert_almost_equal,
+    assert_equal,
+)
 
-from qutip import Qobj, entropy_vn,sigmax,sigmaz
-from qutip.cy.piqs import (get_blocks, j_min, j_vals, m_vals,
-                           _num_dicke_states, _num_dicke_ladders,
-                           get_index, jmm1_dictionary)
+from qutip import Qobj, entropy_vn, sigmax, sigmaz
+from qutip.cy.piqs import (
+    get_blocks,
+    j_min,
+    j_vals,
+    m_vals,
+    _num_dicke_states,
+    _num_dicke_ladders,
+    get_index,
+    jmm1_dictionary,
+)
 from qutip.cy.piqs import Dicke as _Dicke
 from qutip.piqs import *
 
@@ -65,8 +78,7 @@ class TestDicke:
         """
         N_list = [1, 2, 3, 4, 5, 6, 9, 10, 20, 100, 123]
         dicke_states = [num_dicke_states(i) for i in N_list]
-        assert_array_equal(dicke_states, [2, 4, 6, 9, 12, 16, 30, 36, 121,
-                                          2601, 3906])
+        assert_array_equal(dicke_states, [2, 4, 6, 9, 12, 16, 30, 36, 121, 2601, 3906])
         N = -1
         assert_raises(ValueError, num_dicke_states, N)
         N = 0.2
@@ -94,8 +106,12 @@ class TestDicke:
         PIQS: Test the function to get blocks.
         """
         N_list = [1, 2, 5, 7]
-        blocks = [np.array([2]), np.array([3, 4]), np.array([6, 10, 12]),
-                  np.array([8, 14, 18, 20])]
+        blocks = [
+            np.array([2]),
+            np.array([3, 4]),
+            np.array([6, 10, 12]),
+            np.array([8, 14, 18, 20]),
+        ]
         calculated_blocks = [get_blocks(i) for i in N_list]
         for (i, j) in zip(calculated_blocks, blocks):
             assert_array_equal(i, j)
@@ -105,10 +121,13 @@ class TestDicke:
         PIQS: Test calculation of j values for given N.
         """
         N_list = [1, 2, 3, 4, 7]
-        j_vals_real = [np.array([0.5]), np.array([0., 1.]),
-                       np.array([0.5, 1.5]),
-                       np.array([0., 1., 2.]),
-                       np.array([0.5, 1.5, 2.5, 3.5])]
+        j_vals_real = [
+            np.array([0.5]),
+            np.array([0.0, 1.0]),
+            np.array([0.5, 1.5]),
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.5, 1.5, 2.5, 3.5]),
+        ]
         j_vals_calc = [j_vals(i) for i in N_list]
 
         for (i, j) in zip(j_vals_calc, j_vals_real):
@@ -119,10 +138,13 @@ class TestDicke:
         PIQS: Test calculation of m values for a particular j.
         """
         j_list = [0.5, 1, 1.5, 2, 2.5]
-        m_real = [np.array([-0.5, 0.5]), np.array([-1, 0, 1]),
-                  np.array([-1.5, -0.5, 0.5, 1.5]),
-                  np.array([-2, -1, 0, 1, 2]),
-                  np.array([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5])]
+        m_real = [
+            np.array([-0.5, 0.5]),
+            np.array([-1, 0, 1]),
+            np.array([-1.5, -0.5, 0.5, 1.5]),
+            np.array([-2, -1, 0, 1, 2]),
+            np.array([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]),
+        ]
 
         m_calc = [m_vals(i) for i in j_list]
         for (i, j) in zip(m_real, m_calc):
@@ -135,7 +157,7 @@ class TestDicke:
         # test 1
         # mixed state with non-symmetrical block matrix elements
         N = 3
-        true_matrix = (excited(N)+dicke(N,0.5,0.5)).unit()
+        true_matrix = (excited(N) + dicke(N, 0.5, 0.5)).unit()
         test_matrix = mask_dicke_matrix(true_matrix)
         assert_(test_matrix == true_matrix)
         # test 2
@@ -144,16 +166,16 @@ class TestDicke:
         true_matrix = Qobj(block_matrix(N)).unit()
         test_matrix = mask_dicke_matrix(true_matrix)
         assert_(test_matrix == true_matrix)
-        
+
     def test_expand_dicke_matrix(self):
         """
         PIQS: Test the `expand_dicke_matrix` function.
         """
         test_matrix = expand_dicke_matrix(excited(3))
-        true_expanded = np.zeros((8,8))
-        true_expanded[0,0] = 1.
+        true_expanded = np.zeros((8, 8))
+        true_expanded[0, 0] = 1.0
         assert_(test_matrix == Qobj(true_expanded))
-        
+
     def test_dicke_function_trace(self):
         """
         PIQS: Test the `dicke_function_trace` function.
@@ -161,42 +183,42 @@ class TestDicke:
         ## test for N odd
         N = 3
         # test trace
-        rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
-        f = lambda x:x
-        test_val = dicke_function_trace(f,rho_mixed)
+        rho_mixed = (excited(N) + dicke(N, 0.5, 0.5)).unit()
+        f = lambda x: x
+        test_val = dicke_function_trace(f, rho_mixed)
         true_val = (expand_dicke_matrix(rho_mixed)).tr()
         true_val2 = (rho_mixed).tr()
         # test with linear function (trace)
-        assert_almost_equal(test_val,true_val)
-        assert_almost_equal(test_val,true_val2)
+        assert_almost_equal(test_val, true_val)
+        assert_almost_equal(test_val, true_val2)
         # test with nonlinear function
-        f = lambda rho: rho**3
-        test_val3 = dicke_function_trace(f,rho_mixed)
-        true_val3 = (expand_dicke_matrix(rho_mixed)**3).tr()
-        assert_almost_equal(test_val3,true_val3)
+        f = lambda rho: rho ** 3
+        test_val3 = dicke_function_trace(f, rho_mixed)
+        true_val3 = (expand_dicke_matrix(rho_mixed) ** 3).tr()
+        assert_almost_equal(test_val3, true_val3)
         ## test for N even
         N = 4
         # test trace
-        rho_mixed = (excited(N)+dicke(N,0,0)).unit()
-        f = lambda x:x
-        test_val = dicke_function_trace(f,rho_mixed)
+        rho_mixed = (excited(N) + dicke(N, 0, 0)).unit()
+        f = lambda x: x
+        test_val = dicke_function_trace(f, rho_mixed)
         true_val = (expand_dicke_matrix(rho_mixed)).tr()
         true_val2 = (rho_mixed).tr()
         # test with linear function (trace)
-        assert_almost_equal(test_val,true_val)
-        assert_almost_equal(test_val,true_val2)
+        assert_almost_equal(test_val, true_val)
+        assert_almost_equal(test_val, true_val2)
         # test with nonlinear function
-        f = lambda rho: rho**3
-        test_val3 = dicke_function_trace(f,rho_mixed)
-        true_val3 = (expand_dicke_matrix(rho_mixed)**3).tr()
+        f = lambda rho: rho ** 3
+        test_val3 = dicke_function_trace(f, rho_mixed)
+        true_val3 = (expand_dicke_matrix(rho_mixed) ** 3).tr()
         assert np.allclose(test_val3, true_val3)
-        
+
     def test_entropy_vn_dicke(self):
         """
         PIQS: Test the `entropy_vn_dicke` function.
         """
         N = 3
-        rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
+        rho_mixed = (excited(N) + dicke(N, 0.5, 0.5)).unit()
         test_val = entropy_vn_dicke(rho_mixed)
         true_val = entropy_vn(expand_dicke_matrix(rho_mixed))
         assert np.allclose(test_val, true_val)
@@ -206,7 +228,7 @@ class TestDicke:
         PIQS: Test the `purity_dicke` function.
         """
         N = 3
-        rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
+        rho_mixed = (excited(N) + dicke(N, 0.5, 0.5)).unit()
         test_val = purity_dicke(rho_mixed)
         true_val = (expand_dicke_matrix(rho_mixed)).purity()
         assert np.allclose(test_val, true_val)
@@ -216,45 +238,84 @@ class TestDicke:
         PIQS: Test the index fetching function for given j, m, m1 value.
         """
         N = 1
-        jmm1_list = [(0.5, 0.5, 0.5), (0.5, 0.5, -0.5),
-                     (0.5, -0.5, 0.5), (0.5, -0.5, -0.5)]
+        jmm1_list = [
+            (0.5, 0.5, 0.5),
+            (0.5, 0.5, -0.5),
+            (0.5, -0.5, 0.5),
+            (0.5, -0.5, -0.5),
+        ]
         indices = [(0, 0), (0, 1), (1, 0), (1, 1)]
 
         blocks = get_blocks(N)
-        calculated_indices = [get_index(N, jmm1[0], jmm1[1],
-                                        jmm1[2], blocks)
-                              for jmm1 in jmm1_list]
+        calculated_indices = [
+            get_index(N, jmm1[0], jmm1[1], jmm1[2], blocks) for jmm1 in jmm1_list
+        ]
         assert_array_almost_equal(calculated_indices, indices)
         N = 2
         blocks = get_blocks(N)
-        jmm1_list = [(1, 1, 1), (1, 1, 0), (1, 1, -1),
-                     (1, 0, 1), (1, 0, 0), (1, 0, -1),
-                     (1, -1, 1), (1, -1, 0), (1, -1, -1),
-                     (0, 0, 0)]
-        indices = [(0, 0), (0, 1), (0, 2),
-                   (1, 0), (1, 1), (1, 2),
-                   (2, 0), (2, 1), (2, 2),
-                   (3, 3)]
-        calculated_indices = [get_index(N, jmm1[0], jmm1[1],
-                                        jmm1[2], blocks)
-                              for jmm1 in jmm1_list]
+        jmm1_list = [
+            (1, 1, 1),
+            (1, 1, 0),
+            (1, 1, -1),
+            (1, 0, 1),
+            (1, 0, 0),
+            (1, 0, -1),
+            (1, -1, 1),
+            (1, -1, 0),
+            (1, -1, -1),
+            (0, 0, 0),
+        ]
+        indices = [
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (1, 0),
+            (1, 1),
+            (1, 2),
+            (2, 0),
+            (2, 1),
+            (2, 2),
+            (3, 3),
+        ]
+        calculated_indices = [
+            get_index(N, jmm1[0], jmm1[1], jmm1[2], blocks) for jmm1 in jmm1_list
+        ]
         assert_array_almost_equal(calculated_indices, indices)
         N = 3
         blocks = get_blocks(N)
-        jmm1_list = [(1.5, 1.5, 1.5), (1.5, 1.5, 0.5), (1.5, 1.5, -0.5),
-                     (1.5, 1.5, -1.5), (1.5, 0.5, 0.5), (1.5, -0.5, -0.5),
-                     (1.5, -1.5, -1.5), (1.5, -1.5, 1.5), (0.5, 0.5, 0.5),
-                     (0.5, 0.5, -0.5), (0.5, - 0.5, 0.5),
-                     (0.5, -0.5, -0.5)]
+        jmm1_list = [
+            (1.5, 1.5, 1.5),
+            (1.5, 1.5, 0.5),
+            (1.5, 1.5, -0.5),
+            (1.5, 1.5, -1.5),
+            (1.5, 0.5, 0.5),
+            (1.5, -0.5, -0.5),
+            (1.5, -1.5, -1.5),
+            (1.5, -1.5, 1.5),
+            (0.5, 0.5, 0.5),
+            (0.5, 0.5, -0.5),
+            (0.5, -0.5, 0.5),
+            (0.5, -0.5, -0.5),
+        ]
 
-        indices = [(0, 0), (0, 1), (0, 2), (0, 3),
-                   (1, 1), (2, 2), (3, 3), (3, 0),
-                   (4, 4), (4, 5),
-                   (5, 4), (5, 5)]
+        indices = [
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+            (3, 0),
+            (4, 4),
+            (4, 5),
+            (5, 4),
+            (5, 5),
+        ]
 
-        calculated_indices = [get_index(N, jmm1[0], jmm1[1],
-                                        jmm1[2], blocks)
-                              for jmm1 in jmm1_list]
+        calculated_indices = [
+            get_index(N, jmm1[0], jmm1[1], jmm1[2], blocks) for jmm1 in jmm1_list
+        ]
         assert_array_almost_equal(calculated_indices, indices)
 
     def test_jmm1_dictionary(self):
@@ -263,19 +324,33 @@ class TestDicke:
         """
         d1, d2, d3, d4 = jmm1_dictionary(1)
 
-        d1_correct = {(0, 0): (0.5, 0.5, 0.5), (0, 1): (0.5, 0.5, -0.5),
-                      (1, 0): (0.5, -0.5, 0.5), (1, 1): (0.5, -0.5, -0.5)}
+        d1_correct = {
+            (0, 0): (0.5, 0.5, 0.5),
+            (0, 1): (0.5, 0.5, -0.5),
+            (1, 0): (0.5, -0.5, 0.5),
+            (1, 1): (0.5, -0.5, -0.5),
+        }
 
-        d2_correct = {(0.5, -0.5, -0.5): (1, 1), (0.5, -0.5, 0.5): (1, 0),
-                      (0.5, 0.5, -0.5): (0, 1),
-                      (0.5, 0.5, 0.5): (0, 0)}
+        d2_correct = {
+            (0.5, -0.5, -0.5): (1, 1),
+            (0.5, -0.5, 0.5): (1, 0),
+            (0.5, 0.5, -0.5): (0, 1),
+            (0.5, 0.5, 0.5): (0, 0),
+        }
 
-        d3_correct = {0: (0.5, 0.5, 0.5), 1: (0.5, 0.5, -0.5),
-                      2: (0.5, -0.5, 0.5),
-                      3: (0.5, -0.5, -0.5)}
+        d3_correct = {
+            0: (0.5, 0.5, 0.5),
+            1: (0.5, 0.5, -0.5),
+            2: (0.5, -0.5, 0.5),
+            3: (0.5, -0.5, -0.5),
+        }
 
-        d4_correct = {(0.5, -0.5, -0.5): 3, (0.5, -0.5, 0.5): 2,
-                      (0.5, 0.5, -0.5): 1, (0.5, 0.5, 0.5): 0}
+        d4_correct = {
+            (0.5, -0.5, -0.5): 3,
+            (0.5, -0.5, 0.5): 2,
+            (0.5, 0.5, -0.5): 1,
+            (0.5, 0.5, 0.5): 0,
+        }
 
         assert_equal(d1, d1_correct)
         assert_equal(d2, d2_correct)
@@ -284,29 +359,57 @@ class TestDicke:
 
         d1, d2, d3, d4 = jmm1_dictionary(2)
 
-        d1_correct = {(3, 3): (0.0, -0.0, -0.0), (2, 2): (1.0, -1.0, -1.0),
-                      (2, 1): (1.0, -1.0, 0.0), (2, 0): (1.0, -1.0, 1.0),
-                      (1, 2): (1.0, 0.0, -1.0), (1, 1): (1.0, 0.0, 0.0),
-                      (1, 0): (1.0, 0.0, 1.0), (0, 2): (1.0, 1.0, -1.0),
-                      (0, 1): (1.0, 1.0, 0.0), (0, 0): (1.0, 1.0, 1.0)}
+        d1_correct = {
+            (3, 3): (0.0, -0.0, -0.0),
+            (2, 2): (1.0, -1.0, -1.0),
+            (2, 1): (1.0, -1.0, 0.0),
+            (2, 0): (1.0, -1.0, 1.0),
+            (1, 2): (1.0, 0.0, -1.0),
+            (1, 1): (1.0, 0.0, 0.0),
+            (1, 0): (1.0, 0.0, 1.0),
+            (0, 2): (1.0, 1.0, -1.0),
+            (0, 1): (1.0, 1.0, 0.0),
+            (0, 0): (1.0, 1.0, 1.0),
+        }
 
-        d2_correct = {(0.0, -0.0, -0.0): (3, 3), (1.0, -1.0, -1.0): (2, 2),
-                      (1.0, -1.0, 0.0): (2, 1), (1.0, -1.0, 1.0): (2, 0),
-                      (1.0, 0.0, -1.0): (1, 2), (1.0, 0.0, 0.0): (1, 1),
-                      (1.0, 0.0, 1.0): (1, 0), (1.0, 1.0, -1.0): (0, 2),
-                      (1.0, 1.0, 0.0): (0, 1), (1.0, 1.0, 1.0): (0, 0)}
+        d2_correct = {
+            (0.0, -0.0, -0.0): (3, 3),
+            (1.0, -1.0, -1.0): (2, 2),
+            (1.0, -1.0, 0.0): (2, 1),
+            (1.0, -1.0, 1.0): (2, 0),
+            (1.0, 0.0, -1.0): (1, 2),
+            (1.0, 0.0, 0.0): (1, 1),
+            (1.0, 0.0, 1.0): (1, 0),
+            (1.0, 1.0, -1.0): (0, 2),
+            (1.0, 1.0, 0.0): (0, 1),
+            (1.0, 1.0, 1.0): (0, 0),
+        }
 
-        d3_correct = {15: (0.0, -0.0, -0.0), 10: (1.0, -1.0, -1.0),
-                      9: (1.0, -1.0, 0.0), 8: (1.0, -1.0, 1.0),
-                      6: (1.0, 0.0, -1.0), 5: (1.0, 0.0, 0.0),
-                      4: (1.0, 0.0, 1.0), 2: (1.0, 1.0, -1.0),
-                      1: (1.0, 1.0, 0.0), 0: (1.0, 1.0, 1.0)}
+        d3_correct = {
+            15: (0.0, -0.0, -0.0),
+            10: (1.0, -1.0, -1.0),
+            9: (1.0, -1.0, 0.0),
+            8: (1.0, -1.0, 1.0),
+            6: (1.0, 0.0, -1.0),
+            5: (1.0, 0.0, 0.0),
+            4: (1.0, 0.0, 1.0),
+            2: (1.0, 1.0, -1.0),
+            1: (1.0, 1.0, 0.0),
+            0: (1.0, 1.0, 1.0),
+        }
 
-        d4_correct = {(0.0, -0.0, -0.0): 15, (1.0, -1.0, -1.0): 10,
-                      (1.0, -1.0, 0.0): 9, (1.0, -1.0, 1.0): 8,
-                      (1.0, 0.0, -1.0): 6, (1.0, 0.0, 0.0): 5,
-                      (1.0, 0.0, 1.0): 4, (1.0, 1.0, -1.0): 2,
-                      (1.0, 1.0, 0.0): 1, (1.0, 1.0, 1.0): 0}
+        d4_correct = {
+            (0.0, -0.0, -0.0): 15,
+            (1.0, -1.0, -1.0): 10,
+            (1.0, -1.0, 0.0): 9,
+            (1.0, -1.0, 1.0): 8,
+            (1.0, 0.0, -1.0): 6,
+            (1.0, 0.0, 0.0): 5,
+            (1.0, 0.0, 1.0): 4,
+            (1.0, 1.0, -1.0): 2,
+            (1.0, 1.0, 0.0): 1,
+            (1.0, 1.0, 1.0): 0,
+        }
 
         assert_equal(d1, d1_correct)
         assert_equal(d2, d2_correct)
@@ -325,9 +428,15 @@ class TestDicke:
         gD = 0.1
         gP = 0.1
 
-        system = Dicke(N=N, emission=gE, pumping=gP, dephasing=gD,
-                       collective_emission=gCE, collective_pumping=gCP,
-                       collective_dephasing=gCD)
+        system = Dicke(
+            N=N,
+            emission=gE,
+            pumping=gP,
+            dephasing=gD,
+            collective_emission=gCE,
+            collective_pumping=gCP,
+            collective_dephasing=gCD,
+        )
 
         lindbladian = system.lindbladian()
         Ldata = np.zeros((4, 4), dtype="complex")
@@ -336,8 +445,7 @@ class TestDicke:
         Ldata[2] = [0, 0, -0.9, 0]
         Ldata[3] = [0.6, 0, 0, -0.6]
 
-        lindbladian_correct = Qobj(Ldata, dims=[[[2], [2]], [[2], [2]]],
-                                   shape=(4, 4))
+        lindbladian_correct = Qobj(Ldata, dims=[[[2], [2]], [[2], [2]]], shape=(4, 4))
         assert_array_almost_equal(lindbladian.data.toarray(), Ldata)
         N = 2
         gCE = 0.5
@@ -346,9 +454,15 @@ class TestDicke:
         gE = 0.1
         gD = 0.1
         gP = 0.1
-        system = Dicke(N=N, emission=gE, pumping=gP, dephasing=gD,
-                       collective_emission=gCE, collective_pumping=gCP,
-                       collective_dephasing=gCD)
+        system = Dicke(
+            N=N,
+            emission=gE,
+            pumping=gP,
+            dephasing=gD,
+            collective_emission=gCE,
+            collective_pumping=gCP,
+            collective_dephasing=gCD,
+        )
 
         lindbladian = system.lindbladian()
 
@@ -357,18 +471,18 @@ class TestDicke:
         Ldata[1, 1], Ldata[1, 6] = -2, 1.1
         Ldata[2, 2] = -2.2999999999999998
         Ldata[4, 4], Ldata[4, 9] = -2, 1.1
-        Ldata[5, 0], Ldata[5, 5], Ldata[5, 10], Ldata[5, 15] = (1.1, -2.25,
-                                                                1.1, 0.05)
+        Ldata[5, 0], Ldata[5, 5], Ldata[5, 10], Ldata[5, 15] = (1.1, -2.25, 1.1, 0.05)
         Ldata[6, 1], Ldata[6, 6] = 1.1, -2
         Ldata[8, 8] = -2.2999999999999998
         Ldata[9, 4], Ldata[9, 9] = 1.1, -2
         Ldata[10, 5], Ldata[10, 10], Ldata[10, 15] = 1.1, -1.2, 0.1
-        Ldata[15, 0], Ldata[15, 5], Ldata[15, 10], Ldata[15, 15] = (0.1,
-                                                                    0.05,
-                                                                    0.1,
-                                                                    -0.25)
-        lindbladian_correct = Qobj(Ldata, dims=[[[4], [4]], [[4], [4]]],
-                                   shape=(16, 16))
+        Ldata[15, 0], Ldata[15, 5], Ldata[15, 10], Ldata[15, 15] = (
+            0.1,
+            0.05,
+            0.1,
+            -0.25,
+        )
+        lindbladian_correct = Qobj(Ldata, dims=[[[4], [4]], [[4], [4]]], shape=(16, 16))
         assert_array_almost_equal(lindbladian.data.toarray(), Ldata)
 
     def test_gamma(self):
@@ -386,26 +500,31 @@ class TestDicke:
         | 3,-3>
         """
         N = 6
-        collective_emission = 1.
-        emission = 1.
-        dephasing = 1.
-        pumping = 1.
-        collective_pumping = 1.
-        model = _Dicke(N, collective_emission=collective_emission,
-                       emission=emission, dephasing=dephasing,
-                       pumping=pumping, collective_pumping=collective_pumping)
-        tau_calculated = [model.gamma3((3, 1, 1)),
-                          model.gamma2((2, 1, 1)),
-                          model.gamma4((1, 1, 1)),
-                          model.gamma5((3, 0, 0)),
-                          model.gamma1((2, 0, 0)),
-                          model.gamma6((1, 0, 0)),
-                          model.gamma7((3, -1, -1)),
-                          model.gamma8((2, -1, -1)),
-                          model.gamma9((1, -1, -1))]
-        tau_real = [2., 8., 0.333333,
-                    1.5, -19.5, 0.666667,
-                    2., 8., 0.333333]
+        collective_emission = 1.0
+        emission = 1.0
+        dephasing = 1.0
+        pumping = 1.0
+        collective_pumping = 1.0
+        model = _Dicke(
+            N,
+            collective_emission=collective_emission,
+            emission=emission,
+            dephasing=dephasing,
+            pumping=pumping,
+            collective_pumping=collective_pumping,
+        )
+        tau_calculated = [
+            model.gamma3((3, 1, 1)),
+            model.gamma2((2, 1, 1)),
+            model.gamma4((1, 1, 1)),
+            model.gamma5((3, 0, 0)),
+            model.gamma1((2, 0, 0)),
+            model.gamma6((1, 0, 0)),
+            model.gamma7((3, -1, -1)),
+            model.gamma8((2, -1, -1)),
+            model.gamma9((1, -1, -1)),
+        ]
+        tau_real = [2.0, 8.0, 0.333333, 1.5, -19.5, 0.666667, 2.0, 8.0, 0.333333]
         assert_array_almost_equal(tau_calculated, tau_real)
 
     def test_jspin(self):
@@ -495,14 +614,13 @@ class TestDicke:
         state_deg = []
         state_deg = []
         for nn in [1, 2, 3, 4, 7, 8, 9, 10]:
-            state_deg.append(state_degeneracy(nn, nn/2))
+            state_deg.append(state_degeneracy(nn, nn / 2))
         for nn in [1, 2, 3, 4, 7, 8, 9, 10]:
-            state_deg.append(state_degeneracy(nn, (nn/2) % 1))
+            state_deg.append(state_degeneracy(nn, (nn / 2) % 1))
         assert_array_equal(state_deg, true_state_deg)
 
         # check error
         assert_raises(ValueError, state_degeneracy, 2, -1)
-
 
     def test_m_degeneracy(self):
         """
@@ -511,7 +629,7 @@ class TestDicke:
         true_m_deg = [1, 2, 2, 3, 4, 5, 5, 6]
         m_deg = []
         for nn in [1, 2, 3, 4, 7, 8, 9, 10]:
-            m_deg.append(m_degeneracy(nn, -(nn/2) % 1))
+            m_deg.append(m_degeneracy(nn, -(nn / 2) % 1))
         assert_array_equal(m_deg, true_m_deg)
 
         # check error
@@ -527,7 +645,7 @@ class TestDicke:
         true_ap_list = [110, 108, 104, 98, 90, 54, 38, 20, 0]
         ap_list = []
         for m in [0, 1, 2, 3, 4, 7, 8, 9, 10]:
-            ap_list.append(ap(10, m)**2)
+            ap_list.append(ap(10, m) ** 2)
 
         assert_almost_equal(ap_list, true_ap_list)
 
@@ -540,7 +658,7 @@ class TestDicke:
         true_am_list = [110, 110, 108, 104, 98, 68, 54, 38, 20]
         am_list = []
         for m in [0, 1, 2, 3, 4, 7, 8, 9, 10]:
-            am_list.append(am(10, m)**2)
+            am_list.append(am(10, m) ** 2)
 
         assert_almost_equal(am_list, true_am_list)
 
@@ -549,55 +667,75 @@ class TestDicke:
         PIQS: Test the function that creates the SU2 algebra in uncoupled basis.
         The list [sx, sy, sz, sp, sm] is checked for N = 2.
         """
-        sx1 = [[0.0 + 0.j, 0.0 + 0.j, 0.5 + 0.j, 0.0 + 0.j],
-               [0.0 + 0.j, 0.0 + 0.j, 0.0 + 0.j, 0.5 + 0.j],
-               [0.5 + 0.j, 0.0 + 0.j, 0.0 + 0.j, 0.0 + 0.j],
-               [0.0 + 0.j, 0.5 + 0.j, 0.0 + 0.j, 0.0 + 0.j]]
+        sx1 = [
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j],
+            [0.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+        ]
 
-        sx2 = [[0.0 + 0.j, 0.5 + 0.j, 0.0 + 0.j, 0.0 + 0.j],
-               [0.5 + 0.j, 0.0 + 0.j, 0.0 + 0.j, 0.0 + 0.j],
-               [0.0 + 0.j, 0.0 + 0.j, 0.0 + 0.j, 0.5 + 0.j],
-               [0.0 + 0.j, 0.0 + 0.j, 0.5 + 0.j, 0.0 + 0.j]]
+        sx2 = [
+            [0.0 + 0.0j, 0.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j, 0.0 + 0.0j],
+        ]
 
-        sy1 = [[0. + 0.j, 0. + 0.j, 0. - 0.5j, 0. + 0.j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. - 0.5j],
-               [0. + 0.5j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-               [0. + 0.j, 0. + 0.5j, 0. + 0.j, 0. + 0.j]]
+        sy1 = [
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 - 0.5j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 - 0.5j],
+            [0.0 + 0.5j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.5j, 0.0 + 0.0j, 0.0 + 0.0j],
+        ]
 
-        sy2 = [[0. + 0.j, 0. - 0.5j, 0. + 0.j, 0. + 0.j],
-               [0. + 0.5j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. - 0.5j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.5j, 0. + 0.j]]
+        sy2 = [
+            [0.0 + 0.0j, 0.0 - 0.5j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.5j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 - 0.5j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.5j, 0.0 + 0.0j],
+        ]
 
-        sz1 = [[0.5 + 0.j, 0.0 + 0.j, 0.0 + 0.j, 0.0 + 0.j],
-               [0.0 + 0.j, 0.5 + 0.j, 0.0 + 0.j, 0.0 + 0.j],
-               [0.0 + 0.j, 0.0 + 0.j, -0.5 + 0.j, 0.0 + 0.j],
-               [0.0 + 0.j, 0.0 + 0.j, 0.0 + 0.j, -0.5 + 0.j]]
+        sz1 = [
+            [0.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, -0.5 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, -0.5 + 0.0j],
+        ]
 
-        sz2 = [[0.5 + 0.j, 0.0 + 0.j, 0.0 + 0.j, 0.0 + 0.j],
-               [0.0 + 0.j, -0.5 + 0.j, 0.0 + 0.j, 0.0 + 0.j],
-               [0.0 + 0.j, 0.0 + 0.j, 0.5 + 0.j, 0.0 + 0.j],
-               [0.0 + 0.j, 0.0 + 0.j, 0.0 + 0.j, -0.5 + 0.j]]
+        sz2 = [
+            [0.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, -0.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, -0.5 + 0.0j],
+        ]
 
-        sp1 = [[0. + 0.j, 0. + 0.j, 1. + 0.j, 0. + 0.j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.j, 1. + 0.j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j]]
+        sp1 = [
+            [0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+        ]
 
-        sp2 = [[0. + 0.j, 1. + 0.j, 0. + 0.j, 0. + 0.j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.j, 1. + 0.j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j]]
+        sp2 = [
+            [0.0 + 0.0j, 1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+        ]
 
-        sm1 = [[0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-               [1. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-               [0. + 0.j, 1. + 0.j, 0. + 0.j, 0. + 0.j]]
+        sm1 = [
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+        ]
 
-        sm2 = [[0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-               [1. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-               [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-               [0. + 0.j, 0. + 0.j, 1. + 0.j, 0. + 0.j]]
+        sm2 = [
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j, 0.0 + 0.0j],
+        ]
 
         assert_array_equal(spin_algebra(2, "x")[0].full(), sx1)
         assert_array_equal(spin_algebra(2, "x")[1].full(), sx2)
@@ -621,30 +759,40 @@ class TestDicke:
         checked for N = 2.
         """
 
-        jx_n2 = [[0.0 + 0.j, 0.5 + 0.j, 0.5 + 0.j, 0.0 + 0.j],
-                 [0.5 + 0.j, 0.0 + 0.j, 0.0 + 0.j, 0.5 + 0.j],
-                 [0.5 + 0.j, 0.0 + 0.j, 0.0 + 0.j, 0.5 + 0.j],
-                 [0.0 + 0.j, 0.5 + 0.j, 0.5 + 0.j, 0.0 + 0.j]]
+        jx_n2 = [
+            [0.0 + 0.0j, 0.5 + 0.0j, 0.5 + 0.0j, 0.0 + 0.0j],
+            [0.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j],
+            [0.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j],
+            [0.0 + 0.0j, 0.5 + 0.0j, 0.5 + 0.0j, 0.0 + 0.0j],
+        ]
 
-        jy_n2 = [[0. + 0.j, 0. - 0.5j, 0. - 0.5j, 0. + 0.j],
-                 [0. + 0.5j, 0. + 0.j, 0. + 0.j, 0. - 0.5j],
-                 [0. + 0.5j, 0. + 0.j, 0. + 0.j, 0. - 0.5j],
-                 [0. + 0.j, 0. + 0.5j, 0. + 0.5j, 0. + 0.j]]
+        jy_n2 = [
+            [0.0 + 0.0j, 0.0 - 0.5j, 0.0 - 0.5j, 0.0 + 0.0j],
+            [0.0 + 0.5j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 - 0.5j],
+            [0.0 + 0.5j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 - 0.5j],
+            [0.0 + 0.0j, 0.0 + 0.5j, 0.0 + 0.5j, 0.0 + 0.0j],
+        ]
 
-        jz_n2 = [[1. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-                 [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-                 [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-                 [0. + 0.j, 0. + 0.j, 0. + 0.j, -1. + 0.j]]
+        jz_n2 = [
+            [1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, -1.0 + 0.0j],
+        ]
 
-        jp_n2 = [[0. + 0.j, 1. + 0.j, 1. + 0.j, 0. + 0.j],
-                 [0. + 0.j, 0. + 0.j, 0. + 0.j, 1. + 0.j],
-                 [0. + 0.j, 0. + 0.j, 0. + 0.j, 1. + 0.j],
-                 [0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j]]
+        jp_n2 = [
+            [0.0 + 0.0j, 1.0 + 0.0j, 1.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+        ]
 
-        jm_n2 = [[0. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-                 [1. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-                 [1. + 0.j, 0. + 0.j, 0. + 0.j, 0. + 0.j],
-                 [0. + 0.j, 1. + 0.j, 1. + 0.j, 0. + 0.j]]
+        jm_n2 = [
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 1.0 + 0.0j, 1.0 + 0.0j, 0.0 + 0.0j],
+        ]
 
         assert_array_equal(jspin(2, "x", basis="uncoupled").full(), jx_n2)
         assert_array_equal(jspin(2, "y", basis="uncoupled").full(), jy_n2)
@@ -662,19 +810,25 @@ class TestDicke:
         If the matrix element |j,m><j,m'| is allowed it is 1, otherwise 0.
         """
         # N = 1 TLSs
-        block_1 = [[1., 1.], [1., 1.]]
+        block_1 = [[1.0, 1.0], [1.0, 1.0]]
 
         # N = 2 TLSs
-        block_2 = [[1., 1., 1., 0.], [1., 1., 1., 0.],
-                   [1., 1., 1., 0.], [0., 0., 0., 1.]]
+        block_2 = [
+            [1.0, 1.0, 1.0, 0.0],
+            [1.0, 1.0, 1.0, 0.0],
+            [1.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
 
         # N = 3 TLSs
-        block_3 = [[1., 1., 1., 1., 0., 0.],
-                   [1., 1., 1., 1., 0., 0.],
-                   [1., 1., 1., 1., 0., 0.],
-                   [1., 1., 1., 1., 0., 0.],
-                   [0., 0., 0., 0., 1., 1.],
-                   [0., 0., 0., 0., 1., 1.]]
+        block_3 = [
+            [1.0, 1.0, 1.0, 1.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0, 1.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0, 1.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+        ]
 
         assert_equal(Qobj(block_1), Qobj(block_matrix(1)))
         assert_equal(Qobj(block_2), Qobj(block_matrix(2)))
@@ -760,7 +914,7 @@ class TestDicke:
         test_state_uncoupled = excited(2, basis="uncoupled")
         assert_array_equal(test_state_uncoupled.dims, [[2, 2], [2, 2]])
         assert_array_equal(test_state_uncoupled.shape, (4, 4))
-        assert_almost_equal(test_state_uncoupled.full()[0, 0], 1+0j)
+        assert_almost_equal(test_state_uncoupled.full()[0, 0], 1 + 0j)
 
     def test_superradiant(self):
         """
@@ -787,7 +941,7 @@ class TestDicke:
         test_state_uncoupled = superradiant(2, basis="uncoupled")
         assert_array_equal(test_state_uncoupled.dims, [[2, 2], [2, 2]])
         assert_array_equal(test_state_uncoupled.shape, (4, 4))
-        assert_almost_equal(test_state_uncoupled.full()[1, 1], 1+0j)
+        assert_almost_equal(test_state_uncoupled.full()[1, 1], 1 + 0j)
 
     def test_ghz(self):
         """
@@ -795,10 +949,12 @@ class TestDicke:
 
         PIQS: Test for N = 2 in the 'dicke' and in the 'uncoupled' basis.
         """
-        ghz_dicke = Qobj([[0.5, 0, 0.5, 0], [0, 0, 0, 0],
-                          [0.5, 0, 0.5, 0], [0, 0, 0, 0]])
-        ghz_uncoupled = Qobj([[0.5, 0, 0, 0.5], [0, 0, 0, 0],
-                              [0, 0, 0, 0], [0.5, 0, 0, 0.5]])
+        ghz_dicke = Qobj(
+            [[0.5, 0, 0.5, 0], [0, 0, 0, 0], [0.5, 0, 0.5, 0], [0, 0, 0, 0]]
+        )
+        ghz_uncoupled = Qobj(
+            [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]]
+        )
         ghz_uncoupled.dims = [[2, 2], [2, 2]]
         assert_equal(ghz(2), ghz_dicke)
         assert_equal(ghz(2, "uncoupled"), ghz_uncoupled)
@@ -832,24 +988,43 @@ class TestDicke:
         """
         test_identity = identity_uncoupled(4)
         assert_equal(test_identity.dims, [[2, 2, 2, 2], [2, 2, 2, 2]])
-        assert_array_equal(np.diag(test_identity.full()), np.ones(16,
-                                                                  np.complex))
+        assert_array_equal(np.diag(test_identity.full()), np.ones(16, np.complex))
 
     def test_css(self):
         """
         PIQS: Test the calculation of the CSS state.
         """
-        test_css_uncoupled = css(2, basis='uncoupled')
+        test_css_uncoupled = css(2, basis="uncoupled")
         test_css_dicke = css(2)
-        css_uncoupled = 0.25*np.ones((4, 4), dtype=np.complex)
-        css_dicke = np.array([[0.25000000+0.j, 0.35355339+0.j,
-                               0.25000000+0.j, 0.00000000+0.j],
-                               [0.35355339+0.j, 0.50000000+0.j,
-                               0.35355339+0.j,  0.00000000+0.j],
-                               [ 0.25000000+0.j, 0.35355339+0.j,
-                               0.25000000+0.j, 0.00000000+0.j],
-                               [0.00000000+0.j, 0.00000000+0.j,
-                               0.00000000+0.j, 0.00000000+0.j]])
+        css_uncoupled = 0.25 * np.ones((4, 4), dtype=np.complex)
+        css_dicke = np.array(
+            [
+                [
+                    0.25000000 + 0.0j,
+                    0.35355339 + 0.0j,
+                    0.25000000 + 0.0j,
+                    0.00000000 + 0.0j,
+                ],
+                [
+                    0.35355339 + 0.0j,
+                    0.50000000 + 0.0j,
+                    0.35355339 + 0.0j,
+                    0.00000000 + 0.0j,
+                ],
+                [
+                    0.25000000 + 0.0j,
+                    0.35355339 + 0.0j,
+                    0.25000000 + 0.0j,
+                    0.00000000 + 0.0j,
+                ],
+                [
+                    0.00000000 + 0.0j,
+                    0.00000000 + 0.0j,
+                    0.00000000 + 0.0j,
+                    0.00000000 + 0.0j,
+                ],
+            ]
+        )
         assert_array_almost_equal(test_css_uncoupled.full(), css_uncoupled)
         assert_array_almost_equal(test_css_dicke.full(), css_dicke)
 
@@ -860,10 +1035,14 @@ class TestDicke:
         In the "uncoupled" basis of N two-level system (TLS).
         The test is performed for N = 2 and emission = 1.
         """
-        c1 = Qobj([[0, 0, 0, 0], [0, 0, 0, 0], [1, 0, 0, 0],
-                   [0, 1, 0, 0]], dims=[[2, 2], [2, 2]])
-        c2 = Qobj([[0, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0],
-                   [0, 0, 1, 0]], dims=[[2, 2], [2, 2]])
+        c1 = Qobj(
+            [[0, 0, 0, 0], [0, 0, 0, 0], [1, 0, 0, 0], [0, 1, 0, 0]],
+            dims=[[2, 2], [2, 2]],
+        )
+        c2 = Qobj(
+            [[0, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0]],
+            dims=[[2, 2], [2, 2]],
+        )
         true_c_ops = [c1, c2]
         assert_equal(true_c_ops, collapse_uncoupled(N=2, emission=1))
         system = Dicke(N=2, emission=1)
@@ -905,14 +1084,23 @@ class TestDicke:
         """
         PIQS: Test the calculation of the lindbladian matrix.
         """
-        true_L = [[-4, 0, 0, 3], [0, -3.54999995, 0, 0],
-                  [0, 0, -3.54999995, 0], [4, 0, 0, -3]]
+        true_L = [
+            [-4, 0, 0, 3],
+            [0, -3.54999995, 0, 0],
+            [0, 0, -3.54999995, 0],
+            [4, 0, 0, -3],
+        ]
         true_L = Qobj(true_L)
         true_L.dims = [[[2], [2]], [[2], [2]]]
         N = 1
-        test_dicke = _Dicke(N=N, pumping=1, collective_pumping=2,
-                            emission=1, collective_emission=3,
-                            dephasing=0.1)
+        test_dicke = _Dicke(
+            N=N,
+            pumping=1,
+            collective_pumping=2,
+            emission=1,
+            collective_emission=3,
+            dephasing=0.1,
+        )
         test_L = test_dicke.lindbladian()
         assert_array_almost_equal(test_L.full(), true_L.full())
         assert_array_equal(test_L.dims, true_L.dims)
@@ -921,35 +1109,50 @@ class TestDicke:
         """
         PIQS: Test the calculation of the liouvillian matrix.
         """
-        true_L = [[-4, 0, 0, 3], [0, -3.54999995, 0, 0],
-                  [0, 0, -3.54999995, 0], [4, 0, 0, -3]]
+        true_L = [
+            [-4, 0, 0, 3],
+            [0, -3.54999995, 0, 0],
+            [0, 0, -3.54999995, 0],
+            [4, 0, 0, -3],
+        ]
         true_L = Qobj(true_L)
         true_L.dims = [[[2], [2]], [[2], [2]]]
-        true_H = [[1. + 0.j, 1. + 0.j], [1. + 0.j, -1. + 0.j]]
+        true_H = [[1.0 + 0.0j, 1.0 + 0.0j], [1.0 + 0.0j, -1.0 + 0.0j]]
         true_H = Qobj(true_H)
         true_H.dims = [[[2], [2]]]
-        true_liouvillian = [[-4, -1.j, 1.j, 3],
-                            [-1.j, -3.54999995 + 2.j, 0, 1.j],
-                            [1.j, 0, -3.54999995 - 2.j, -1.j],
-                            [4, +1.j, -1.j, -3]]
+        true_liouvillian = [
+            [-4, -1.0j, 1.0j, 3],
+            [-1.0j, -3.54999995 + 2.0j, 0, 1.0j],
+            [1.0j, 0, -3.54999995 - 2.0j, -1.0j],
+            [4, +1.0j, -1.0j, -3],
+        ]
         true_liouvillian = Qobj(true_liouvillian)
         true_liouvillian.dims = [[[2], [2]], [[2], [2]]]
         N = 1
-        test_piqs = Dicke(hamiltonian=sigmaz() + sigmax(), N=N,
-                          pumping=1, collective_pumping=2, emission=1,
-                          collective_emission=3, dephasing=0.1)
+        test_piqs = Dicke(
+            hamiltonian=sigmaz() + sigmax(),
+            N=N,
+            pumping=1,
+            collective_pumping=2,
+            emission=1,
+            collective_emission=3,
+            dephasing=0.1,
+        )
         test_liouvillian = test_piqs.liouvillian()
         test_hamiltonian = test_piqs.hamiltonian
-        assert_array_almost_equal(
-            test_liouvillian.full(),
-            true_liouvillian.full())
+        assert_array_almost_equal(test_liouvillian.full(), true_liouvillian.full())
         assert_array_almost_equal(test_hamiltonian.full(), true_H.full())
         assert_array_equal(test_liouvillian.dims, test_liouvillian.dims)
 
         # no Hamiltonian
-        test_piqs = Dicke(N=N,
-                          pumping=1, collective_pumping=2, emission=1,
-                          collective_emission=3, dephasing=0.1)
+        test_piqs = Dicke(
+            N=N,
+            pumping=1,
+            collective_pumping=2,
+            emission=1,
+            collective_emission=3,
+            dephasing=0.1,
+        )
         liouv = test_piqs.liouvillian()
         lindblad = test_piqs.lindbladian()
         assert_equal(liouv, lindblad)
@@ -1174,10 +1377,12 @@ class TestDicke:
         assert_almost_equal(true_gamma_3, test_gamma_3)
         assert_almost_equal(true_gamma_4, test_gamma_4)
 
+
 class TestPim:
     """
     Tests for the `qutip.piqs.Pim` class.
     """
+
     def test_gamma(self):
         """
         PIQS: Test the calculation of various gamma values for diagonal system.
@@ -1193,26 +1398,31 @@ class TestPim:
         | 3,-3>
         """
         N = 6
-        collective_emission = 1.
-        emission = 1.
-        dephasing = 1.
-        pumping = 1.
-        collective_pumping = 1.
-        model = Pim(N, collective_emission=collective_emission,
-                       emission=emission, dephasing=dephasing,
-                       pumping=pumping, collective_pumping=collective_pumping)
-        tau_calculated = [model.tau3(3, 1),
-                          model.tau2(2, 1),
-                          model.tau4(1, 1),
-                          model.tau5(3, 0),
-                          model.tau1(2, 0),
-                          model.tau6(1, 0),
-                          model.tau7(3, -1),
-                          model.tau8(2, -1),
-                          model.tau9(1, -1)]
-        tau_real = [2., 8., 0.333333,
-                    1.5, -19.5, 0.666667,
-                    2., 8., 0.333333]
+        collective_emission = 1.0
+        emission = 1.0
+        dephasing = 1.0
+        pumping = 1.0
+        collective_pumping = 1.0
+        model = Pim(
+            N,
+            collective_emission=collective_emission,
+            emission=emission,
+            dephasing=dephasing,
+            pumping=pumping,
+            collective_pumping=collective_pumping,
+        )
+        tau_calculated = [
+            model.tau3(3, 1),
+            model.tau2(2, 1),
+            model.tau4(1, 1),
+            model.tau5(3, 0),
+            model.tau1(2, 0),
+            model.tau6(1, 0),
+            model.tau7(3, -1),
+            model.tau8(2, -1),
+            model.tau9(1, -1),
+        ]
+        tau_real = [2.0, 8.0, 0.333333, 1.5, -19.5, 0.666667, 2.0, 8.0, 0.333333]
         assert_array_almost_equal(tau_calculated, tau_real)
 
     def test_isdicke(self):
@@ -1220,12 +1430,12 @@ class TestPim:
         PIQS: Test the `isdicke` function
         """
         N1 = 1
-        g0=.01
-        nth=.01
-        gP=g0*nth
-        gL=g0*(0.1+nth)
-        gS= 0.1
-        gD= 0.1
+        g0 = 0.01
+        nth = 0.01
+        gP = g0 * nth
+        gL = g0 * (0.1 + nth)
+        gS = 0.1
+        gD = 0.1
 
         pim1 = Pim(N1, gS, gL, gD, gP)
 
@@ -1245,9 +1455,9 @@ class TestPim:
         PIQS: Test the isdiagonal function.
         """
         mat1 = np.array([[1, 2], [3, 4]])
-        mat2 = np.array([[1, 0.], [0., 2]])
-        mat3 = np.array([[1+1j, 0.], [0.-2j, 2-2j]])
-        mat4 = np.array([[1+1j, 0.], [0., 2-2j]])
+        mat2 = np.array([[1, 0.0], [0.0, 2]])
+        mat3 = np.array([[1 + 1j, 0.0], [0.0 - 2j, 2 - 2j]])
+        mat4 = np.array([[1 + 1j, 0.0], [0.0, 2 - 2j]])
         assert_equal(isdiagonal(mat1), False)
         assert_equal(isdiagonal(mat2), True)
         assert_equal(isdiagonal(mat3), False)
@@ -1269,7 +1479,7 @@ class TestPim:
         test_matrix = ensemble.coefficient_matrix().todense()
         ensemble2 = Dicke(N, emission=1)
         test_matrix2 = ensemble.coefficient_matrix().todense()
-        true_matrix = [[-2, 0, 0, 0], [ 1, -1, 0, 0], [ 0, 1, 0, 1.], [ 1, 0, 0, -1.]]
+        true_matrix = [[-2, 0, 0, 0], [1, -1, 0, 0], [0, 1, 0, 1.0], [1, 0, 0, -1.0]]
 
         assert_array_almost_equal(test_matrix, true_matrix)
         assert_array_almost_equal(test_matrix2, true_matrix)
@@ -1290,21 +1500,19 @@ class TestPim:
         non_diag_initial_state = ghz(4)
         tlist = np.linspace(0, 10, 100)
 
-        assert_raises(ValueError, non_diag_system.pisolve,
-                      diag_initial_state, tlist)
-        assert_raises(ValueError, non_diag_system.pisolve,
-                      non_diag_initial_state, tlist)
-        assert_raises(ValueError, diag_system.pisolve,
-                      non_diag_initial_state, tlist)
+        assert_raises(ValueError, non_diag_system.pisolve, diag_initial_state, tlist)
+        assert_raises(
+            ValueError, non_diag_system.pisolve, non_diag_initial_state, tlist
+        )
+        assert_raises(ValueError, diag_system.pisolve, non_diag_initial_state, tlist)
 
-        non_dicke_initial_state = excited(4, basis='uncoupled')
-        assert_raises(ValueError, diag_system.pisolve,
-                      non_dicke_initial_state, tlist)
+        non_dicke_initial_state = excited(4, basis="uncoupled")
+        assert_raises(ValueError, diag_system.pisolve, non_dicke_initial_state, tlist)
 
         # no Hamiltonian
         no_hamiltonian_system = Dicke(4, emission=0.1)
         result = no_hamiltonian_system.pisolve(diag_initial_state, tlist)
-        assert_equal(True, len(result.states)>0)
+        assert_equal(True, len(result.states) > 0)
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -38,7 +38,7 @@ from numpy.testing import (assert_, run_module_suite, assert_raises,
                            assert_array_equal, assert_array_almost_equal,
                            assert_almost_equal, assert_equal)
 
-from qutip import Qobj, entropy_vn
+from qutip import Qobj, entropy_vn,sigmax,sigmaz
 from qutip.cy.piqs import (get_blocks, j_min, j_vals, m_vals,
                            _num_dicke_states, _num_dicke_ladders,
                            get_index, jmm1_dictionary)

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -38,7 +38,7 @@ from numpy.testing import (assert_, run_module_suite, assert_raises,
                            assert_array_equal, assert_array_almost_equal,
                            assert_almost_equal, assert_equal)
 
-from qutip import Qobj
+from qutip import Qobj, entropy_vn
 from qutip.cy.piqs import (get_blocks, j_min, j_vals, m_vals,
                            _num_dicke_states, _num_dicke_ladders,
                            get_index, jmm1_dictionary)

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -154,6 +154,23 @@ class TestDicke:
         true_expanded[0,0] = 1.
         assert_(test_matrix == Qobj(true_expanded))
         
+    def test_dicke_trace(self):
+        """
+        PIQS: Test the `dicke_trace` function.
+        """
+        N = 3
+        rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
+        test_val = dicke_trace(rho_mixed,f=None)
+        true_val = (expand_dicke_matrix(rho_mixed)).tr()
+        true_val2 = (rho_mixed).tr()
+        # test with linear function (trace)
+        assert_almost_equal(test_val,true_val)
+        assert_almost_equal(test_val,true_val2)
+        # test with nonlinear function
+        test_val3 = dicke_trace(rho_mixed,lambda rho: (rho**3).tr())
+        true_val3 = (expand_dicke_matrix(rho_mixed)**3).tr()
+        assert_almost_equal(test_val3,true_val3)
+        
     def test_entropy_vn_dicke(self):
         """
         PIQS: Test the `entropy_vn_dicke` function.

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -154,7 +154,7 @@ class TestDicke:
         true_expanded[0,0] = 1.
         assert_(test_matrix == Qobj(true_expanded))
         
-    def test_dicke_trace(self):
+    def test_dicke_function_trace(self):
         """
         PIQS: Test the `dicke_trace` function.
         """

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -43,7 +43,7 @@ from numpy.testing import (
     assert_almost_equal,
     assert_equal,
 )
-
+from scipy.sparse import block_diag
 from qutip import Qobj, entropy_vn, sigmax, sigmaz
 from qutip.cy.piqs import (
     get_blocks,
@@ -150,28 +150,32 @@ class TestDicke:
         for (i, j) in zip(m_real, m_calc):
             assert_array_equal(i, j)
 
-    def test_mask_dicke_matrix(self):
+    def test_dicke_blocks(self):
         """
-        PIQS: Test the `mask_dicke_matrix` function.
+        PIQS: Test the `dicke_blocks` function.
         """
         # test 1
         # mixed state with non-symmetrical block matrix elements
         N = 3
         true_matrix = (excited(N) + dicke(N, 0.5, 0.5)).unit()
-        test_matrix = mask_dicke_matrix(true_matrix)
+        test_blocks = dicke_blocks(true_matrix)
+        test_matrix = Qobj(block_diag(test_blocks))
         assert_(test_matrix == true_matrix)
         # test 2
         # all elements in block-diagonal matrix
         N = 4
         true_matrix = Qobj(block_matrix(N)).unit()
-        test_matrix = mask_dicke_matrix(true_matrix)
+        test_blocks = dicke_blocks(true_matrix)
+        test_matrix = Qobj(block_diag(test_blocks))
         assert_(test_matrix == true_matrix)
 
-    def test_expand_dicke_matrix(self):
+    def test_dicke_blocks_full(self):
         """
-        PIQS: Test the `expand_dicke_matrix` function.
+        PIQS: Test the `dicke_blocks_full` function.
         """
-        test_matrix = expand_dicke_matrix(excited(3))
+        N = 3
+        test_blocks = dicke_blocks_full(excited(3))
+        test_matrix = Qobj(block_diag(test_blocks))
         true_expanded = np.zeros((8, 8))
         true_expanded[0, 0] = 1.0
         assert_(test_matrix == Qobj(true_expanded))
@@ -186,7 +190,7 @@ class TestDicke:
         rho_mixed = (excited(N) + dicke(N, 0.5, 0.5)).unit()
         f = lambda x: x
         test_val = dicke_function_trace(f, rho_mixed)
-        true_val = (expand_dicke_matrix(rho_mixed)).tr()
+        true_val = (Qobj(block_diag(dicke_blocks_full(rho_mixed)))).tr()
         true_val2 = (rho_mixed).tr()
         # test with linear function (trace)
         assert_almost_equal(test_val, true_val)
@@ -194,7 +198,7 @@ class TestDicke:
         # test with nonlinear function
         f = lambda rho: rho ** 3
         test_val3 = dicke_function_trace(f, rho_mixed)
-        true_val3 = (expand_dicke_matrix(rho_mixed) ** 3).tr()
+        true_val3 = (Qobj(block_diag(dicke_blocks_full(rho_mixed))) ** 3).tr()
         assert_almost_equal(test_val3, true_val3)
         ## test for N even
         N = 4
@@ -202,7 +206,7 @@ class TestDicke:
         rho_mixed = (excited(N) + dicke(N, 0, 0)).unit()
         f = lambda x: x
         test_val = dicke_function_trace(f, rho_mixed)
-        true_val = (expand_dicke_matrix(rho_mixed)).tr()
+        true_val = (Qobj(block_diag(dicke_blocks_full(rho_mixed)))).tr()
         true_val2 = (rho_mixed).tr()
         # test with linear function (trace)
         assert_almost_equal(test_val, true_val)
@@ -210,7 +214,7 @@ class TestDicke:
         # test with nonlinear function
         f = lambda rho: rho ** 3
         test_val3 = dicke_function_trace(f, rho_mixed)
-        true_val3 = (expand_dicke_matrix(rho_mixed) ** 3).tr()
+        true_val3 = (Qobj(block_diag(dicke_blocks_full(rho_mixed))) ** 3).tr()
         assert np.allclose(test_val3, true_val3)
 
     def test_entropy_vn_dicke(self):
@@ -220,7 +224,7 @@ class TestDicke:
         N = 3
         rho_mixed = (excited(N) + dicke(N, 0.5, 0.5)).unit()
         test_val = entropy_vn_dicke(rho_mixed)
-        true_val = entropy_vn(expand_dicke_matrix(rho_mixed))
+        true_val = entropy_vn(Qobj(block_diag(dicke_blocks_full(rho_mixed))))
         assert np.allclose(test_val, true_val)
 
     def test_purity_dicke(self):
@@ -230,7 +234,7 @@ class TestDicke:
         N = 3
         rho_mixed = (excited(N) + dicke(N, 0.5, 0.5)).unit()
         test_val = purity_dicke(rho_mixed)
-        true_val = (expand_dicke_matrix(rho_mixed)).purity()
+        true_val = (Qobj(block_diag(dicke_blocks_full(rho_mixed)))).purity()
         assert np.allclose(test_val, true_val)
 
     def test_get_index(self):

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -156,20 +156,38 @@ class TestDicke:
         
     def test_dicke_function_trace(self):
         """
-        PIQS: Test the `dicke_trace` function.
+        PIQS: Test the `dicke_function_trace` function.
         """
         N = 3
+        # test trace
         rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
-        test_val = dicke_trace(rho_mixed,f=None)
+        f = lambda x:x
+        test_val = dicke_function_trace(f,rho_mixed)
         true_val = (expand_dicke_matrix(rho_mixed)).tr()
         true_val2 = (rho_mixed).tr()
         # test with linear function (trace)
         assert_almost_equal(test_val,true_val)
         assert_almost_equal(test_val,true_val2)
         # test with nonlinear function
-        test_val3 = dicke_trace(rho_mixed,lambda rho: (rho**3).tr())
+        f = lambda rho: rho**3
+        test_val3 = dicke_function_trace(f,rho_mixed)
         true_val3 = (expand_dicke_matrix(rho_mixed)**3).tr()
         assert_almost_equal(test_val3,true_val3)
+        N = 4
+        # test trace
+        rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
+        f = lambda x:x
+        test_val = dicke_function_trace(f,rho_mixed)
+        true_val = (expand_dicke_matrix(rho_mixed)).tr()
+        true_val2 = (rho_mixed).tr()
+        # test with linear function (trace)
+        assert_almost_equal(test_val,true_val)
+        assert_almost_equal(test_val,true_val2)
+        # test with nonlinear function
+        f = lambda rho: rho**3
+        test_val3 = dicke_function_trace(f,rho_mixed)
+        true_val3 = (expand_dicke_matrix(rho_mixed)**3).tr()
+        assert np.allclose(test_val3, true_val3)
         
     def test_entropy_vn_dicke(self):
         """
@@ -179,7 +197,7 @@ class TestDicke:
         rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
         test_val = entropy_vn_dicke(rho_mixed)
         true_val = entropy_vn(expand_dicke_matrix(rho_mixed))
-        assert_(test_val == true_val)
+        assert np.allclose(test_val, true_val)
 
     def test_purity_dicke(self):
         """
@@ -189,7 +207,7 @@ class TestDicke:
         rho_mixed = (excited(N)+dicke(N,0.5,0.5)).unit()
         test_val = purity_dicke(rho_mixed)
         true_val = (expand_dicke_matrix(rho_mixed)).purity()
-        assert_(test_val == true_val)
+        assert np.allclose(test_val, true_val)
 
     def test_get_index(self):
         """


### PR DESCRIPTION
Addressing #993: nonlinear functions such as the Von Neumann entropy or purity of a density matrix written in the Dicke basis need to account for the identical copies of the blocks relative to non-symmetrical Dicke states. 

This can be done by cycling into the blocks and applying the correct weight accounting for degeneracy (using `piqs.state_degeneracy`). 

This PR also contains auxiliary functions to visualize and unpack the Dicke-basis density matrix into the full 2^N space still of collective spin but with degenerate blocks. 

It uses the `purity` method proposed in #1045. 

Will add info in User Guide and notebooks to highlight this features that need to be considered to correctly calculate nonlinear functions of a density matrix in the Dicke basis.  