### PR TITLE
Fix wrong decomposition of snot (hadamard) gate in resolve_gates

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -489,11 +489,11 @@ class QubitCircuit(object):
                 temp_resolved.append(Gate("GLOBALPHASE", None, None,
                                           arg_value=np.pi / 2,
                                           arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RX", gate.targets, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
                 temp_resolved.append(Gate("RY", gate.targets, None,
                                           arg_value=np.pi / 2,
                                           arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RX", gate.targets, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
             elif gate.name == "PHASEGATE":
                 temp_resolved.append(Gate("GLOBALPHASE", None, None,
                                           arg_value=gate.arg_value / 2,

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -128,6 +128,18 @@ class TestQubitCircuit:
         U2 = gate_sequence_product(qc2.propagators())
         assert_((U1 - U2).norm() < 1e-12)
 
+    def testSNOTdecompose(self):
+        """
+        SNOT to rotation: compare unitary matrix for SNOT and product of
+        resolved matrices in terms of rotation gates.
+        """
+        qc1 = QubitCircuit(1)
+        qc1.add_gate("SNOT", targets=0)
+        U1 = gate_sequence_product(qc1.propagators())
+        qc2 = qc1.resolve_gates()
+        U2 = gate_sequence_product(qc2.propagators())
+        assert_((U1 - U2).norm() < 1e-12)
+
     def testadjacentgates(self):
         """
         Adjacent Gates: compare unitary matrix for ISWAP and product of


### PR DESCRIPTION
The decomposition in `qubitcircuit.py` was wrong.

This can be seen by running
```
qc = QubitCircuit(1)
qc.add_gate("SNOT", targets=0)
dec_qc = qc.resolve_gates()
dec_snot = gate_sequence_product(dec_qc.propagators())
print(snot())
print(dec_snot)
```