### PR TITLE
Time-dependent coefficients without cubic interpolation in QobjEvo

### DIFF
--- a/qutip/cy/cqobjevo_factor.pyx
+++ b/qutip/cy/cqobjevo_factor.pyx
@@ -227,7 +227,7 @@ cdef class InterCoeffT(CoeffFunc):
         self.M = state[5]
 
 
-cdef class StepCoeffT(CoeffFunc):
+cdef class StepCoeff(CoeffFunc):
     cdef int n_t
     cdef double[::1] tlist
     cdef complex[:,::1] y
@@ -243,58 +243,32 @@ cdef class StepCoeffT(CoeffFunc):
             for j in range(self.n_t):
                 self.y[i,j] = ops[i][2][j]
         
+    def set_arg(self, args):
+        pass
+
+    def __getstate__(self):
+        return (self._num_ops, self.n_t, None, np.array(self.tlist),
+                np.array(self.y))
+
+    def __setstate__(self, state):
+        self._num_ops = state[0]
+        self.n_t = state[1]
+        self.tlist = state[3]
+        self.y = state[4]
+
+
+cdef class StepCoeffT(StepCoeff):
     cdef void _call_core(self, double t, complex* coeff):
         cdef int i
         for i in range(self._num_ops):
             coeff[i] = _step_complex_t(t, self.tlist, self.y[i, :], self.n_t)
 
-    def set_arg(self, args):
-        pass
 
-    def __getstate__(self):
-        return (self._num_ops, self.n_t, None, np.array(self.tlist),
-                np.array(self.y))
-
-    def __setstate__(self, state):
-        self._num_ops = state[0]
-        self.n_t = state[1]
-        self.tlist = state[3]
-        self.y = state[4]
-
-
-cdef class StepCoeffCte(CoeffFunc):
-    cdef int n_t
-    cdef double[::1] tlist
-    cdef complex[:,::1] y
-
-    def __init__(self, ops, args, tlist):
-        cdef int i, j
-        self._args = {}
-        self._num_ops = len(ops)
-        self.tlist = tlist
-        self.n_t = len(tlist)
-        self.y = np.zeros((self._num_ops, self.n_t), dtype=complex)
-        for i in range(self._num_ops):
-            for j in range(self.n_t):
-                self.y[i,j] = ops[i][2][j]
-        
+cdef class StepCoeffCte(StepCoeff): 
     cdef void _call_core(self, double t, complex* coeff):
         cdef int i
         for i in range(self._num_ops):
             coeff[i] = _step_complex_cte(t, self.tlist, self.y[i, :], self.n_t)
-
-    def set_arg(self, args):
-        pass
-
-    def __getstate__(self):
-        return (self._num_ops, self.n_t, None, np.array(self.tlist),
-                np.array(self.y))
-
-    def __setstate__(self, state):
-        self._num_ops = state[0]
-        self.n_t = state[1]
-        self.tlist = state[3]
-        self.y = state[4]
 
 
 cdef class StrCoeff(CoeffFunc):

--- a/qutip/cy/cqobjevo_factor.pyx
+++ b/qutip/cy/cqobjevo_factor.pyx
@@ -245,7 +245,6 @@ cdef class StepCoeffT(CoeffFunc):
         
     cdef void _call_core(self, double t, complex* coeff):
         cdef int i
-        # t_ind = np.searchsorted(self.tlist, t, side='right') - 1
         for i in range(self._num_ops):
             coeff[i] = _step_complex_t(t, self.tlist, self.y[i, :], self.n_t)
 
@@ -261,13 +260,6 @@ cdef class StepCoeffT(CoeffFunc):
         self.n_t = state[1]
         self.tlist = state[3]
         self.y = state[4]
-
-    def temp(self, t):
-        cdef int c_t = t
-        # TODO how is dynamic length handled?
-        cdef complex coeff[10]
-        self._call_core(c_t, &coeff[0])
-        return coeff
 
 
 cdef class StepCoeffCte(CoeffFunc):
@@ -303,12 +295,6 @@ cdef class StepCoeffCte(CoeffFunc):
         self.n_t = state[1]
         self.tlist = state[3]
         self.y = state[4]
