### PR TITLE
Fixed PolyDataMapper construction

### DIFF
--- a/qutip/bloch3d.py
+++ b/qutip/bloch3d.py
@@ -352,7 +352,8 @@ class Bloch3d():
             cone = tvtk.ConeSource(height=self.vector_head_height,
                                    radius=self.vector_head_radius,
                                    resolution=100)
-            cone_mapper = tvtk.PolyDataMapper(input=cone.output)
+            cone_mapper = tvtk.PolyDataMapper(
+                input_connection=cone.output_port)
             prop = tvtk.Property(opacity=self.vector_alpha, color=color)
             cc = tvtk.Actor(mapper=cone_mapper, property=prop)
             cc.rotate_z(np.degrees(phi))


### PR DESCRIPTION
Attempting to use `add_states()` on a Bloch3d instances results in an exception delayed to when attempting to show it. The line
`cone_mapper = tvtk.PolyDataMapper(input=cone.output)`
is the culprit, as the `input` and `output` attributes were deprecated for VTK 7.x. A quick updating of the attribute names fixes this.