### PR TITLE
expand_oper for composite system with arbitrary dimensions

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -1033,8 +1033,8 @@ class QubitCircuit(object):
                 else:
                     raise ValueError(
                         "gate function takes at most one parameters.")
-                self.U_list.append(
-                    expand_oper(oper, N=self.N,
+                self.U_list.append(expand_oper(
+                        oper, N=self.N,
                         targets=gate.targets, dims=self.dims))
 
             else:

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -1033,7 +1033,7 @@ class QubitCircuit(object):
                 else:
                     raise ValueError(
                         "gate function takes at most one parameters.")
-                self.U_list.append(expand_oper(
+                self.U_list.append(expand_operator(
                         oper, N=self.N,
                         targets=gate.targets, dims=self.dims))
 

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -181,6 +181,10 @@ class QubitCircuit(object):
         Define a dictionary of the custom gates. See examples for detail.
     input_states : list
         A list of string such as `0`,'+', "A", "Y". Only used for latex.
+    dims : list
+        A list of integer for the dimension of each composite system.
+        e.g [2,2,2,2,2] for 5 qubits system. If None, qubits system
+        will be the default option.
 
     Examples
     --------
@@ -193,7 +197,7 @@ class QubitCircuit(object):
     """
 
     def __init__(self, N, input_states=None, output_states=None,
-                 reverse_states=True, user_gates=None):
+                 reverse_states=True, user_gates=None, dims=None):
         # number of qubits in the register
         self.N = N
         self.reverse_states = reverse_states
@@ -201,6 +205,7 @@ class QubitCircuit(object):
         self.U_list = []
         self.input_states = [None for i in range(N)]
         self.output_states = [None for i in range(N)]
+        self.dims = dims
         if user_gates is None:
             self.user_gates = {}
         else:
@@ -1028,7 +1033,9 @@ class QubitCircuit(object):
                 else:
                     raise ValueError(
                         "gate function takes at most one parameters.")
-                self.U_list.append(expand_oper(oper, self.N, gate.targets))
+                self.U_list.append(
+                    expand_oper(oper, N=self.N,
+                        targets=gate.targets, dims=self.dims))
 
             else:
                 raise NotImplementedError(

--- a/qutip/qip/gates.py
+++ b/qutip/qip/gates.py
@@ -1166,7 +1166,7 @@ def _targets_to_list(targets, oper=None, N=None):
         targets = list(range(len(oper.dims[0])))
     if not isinstance(targets, Iterable):
         targets = [targets]
-    if not all([isinstance(t, numbers.Integral) for t in targets])):
+    if not all([isinstance(t, numbers.Integral) for t in targets]):
         raise TypeError(
             "targets should be "
             "an integer or a list of integer")

--- a/qutip/qip/gates.py
+++ b/qutip/qip/gates.py
@@ -1135,7 +1135,7 @@ def _check_qubits_oper(oper, dims=None, targets=None):
         raise ValueError(
             "The operator is not an "
             "Qobj with the same input and output dimensions.")
-    # if operator dims matches dims
+    # if operator dims matches the target dims
     if dims is not None and targets is not None:
         targ_dims = [dims[t] for t in targets]
         if oper.dims[0] != targ_dims:
@@ -1164,16 +1164,12 @@ def _targets_to_list(targets, oper=None, N=None):
     # if targets is a list of integer
     if targets is None:
         targets = list(range(len(oper.dims[0])))
-    elif isinstance(targets, numbers.Integral):
+    if not isinstance(targets, Iterable):
         targets = [targets]
-    elif isinstance(targets, Iterable) and (
-            all([isinstance(t, numbers.Integral) for t in targets])):
-        pass
-    else:
+    if not all([isinstance(t, numbers.Integral) for t in targets])):
         raise TypeError(
             "targets should be "
-            "an integer or a list of integer, but {} "
-            "was given.".format(targets))
+            "an integer or a list of integer")
     # if targets has correct length
     if oper is not None:
         req_num = len(oper.dims[0])
@@ -1242,7 +1238,7 @@ def expand_oper(oper, N, targets, dims=None):
     return tensor([oper] + id_list).permute(new_order)
 
 
-def expand_oper_periodic(oper, N, targets=None):
+def expand_oper_periodic(oper, N, targets=None, dims=None):
     """
     Expand a qubis operator to one that acts on a N-qutbis system for
     all cyclic permutation of the target qubits.
@@ -1271,5 +1267,5 @@ def expand_oper_periodic(oper, N, targets=None):
     for i in range(N):
         new_targets = np.mod(np.array(targets)+i, N)
         oper_list.append(
-            expand_oper(oper, N, new_targets))
+            expand_oper(oper, N=N, targets=new_targets, dims=dims))
     return oper_list

--- a/qutip/qip/gates.py
+++ b/qutip/qip/gates.py
@@ -1123,11 +1123,11 @@ def _check_qubits_oper(oper, dims=None, targets=None):
     ----------
     oper : :class:`qutip.Qboj`
         The quantum object to be checked.
-    dims : list
+    dims : list, optional
         A list of integer for the dimension of each composite system.
-        e.g [2,2,2,2,2] for 5 qubits system. If None, qubits system
+        e.g ``[2, 2, 2, 2, 2]`` for 5 qubits system. If None, qubits system
         will be the default.
-    targets : int or list of int
+    targets : int or list of int, optional
         The indices of qubits that are acted on.
     """
     # if operator matches N
@@ -1153,12 +1153,12 @@ def _targets_to_list(targets, oper=None, N=None):
     ----------
     targets : int or list of int
         The indices of qubits that are acted on.
-    oper : :class:`qutip.Qobj`
-        An operator acts on qubits, the type of the `Qobj`
+    oper : :class:`qutip.Qobj`, optional
+        An operator acts on qubits, the type of the :class:`qutip.Qobj`
         has to be an operator
         and the dimension matches the tensored qubit Hilbert space
-        e.g. dims = ``[[2,2,2],[2,2,2]]``
-    N : int
+        e.g. dims = ``[[2, 2, 2], [2, 2, 2]]``
+    N : int, optional
         The number of qubits in the system.
     """
     # if targets is a list of integer
@@ -1193,21 +1193,21 @@ def expand_operator(oper, N, targets, dims=None, cyclic_permutation=False):
     Parameters
     ----------
     oper : :class:`qutip.Qobj`
-        An operator acts on qubits, the type of the `Qobj`
+        An operator acts on qubits, the type of the :class:`qutip.Qobj`
         has to be an operator
         and the dimension matches the tensored qubit Hilbert space
-        e.g. dims = ``[[2,2,2],[2,2,2]]``
+        e.g. dims = ``[[2, 2, 2], [2, 2, 2]]``
     N : int
         The number of qubits in the system.
     targets : int or list of int
         The indices of qubits that are acted on.
-    dims : list
+    dims : list, optional
         A list of integer for the dimension of each composite system.
-        E.g ``[2,2,2,2,2]`` for 5 qubits system. If None, qubits system
+        E.g ``[2, 2, 2, 2, 2]`` for 5 qubits system. If None, qubits system
         will be the default option.
-    cyclic_permutation : boolean
+    cyclic_permutation : boolean, optional
         Expand for all cyclic permutation of the targets.
-        E.g. if N=3 and `oper` is a 2-qubit operator,
+        E.g. if ``N=3`` and `oper` is a 2-qubit operator,
         the result will be a list of three operators,
         each acting on qubits 0 and 1, 1 and 2, 2 and 0.
 
@@ -1219,7 +1219,7 @@ def expand_operator(oper, N, targets, dims=None, cyclic_permutation=False):
     Notes
     -----
     This is equivalent to gate_expand_1toN, gate_expand_2toN,
-    gate_expand_3toN in `qutip.qip.gate.py`, but works for any dimension.
+    gate_expand_3toN in ``qutip.qip.gate.py``, but works for any dimension.
     """
     if dims is None:
         dims = [2] * N

--- a/qutip/qip/gates.py
+++ b/qutip/qip/gates.py
@@ -51,7 +51,7 @@ __all__ = ['rx', 'ry', 'rz', 'sqrtnot', 'snot', 'phasegate', 'qrot',
            'toffoli', 'rotation', 'controlled_gate',
            'globalphase', 'hadamard_transform', 'gate_sequence_product',
            'gate_expand_1toN', 'gate_expand_2toN', 'gate_expand_3toN',
-           'qubit_clifford_group', 'expand_oper', 'expand_oper_nearest']
+           'qubit_clifford_group', 'expand_oper', 'expand_oper_cycper']
 
 #
 # Single Qubit Gates
@@ -1238,7 +1238,7 @@ def expand_oper(oper, N, targets, dims=None):
     return tensor([oper] + id_list).permute(new_order)
 
 
-def expand_oper_nearest(oper, N, targets=None, dims=None):
+def expand_oper_cycper(oper, N, targets=None, dims=None):
     """
     Expand a qubis operator to one that acts on a N-qubit system for
     all cyclic permutation of the target qubits. E.g. if N=3 and `oper`

--- a/qutip/qip/gates.py
+++ b/qutip/qip/gates.py
@@ -51,7 +51,7 @@ __all__ = ['rx', 'ry', 'rz', 'sqrtnot', 'snot', 'phasegate', 'qrot',
            'toffoli', 'rotation', 'controlled_gate',
            'globalphase', 'hadamard_transform', 'gate_sequence_product',
            'gate_expand_1toN', 'gate_expand_2toN', 'gate_expand_3toN',
-           'qubit_clifford_group', 'expand_oper', 'expand_oper_periodic']
+           'qubit_clifford_group', 'expand_oper', 'expand_oper_nearest']
 
 #
 # Single Qubit Gates
@@ -1188,7 +1188,7 @@ def _targets_to_list(targets, oper=None, N=None):
 
 def expand_oper(oper, N, targets, dims=None):
     """
-    Expand a qubits operator to one that acts on a N-qutbis system.
+    Expand a qubits operator to one that acts on a N-qubit system.
 
     Parameters
     ----------
@@ -1238,10 +1238,12 @@ def expand_oper(oper, N, targets, dims=None):
     return tensor([oper] + id_list).permute(new_order)
 
 
-def expand_oper_periodic(oper, N, targets=None, dims=None):
+def expand_oper_nearest(oper, N, targets=None, dims=None):
     """
-    Expand a qubis operator to one that acts on a N-qutbis system for
-    all cyclic permutation of the target qubits.
+    Expand a qubis operator to one that acts on a N-qubit system for
+    all cyclic permutation of the target qubits. E.g. if N=3 and `oper`
+    is a 2-qubit operator, the result will be a list of three operators,
+    each acting on qubits 0 and 1, 1 and 2, 2 and 3.
 
     Parameters
     ----------

--- a/qutip/qip/gates.py
+++ b/qutip/qip/gates.py
@@ -1115,7 +1115,7 @@ def gate_expand_3toN(U, N, controls=[0, 1], target=2):
     return tensor([U] + [identity(2)] * (N - 3)).permute(p)
 
 
-def _check_qubits_oper(oper, N=None):
+def _check_qubits_oper(oper, dims=None, targets=None):
     """
     Check if it is an operator acting on a qubit system.
 
@@ -1124,59 +1124,52 @@ def _check_qubits_oper(oper, N=None):
     oper : :class:`qutip.Qboj`
         The quantum object to be checked.
     """
-    check = True
-    if not isinstance(oper, Qobj):
-        check = False
-    elif oper.dims[0] != oper.dims[1]:
-        check = False
-    elif oper.dims[0] != len(oper.dims[0]) * [2]:
-        check = False
-    if N is not None and len(oper.dims[0]) > N:
+    # if operator matches N
+    if not isinstance(oper, Qobj) or oper.dims[0] != oper.dims[1]:
         raise ValueError(
-            "The dimension of the operator "
-            "cannot be larger than the system dimension "
-            "N={}.".format(N))
-    if not check:
-        raise ValueError(
-            "The following operator is not an "
-            "operator on a qubits system:\n{}".format(oper))
+            "The operator is not an "
+            "Qobj with the same input and output dimensions.")
+    # if operator dims matches dims
+    if dims is not None and targets is not None:
+        targ_dims = [dims[t] for t in targets]
+        if oper.dims[0] != targ_dims:
+         raise ValueError(
+             "The operator dims {} do not match "
+             "the target dims {}.".format(
+                 oper.dims[0], targ_dims))
 
 
 def _targets_to_list(targets, oper=None, N=None):
-    # Check validity of targets
+    # if targets is a list of integer
     if targets is None:
         targets = list(range(len(oper.dims[0])))
     elif isinstance(targets, numbers.Integral):
         targets = [targets]
-    elif isinstance(targets, Iterable):
+    elif isinstance(targets, Iterable) and (
+        all([isinstance(t, numbers.Integral) for t in targets])):
         pass
     else:
         raise TypeError(
             "targets should be "
             "an integer or a list of integer, but {} "
             "was given.".format(targets))
-    if not all([isinstance(t, numbers.Integral) for t in targets]):
-        raise TypeError(
-            "Targets should be "
-            "an integer or a list of integer, but {} "
-            "was given.".format(targets))
-
+    # if targets has correct length
     if oper is not None:
         req_num = len(oper.dims[0])
-        if len(targets) != req_num:  # correct number of targets
+        if len(targets) != req_num:
             raise ValueError(
                 "The given operator needs {} "
                 "target qutbis, "
                 "but {} given.".format(
                     req_num, len(targets)))
-
+    # if targets is smaller than N
     if N is not None:
         if not all([t<N for t in targets]):
             raise ValueError("Targets must be smaller than N={}.".format(N))
     return targets
 
 
-def expand_oper(oper, N, targets):
+def expand_oper(oper, N, targets, dims=None):
     """
     Expand a qubits operator to one that acts on a N-qutbis system.
 
@@ -1202,24 +1195,25 @@ def expand_oper(oper, N, targets):
     This is equivalent to gate_expand_1toN, gate_expand_2toN,
     gate_expand_3toN in `qutip.qip.gate.py`, but works for any dimension.
     """
-    _check_qubits_oper(oper, N=N)
+    if dims is None:
+        dims = [2] * N
     targets = _targets_to_list(targets, oper=oper, N=N)
+    _check_qubits_oper(oper, dims=dims, targets=targets)
 
     # Generate the correct order for qubits permutation,
-    # eg. if N = 5, targets = [3,0], the order is [1,x,x,0,x].
+    # eg. if N = 5, targets = [3,0], the order is [1,2,3,0,4].
     # If the operator is cnot,
     # this order means that the 3rd qubit controls the 0th qubit.
-    new_order = list(range(N))
-    old_ind = range(len(targets))
-    for i in old_ind:
-        new_order[targets[i]] = i
-    old_ind_set = set(old_ind)
-    targets_set = set(targets)
-    mod_value = targets_set.difference(old_ind_set)
-    mod_ind = old_ind_set.difference(targets_set)
-    for ind, value in zip(mod_ind, mod_value):
-        new_order[ind] = value
-    return tensor([oper] + [identity(2)]*(N-len(targets))).permute(new_order)
+    new_order = [0] * N
+    for i, t in enumerate(targets):
+        new_order[t] = i
+    # allocate the rest qutbits (not targets) to the empty position in new_order
+    rest_pos = [q for q in list(range(N)) if q not in targets]
+    rest_qubits = list(range(len(targets), N))
+    for i, ind in enumerate(rest_pos):
+        new_order[ind] = rest_qubits[i]
+    id_list = [identity(dims[i]) for i in rest_pos]
+    return tensor([oper] + id_list).permute(new_order)
 
 
 def expand_oper_periodic(oper, N, targets=None):
@@ -1244,7 +1238,6 @@ def expand_oper_periodic(oper, N, targets=None):
     oper_list : list
         A list of expanded qubits operator acting on a system with N qubits.
     """
-    _check_qubits_oper(oper, N=N)
     targets = _targets_to_list(targets, oper=oper, N=N)
     if len(targets) == N:
         return oper

--- a/qutip/qip/gates.py
+++ b/qutip/qip/gates.py
@@ -1117,12 +1117,18 @@ def gate_expand_3toN(U, N, controls=[0, 1], target=2):
 
 def _check_qubits_oper(oper, dims=None, targets=None):
     """
-    Check if it is an operator acting on a qubit system.
+    Check if the given operator is valid.
 
     Parameters
     ----------
     oper : :class:`qutip.Qboj`
         The quantum object to be checked.
+    dims : list
+        A list of integer for the dimension of each composite system.
+        e.g [2,2,2,2,2] for 5 qubits system. If None, qubits system
+        will be the default.
+    targets : int or list of int
+        The indices of qubits that are acted on.
     """
     # if operator matches N
     if not isinstance(oper, Qobj) or oper.dims[0] != oper.dims[1]:
@@ -1133,20 +1139,35 @@ def _check_qubits_oper(oper, dims=None, targets=None):
     if dims is not None and targets is not None:
         targ_dims = [dims[t] for t in targets]
         if oper.dims[0] != targ_dims:
-         raise ValueError(
-             "The operator dims {} do not match "
-             "the target dims {}.".format(
-                 oper.dims[0], targ_dims))
+            raise ValueError(
+                "The operator dims {} do not match "
+                "the target dims {}.".format(
+                    oper.dims[0], targ_dims))
 
 
 def _targets_to_list(targets, oper=None, N=None):
+    """
+    transform targets to a list and check validity.
+
+    Parameters
+    ----------
+    targets : int or list of int
+        The indices of qubits that are acted on.
+    oper : :class:`qutip.Qobj`
+        An operator acts on qubits, the type of the `Qobj`
+        has to be an operator
+        and the dimension matches the tensored qubit Hilbert space
+        e.g. dims = [[2,2,2],[2,2,2]]
+    N : int
+        The number of qubits in the system.
+    """
     # if targets is a list of integer
     if targets is None:
         targets = list(range(len(oper.dims[0])))
     elif isinstance(targets, numbers.Integral):
         targets = [targets]
     elif isinstance(targets, Iterable) and (
-        all([isinstance(t, numbers.Integral) for t in targets])):
+            all([isinstance(t, numbers.Integral) for t in targets])):
         pass
     else:
         raise TypeError(
@@ -1164,7 +1185,7 @@ def _targets_to_list(targets, oper=None, N=None):
                     req_num, len(targets)))
     # if targets is smaller than N
     if N is not None:
-        if not all([t<N for t in targets]):
+        if not all([t < N for t in targets]):
             raise ValueError("Targets must be smaller than N={}.".format(N))
     return targets
 
@@ -1178,12 +1199,16 @@ def expand_oper(oper, N, targets, dims=None):
     oper : :class:`qutip.Qobj`
         An operator acts on qubits, the type of the `Qobj`
         has to be an operator
-        and the dimension matches the tensored qubit Hilbertspace
+        and the dimension matches the tensored qubit Hilbert space
         e.g. dims = [[2,2,2],[2,2,2]]
     N : int
         The number of qubits in the system.
     targets : int or list of int
         The indices of qubits that are acted on.
+    dims : list
+        A list of integer for the dimension of each composite system.
+        e.g [2,2,2,2,2] for 5 qubits system. If None, qubits system
+        will be the default option.
 
     Returns
     -------
@@ -1207,7 +1232,8 @@ def expand_oper(oper, N, targets, dims=None):
     new_order = [0] * N
     for i, t in enumerate(targets):
         new_order[t] = i
-    # allocate the rest qutbits (not targets) to the empty position in new_order
+    # allocate the rest qutbits (not targets) to the empty
+    # position in new_order
     rest_pos = [q for q in list(range(N)) if q not in targets]
     rest_qubits = list(range(len(targets), N))
     for i, ind in enumerate(rest_pos):
@@ -1218,7 +1244,7 @@ def expand_oper(oper, N, targets, dims=None):
 
 def expand_oper_periodic(oper, N, targets=None):
     """
-    Expand a qutbis operator to one that acts on a N-qutbis system for
+    Expand a qubis operator to one that acts on a N-qutbis system for
     all cyclic permutation of the target qubits.
 
     Parameters
@@ -1226,7 +1252,7 @@ def expand_oper_periodic(oper, N, targets=None):
     oper : :class:`qutip.Qobj`
         An operator acts on qubits, the type of the `Qobj`
         has to be an operator
-        and the dimension matches the tensored qubit Hilbertspace
+        and the dimension matches the tensored qubit Hilbert space
         e.g. dims = [[2,2,2],[2,2,2]]
     N : int
         The number of qubits in the system.

--- a/qutip/qip/gates.py
+++ b/qutip/qip/gates.py
@@ -1157,7 +1157,7 @@ def _targets_to_list(targets, oper=None, N=None):
         An operator acts on qubits, the type of the `Qobj`
         has to be an operator
         and the dimension matches the tensored qubit Hilbert space
-        e.g. dims = [[2,2,2],[2,2,2]]
+        e.g. dims = ``[[2,2,2],[2,2,2]]``
     N : int
         The number of qubits in the system.
     """
@@ -1196,14 +1196,14 @@ def expand_operator(oper, N, targets, dims=None, cyclic_permutation=False):
         An operator acts on qubits, the type of the `Qobj`
         has to be an operator
         and the dimension matches the tensored qubit Hilbert space
-        e.g. dims = [[2,2,2],[2,2,2]]
+        e.g. dims = ``[[2,2,2],[2,2,2]]``
     N : int
         The number of qubits in the system.
     targets : int or list of int
         The indices of qubits that are acted on.
     dims : list
         A list of integer for the dimension of each composite system.
-        e.g [2,2,2,2,2] for 5 qubits system. If None, qubits system
+        E.g ``[2,2,2,2,2]`` for 5 qubits system. If None, qubits system
         will be the default option.
     cyclic_permutation : boolean
         Expand for all cyclic permutation of the targets.

--- a/qutip/qip/gates.py
+++ b/qutip/qip/gates.py
@@ -1216,8 +1216,8 @@ def expand_operator(oper, N, targets, dims=None, cyclic_permutation=False):
     expanded_oper : :class:`qutip.Qobj`
         The expanded qubits operator acting on a system with N qubits.
 
-    Note
-    ----
+    Notes
+    -----
     This is equivalent to gate_expand_1toN, gate_expand_2toN,
     gate_expand_3toN in `qutip.qip.gate.py`, but works for any dimension.
     """

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -39,7 +39,8 @@ from qutip.operators import identity, qeye, sigmax, sigmay, sigmaz
 from qutip.qip import (rx, ry, rz, phasegate, qrot, cnot, swap, iswap,
                        sqrtswap, molmer_sorensen,
                        toffoli, fredkin, gate_expand_3toN, 
-                       qubit_clifford_group, expand_oper)
+                       qubit_clifford_group, expand_oper,
+                       expand_oper_periodic)
 from qutip.random_objects import rand_ket, rand_herm, rand_unitary
 from qutip.tensor import tensor
 from qutip.qobj import Qobj