-
-    def temp(self, t):
-        cdef int c_t = t
-        cdef complex coeff[10]
-        self._call_core(c_t, &coeff[0])
-        return coeff
 
 
 cdef class StrCoeff(CoeffFunc):

--- a/qutip/cy/inter.pxd
+++ b/qutip/cy/inter.pxd
@@ -48,3 +48,11 @@ cdef double _spline_float_t_second(double x, double[::1] t,
 cdef double _spline_float_cte_second(double x, double[::1] t,
                                      double[::1] y, double[::1] M,
                                      int N, double dt)
+
+cdef double _step_float_cte(double x, double[::1] t, double[::1] y, int n_t)
+
+cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y, int n_t)
+
+cdef double _step_float_t(double x, double[::1] t, double[::1] y, int n_t)
+
+cdef complex _step_complex_t(double x, double[::1] t, complex[::1] y, int n_t)

--- a/qutip/cy/inter.pyx
+++ b/qutip/cy/inter.pyx
@@ -196,3 +196,53 @@ cdef complex _spline_complex_t_second(double x,
     cdef complex Mb = M[p] * dt2
     return te * (Mb * te * te + (y[p]   - Mb)) + \
            tb * (Me * tb * tb + (y[p+1] - Me))
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef double _step_float_cte(double x, double[::1] t, double[::1] y, int n_t):
+    if x < t[0]:
+        return 0
+    elif x >= t[n_t-1]:
+        return 0
+    cdef int ind = <int>(x/t[n_t-1]*(n_t-1))
+    return y[ind]
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y, int n_t):
+    if x < t[0]:
+        return 0
+    elif x >= t[n_t-1]:
+        return 0
+    cdef int ind = <int>(x/t[n_t-1]*(n_t-1))
+    return y[ind]
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef double _step_float_t(double x, double[::1] t, double[::1] y, int n_t):
+    if x < t[0]:
+        return 0
+    elif x >= t[n_t-1]:
+        return 0
+    # TODO this can be moved out for better performance
+    cdef int ind = _binary_search(x, t, n_t)
+    return y[ind]
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef complex _step_complex_t(double x, double[::1] t, complex[::1] y, int n_t):
+    if x < t[0]:
+        return 0
+    elif x >= t[n_t-1]:
+        return 0
+    # TODO this can be moved out for better performance
+    cdef int ind = _binary_search(x, t, n_t)
+    return y[ind]

--- a/qutip/cy/inter.pyx
+++ b/qutip/cy/inter.pyx
@@ -203,9 +203,9 @@ cdef complex _spline_complex_t_second(double x,
 @cython.cdivision(True)
 cdef double _step_float_cte(double x, double[::1] t, double[::1] y, int n_t):
     if x < t[0]:
-        return 0
+        return y[0]
     elif x >= t[n_t-1]:
-        return 0
+        return y[n_t-1]
     cdef int ind = <int>(x/t[n_t-1]*(n_t-1))
     return y[ind]
 
@@ -215,9 +215,9 @@ cdef double _step_float_cte(double x, double[::1] t, double[::1] y, int n_t):
 @cython.cdivision(True)
 cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y, int n_t):
     if x < t[0]:
-        return 0
+        return y[0]
     elif x >= t[n_t-1]:
-        return 0
+        return y[n_t-1]
     cdef int ind = <int>(x/t[n_t-1]*(n_t-1))
     return y[ind]
 
@@ -227,9 +227,9 @@ cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y, int n_t)
 @cython.cdivision(True)
 cdef double _step_float_t(double x, double[::1] t, double[::1] y, int n_t):
     if x < t[0]:
-        return 0
+        return y[0]
     elif x >= t[n_t-1]:
-        return 0
+        return y[n_t-1]
     # TODO this can be moved out for better performance
     cdef int ind = _binary_search(x, t, n_t)
     return y[ind]
@@ -240,9 +240,9 @@ cdef double _step_float_t(double x, double[::1] t, double[::1] y, int n_t):
 @cython.cdivision(True)
 cdef complex _step_complex_t(double x, double[::1] t, complex[::1] y, int n_t):
     if x < t[0]:
-        return 0
+        return y[0]
     elif x >= t[n_t-1]:
-        return 0
+        return y[n_t-1]
     # TODO this can be moved out for better performance
     cdef int ind = _binary_search(x, t, n_t)
     return y[ind]

--- a/qutip/cy/inter.pyx
+++ b/qutip/cy/inter.pyx
@@ -206,8 +206,8 @@ cdef double _step_float_cte(double x, double[::1] t, double[::1] y, int n_t):
         return y[0]
     elif x >= t[n_t-1]:
         return y[n_t-1]
-    cdef int ind = <int>(x/t[n_t-1]*(n_t-1))
-    return y[ind]
+    cdef int p = <int> ((x-t[0]) / (t[n_t-1]-t[0]) * (n_t-1))
+    return y[p]
 
 
 @cython.wraparound(False)
@@ -218,8 +218,8 @@ cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y, int n_t)
         return y[0]
     elif x >= t[n_t-1]:
         return y[n_t-1]
-    cdef int ind = <int>(x/t[n_t-1]*(n_t-1))
-    return y[ind]
+    cdef int p = <int> ((x-t[0]) / (t[n_t-1]-t[0]) * (n_t-1))
+    return y[p]
 
 
 @cython.wraparound(False)
@@ -231,8 +231,8 @@ cdef double _step_float_t(double x, double[::1] t, double[::1] y, int n_t):
     elif x >= t[n_t-1]:
         return y[n_t-1]
     # TODO this can be moved out for better performance
-    cdef int ind = _binary_search(x, t, n_t)
-    return y[ind]
+    cdef int p = _binary_search(x, t, n_t)
+    return y[p]
 
 
 @cython.wraparound(False)
@@ -244,5 +244,5 @@ cdef complex _step_complex_t(double x, double[::1] t, complex[::1] y, int n_t):
     elif x >= t[n_t-1]:
         return y[n_t-1]
     # TODO this can be moved out for better performance
-    cdef int ind = _binary_search(x, t, n_t)
-    return y[ind]
+    cdef int p = _binary_search(x, t, n_t)
+    return y[p]

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -155,11 +155,7 @@ class _CubicSplineWrapper:
             self.func = CubicSpline(self.tlist, self.coeff)
 
     def __call__(self, t, args={}):
-        try:
-            (self.func([t])[0])
-        except:
-            print(t)
-            print(self.coeff)
+        self.func([t])[0]
         return self.func([t])[0]
 
 
@@ -243,6 +239,10 @@ class QobjEvo:
     A list of times (float64) at which the coeffients must be given (tlist).
     The coeffients array must have the same len as the tlist.
     The time of the tlist do not need to be equidistant, but must be sorted.
