### PR TITLE
Bugfix: permute and correlator

### DIFF
--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -1348,14 +1348,16 @@ def _transform_shift_one_coeff(op, args):
     if isinstance(op, types.FunctionType):
         # function-list based time-dependence
         if isinstance(args, dict):
+            def fn(t, args_i):
+                return op(t + args_i["_t0"], args_i)
             fn = lambda t, args_i: \
                 op(t + args_i["_t0"], args_i)
         else:
-            fn = lambda t, args_i: \
-                op(t + args_i["_t0"], args_i["_user_args"])
+            def fn(t, args_i):
+                return op(t + args_i["_t0"], args_i["_user_args"])
     else:
         fn = sub("(?<=[^0-9a-zA-Z_])t(?=[^0-9a-zA-Z_])",
-             "(t+_t0)", " " + op + " ")
+                 "(t+_t0)", " " + op + " ")
     return fn
 
 
@@ -1366,7 +1368,8 @@ def _transform_shift_one_op(op, args={}):
         new_op = op
         new_op._shift
     elif callable(op):
-        new_op = lambda t, args_i: op(t+args_i["_t0"], args_i)
+        def new_op(t, args_i):
+            return op(t + args_i["_t0"], args_i)
     elif isinstance(op, list):
         new_op = []
         for block in op:

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -502,7 +502,7 @@ class Qobj(object):
                     # to have uneven length (non-square Qobjs).
                     # We use None as padding so that it doesn't match anything,
                     # and will never cause a partial trace on the other side.
-                    mask = [l == r == 1 for l, r in zip_longest(dims[0], 
+                    mask = [l == r == 1 for l, r in zip_longest(dims[0],
                                                                 dims[1],
                                                                 fillvalue=None)]
                     # To ensure that there are still any dimensions left, we
@@ -1036,7 +1036,7 @@ class Qobj(object):
 
         """
         return zcsr_trace(self.data, self.isherm)
-    
+
     def purity(self):
         """Calculate purity of a quantum object.
 
@@ -1335,6 +1335,7 @@ class Qobj(object):
         """
         q = Qobj()
         q.data, q.dims = _permute(self, order)
+        q.data.sort_indices()
         return q.tidyup() if settings.auto_tidyup else q
 
     def tidyup(self, atol=settings.auto_tidyup_atol):
@@ -1839,7 +1840,7 @@ class Qobj(object):
         Parameters
         ----------
         B : :class:`qutip.Qobj` or None
-            If B is not None, the diamond distance d(A, B) = dnorm(A - B) 
+            If B is not None, the diamond distance d(A, B) = dnorm(A - B)
             between this operator and B is returned instead of the diamond norm.
 
         Returns
@@ -1878,7 +1879,7 @@ class Qobj(object):
                     else sr.to_choi(self)
                 )
                 # If J isn't hermitian, then that could indicate either
-                # that J is not normal, or is normal,  
+                # that J is not normal, or is normal,
                 # but has complex eigenvalues.
                 # In either case, it makes no sense to then demand that the
                 # eigenvalues be non-negative.

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -52,6 +52,7 @@ import pickle
 import sys
 import scipy
 import os
+from re import sub
 
 if qset.has_openmp:
     from qutip.cy.openmp.cqobjevo_omp import (CQobjCteOmp, CQobjEvoTdOmp,

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -1266,7 +1266,7 @@ class QobjEvo:
 
     def _shift(self):
         self.compiled = ""
-        self.args.update({"_t0":0})
+        self.args.update({"_t0": 0})
         new_ops = []
         for op in self.ops:
             new_op = [op.qobj, None, None, op.type]

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -666,5 +666,31 @@ def test_fn_list_td_corr():
     assert_(abs(g20 - 0.85) < 1e-2)
 
 
+def test_fn_list_td_corr():
+    """
+    correlation: multi time-dependent factor
+    """
+    # test for bug of issue #1048
+    sm = destroy(2)
+    args = {}
+
+    def step_func(t, args={}):
+        return np.arctan(t-2)/np.pi + 0.5
+
+    def inv_step_func(t, args={}):
+        return np.arctan(-(t-2))/np.pi + 0.5
+
+    H1 = [[(sm + sm.dag()), step_func], [qeye(2), inv_step_func]]
+
+    H2 = [[qeye(2), inv_step_func], [(sm + sm.dag()), step_func]]
+    
+    tlist = np.linspace(0, 5, 6)
+    corr1 = correlation_2op_2t(H1, fock(2, 0), tlist, tlist, [sm],
+                               sm.dag(), sm, args=args)
+    corr2 = correlation_2op_2t(H2, fock(2, 0), tlist, tlist, [sm],
+                               sm.dag(), sm, args=args)
+    assert_(np.sum(np.abs(corr1-corr2)) < 1e-5)
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_qobjevo.py
+++ b/qutip/tests/test_qobjevo.py
@@ -342,6 +342,36 @@ def test_QobjEvo_compress():
     _assert_qobj_almost_eq(td_obj_2(t), td_obj_1(t))
 
 
+def test_QobjEvo_shift():
+    """QobjEvo _shift time"""
+    tlist = np.linspace(0, 1, 300)
+    td_obj_1 = QobjEvo(_random_QobjEvo((1,1), [0,0], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_1s = td_obj_1.copy()
+    td_obj_1s._shift()
+    td_obj_2 = QobjEvo(_random_QobjEvo((1,1), [1,1], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_2s = td_obj_2.copy()
+    td_obj_2s._shift()
+
+    _assert_qobj_almost_eq(td_obj_1(0),td_obj_1s(1, args={"_t0":-1}))
+    _assert_qobj_almost_eq(td_obj_2(0),td_obj_2s(1, args={"_t0":-1}))
+    td_obj_1s.arguments({"_t0":-1})
+    td_obj_2s.arguments({"_t0":-1})
+    _assert_qobj_almost_eq(td_obj_1(0),td_obj_1s(1))
+    _assert_qobj_almost_eq(td_obj_2(0),td_obj_2s(1))
+    td_obj_1s.compile()
+    td_obj_2s.compile()
+    _assert_qobj_almost_eq(td_obj_1(0),td_obj_1s(1))
+    _assert_qobj_almost_eq(td_obj_2(0),td_obj_2s(1))
+    _assert_qobj_almost_eq(td_obj_1(0),td_obj_1s(2, args={"_t0":-2}))
+    _assert_qobj_almost_eq(td_obj_2(0),td_obj_2s(2, args={"_t0":-2}))
+    td_obj_1s.arguments({"_t0":-2})
+    td_obj_2s.arguments({"_t0":-2})
+    _assert_qobj_almost_eq(td_obj_1(0),td_obj_1s(2))
+    _assert_qobj_almost_eq(td_obj_2(0),td_obj_2s(2))
+
+
 def test_QobjEvo_apply():
     "QobjEvo apply"
     def multiply(qobj,b,factor = 3.):


### PR DESCRIPTION
Fix bug of issues #1048 and #1051:
- Sort csr_matrix after Qobj.permute.
- Corrected bug in the time shifting function in correlation. Added the shift capacity to QobjEvo.

Merge to 4.4.1?