@@ -290,24 +291,30 @@ class TestGates:
         """
         gate : expand qubits operator to a N qubits system.
         """
+        # oper size is N, no expansion
+        oper = tensor(sigmax(), sigmay())
+        assert_allclose(expand_oper(oper=oper, targets=[0, 1], N=2), oper)
+        assert_allclose(expand_oper(oper=oper, targets=[1, 0], N=2), 
+                            tensor(sigmay(), sigmax()))
+
         # random single qubit gate test, integer as target
         r = rand_unitary(2)
-        assert(expand_oper(r, 3, 0) == tensor([r, identity(2), identity(2)]))
-        assert(expand_oper(r, 3, 1) == tensor([identity(2), r, identity(2)]))
-        assert(expand_oper(r, 3, 2) == tensor([identity(2), identity(2), r]))
+        assert_allclose(expand_oper(r, 3, 0), tensor([r, identity(2), identity(2)]))
+        assert_allclose(expand_oper(r, 3, 1), tensor([identity(2), r, identity(2)]))
+        assert_allclose(expand_oper(r, 3, 2), tensor([identity(2), identity(2), r]))
 
         # random 2qubits gate test, list as target
         r2 = rand_unitary(4)
         r2.dims = [[2, 2], [2, 2]]
-        assert(expand_oper(r2, 3, [2, 1]) == tensor(
+        assert_allclose(expand_oper(r2, 3, [2, 1]), tensor(
             [identity(2), r2.permute([1, 0])]))
-        assert(expand_oper(r2, 3, [0, 1]) == tensor(
+        assert_allclose(expand_oper(r2, 3, [0, 1]), tensor(
             [r2, identity(2)]))
-        assert(expand_oper(r2, 3, [0, 2]) == tensor(
+        assert_allclose(expand_oper(r2, 3, [0, 2]), tensor(
             [r2, identity(2)]).permute([0, 2, 1]))
 
         # cnot expantion, qubit 2 control qubit 0
-        assert(expand_oper(cnot(), 3, [2, 0]) == Qobj([
+        assert_allclose(expand_oper(cnot(), 3, [2, 0]), Qobj([
             [1., 0., 0., 0., 0., 0., 0., 0.],
             [0., 0., 0., 0., 0., 1., 0., 0.],
             [0., 0., 1., 0., 0., 0., 0., 0.],
@@ -317,6 +324,16 @@ class TestGates:
             [0., 0., 0., 0., 0., 0., 1., 0.],
             [0., 0., 0., 1., 0., 0., 0., 0.]],
             dims=[[2, 2, 2], [2, 2, 2]]))
+
+        # test periodically expansion
+        result = expand_oper_periodic(
+            tensor([sigmaz(),sigmax()]), N=3, targets=[2 ,0])
+        mat1 = tensor(sigmax(), qeye(2), sigmaz())
+        mat2 = tensor(sigmaz(), sigmax(), qeye(2))
+        mat3 = tensor(qeye(2), sigmaz(), sigmax())
+        assert_(mat1 in result)
+        assert_(mat2 in result)
+        assert_(mat3 in result)
 
     def test_molmer_sorensen(self):
         """
@@ -356,6 +373,7 @@ class TestGates:
             qrot(np.pi/4., np.pi/3., N=2, target=1),
             tensor([identity(2), qrot(np.pi/4., np.pi/3.)])
         )
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -40,8 +40,7 @@ from qutip.operators import identity, qeye, sigmax, sigmay, sigmaz
 from qutip.qip import (rx, ry, rz, phasegate, qrot, cnot, swap, iswap,
                        sqrtswap, molmer_sorensen,
                        toffoli, fredkin, gate_expand_3toN, 
-                       qubit_clifford_group, expand_oper,
-                       expand_oper_cycper)
+                       qubit_clifford_group, expand_operator)
 from qutip.random_objects import rand_ket, rand_herm, rand_unitary, rand_dm
 from qutip.tensor import tensor
 from qutip.qobj import Qobj
@@ -288,34 +287,34 @@ class TestGates:
                         o2 = psi_ref_out.overlap(psi_ref_in)
                         assert_(abs(o1 - o2) < 1e-12)
 
-    def test_expand_oper(self):
+    def test_expand_operator(self):
         """
         gate : expand qubits operator to a N qubits system.
         """
         # oper size is N, no expansion
         oper = tensor(sigmax(), sigmay())
-        assert_allclose(expand_oper(oper=oper, targets=[0, 1], N=2), oper)
-        assert_allclose(expand_oper(oper=oper, targets=[1, 0], N=2), 
+        assert_allclose(expand_operator(oper=oper, targets=[0, 1], N=2), oper)
+        assert_allclose(expand_operator(oper=oper, targets=[1, 0], N=2), 
                             tensor(sigmay(), sigmax()))
 
         # random single qubit gate test, integer as target
         r = rand_unitary(2)
-        assert_allclose(expand_oper(r, 3, 0), tensor([r, identity(2), identity(2)]))
-        assert_allclose(expand_oper(r, 3, 1), tensor([identity(2), r, identity(2)]))
-        assert_allclose(expand_oper(r, 3, 2), tensor([identity(2), identity(2), r]))
+        assert_allclose(expand_operator(r, 3, 0), tensor([r, identity(2), identity(2)]))
+        assert_allclose(expand_operator(r, 3, 1), tensor([identity(2), r, identity(2)]))
+        assert_allclose(expand_operator(r, 3, 2), tensor([identity(2), identity(2), r]))
 
         # random 2qubits gate test, list as target
         r2 = rand_unitary(4)
         r2.dims = [[2, 2], [2, 2]]
-        assert_allclose(expand_oper(r2, 3, [2, 1]), tensor(
+        assert_allclose(expand_operator(r2, 3, [2, 1]), tensor(
             [identity(2), r2.permute([1, 0])]))
-        assert_allclose(expand_oper(r2, 3, [0, 1]), tensor(
+        assert_allclose(expand_operator(r2, 3, [0, 1]), tensor(
             [r2, identity(2)]))
-        assert_allclose(expand_oper(r2, 3, [0, 2]), tensor(
+        assert_allclose(expand_operator(r2, 3, [0, 2]), tensor(
             [r2, identity(2)]).permute([0, 2, 1]))
 
         # cnot expantion, qubit 2 control qubit 0
-        assert_allclose(expand_oper(cnot(), 3, [2, 0]), Qobj([
+        assert_allclose(expand_operator(cnot(), 3, [2, 0]), Qobj([
             [1., 0., 0., 0., 0., 0., 0., 0.],
             [0., 0., 0., 0., 0., 1., 0., 0.],
             [0., 0., 1., 0., 0., 0., 0., 0.],
@@ -326,9 +325,10 @@ class TestGates:
             [0., 0., 0., 1., 0., 0., 0., 0.]],
             dims=[[2, 2, 2], [2, 2, 2]]))
 
-        # test periodically expansion
-        result = expand_oper_cycper(
-            tensor([sigmaz(), sigmax()]), N=3, targets=[2, 0])
+        # test expansion with cyclic permutation
+        result = expand_operator(
+            tensor([sigmaz(), sigmax()]), N=3, targets=[2, 0],
+            cyclic_permutation=True)
         mat1 = tensor(sigmax(), qeye(2), sigmaz())
         mat2 = tensor(sigmaz(), sigmax(), qeye(2))
         mat3 = tensor(qeye(2), sigmaz(), sigmax())
@@ -341,13 +341,13 @@ class TestGates:
         oper = tensor([sigmax(), mat3])
         N = 4
         dims = [2, 2, 3, 4]
-        result = expand_oper(oper, N, targets=[0, 2], dims=dims)
+        result = expand_operator(oper, N, targets=[0, 2], dims=dims)
         assert_array_equal(result.dims[0], dims)
         dims = [3, 2, 4, 2]
-        result = expand_oper(oper, N, targets=[3, 0], dims=dims)
+        result = expand_operator(oper, N, targets=[3, 0], dims=dims)
         assert_array_equal(result.dims[0], dims)
         dims = [3, 2, 4, 2]
-        result = expand_oper(oper, N, targets=[1, 0], dims=dims)
+        result = expand_operator(oper, N, targets=[1, 0], dims=dims)
         assert_array_equal(result.dims[0], dims)
 
     def test_molmer_sorensen(self):

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -33,7 +33,8 @@
 
 import itertools
 import numpy as np
-from numpy.testing import assert_, assert_allclose, run_module_suite
+from numpy.testing import (assert_, assert_allclose, assert_array_equal, 
+                           run_module_suite)
 from qutip.states import basis, ket2dm
 from qutip.operators import identity, qeye, sigmax, sigmay, sigmaz
 from qutip.qip import (rx, ry, rz, phasegate, qrot, cnot, swap, iswap,
@@ -334,6 +335,20 @@ class TestGates:
         assert_(mat1 in result)
         assert_(mat2 in result)
         assert_(mat3 in result)
+
+        # test for dimensions other than 2
+        mat3 = rand_dm(3, density=1.)
+        oper = tensor([sigmax(), mat3])
+        N = 4
+        dims = [2,2,3,4]
+        result = expand_oper(oper, N, targets=[0,2], dims=dims)
+        assert_array_equal(result.dims[0], dims)
+        dims = [3,2,4,2]
+        result = expand_oper(oper, N, targets=[3,0], dims=dims)
+        assert_array_equal(result.dims[0], dims)
+        dims = [3,2,4,2]
+        result = expand_oper(oper, N, targets=[1,0], dims=dims)
+        assert_array_equal(result.dims[0], dims)
 
     def test_molmer_sorensen(self):
         """

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -42,7 +42,7 @@ from qutip.qip import (rx, ry, rz, phasegate, qrot, cnot, swap, iswap,
                        toffoli, fredkin, gate_expand_3toN, 
                        qubit_clifford_group, expand_oper,
                        expand_oper_periodic)
-from qutip.random_objects import rand_ket, rand_herm, rand_unitary
+from qutip.random_objects import rand_ket, rand_herm, rand_unitary, rand_dm
 from qutip.tensor import tensor
 from qutip.qobj import Qobj
 
@@ -328,7 +328,7 @@ class TestGates:
 
         # test periodically expansion
         result = expand_oper_periodic(
-            tensor([sigmaz(),sigmax()]), N=3, targets=[2 ,0])
+            tensor([sigmaz(), sigmax()]), N=3, targets=[2, 0])
         mat1 = tensor(sigmax(), qeye(2), sigmaz())
         mat2 = tensor(sigmaz(), sigmax(), qeye(2))
         mat3 = tensor(qeye(2), sigmaz(), sigmax())
@@ -340,14 +340,14 @@ class TestGates:
         mat3 = rand_dm(3, density=1.)
         oper = tensor([sigmax(), mat3])
         N = 4
-        dims = [2,2,3,4]
-        result = expand_oper(oper, N, targets=[0,2], dims=dims)
+        dims = [2, 2, 3, 4]
+        result = expand_oper(oper, N, targets=[0, 2], dims=dims)
         assert_array_equal(result.dims[0], dims)
-        dims = [3,2,4,2]
-        result = expand_oper(oper, N, targets=[3,0], dims=dims)
+        dims = [3, 2, 4, 2]
+        result = expand_oper(oper, N, targets=[3, 0], dims=dims)
         assert_array_equal(result.dims[0], dims)
-        dims = [3,2,4,2]
-        result = expand_oper(oper, N, targets=[1,0], dims=dims)
+        dims = [3, 2, 4, 2]
+        result = expand_oper(oper, N, targets=[1, 0], dims=dims)
         assert_array_equal(result.dims[0], dims)
 
     def test_molmer_sorensen(self):

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -41,7 +41,7 @@ from qutip.qip import (rx, ry, rz, phasegate, qrot, cnot, swap, iswap,
                        sqrtswap, molmer_sorensen,
                        toffoli, fredkin, gate_expand_3toN, 
                        qubit_clifford_group, expand_oper,
-                       expand_oper_periodic)
+                       expand_oper_nearest)
 from qutip.random_objects import rand_ket, rand_herm, rand_unitary, rand_dm
 from qutip.tensor import tensor
 from qutip.qobj import Qobj
@@ -327,7 +327,7 @@ class TestGates:
             dims=[[2, 2, 2], [2, 2, 2]]))
 
         # test periodically expansion
-        result = expand_oper_periodic(
+        result = expand_oper_nearest(
             tensor([sigmaz(), sigmax()]), N=3, targets=[2, 0])
         mat1 = tensor(sigmax(), qeye(2), sigmaz())
         mat2 = tensor(sigmaz(), sigmax(), qeye(2))

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -41,7 +41,7 @@ from qutip.qip import (rx, ry, rz, phasegate, qrot, cnot, swap, iswap,
                        sqrtswap, molmer_sorensen,
                        toffoli, fredkin, gate_expand_3toN, 
                        qubit_clifford_group, expand_oper,
-                       expand_oper_nearest)
+                       expand_oper_cycper)
 from qutip.random_objects import rand_ket, rand_herm, rand_unitary, rand_dm
 from qutip.tensor import tensor
 from qutip.qobj import Qobj
@@ -327,7 +327,7 @@ class TestGates:
             dims=[[2, 2, 2], [2, 2, 2]]))
 
         # test periodically expansion
-        result = expand_oper_nearest(
+        result = expand_oper_cycper(
             tensor([sigmaz(), sigmax()]), N=3, targets=[2, 0])
         mat1 = tensor(sigmax(), qeye(2), sigmaz())
         mat2 = tensor(sigmaz(), sigmax(), qeye(2))

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -33,7 +33,7 @@
 
 import numpy as np
 from numpy.testing import assert_, assert_allclose, run_module_suite
-from qutip.qip.gates import gate_sequence_product, rx, identity, expand_oper
+from qutip.qip.gates import gate_sequence_product, rx, identity, expand_operator
 from qutip.qip.circuit import QubitCircuit, Gate
 from qutip.tensor import tensor
 from qutip.qobj import Qobj, ptrace


### PR DESCRIPTION
1. Generalize expand_oper to arbitrary dimensions instead of only qubits system. Together with user-defined gate, this would allow quantum circuit of n-level-system.
2. A method `expand_oper_periodic` can be used to expand gate for all cyclic permutation of the given target qubits. ([0, 1], [1, 2], [2, 0] for 3 qubits system)