+    By default, a cubic spline interpolation will be used for the coefficient
+    at time t.
+    If the coefficients are to be treated as step function, use the arguments
+    args = {"_step_func_coeff": True}
     *Examples*
         tlist = np.logspace(-5,0,100)
         H = QobjEvo([H0, [H1, np.exp(-1j*tlist)], [H2, np.cos(2.*tlist)]],

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -145,7 +145,7 @@ class _CubicSplineWrapper:
         self.tlist = tlist
         try:
             use_step_func = args["_step_func_coeff"]
-        except:
+        except KeyError:
             use_step_func = 0
         if use_step_func:
             self.func = interp1d(
@@ -1462,7 +1462,7 @@ class QobjEvo:
             elif self.type == "array":
                 try:
                     use_step_func = self.args["_step_func_coeff"]
-                except:
+                except KeyError:
                     use_step_func = 0
                 if np.allclose(np.diff(self.tlist),
                             self.tlist[1] - self.tlist[0]):

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -143,14 +143,16 @@ class _CubicSplineWrapper:
     def __init__(self, tlist, coeff, args=None):
         self.coeff = coeff
         self.tlist = tlist
-        if "_step_func_coeff" not in args:
-            self.func = CubicSpline(self.tlist, self.coeff)
-        elif args["_step_func_coeff"] == 1:
+        try:
+            use_step_func = args["_step_func_coeff"]
+        except:
+            use_step_func = 0
+        if use_step_func:
             self.func = interp1d(
                 self.tlist, self.coeff, kind="previous",
                 bounds_error=False, fill_value=0.)
         else:
-            raise ValueError("Unknow spline kind.")
+            self.func = CubicSpline(self.tlist, self.coeff)
 
     def __call__(self, t, args={}):
         try:
@@ -1458,25 +1460,25 @@ class QobjEvo:
                 self.compiled_qobjevo.set_factor(obj=self.coeff_get)
                 self.compiled += "cyfactor"
             elif self.type == "array":
+                try:
+                    use_step_func = self.args["_step_func_coeff"]
+                except:
+                    use_step_func = 0
                 if np.allclose(np.diff(self.tlist),
                             self.tlist[1] - self.tlist[0]):
-                    if "_step_func_coeff" not in self.args:
-                        self.coeff_get = InterCoeffCte(
-                            self.ops, None, self.tlist)
-                    elif self.args["_step_func_coeff"] == 1:
+                    if use_step_func:
                         self.coeff_get = StepCoeffCte(
                             self.ops, None, self.tlist)
                     else:
-                        raise ValueError("Unknow spline kind.")
-                else:
-                    if "_step_func_coeff" not in self.args:
-                        self.coeff_get = InterCoeffT(
+                        self.coeff_get = InterCoeffCte(
                             self.ops, None, self.tlist)
-                    elif self.args["_step_func_coeff"] == 1:
+                else:
+                    if use_step_func:
                         self.coeff_get = StepCoeffT(
                             self.ops, None, self.tlist)
                     else:
-                        raise ValueError("Unknow spline kind.")
+                        self.coeff_get = InterCoeffT(
+                            self.ops, None, self.tlist)
                 self.compiled += "cyfactor"
                 self.compiled_qobjevo.set_factor(obj=self.coeff_get)
             elif self.type == "spline":

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -155,7 +155,6 @@ class _CubicSplineWrapper:
             self.func = CubicSpline(self.tlist, self.coeff)
 
     def __call__(self, t, args={}):
-        self.func([t])[0]
         return self.func([t])[0]
 
 

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -162,7 +162,7 @@ include """ + _include_string + "\n\n"
             dt_times = str(tlist[1]-tlist[0])
             try:
                 use_step_func = args["_step_func_coeff"]
-            except:
+            except KeyError:
                 use_step_func = 0
             if dt_cte:
                 if isinstance(op.coeff[0], (float, np.float32, np.float64)):

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -160,47 +160,43 @@ include """ + _include_string + "\n\n"
             s_str = "_spline_" + str(N_np)
             N_times = str(len(tlist))
             dt_times = str(tlist[1]-tlist[0])
+            try:
+                use_step_func = args["_step_func_coeff"]
+            except:
+                use_step_func = 0
             if dt_cte:
                 if isinstance(op.coeff[0], (float, np.float32, np.float64)):
-                    if "_step_func_coeff" not in args:
-                        string = "_spline_float_cte_second(t, " + t_str + ", " +\
-                                y_str + ", " + s_str + ", " + N_times + ", " +\
-                                dt_times + ")"
-                    elif args["_step_func_coeff"] == 1:
-                        print("here")
+                    if use_step_func:
                         string = "_step_float_cte(t, " + t_str + ", " +\
                                 y_str + ", " + N_times + ")"
                     else:
-                        raise ValueError("Unknow spline kind.")
-                elif isinstance(op.coeff[0], (complex, np.complex128)):
-                    if "_step_func_coeff" not in args:
-                        string = "_spline_complex_cte_second(t, " + t_str + ", " +\
+                        string = "_spline_float_cte_second(t, " + t_str + ", " +\
                                 y_str + ", " + s_str + ", " + N_times + ", " +\
                                 dt_times + ")"
-                    elif args["_step_func_coeff"] == 1:
+
+                elif isinstance(op.coeff[0], (complex, np.complex128)):
+                    if use_step_func:
                         string = "_step_complex_cte(t, " + t_str + ", " +\
                                 y_str + ", " + N_times + ")"
                     else:
-                        raise ValueError("Unknow spline kind.")
+                        string = "_spline_complex_cte_second(t, " + t_str + ", " +\
+                                y_str + ", " + s_str + ", " + N_times + ", " +\
+                                dt_times + ")"
             else:
                 if isinstance(op.coeff[0], (float, np.float32, np.float64)):
-                    if "_step_func_coeff" not in args:
-                        string = "_spline_float_t_second(t, " + t_str + ", " +\
-                             y_str + ", " + s_str + ", " + N_times + ")"
-                    elif args["_step_func_coeff"] == 1:
+                    if use_step_func:
                         string = "_step_float_t(t, " + t_str + ", " +\
                              y_str + ", " + N_times + ")"
                     else:
-                        raise ValueError("Unknow spline kind.")
-                elif isinstance(op.coeff[0], (complex, np.complex128)):
-                    if "_step_func_coeff" not in args:
-                        string = "_spline_complex_t_second(t, " + t_str + ", " +\
+                        string = "_spline_float_t_second(t, " + t_str + ", " +\
                              y_str + ", " + s_str + ", " + N_times + ")"
-                    elif args["_step_func_coeff"] == 1:
+                elif isinstance(op.coeff[0], (complex, np.complex128)):
+                    if use_step_func:
                         string = "_step_complex_t(t, " + t_str + ", " +\
                              y_str + ", " + N_times + ")"
                     else:
-                        raise ValueError("Unknow spline kind.")
+                        string = "_spline_complex_t_second(t, " + t_str + ", " +\
+                             y_str + ", " + s_str + ", " + N_times + ")"
             compile_list.append(string)
             args[t_str] = tlist
             args[y_str] = op.coeff

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -135,6 +135,8 @@ cdef extern from "numpy/arrayobject.h" nogil:
 from qutip.cy.spmatfuncs cimport spmvpy
 from qutip.cy.inter cimport _spline_complex_t_second, _spline_complex_cte_second
 from qutip.cy.inter cimport _spline_float_t_second, _spline_float_cte_second
+from qutip.cy.inter cimport _step_float_cte, _step_complex_cte
+from qutip.cy.inter cimport _step_float_t, _step_complex_t
 from qutip.cy.interpolate cimport (interp, zinterp)
 from qutip.cy.cqobjevo_factor cimport StrCoeff
 from qutip.cy.cqobjevo cimport CQobjEvo
@@ -160,20 +162,45 @@ include """ + _include_string + "\n\n"
             dt_times = str(tlist[1]-tlist[0])
             if dt_cte:
                 if isinstance(op.coeff[0], (float, np.float32, np.float64)):
-                    string = "_spline_float_cte_second(t, " + t_str + ", " +\
-                              y_str + ", " + s_str + ", " + N_times + ", " +\
-                              dt_times + ")"
+                    if "_step_func_coeff" not in args:
+                        string = "_spline_float_cte_second(t, " + t_str + ", " +\
+                                y_str + ", " + s_str + ", " + N_times + ", " +\
+                                dt_times + ")"
+                    elif args["_step_func_coeff"] == 1:
+                        print("here")
+                        string = "_step_float_cte(t, " + t_str + ", " +\
+                                y_str + ", " + N_times + ")"
+                    else:
+                        raise ValueError("Unknow spline kind.")
                 elif isinstance(op.coeff[0], (complex, np.complex128)):
-                    string = "_spline_complex_cte_second(t, " + t_str + ", " +\
-                              y_str + ", " + s_str + ", " + N_times + ", " +\
-                              dt_times + ")"
+                    if "_step_func_coeff" not in args:
+                        string = "_spline_complex_cte_second(t, " + t_str + ", " +\
+                                y_str + ", " + s_str + ", " + N_times + ", " +\
+                                dt_times + ")"
+                    elif args["_step_func_coeff"] == 1:
+                        string = "_step_complex_cte(t, " + t_str + ", " +\
+                                y_str + ", " + N_times + ")"
+                    else:
+                        raise ValueError("Unknow spline kind.")
             else:
                 if isinstance(op.coeff[0], (float, np.float32, np.float64)):
-                    string = "_spline_float_t_second(t, " + t_str + ", " +\
+                    if "_step_func_coeff" not in args:
+                        string = "_spline_float_t_second(t, " + t_str + ", " +\
                              y_str + ", " + s_str + ", " + N_times + ")"
+                    elif args["_step_func_coeff"] == 1:
+                        string = "_step_float_t(t, " + t_str + ", " +\
+                             y_str + ", " + N_times + ")"
+                    else:
+                        raise ValueError("Unknow spline kind.")
                 elif isinstance(op.coeff[0], (complex, np.complex128)):
-                    string = "_spline_complex_t_second(t, " + t_str + ", " +\
+                    if "_step_func_coeff" not in args:
+                        string = "_spline_complex_t_second(t, " + t_str + ", " +\
                              y_str + ", " + s_str + ", " + N_times + ")"
+                    elif args["_step_func_coeff"] == 1:
+                        string = "_step_complex_t(t, " + t_str + ", " +\
+                             y_str + ", " + N_times + ")"
+                    else:
+                        raise ValueError("Unknow spline kind.")
             compile_list.append(string)
             args[t_str] = tlist
             args[y_str] = op.coeff

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -34,12 +34,13 @@
 from functools import partial
 
 import numpy as np
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_, run_module_suite, assert_allclose
 
 # disable the MC progress bar
 import os
 
 from qutip import *
+from qutip.random_objects import rand_ket
 
 os.environ['QUTIP_GRAPHICS'] = "NO"
 
@@ -755,6 +756,93 @@ class TestMESolverMisc:
         assert_(psi0.dims == result.final_state.dims)
 
 
+class TestMESolveStepFuncCoeff:
+    """
+    A Test class for using time-dependent array coefficients
+    as step functions instead of doing interpolation
+    """
+    def python_coeff(self, t, args):
+        if t < np.pi/2:
+            return 1.
+        else:
+            return 0.
+
+    def test_py_coeff(self):
+        """
+        Test for Python function as coefficient as step function coeff
+        """
+        rho0 = rand_ket(2)
+        tlist = np.array([0, np.pi/2])
+        qu = QobjEvo([[sigmax(), self.python_coeff]],
+                     tlist=tlist, args={"_step_func_coeff": 1})
+        result = mesolve(qu, rho0=rho0, tlist=tlist)
+        assert(qu.type == "func")
+        assert_allclose(
+            fidelity(result.states[-1], sigmax()*rho0), 1, rtol=1.e-7)
+
+    def test_array_cte_coeff(self):
+        """
+        Test for Array coefficient with uniform tlist as step function coeff
+        """
+        rho0 = rand_ket(2)
+        tlist = np.array([0., np.pi/2, np.pi], dtype=float)
+        npcoeff = np.array([0.25, 0.75, 0.75])
+        qu = QobjEvo([[sigmax(), npcoeff]],
+                     tlist=tlist, args={"_step_func_coeff": 1})
+        result = mesolve(qu, rho0=rho0, tlist=tlist)
+        assert(qu.type == "array")
+        assert_allclose(
+            fidelity(result.states[-1], sigmax()*rho0), 1, rtol=1.e-7)
+
+    def test_array_t_coeff(self):
+        """
+        Test for Array with non-uniform tlist as step function coeff
+        """
+        rho0 = rand_ket(2)
+        tlist = np.array([0., np.pi/2, np.pi*3/2], dtype=float)
+        npcoeff = np.array([0.5, 0.25, 0.25])
+        qu = QobjEvo([[sigmax(), npcoeff]],
+                     tlist=tlist, args={"_step_func_coeff": 1})
+        result = mesolve(qu, rho0=rho0, tlist=tlist)
+        assert(qu.type == "array")
+        assert_allclose(
+            fidelity(result.states[-1], sigmax()*rho0), 1, rtol=1.e-7)
+
+    def test_array_str_coeff(self):
+        """
+        Test for Array and string as step function coeff.
+        qobjevo_codegen is used and uniform tlist
+        """
+        rho0 = rand_ket(2)
+        tlist = np.array([0., np.pi/2, np.pi], dtype=float)
+        npcoeff1 = np.array([0.25, 0.75, 0.75], dtype=complex)
+        npcoeff2 = np.array([0.5, 1.5, 1.5], dtype=float)
+        strcoeff = "1."
+        qu = QobjEvo(
+            [[sigmax(), npcoeff1], [sigmax(), strcoeff], [sigmax(), npcoeff2]],
+            tlist=tlist, args={"_step_func_coeff": 1})
+        result = mesolve(qu, rho0=rho0, tlist=tlist)
+        assert_allclose(
+            fidelity(result.states[-1], sigmax()*rho0), 1, rtol=1.e-7)
+
+    def test_array_str_py_coeff(self):
+        """
+        Test for Array, string and Python function as step function coeff.
+        qobjevo_codegen is used and non non-uniform tlist
+        """
+        rho0 = rand_ket(2)
+        tlist = np.array([0., np.pi/4, np.pi/2, np.pi], dtype=float)
+        npcoeff1 = np.array([0.4, 1.6, 1.0, 1.0], dtype=complex)
+        npcoeff2 = np.array([0.4, 1.6, 1.0, 1.0], dtype=float)
+        strcoeff = "1."
+        qu = QobjEvo(
+            [[sigmax(), npcoeff1], [sigmax(), npcoeff2], 
+             [sigmax(), self.python_coeff], [sigmax(), strcoeff]],
+            tlist=tlist, args={"_step_func_coeff": 1})
+        result = mesolve(qu, rho0=rho0, tlist=tlist)
+        assert(qu.type == "mixed_callable")
+        assert_allclose(
+            fidelity(result.states[-1], sigmax()*rho0), 1, rtol=1.e-7)
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -836,7 +836,7 @@ class TestMESolveStepFuncCoeff:
         npcoeff2 = np.array([0.4, 1.6, 1.0, 1.0], dtype=float)
         strcoeff = "1."
         qu = QobjEvo(
-            [[sigmax(), npcoeff1], [sigmax(), npcoeff2], 
+            [[sigmax(), npcoeff1], [sigmax(), npcoeff2],
              [sigmax(), self.python_coeff], [sigmax(), strcoeff]],
             tlist=tlist, args={"_step_func_coeff": 1})
         result = mesolve(qu, rho0=rho0, tlist=tlist)

--- a/qutip/tests/test_qobjevo.py
+++ b/qutip/tests/test_qobjevo.py
@@ -215,13 +215,14 @@ def test_QobjEvo_step_coeff():
     assert_equal(qobjevo.ops[1].get_coeff(7.0), coeff2[5])
     assert_equal(qobjevo.ops[1].get_coeff(5.0001), coeff2[3])
     assert_equal(qobjevo.ops[1].get_coeff(3.9999), coeff2[1])
+
     qobjevo.compile()
     assert_equal(qobjevo.coeff_get(2.0), [coeff1[0], coeff2[0]])
     assert_equal(qobjevo.coeff_get(7.0), [coeff1[5], coeff2[5]])
     assert_equal(qobjevo.coeff_get(4.0001), [coeff1[2], coeff2[2]])
     assert_equal(qobjevo.coeff_get(3.9999), [coeff1[1], coeff2[1]])
 
-    # non-uniform t and start from 1
+    # non-uniform t
     tlist = np.array([1, 2, 4, 5, 6, 8], dtype=float)
     qobjevo = QobjEvo([[sigmaz(), coeff1], [sigmax(), coeff2]],
         tlist=tlist, args={"_step_func_coeff":True})

--- a/qutip/tests/test_qobjevo.py
+++ b/qutip/tests/test_qobjevo.py
@@ -199,6 +199,51 @@ def test_QobjEvo_call_args():
         assert_equal(len((op(t) - O_target1).tidyup(1e-10).data.data),0)
 
 
+def test_QobjEvo_step_coeff():
+    coeff1 = np.random.rand(6)
+    coeff2 = np.random.rand(6) + np.random.rand(6) * 1.j
+    # uniform t
+    tlist = np.array([2, 3, 4, 5, 6, 7], dtype=float)
+    qobjevo = QobjEvo([[sigmaz(), coeff1], [sigmax(), coeff2]], 
+                    tlist=tlist, args={"_step_func_coeff":True})
+    assert_equal(qobjevo.ops[0].get_coeff(2.0), coeff1[0])
+    assert_equal(qobjevo.ops[0].get_coeff(7.0), coeff1[5])
+    assert_equal(qobjevo.ops[0].get_coeff(5.0001), coeff1[3])
+    assert_equal(qobjevo.ops[0].get_coeff(3.9999), coeff1[1])
+
+    assert_equal(qobjevo.ops[1].get_coeff(2.0), coeff2[0])
+    assert_equal(qobjevo.ops[1].get_coeff(7.0), coeff2[5])
+    assert_equal(qobjevo.ops[1].get_coeff(5.0001), coeff2[3])
+    assert_equal(qobjevo.ops[1].get_coeff(3.9999), coeff2[1])
+    qobjevo.compile()
+    assert_equal(qobjevo.coeff_get(2.0), [coeff1[0], coeff2[0]])
+    assert_equal(qobjevo.coeff_get(7.0), [coeff1[5], coeff2[5]])
+    assert_equal(qobjevo.coeff_get(4.0001), [coeff1[2], coeff2[2]])
+    assert_equal(qobjevo.coeff_get(3.9999), [coeff1[1], coeff2[1]])
+
+    # non-uniform t and start from 1
+    tlist = np.array([1, 2, 4, 5, 6, 8], dtype=float)
+    qobjevo = QobjEvo([[sigmaz(), coeff1], [sigmax(), coeff2]],
+        tlist=tlist, args={"_step_func_coeff":True})
+    assert_equal(qobjevo.ops[0].get_coeff(1.0), coeff1[0])
+    assert_equal(qobjevo.ops[0].get_coeff(8.0), coeff1[5])
+    assert_equal(qobjevo.ops[0].get_coeff(3.9999), coeff1[1])
+    assert_equal(qobjevo.ops[0].get_coeff(4.23), coeff1[2])
+    assert_equal(qobjevo.ops[0].get_coeff(1.23), coeff1[0])
+
+    assert_equal(qobjevo.ops[1].get_coeff(1.0), coeff2[0])
+    assert_equal(qobjevo.ops[1].get_coeff(8.0), coeff2[5])
+    assert_equal(qobjevo.ops[1].get_coeff(6.7), coeff2[4])
+    assert_equal(qobjevo.ops[1].get_coeff(7.9999), coeff2[4])
+    assert_equal(qobjevo.ops[1].get_coeff(3.9999), coeff2[1])
+
+    qobjevo.compile()
+    assert_equal(qobjevo.coeff_get(1.0), [coeff1[0], coeff2[0]])
+    assert_equal(qobjevo.coeff_get(3.999), [coeff1[1], coeff2[1]])
+    assert_equal(qobjevo.coeff_get(6.3), [coeff1[4], coeff2[4]])
+    assert_equal(qobjevo.coeff_get(1.0001), [coeff1[0], coeff2[0]])
+
+
 def test_QobjEvo_copy():
     "QobjEvo copy"
     tlist = np.linspace(0,1,300)


### PR DESCRIPTION
Implement an option for using array-like coefficients as step-function instead of cubic-spline:
e.g. 
```
tlist = np.array([0., 1., 2., 3.])
coeff = np.array([1., 2., 3., 3.])
```
The coefficient is 1 in the time interval [0,1), 2 in [1,2) and so on. The last element in `coeff` is just a place holder and has no effect.

@Ericgig Do you think the following might be useful?
1. In `inter.pyx` many functions have two versions, one for complex input and one for float. Now there are 4 pairs of them, will it helps if I try to merge them with fused type in Cython?
2. For non-uniform `tlist`, `_binary_search` is used to find the current index inside the method such as `_spline_float_t_second`, but very often we call this method within a loop for the same `t`. It would improve the performance if `_binary_search` is called outside once for all `t`.