### PR TITLE
Qutip 4.4.1

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,21 +2,21 @@ version: "2"
 checks:
   argument-count:
     config:
-      threshold: 6
+      threshold: 8
   complex-logic:
     config:
-      threshold: 5
+      threshold: 10
   file-lines:
     enabled: false
   method-complexity:
     config:
-      threshold: 5
+      threshold: 10
   method-count:
     config:
       threshold: 50
   method-lines:
     config:
-      threshold: 50
+      threshold: 70
   nested-control-flow:
     config:
       threshold: 4

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -51,6 +51,7 @@ from qutip.mesolve import mesolve
 from qutip.mcsolve import mcsolve
 from qutip.operators import qeye
 from qutip.qobj import Qobj, isket, issuper
+from qutip.qobjevo import QobjEvo
 from qutip.rhs_generate import rhs_clear, _td_wrap_array_str
 from qutip.cy.utilities import _cython_build_cleanup
 from qutip.settings import debug
@@ -576,12 +577,12 @@ def spectrum_correlation_fft(tlist, y, inverse=False):
     dt = tlist[1] - tlist[0]
     if not np.allclose(np.diff(tlist), dt*np.ones(N-1,dtype=float)):
         raise Exception('tlist must be equally spaced for FFT.')
-    
+
     if inverse:
            F = N * scipy.fftpack.ifft(y)
     else:
            F = scipy.fftpack.fft(y)
-    
+
     # calculate the frequencies for the components in F
     f = scipy.fftpack.fftfreq(N, dt)
 
@@ -813,7 +814,7 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
     References
     ----------
     See, Gardiner, Quantum Noise, Section 5.2.
-                       
+
     .. note:: Deprecated in QuTiP 3.1
               Use correlation_3op_1t() instead.
 
@@ -1100,7 +1101,7 @@ def _correlation_me_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     rho_t = mesolve(H, rho0, tlist, c_ops, [],
                     args=args, options=options).states
     corr_mat = np.zeros([np.size(tlist), np.size(taulist)], dtype=complex)
-    H_shifted, c_ops_shifted, _args = _transform_L_t_shift(H, c_ops, args)
+    H_shifted, c_ops_shifted, _args = _transform_L_t_shift_new(H, c_ops, args)
     if config.tdname:
         _cython_build_cleanup(config.tdname)
     rhs_clear()
@@ -1229,7 +1230,7 @@ def _correlation_mc_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
     ).states
 
     corr_mat = np.zeros([np.size(tlist), np.size(taulist)], dtype=complex)
-    H_shifted, c_ops_shifted, _args = _transform_L_t_shift(H, c_ops, args)
+    H_shifted, c_ops_shifted, _args = _transform_L_t_shift_new(H, c_ops, args)
     if config.tdname:
         _cython_build_cleanup(config.tdname)
     rhs_clear()
@@ -1291,10 +1292,10 @@ def _correlation_mc_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
                     dtype=corr_mat.dtype
                 )
                 corr_mat[t_idx, :] += corr_mat_add
-                    
+
         if t_idx == 1:
             options.rhs_reuse = True
-    
+
     if config.tdname:
         _cython_build_cleanup(config.tdname)
     rhs_clear()
@@ -1303,7 +1304,6 @@ def _correlation_mc_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
 
 
 # pseudo-inverse solvers
-
 def _spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
     """
     Internal function for calculating the spectrum of the correlation function
@@ -1344,126 +1344,52 @@ def _spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
 
 
 # auxiliary
+def _transform_shift_one_coeff(op, args):
+    if isinstance(op, types.FunctionType):
+        # function-list based time-dependence
+        if isinstance(args, dict):
+            def fn(t, args_i):
+                return op(t + args_i["_t0"], args_i)
+            fn = lambda t, args_i: \
+                op(t + args_i["_t0"], args_i)
+        else:
+            def fn(t, args_i):
+                return op(t + args_i["_t0"], args_i["_user_args"])
+    else:
+        fn = sub("(?<=[^0-9a-zA-Z_])t(?=[^0-9a-zA-Z_])",
+                 "(t+_t0)", " " + op + " ")
+    return fn
 
-def _transform_L_t_shift(H, c_ops, args={}):
-    """
-    Time shift the Hamiltonian with private time-shift variable _t0
-    """
 
-    # while this list doesn't seem exhaustive, mesolve has already been called
-    # and has hence called _td_format_check from qutip.rhs_generate. important
-    # to keep in mind is that mesolve already requires the types of
-    # time-dependence to be the same for the hamiltonian as for the collapse
-    # operators.
-
-
-    if isinstance(H, Qobj):
-        # constant hamiltonian
-        H_shifted = H  # not shifted!
-
-    c_ops_is_td = False
-    if isinstance(c_ops, list):
-        for i in range(len(c_ops)):
-            # test is collapse operators are time-dependent
-            if isinstance(c_ops[i], list):
-                c_ops_is_td = True
-
-    if not c_ops_is_td:
-        # constant collapse operators
-        c_ops_shifted = c_ops  # not shifted!
-
-    if isinstance(H, Qobj) and not c_ops_is_td:
-        # constant hamiltonian and collapse operators
-        _args = args  # not shifted!
-
-    if isinstance(H, types.FunctionType):
-        # function-callback based time-dependence
-        if isinstance(args, dict) or args is None:
-            if args is None:
-                _args = {"_t0": 0}
+def _transform_shift_one_op(op, args={}):
+    if isinstance(op, Qobj):
+        new_op = op
+    elif isinstance(op, QobjEvo):
+        new_op = op
+        new_op._shift
+    elif callable(op):
+        def new_op(t, args_i):
+            return op(t + args_i["_t0"], args_i)
+    elif isinstance(op, list):
+        new_op = []
+        for block in op:
+            if isinstance(block, list):
+                new_op.append([block[0],
+                               _transform_shift_one_coeff(block[1], args)])
             else:
-                _args = args.copy()
-                _args["_t0"] = 0
-            H_shifted = lambda t, args_i: H(t+args_i["_t0"], args_i)
-        else:
-            raise TypeError("If using function-callback based Hamiltonian" +
-                            "time-dependence, args must be a dictionary")
+                new_op.append(block)
+    return new_op
 
-    if isinstance(H, list) or c_ops_is_td:
-        # string/function-list based time-dependence
-        if args is None:
-            _args = {"_t0": 0}
-        elif isinstance(args, dict):
-            _args = args.copy()
-            _args["_t0"] = 0
-        else:
-            _args = {"_user_args": args, "_t0": 0}
 
-        if isinstance(H, list):
-            # hamiltonian is time-dependent
-            H_shifted = []
-
-            for i in range(len(H)):
-                if isinstance(H[i], list):
-                    # modify Hamiltonian time dependence in accordance with the
-                    # quantum regression theorem
-                    if isinstance(args, dict) or args is None:
-                        if isinstance(H[i][1], types.FunctionType):
-                            # function-list based time-dependence
-                            fn = lambda t, args_i: \
-                                H[i][1](t + args_i["_t0"], args_i)
-                        else:
-                            # string-list based time-dependence
-                            # Again, note: _td_format_check already raises
-                            # errors formixed td formatting
-                            fn = sub("(?<=[^0-9a-zA-Z_])t(?=[^0-9a-zA-Z_])",
-                                     "(t+_t0)", H[i][1])
-                    else:
-                        if isinstance(H[i][1], types.FunctionType):
-                            # function-list based time-dependence
-                            fn = lambda t, args_i: \
-                                H[i][1](t + args_i["_t0"],
-                                        args_i["_user_args"])
-                        else:
-                            raise TypeError("If using string-list based" +
-                                            "Hamiltonian time-dependence, " +
-                                            "args must be a dictionary")
-                    H_shifted.append([H[i][0], fn])
-                else:
-                    H_shifted.append(H[i])
-
-        if c_ops_is_td:
-            # collapse operators are time-dependent
-            c_ops_shifted = []
-
-            for i in range(len(c_ops)):
-                if isinstance(c_ops[i], list):
-                    # modify collapse operators time dependence in accordance
-                    # with the quantum regression theorem
-                    if isinstance(args, dict) or args is None:
-                        if isinstance(c_ops[i][1], types.FunctionType):
-                            # function-list based time-dependence
-                            fn = lambda t, args_i: \
-                                c_ops[i][1](t + args_i["_t0"], args_i)
-                        else:
-                            # string-list based time-dependence
-                            # Again, note: _td_format_check already raises
-                            # errors formixed td formatting
-                            fn = sub("(?<=[^0-9a-zA-Z_])t(?=[^0-9a-zA-Z_])",
-                                     "(t+_t0)", c_ops[i][1])
-                    else:
-                        if isinstance(H[i][1], types.FunctionType):
-                            # function-list based time-dependence
-                            fn = lambda t, args_i: \
-                                c_ops[i][1](t + args_i["_t0"],
-                                            args_i["_user_args"])
-                        else:
-                            raise TypeError("If using string-list based" +
-                                            "collapse operator" +
-                                            "time-dependence, " +
-                                            "args must be a dictionary")
-                    c_ops_shifted.append([c_ops[i][0], fn])
-                else:
-                    c_ops_shifted.append(c_ops[i])
+def _transform_L_t_shift_new(H, c_ops, args={}):
+    H_shifted = _transform_shift_one_op(H, args)
+    c_ops_shifted = [_transform_shift_one_op(op, args) for op in c_ops]
+    if args is None:
+        _args = {"_t0": 0}
+    elif isinstance(args, dict):
+        _args = args.copy()
+        _args["_t0"] = 0
+    else:
+        _args = {"_user_args": args, "_t0": 0}
 
     return H_shifted, c_ops_shifted, _args

--- a/qutip/cy/cqobjevo_factor.pyx
+++ b/qutip/cy/cqobjevo_factor.pyx
@@ -39,7 +39,8 @@ cimport cython
 cimport libc.math
 from qutip.cy.inter import _prep_cubic_spline
 from qutip.cy.inter cimport (_spline_complex_cte_second,
-                             _spline_complex_t_second)
+                             _spline_complex_t_second,
+                             _step_complex_t, _step_complex_cte)
 from qutip.cy.interpolate cimport (interp, zinterp)
 from qutip.cy.cqobjevo cimport CQobjEvo
 
@@ -224,6 +225,50 @@ cdef class InterCoeffT(CoeffFunc):
         self.tlist = state[3]
         self.y = state[4]
         self.M = state[5]
+
+
+cdef class StepCoeff(CoeffFunc):
+    cdef int n_t
+    cdef double[::1] tlist
+    cdef complex[:,::1] y
+
+    def __init__(self, ops, args, tlist):
+        cdef int i, j
+        self._args = {}
+        self._num_ops = len(ops)
+        self.tlist = tlist
+        self.n_t = len(tlist)
+        self.y = np.zeros((self._num_ops, self.n_t), dtype=complex)
+        for i in range(self._num_ops):
+            for j in range(self.n_t):
+                self.y[i,j] = ops[i][2][j]
+        
+    def set_arg(self, args):
+        pass
+
+    def __getstate__(self):
+        return (self._num_ops, self.n_t, None, np.array(self.tlist),
+                np.array(self.y))
+
+    def __setstate__(self, state):
+        self._num_ops = state[0]
+        self.n_t = state[1]
+        self.tlist = state[3]
+        self.y = state[4]
+
+
+cdef class StepCoeffT(StepCoeff):
+    cdef void _call_core(self, double t, complex* coeff):
+        cdef int i
+        for i in range(self._num_ops):
+            coeff[i] = _step_complex_t(t, self.tlist, self.y[i, :], self.n_t)
+
+
+cdef class StepCoeffCte(StepCoeff): 
+    cdef void _call_core(self, double t, complex* coeff):
+        cdef int i
+        for i in range(self._num_ops):
+            coeff[i] = _step_complex_cte(t, self.tlist, self.y[i, :], self.n_t)
 
 
 cdef class StrCoeff(CoeffFunc):

--- a/qutip/cy/inter.pxd
+++ b/qutip/cy/inter.pxd
@@ -48,3 +48,11 @@ cdef double _spline_float_t_second(double x, double[::1] t,
 cdef double _spline_float_cte_second(double x, double[::1] t,
                                      double[::1] y, double[::1] M,
                                      int N, double dt)
+
+cdef double _step_float_cte(double x, double[::1] t, double[::1] y, int n_t)
+
+cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y, int n_t)
+
+cdef double _step_float_t(double x, double[::1] t, double[::1] y, int n_t)
+
+cdef complex _step_complex_t(double x, double[::1] t, complex[::1] y, int n_t)

--- a/qutip/cy/inter.pyx
+++ b/qutip/cy/inter.pyx
@@ -116,8 +116,9 @@ cdef double _spline_float_cte_second(double x,
         return y[0]
     elif x > t[n_t-1]:
         return y[n_t-1]
-    cdef int p = <int>(x/dt)
-    cdef double tb = (x/dt - p)
+    cdef double xx = (x-t[0])/dt
+    cdef int p = <int>xx
+    cdef double tb = (xx - p)
     cdef double te = 1 - tb
     cdef double dt2 = dt * dt
     cdef double Me = M[p+1] * dt2
@@ -164,8 +165,9 @@ cdef complex _spline_complex_cte_second(double x,
         return y[0]
     elif x > t[n_t-1]:
         return y[n_t-1]
-    cdef int p = <int>(x/dt)
-    cdef double tb = (x/dt - p)
+    cdef double xx = (x-t[0])/dt
+    cdef int p = <int>xx
+    cdef double tb = (xx - p)
     cdef double te = 1 - tb
     cdef double dt2 = dt * dt
     cdef complex Me = M[p+1] * dt2

--- a/qutip/cy/inter.pyx
+++ b/qutip/cy/inter.pyx
@@ -198,3 +198,53 @@ cdef complex _spline_complex_t_second(double x,
     cdef complex Mb = M[p] * dt2
     return te * (Mb * te * te + (y[p]   - Mb)) + \
            tb * (Me * tb * tb + (y[p+1] - Me))
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef double _step_float_cte(double x, double[::1] t, double[::1] y, int n_t):
+    if x < t[0]:
+        return y[0]
+    elif x >= t[n_t-1]:
+        return y[n_t-1]
+    cdef int p = <int> ((x-t[0]) / (t[n_t-1]-t[0]) * (n_t-1))
+    return y[p]
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y, int n_t):
+    if x < t[0]:
+        return y[0]
+    elif x >= t[n_t-1]:
+        return y[n_t-1]
+    cdef int p = <int> ((x-t[0]) / (t[n_t-1]-t[0]) * (n_t-1))
+    return y[p]
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef double _step_float_t(double x, double[::1] t, double[::1] y, int n_t):
+    if x < t[0]:
+        return y[0]
+    elif x >= t[n_t-1]:
+        return y[n_t-1]
+    # TODO this can be moved out for better performance
+    cdef int p = _binary_search(x, t, n_t)
+    return y[p]
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef complex _step_complex_t(double x, double[::1] t, complex[::1] y, int n_t):
+    if x < t[0]:
+        return y[0]
+    elif x >= t[n_t-1]:
+        return y[n_t-1]
+    # TODO this can be moved out for better performance
+    cdef int p = _binary_search(x, t, n_t)
+    return y[p]

--- a/qutip/mcsolve.py
+++ b/qutip/mcsolve.py
@@ -76,9 +76,8 @@ class qutip_zvode(zvode):
         return r
 
 def mcsolve(H, psi0, tlist, c_ops=[], e_ops=[], ntraj=0,
-            args={}, options=Options(),
-            progress_bar=True, map_func=parallel_map, map_kwargs={},
-            _safe_mode=True, _exp=False):
+            args={}, options=None, progress_bar=True,
+            map_func=parallel_map, map_kwargs={}, _safe_mode=True):
     """Monte Carlo evolution of a state vector :math:`|\psi \\rangle` for a
     given Hamiltonian and sets of collapse operators, and possibly, operators
     for calculating expectation values. Options for the underlying ODE solver
@@ -174,6 +173,9 @@ def mcsolve(H, psi0, tlist, c_ops=[], e_ops=[], ntraj=0,
     if isinstance(c_ops, (Qobj, QobjEvo)):
         c_ops = [c_ops]
 
+    if options is None:
+        options = Options()
+
     if options.rhs_reuse and not isinstance(H, SolverSystem):
         # TODO: deprecate when going to class based solver.
         if "mcsolve" in solver_safe:
@@ -202,7 +204,7 @@ def mcsolve(H, psi0, tlist, c_ops=[], e_ops=[], ntraj=0,
         raise Exception("Initial state must be a state vector.")
 
     # load monte carlo class
-    mc = _MC(options, _exp)
+    mc = _MC(options)
 
 
     if isinstance(H, SolverSystem):
@@ -235,7 +237,9 @@ class _MC():
     """
     Private class for solving Monte Carlo evolution from mcsolve
     """
-    def __init__(self, options=Options(), _exp=False):
+    def __init__(self, options=None):
+        if options is None:
+            options = Options()
         self.options = options
         self.ss = None
         self.tlist = None
@@ -251,9 +255,6 @@ class _MC():
         self._expect_out = []
         self._collapse = []
         self._ss_out = []
-
-        # Flag
-        self._experimental = _exp
 
     def reset(self, t=0., psi0=None):
         if psi0 is not None:
@@ -426,9 +427,10 @@ class _MC():
             progress_bar = TextProgressBar()
 
         # set arguments for input to monte carlo
-        map_kwargs = {'progress_bar': progress_bar,
+        map_kwargs_ = {'progress_bar': progress_bar,
                       'num_cpus': options.num_cpus}
-        map_kwargs.update(map_kwargs)
+        map_kwargs_.update(map_kwargs)
+        map_kwargs = map_kwargs_
 
         if self.e_ops is None:
             self.set_e_ops()
@@ -598,7 +600,7 @@ class _MC():
             output.states = self.runs_states
 
         if options.store_final_state:
-            if not self._experimental or options.average_states:
+            if options.average_states:
                 output.final_state = self.final_state
             else:
                 output.final_state = self.runs_final_states

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -236,7 +236,6 @@ def mesolve(H, rho0, tlist, c_ops=[], e_ops=[], args={}, options=Options(),
                             options.rhs_with_state))
 
     if not use_mesolve:
-        print("no collapse operator, using sesolve")
         return sesolve(H, rho0, tlist, e_ops=e_ops, args=args, options=options,
                     progress_bar=progress_bar, _safe_mode=_safe_mode)
 

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -58,8 +58,8 @@ from qutip.cy.openmp.utilities import check_use_openmp, openmp_components
 # pass on to wavefunction solver or master equation solver depending on whether
 # any collapse operators were given.
 #
-def mesolve(H, rho0, tlist, c_ops=[], e_ops=[], args={}, options=Options(),
-            progress_bar=BaseProgressBar(), _safe_mode=True):
+def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None,
+            progress_bar=None, _safe_mode=True):
     """
     Master equation evolution of a density matrix for a given Hamiltonian and
     set of collapse operators, or a Liouvillian.
@@ -157,22 +157,22 @@ def mesolve(H, rho0, tlist, c_ops=[], e_ops=[], args={}, options=Options(),
     tlist : *list* / *array*
         list of times for :math:`t`.
 
-    c_ops : list of :class:`qutip.Qobj`
+    c_ops : None / list of :class:`qutip.Qobj`
         single collapse operator, or list of collapse operators, or a list
         of Liouvillian superoperators.
 
-    e_ops : list of :class:`qutip.Qobj` / callback function single
+    e_ops : None / list of :class:`qutip.Qobj` / callback function single
         single operator or list of operators for which to evaluate
         expectation values.
 
-    args : *dictionary*
+    args : None / *dictionary*
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : :class:`qutip.Options`
+    options : None / :class:`qutip.Options`
         with options for the solver.
 
-    progress_bar : BaseProgressBar
+    progress_bar : None / BaseProgressBar
         Optional instance of BaseProgressBar, or a subclass thereof, for
         showing the progress of the simulation.
 
@@ -188,11 +188,13 @@ def mesolve(H, rho0, tlist, c_ops=[], e_ops=[], args={}, options=Options(),
         operators for which to calculate the expectation values.
 
     """
-    # check whether c_ops or e_ops is is a single operator
-    # if so convert it to a list containing only that operator
+    if c_ops is None:
+        c_ops = []
     if isinstance(c_ops, (Qobj, QobjEvo)):
         c_ops = [c_ops]
 
+    if e_ops is None:
+        e_ops = []
     if isinstance(e_ops, Qobj):
         e_ops = [e_ops]
 
@@ -202,6 +204,8 @@ def mesolve(H, rho0, tlist, c_ops=[], e_ops=[], args={}, options=Options(),
     else:
         e_ops_dict = None
 
+    if progress_bar is None:
+        progress_bar = BaseProgressBar()
     if progress_bar is True:
         progress_bar = TextProgressBar()
 
@@ -212,6 +216,8 @@ def mesolve(H, rho0, tlist, c_ops=[], e_ops=[], args={}, options=Options(),
         raise TypeError("Must have e_ops = [] when initial condition rho0 is" +
                 " a superoperator.")
 
+    if options is None:
+        options = Options()
     if options.rhs_reuse and not isinstance(H, SolverSystem):
         # TODO: deprecate when going to class based solver.
         if "mesolve" in solver_safe:
@@ -221,7 +227,9 @@ def mesolve(H, rho0, tlist, c_ops=[], e_ops=[], args={}, options=Options(),
             pass
             # raise Exception("Could not find the Hamiltonian to reuse.")
 
-    #check if should use OPENMP
+    if args is None:
+        args = {}
+
     check_use_openmp(options)
 
     use_mesolve = ((c_ops and len(c_ops) > 0)

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -502,7 +502,7 @@ class Qobj(object):
                     # to have uneven length (non-square Qobjs).
                     # We use None as padding so that it doesn't match anything,
                     # and will never cause a partial trace on the other side.
-                    mask = [l == r == 1 for l, r in zip_longest(dims[0], 
+                    mask = [l == r == 1 for l, r in zip_longest(dims[0],
                                                                 dims[1],
                                                                 fillvalue=None)]
                     # To ensure that there are still any dimensions left, we
@@ -1036,7 +1036,7 @@ class Qobj(object):
 
         """
         return zcsr_trace(self.data, self.isherm)
-    
+
     def purity(self):
         """Calculate purity of a quantum object.
 
@@ -1335,6 +1335,7 @@ class Qobj(object):
         """
         q = Qobj()
         q.data, q.dims = _permute(self, order)
+        q.data.sort_indices()
         return q.tidyup() if settings.auto_tidyup else q
 
     def tidyup(self, atol=settings.auto_tidyup_atol):
@@ -1839,7 +1840,7 @@ class Qobj(object):
         Parameters
         ----------
         B : :class:`qutip.Qobj` or None
-            If B is not None, the diamond distance d(A, B) = dnorm(A - B) 
+            If B is not None, the diamond distance d(A, B) = dnorm(A - B)
             between this operator and B is returned instead of the diamond norm.
 
         Returns
@@ -1878,7 +1879,7 @@ class Qobj(object):
                     else sr.to_choi(self)
                 )
                 # If J isn't hermitian, then that could indicate either
-                # that J is not normal, or is normal,  
+                # that J is not normal, or is normal,
                 # but has complex eigenvalues.
                 # In either case, it makes no sense to then demand that the
                 # eigenvalues be non-negative.

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -502,11 +502,12 @@ class Qobj(object):
                     # to have uneven length (non-square Qobjs).
                     # We use None as padding so that it doesn't match anything,
                     # and will never cause a partial trace on the other side.
-                    mask = [l == r == 1 for l, r in zip_longest(dims[0], dims[1],
+                    mask = [l == r == 1 for l, r in zip_longest(dims[0], 
+                                                                dims[1],
                                                                 fillvalue=None)]
                     # To ensure that there are still any dimensions left, we
-                    # use max() to add a dimensions list of [1] if all matching dims
-                    # are traced out of that side.
+                    # use max() to add a dimensions list of [1] if all matching
+                    # dims are traced out of that side.
                     out.dims = [max([1],
                                     [dim for dim, m in zip(dims[0], mask)
                                     if not m]),
@@ -1031,11 +1032,33 @@ class Qobj(object):
         Returns
         -------
         trace : float
-            Returns ``real`` if operator is Hermitian, returns ``complex``
-            otherwise.
+            Returns the trace of the quantum object.
 
         """
         return zcsr_trace(self.data, self.isherm)
+    
+    def purity(self):
+        """Calculate purity of a quantum object.
+
+        Returns
+        -------
+        state_purity : float
+            Returns the purity of a quantum object.
+            For a pure state, the purity is 1.
+            For a mixed state of dimension `d`, 1/d<=purity<1.
+
+        """
+        rho = self
+        if (rho.type == "super"):
+            raise TypeError('Purity is defined on a density matrix or state.')
+
+        if rho.type == "ket" or rho.type == "bra":
+            state_purity = (rho*rho.dag()).tr()
+
+        if rho.type == "oper":
+            state_purity = (rho*rho).tr()
+
+        return state_purity
 
     def full(self, order='C', squeeze=False):
         """Dense array from quantum object.
@@ -1521,7 +1544,9 @@ class Qobj(object):
             elif bra.isket and ket.isket:
                 return zcsr_mat_elem(self.data,bra.data,ket.data,0)
             else:
-                raise TypeError("Can only calculate matrix elements for bra and ket vectors.")
+                err = "Can only calculate matrix elements for bra"
+                err += " and ket vectors."
+                raise TypeError(err)
 
     def overlap(self, other):
         """Overlap between two state vectors or two operators.
@@ -1566,7 +1591,8 @@ class Qobj(object):
                 elif other.isoper:
                     return (qutip.states.ket2dm(self).dag() * other).tr()
                 else:
-                    raise TypeError("Can only calculate overlap for state vector Qobjs")
+                    err = "Can only calculate overlap for state vector Qobjs"
+                    raise TypeError(err)
 
             elif self.isket:
                 if other.isbra:
@@ -1576,7 +1602,8 @@ class Qobj(object):
                 elif other.isoper:
                     return (qutip.states.ket2dm(self).dag() * other).tr()
                 else:
-                    raise TypeError("Can only calculate overlap for state vector Qobjs")
+                    err = "Can only calculate overlap for state vector Qobjs"
+                    raise TypeError(err)
 
             elif self.isoper:
                 if other.isket or other.isbra:
@@ -1584,7 +1611,8 @@ class Qobj(object):
                 elif other.isoper:
                     return (self.dag() * other).tr()
                 else:
-                    raise TypeError("Can only calculate overlap for state vector Qobjs")
+                    err = "Can only calculate overlap for state vector Qobjs"
+                    raise TypeError(err)
 
 
         raise TypeError("Can only calculate overlap for state vector Qobjs")
@@ -1811,8 +1839,8 @@ class Qobj(object):
         Parameters
         ----------
         B : :class:`qutip.Qobj` or None
-            If B is not None, the diamond distance d(A, B) = dnorm(A - B) between
-            this operator and B is returned instead of the diamond norm.
+            If B is not None, the diamond distance d(A, B) = dnorm(A - B) 
+            between this operator and B is returned instead of the diamond norm.
 
         Returns
         -------
@@ -1850,7 +1878,8 @@ class Qobj(object):
                     else sr.to_choi(self)
                 )
                 # If J isn't hermitian, then that could indicate either
-                # that J is not normal, or is normal, but has complex eigenvalues.
+                # that J is not normal, or is normal,  
+                # but has complex eigenvalues.
                 # In either case, it makes no sense to then demand that the
                 # eigenvalues be non-negative.
                 if not J.isherm:

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -353,7 +353,6 @@ class QobjEvo:
 
     _cdc()
         Return self.dag() * self.
-        Only possible if num_obj == 1
 
     permute(order)
         Returns composite qobj with indices reordered.

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -467,7 +467,9 @@ class QobjEvo:
                     self.ops.append(EvoElement(op[0], op[1], op[1], "spline"))
 
             nops = sum(op_type_count)
-            if op_type_count[0] == nops:
+            if all([op_t == 0 for op_t in op_type]):
+                self.type = "cte"
+            elif op_type_count[0] == nops:
                 self.type = "func"
             elif op_type_count[1] == nops:
                 self.type = "string"
@@ -1129,7 +1131,9 @@ class QobjEvo:
                 op_type_count[3] += 1
 
         nops = sum(op_type_count)
-        if op_type_count[0] == nops:
+        if not self.ops and self.dummy_cte is False:
+            self.type = "cte"
+        elif op_type_count[0] == nops:
             self.type = "func"
         elif op_type_count[1] == nops:
             self.type = "string"

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -53,6 +53,7 @@ import pickle
 import sys
 import scipy
 import os
+from re import sub
 
 if qset.has_openmp:
     from qutip.cy.openmp.cqobjevo_omp import (CQobjCteOmp, CQobjEvoTdOmp,
@@ -350,7 +351,7 @@ class QobjEvo:
     trans()
         Return the transpose of quantum object.
 
-    norm()
+    _cdc()
         Return self.dag() * self.
         Only possible if num_obj == 1
 
@@ -1240,6 +1241,7 @@ class QobjEvo:
         return res
 
     def _f_norm2(self):
+        self.compiled = ""
         new_ops = []
         for op in self.ops:
             new_op = [op.qobj, None, None, op.type]
@@ -1263,6 +1265,7 @@ class QobjEvo:
         return self
 
     def _f_conj(self):
+        self.compiled = ""
         new_ops = []
         for op in self.ops:
             new_op = [op.qobj, None, None, op.type]
@@ -1278,6 +1281,33 @@ class QobjEvo:
                     self.tlist, new_op[2], args=self.args)
             elif op.type == "spline":
                 new_op[1] = _Conj(op.get_coeff)
+                new_op[2] = new_op[1]
+                new_op[3] = "func"
+                self.type = "mixed_callable"
+            new_ops.append(EvoElement.make(new_op))
+        self.ops = new_ops
+        return self
+
+    def _shift(self):
+        self.compiled = ""
+        self.args.update({"_t0": 0})
+        new_ops = []
+        for op in self.ops:
+            new_op = [op.qobj, None, None, op.type]
+            if op.type == "func":
+                new_op[1] = _Shift(op.get_coeff)
+                new_op[2] = new_op[1]
+            elif op.type == "string":
+                new_op[2] = sub("(?<=[^0-9a-zA-Z_])t(?=[^0-9a-zA-Z_])",
+                                "(t+_t0)", " " + op.coeff + " ")
+                new_op[1] = _StrWrapper(new_op[2])
+            elif op.type == "array":
+                new_op[2] = _Shift(op.get_coeff)
+                new_op[1] = new_op[1]
+                new_op[3] = "func"
+                self.type = "mixed_callable"
+            elif op.type == "spline":
+                new_op[1] = _Shift(op.get_coeff)
                 new_op[2] = new_op[1]
                 new_op[3] = "func"
                 self.type = "mixed_callable"
@@ -1630,6 +1660,14 @@ class _Norm2():
 
     def __call__(self, t, args):
         return self.func(t, args)*np.conj(self.func(t, args))
+
+
+class _Shift():
+    def __init__(self, f):
+        self.func = f
+
+    def __call__(self, t, args):
+        return np.conj(self.func(t + args["_t0"], args))
 
 
 class _Conj():

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -414,7 +414,7 @@ class QobjEvo:
 
         self.const = False
         self.dummy_cte = False
-        self.args = args.copy() if copy else args
+        self.args = args.copy()
         self.dynamics_args = []
         self.cte = None
         self.tlist = tlist

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -37,7 +37,7 @@ __all__ = ['QobjEvo']
 from qutip.qobj import Qobj
 import qutip.settings as qset
 from qutip.interpolate import Cubic_Spline
-from scipy.interpolate import CubicSpline
+from scipy.interpolate import CubicSpline, interp1d
 from functools import partial, wraps
 from types import FunctionType, BuiltinFunctionType
 import numpy as np
@@ -47,7 +47,8 @@ from qutip.cy.spmatfuncs import (cy_expect_rho_vec, cy_expect_psi, spmv, cy_spmm
 from qutip.cy.cqobjevo import (CQobjCte, CQobjCteDense, CQobjEvoTd,
                                  CQobjEvoTdMatched, CQobjEvoTdDense)
 from qutip.cy.cqobjevo_factor import (InterCoeffT, InterCoeffCte,
-                                      InterpolateCoeff, StrCoeff)
+                                      InterpolateCoeff, StrCoeff,
+                                      StepCoeffCte, StepCoeffT)
 import pickle
 import sys
 import scipy
@@ -139,10 +140,19 @@ class _StrWrapper:
 class _CubicSplineWrapper:
     # Using scipy's CubicSpline since Qutip's one
     # only accept linearly distributed tlist
-    def __init__(self, tlist, coeff):
+    def __init__(self, tlist, coeff, args=None):
         self.coeff = coeff
         self.tlist = tlist
-        self.func = CubicSpline(self.tlist, self.coeff)
+        try:
+            use_step_func = args["_step_func_coeff"]
+        except KeyError:
+            use_step_func = 0
+        if use_step_func:
+            self.func = interp1d(
+                self.tlist, self.coeff, kind="previous",
+                bounds_error=False, fill_value=0.)
+        else:
+            self.func = CubicSpline(self.tlist, self.coeff)
 
     def __call__(self, t, args={}):
         return self.func([t])[0]
@@ -228,6 +238,10 @@ class QobjEvo:
     A list of times (float64) at which the coeffients must be given (tlist).
     The coeffients array must have the same len as the tlist.
     The time of the tlist do not need to be equidistant, but must be sorted.
+    By default, a cubic spline interpolation will be used for the coefficient
+    at time t.
+    If the coefficients are to be treated as step function, use the arguments
+    args = {"_step_func_coeff": True}
     *Examples*
         tlist = np.logspace(-5,0,100)
         H = QobjEvo([H0, [H1, np.exp(-1j*tlist)], [H2, np.cos(2.*tlist)]],
@@ -460,8 +474,10 @@ class QobjEvo:
                                     op[1], "string"))
                 elif type_ == 3:
                     op_type_count[2] += 1
-                    self.ops.append(EvoElement(op[0], _CubicSplineWrapper(tlist, op[1]),
-                                     op[1].copy(), "array"))
+                    self.ops.append(EvoElement(
+                        op[0],
+                        _CubicSplineWrapper(tlist, op[1], args=self.args),
+                        op[1].copy(), "array"))
                 elif type_ == 4:
                     op_type_count[3] += 1
                     self.ops.append(EvoElement(op[0], op[1], op[1], "spline"))
@@ -1066,7 +1082,8 @@ class QobjEvo:
                 for i in _set[1:]:
                     new_array += self.ops[i].coeff
                 new_op[2] = new_array
-                new_op[1] = _CubicSplineWrapper(self.tlist, new_array)
+                new_op[1] = _CubicSplineWrapper(
+                    self.tlist, new_array, args=self.args)
                 new_ops.append(EvoElement.make(new_op))
 
         self.ops = new_ops
@@ -1205,7 +1222,8 @@ class QobjEvo:
                     ff = function(f, *args, **kw_args)
                     for i, v in enumerate(op.coeff):
                         op.coeff[i] = ff(v)
-                    op.get_coeff = _CubicSplineWrapper(self.tlist, op.coeff)
+                    op.get_coeff = _CubicSplineWrapper(
+                        self.tlist, op.coeff, args=self.args)
                 else:
                     op.coeff = op.get_coeff
                     op.type = "func"
@@ -1233,7 +1251,8 @@ class QobjEvo:
                 new_op[1] = _StrWrapper(new_op[2])
             elif op.type == "array":
                 new_op[2] = np.abs(op.coeff)**2
-                new_op[1] = _CubicSplineWrapper(self.tlist, new_op[2])
+                new_op[1] = _CubicSplineWrapper(
+                    self.tlist, new_op[2], args=self.args)
             elif op.type == "spline":
                 new_op[1] = _Norm2(op.get_coeff)
                 new_op[2] = new_op[1]
@@ -1255,7 +1274,8 @@ class QobjEvo:
                 new_op[1] = _StrWrapper(new_op[2])
             elif op.type == "array":
                 new_op[2] = np.conj(op.coeff)
-                new_op[1] = _CubicSplineWrapper(self.tlist, new_op[2])
+                new_op[1] = _CubicSplineWrapper(
+                    self.tlist, new_op[2], args=self.args)
             elif op.type == "spline":
                 new_op[1] = _Conj(op.get_coeff)
                 new_op[2] = new_op[1]
@@ -1443,12 +1463,25 @@ class QobjEvo:
                 self.compiled_qobjevo.set_factor(obj=self.coeff_get)
                 self.compiled += "cyfactor"
             elif self.type == "array":
+                try:
+                    use_step_func = self.args["_step_func_coeff"]
+                except KeyError:
+                    use_step_func = 0
                 if np.allclose(np.diff(self.tlist),
-                               self.tlist[1] - self.tlist[0]):
-                    self.coeff_get = InterCoeffCte(self.ops, None,
-                                                     self.tlist)
+                            self.tlist[1] - self.tlist[0]):
+                    if use_step_func:
+                        self.coeff_get = StepCoeffCte(
+                            self.ops, None, self.tlist)
+                    else:
+                        self.coeff_get = InterCoeffCte(
+                            self.ops, None, self.tlist)
                 else:
-                    self.coeff_get = InterCoeffT(self.ops, None, self.tlist)
+                    if use_step_func:
+                        self.coeff_get = StepCoeffT(
+                            self.ops, None, self.tlist)
+                    else:
+                        self.coeff_get = InterCoeffT(
+                            self.ops, None, self.tlist)
                 self.compiled += "cyfactor"
                 self.compiled_qobjevo.set_factor(obj=self.coeff_get)
             elif self.type == "spline":

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -135,6 +135,8 @@ cdef extern from "numpy/arrayobject.h" nogil:
 from qutip.cy.spmatfuncs cimport spmvpy
 from qutip.cy.inter cimport _spline_complex_t_second, _spline_complex_cte_second
 from qutip.cy.inter cimport _spline_float_t_second, _spline_float_cte_second
+from qutip.cy.inter cimport _step_float_cte, _step_complex_cte
+from qutip.cy.inter cimport _step_float_t, _step_complex_t
 from qutip.cy.interpolate cimport (interp, zinterp)
 from qutip.cy.cqobjevo_factor cimport StrCoeff
 from qutip.cy.cqobjevo cimport CQobjEvo
@@ -158,21 +160,42 @@ include """ + _include_string + "\n\n"
             s_str = "_spline_" + str(N_np)
             N_times = str(len(tlist))
             dt_times = str(tlist[1]-tlist[0])
+            try:
+                use_step_func = args["_step_func_coeff"]
+            except KeyError:
+                use_step_func = 0
             if dt_cte:
                 if isinstance(op.coeff[0], (float, np.float32, np.float64)):
-                    string = "_spline_float_cte_second(t, " + t_str + ", " +\
-                              y_str + ", " + s_str + ", " + N_times + ", " +\
-                              dt_times + ")"
+                    if use_step_func:
+                        string = "_step_float_cte(t, " + t_str + ", " +\
+                                y_str + ", " + N_times + ")"
+                    else:
+                        string = "_spline_float_cte_second(t, " + t_str + ", " +\
+                                y_str + ", " + s_str + ", " + N_times + ", " +\
+                                dt_times + ")"
+
                 elif isinstance(op.coeff[0], (complex, np.complex128)):
-                    string = "_spline_complex_cte_second(t, " + t_str + ", " +\
-                              y_str + ", " + s_str + ", " + N_times + ", " +\
-                              dt_times + ")"
+                    if use_step_func:
+                        string = "_step_complex_cte(t, " + t_str + ", " +\
+                                y_str + ", " + N_times + ")"
+                    else:
+                        string = "_spline_complex_cte_second(t, " + t_str + ", " +\
+                                y_str + ", " + s_str + ", " + N_times + ", " +\
+                                dt_times + ")"
             else:
                 if isinstance(op.coeff[0], (float, np.float32, np.float64)):
-                    string = "_spline_float_t_second(t, " + t_str + ", " +\
+                    if use_step_func:
+                        string = "_step_float_t(t, " + t_str + ", " +\
+                             y_str + ", " + N_times + ")"
+                    else:
+                        string = "_spline_float_t_second(t, " + t_str + ", " +\
                              y_str + ", " + s_str + ", " + N_times + ")"
                 elif isinstance(op.coeff[0], (complex, np.complex128)):
-                    string = "_spline_complex_t_second(t, " + t_str + ", " +\
+                    if use_step_func:
+                        string = "_step_complex_t(t, " + t_str + ", " +\
+                             y_str + ", " + N_times + ")"
+                    else:
+                        string = "_spline_complex_t_second(t, " + t_str + ", " +\
                              y_str + ", " + s_str + ", " + N_times + ")"
             compile_list.append(string)
             args[t_str] = tlist

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -262,18 +262,20 @@ def rand_unitary_haar(N=2, dims=None, seed=None):
     U.dims = dims
     return U
 
-def rand_ket(N, density=1, dims=None, seed=None):
+
+def rand_ket(N=0, density=1, dims=None, seed=None):
     """Creates a random Nx1 sparse ket vector.
 
     Parameters
     ----------
     N : int
         Number of rows for output quantum operator.
+        If None or 0, N is deduced from dims.
     density : float
         Density between [0,1] of output ket state.
     dims : list
-        Left-dimensions of quantum object.  Used for specifying
-        tensor structure. Default is dims=[[N]].
+        Dimensions of quantum object.  Used for specifying
+        tensor structure. Default is dims=[[N],[1]].
 
     Returns
     -------
@@ -283,8 +285,13 @@ def rand_ket(N, density=1, dims=None, seed=None):
     """
     if seed is not None:
         np.random.seed(seed=seed)
-    if dims:
-        _check_ket_dims(dims, N)
+    if N and dims:
+        _check_dims(dims, N, 1)
+    elif dims:
+        N = prod(dims[0])
+        _check_dims(dims, N, 1)
+    else:
+        dims = [[N],[1]]
     X = sp.rand(N, 1, density, format='csr')
     X.data = X.data - 0.5
     Y = X.copy()
@@ -292,10 +299,7 @@ def rand_ket(N, density=1, dims=None, seed=None):
     X = X + Y
     X.sort_indices()
     X = Qobj(X)
-    if dims:
-        return Qobj(X / X.norm(), dims=dims)
-    else:
-        return Qobj(X / X.norm())
+    return Qobj(X / X.norm(), dims=dims)
 
 
 def rand_ket_haar(N=2, dims=None, seed=None):
@@ -303,23 +307,25 @@ def rand_ket_haar(N=2, dims=None, seed=None):
     Returns a Haar random pure state of dimension ``dim`` by
     applying a Haar random unitary to a fixed pure state.
 
-
     Parameters
     ----------
     N : int
         Dimension of the state vector to be returned.
-
+        If None or 0, N is deduced from dims.
     dims : list of ints, or None
-        Left-dimensions of the resultant quantum object.
-        If None, [N] is used.
+        Dimensions of the resultant quantum object.
+        If None, [[N],[1]] is used.
 
     Returns
     -------
     psi : Qobj
         A random state vector drawn from the Haar measure.
     """
-    if dims:
-        _check_ket_dims(dims, N)
+    if N and dims:
+        _check_dims(dims, N, 1)
+    elif dims:
+        N = prod(dims[0])
+        _check_dims(dims, N, 1)
     else:
         dims = [[N],[1]]
     psi = rand_unitary_haar(N, seed=seed) * basis(N, 0)
@@ -665,12 +671,6 @@ def rand_stochastic(N, density=0.75, kind='left', dims=None, seed=None):
 
 
 
-
-def _check_ket_dims(dims, N1):
-    if (not isinstance(dims, list)) or (not isinstance(dims[0], list)):
-        raise TypeError("Left and right Qobj dimensions must be lists of ints. E.g.: [2, 3].")
-    if np.prod(dims) != N1:
-        raise ValueError("Qobj dimensions must match matrix shape.")
 
 def _check_dims(dims, N1, N2):
     if len(dims) != 2:

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -53,8 +53,8 @@ from qutip.superoperator import vec2mat
 from qutip.ui.progressbar import (BaseProgressBar, TextProgressBar)
 from qutip.cy.openmp.utilities import check_use_openmp, openmp_components
 
-def sesolve(H, psi0, tlist, e_ops=[], args={}, options=Options(),
-            progress_bar=BaseProgressBar(), _safe_mode=True):
+def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
+            progress_bar=None, _safe_mode=True):
     """
     Schrodinger equation evolution of a state vector or unitary matrix
     for a given Hamiltonian.
@@ -86,19 +86,19 @@ def sesolve(H, psi0, tlist, e_ops=[], args={}, options=Options(),
     tlist : *list* / *array*
         list of times for :math:`t`.
 
-    e_ops : list of :class:`qutip.qobj` / callback function
+    e_ops : None / list of :class:`qutip.qobj` / callback function
         single operator or list of operators for which to evaluate
         expectation values.
         For list operator evolution, the overlapse is computed:
             tr(e_ops[i].dag()*op(t))
 
-    args : *dictionary*
+    args : None / *dictionary*
         dictionary of parameters for time-dependent Hamiltonians
 
-    options : :class:`qutip.Qdeoptions`
+    options : None / :class:`qutip.Qdeoptions`
         with options for the ODE solver.
 
-    progress_bar : BaseProgressBar
+    progress_bar : None / BaseProgressBar
         Optional instance of BaseProgressBar, or a subclass thereof, for
         showing the progress of the simulation.
 
@@ -115,6 +115,8 @@ def sesolve(H, psi0, tlist, e_ops=[], args={}, options=Options(),
         which to calculate the expectation values.
 
     """
+    if e_ops is None:
+        e_ops = []
     if isinstance(e_ops, Qobj):
         e_ops = [e_ops]
     elif isinstance(e_ops, dict):
@@ -123,6 +125,8 @@ def sesolve(H, psi0, tlist, e_ops=[], args={}, options=Options(),
     else:
         e_ops_dict = None
 
+    if progress_bar is None:
+        progress_bar = BaseProgressBar()
     if progress_bar is True:
         progress_bar = TextProgressBar()
 
@@ -131,6 +135,8 @@ def sesolve(H, psi0, tlist, e_ops=[], args={}, options=Options(),
                         " a ket as initial state"
                         " or a unitary as initial operator.")
 
+    if options is None:
+        options = Options()
     if options.rhs_reuse and not isinstance(H, SolverSystem):
         # TODO: deprecate when going to class based solver.
         if "sesolve" in solver_safe:
@@ -140,7 +146,9 @@ def sesolve(H, psi0, tlist, e_ops=[], args={}, options=Options(),
             pass
             # raise Exception("Could not find the Hamiltonian to reuse.")
 
-    #check if should use OPENMP
+    if args is None:
+        args = {}
+
     check_use_openmp(options)
 
     if isinstance(H, SolverSystem):

--- a/qutip/simdiag.py
+++ b/qutip/simdiag.py
@@ -99,13 +99,13 @@ def simdiag(ops, evals=True):
         if len(inds) > 1:  # if at least 2 eigvals are degenerate
             eigvecs_array[inds] = degen(
                 tol, eigvecs_array[inds],
-                np.array([ops[kk] for kk in range(1, num_ops)]))
+                np.array([ops[kk] for kk in range(1, num_ops)], dtype=object))
         k = max(inds) + 1
     eigvals_out = np.zeros((num_ops, len(ds)), dtype=float)
     kets_out = np.array([Qobj(eigvecs_array[j] / la.norm(eigvecs_array[j]),
                               dims=[ops[0].dims[0], [1]],
                               shape=[ops[0].shape[0], 1])
-                         for j in range(len(ds))])
+                         for j in range(len(ds))], dtype=object)
     if not evals:
         return kets_out
     else:
@@ -148,6 +148,7 @@ def degen(tol, in_vecs, ops):
         inds = rng[inds]
         if len(inds) > 1:  # if at least 2 eigvals are degenerate
             vecs_out[inds] = degen(tol, vecs_out[inds],
-                                   np.array([ops[jj] for jj in range(1, n)]))
+                                   np.array([ops[jj] for jj in range(1, n)],
+                                            dtype=object))
         k = max(inds) + 1
     return vecs_out

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -32,13 +32,15 @@
 ###############################################################################
 from __future__ import print_function
 
-__all__ = ['Options', 'Odeoptions', 'Odedata']
+__all__ = ['Options', 'Odeoptions', 'Odedata', 'ExpectOps']
 
-import sys
-import datetime
-from collections import OrderedDict
 import os
+import sys
 import warnings
+import datetime
+import numpy as np
+from qutip.qobjevo import QobjEvo
+from collections import OrderedDict
 from qutip import __version__
 from qutip.qobj import Qobj
 import qutip.settings as qset
@@ -46,11 +48,11 @@ from types import FunctionType, BuiltinFunctionType
 
 solver_safe = {}
 
+
 class SolverSystem():
     pass
 
-import numpy as np
-from qutip.qobjevo import QobjEvo
+
 class ExpectOps:
     """
         Contain and compute expectation values
@@ -283,7 +285,8 @@ class Options():
         self.store_states = store_states
         # average mcsolver density matricies assuming steady state evolution
         self.steady_state_average = steady_state_average
-        # Normalize output of solvers (turned off for batch unitary propagator mode)
+        # Normalize output of solvers
+        # (turned off for batch unitary propagator mode)
         self.normalize_output = normalize_output
         # Use OPENMP for sparse matrix vector multiplication
         self.use_openmp = use_openmp
@@ -405,7 +408,6 @@ class SolverConfiguration():
         self.reset()
 
     def reset(self):
-
         # General stuff
         self.tlist = None       # evaluations times
         self.ntraj = None       # number / list of trajectories
@@ -425,7 +427,6 @@ class SolverConfiguration():
         self.soft_reset()
 
     def soft_reset(self):
-
         # Hamiltonian stuff
         self.h_td_inds = []  # indicies of time-dependent Hamiltonian operators
         self.h_tdterms = []  # List of td strs and funcs
@@ -492,6 +493,7 @@ def _format_time(t, tt=None, ttt=None):
         time_str += " ({:03.2f}% total)".format(solve_percent)
 
     return time_str
+
 
 class Stats(object):
     """
@@ -725,6 +727,7 @@ class Stats(object):
             sect.clear()
         self.total_time = None
 
+
 class _StatsSection(object):
     """
     Not intended to be directly instantiated
@@ -827,8 +830,8 @@ class _StatsSection(object):
                 try:
                     value = sep + value
                 except:
-                    TypeError("It is not possible to concatenate the value with "
-                                "the given seperator")
+                    TypeError("It is not possible to concatenate the value "
+                              "with the given seperator")
             self.messages[key] += value
         else:
             self.messages[key] = value
@@ -883,8 +886,6 @@ class _StatsSection(object):
         self.timings.clear()
         self.messages.clear()
         self.total_time = None
-
-
 
 
 def _solver_safety_check(H, state=None, c_ops=[], e_ops=[], args={}):
@@ -961,6 +962,7 @@ def _solver_safety_check(H, state=None, c_ops=[], e_ops=[], args={}):
     else:
         raise Exception('Invalid e_ops specification.')
 
+
 def _structure_check(Hdims, Htype, state):
     if state is not None:
         # Input state is a ket vector
@@ -968,11 +970,13 @@ def _structure_check(Hdims, Htype, state):
             # Input is Hamiltonian
             if Htype == 'oper':
                 if Hdims[1] != state.dims[0]:
-                    raise Exception('Input operator and ket do not share same structure.')
+                    raise Exception('Input operator and ket do not '
+                                    'share same structure.')
             # Input is super and state is ket
             elif Htype == 'super':
                 if Hdims[1][1] != state.dims[0]:
-                    raise Exception('Input operator and ket do not share same structure.')
+                    raise Exception('Input operator and ket do not '
+                                    'share same structure.')
             else:
                 raise Exception('Invalid input operator.')
         # Input state is a density matrix
@@ -980,11 +984,13 @@ def _structure_check(Hdims, Htype, state):
             # Input is Hamiltonian and state is density matrix
             if Htype == 'oper':
                 if Hdims[1] != state.dims[0]:
-                    raise Exception('Input operators do not share same structure.')
+                    raise Exception('Input operators do not '
+                                    'share same structure.')
             # Input is super op. and state is density matrix
             elif Htype == 'super':
                 if Hdims[1] != state.dims:
-                    raise Exception('Input operators do not share same structure.')
+                    raise Exception('Input operators do not '
+                                    'share same structure.')
 
 
 #

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -666,5 +666,31 @@ def test_fn_list_td_corr():
     assert_(abs(g20 - 0.85) < 1e-2)
 
 
+def test_fn_list_td_corr():
+    """
+    correlation: multi time-dependent factor
+    """
+    # test for bug of issue #1048
+    sm = destroy(2)
+    args = {}
+
+    def step_func(t, args={}):
+        return np.arctan(t-2)/np.pi + 0.5
+
+    def inv_step_func(t, args={}):
+        return np.arctan(-(t-2))/np.pi + 0.5
+
+    H1 = [[(sm + sm.dag()), step_func], [qeye(2), inv_step_func]]
+
+    H2 = [[qeye(2), inv_step_func], [(sm + sm.dag()), step_func]]
+    
+    tlist = np.linspace(0, 5, 6)
+    corr1 = correlation_2op_2t(H1, fock(2, 0), tlist, tlist, [sm],
+                               sm.dag(), sm, args=args)
+    corr2 = correlation_2op_2t(H2, fock(2, 0), tlist, tlist, [sm],
+                               sm.dag(), sm, args=args)
+    assert_(np.sum(np.abs(corr1-corr2)) < 1e-5)
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -610,10 +610,25 @@ def test_QobjNorm():
     assert_equal(
         np.abs(A.norm('fro') - la.norm(A.full(), 'fro')) < 1e-12, True)
     # operator trace norm
-    a = rand_herm(10,0.25)
+    a = rand_herm(10, 0.25)
     assert_almost_equal(a.norm(), (a*a.dag()).sqrtm().tr().real)
-    b = rand_herm(10,0.25) - 1j*rand_herm(10,0.25)
+    b = rand_herm(10, 0.25) - 1j*rand_herm(10, 0.25)
     assert_almost_equal(b.norm(), (b*b.dag()).sqrtm().tr().real)
+
+def test_QobjPurity():
+    "Tests the purity method of `Qobj`"
+    psi = basis(2, 1)
+    # check purity of pure ket state
+    assert_almost_equal(psi.purity(), 1)
+    # check purity of pure ket state (superposition)
+    psi2 = basis(2, 0)
+    psi_tot = (psi+psi2).unit() 
+    assert_almost_equal(psi_tot.purity(), 1)
+    # check purity of density matrix of pure state 
+    assert_almost_equal(ket2dm(psi_tot).purity(), 1)
+    # check purity of maximally mixed density matrix
+    rho_mixed = (ket2dm(psi)+ket2dm(psi2)).unit() 
+    assert_almost_equal(rho_mixed.purity(), 0.5)
 
 def test_QobjPermute():
     "Qobj permute"

--- a/qutip/tests/test_qobjevo.py
+++ b/qutip/tests/test_qobjevo.py
@@ -199,6 +199,52 @@ def test_QobjEvo_call_args():
         assert_equal(len((op(t) - O_target1).tidyup(1e-10).data.data),0)
 
 
+def test_QobjEvo_step_coeff():
+    coeff1 = np.random.rand(6)
+    coeff2 = np.random.rand(6) + np.random.rand(6) * 1.j
+    # uniform t
+    tlist = np.array([2, 3, 4, 5, 6, 7], dtype=float)
+    qobjevo = QobjEvo([[sigmaz(), coeff1], [sigmax(), coeff2]], 
+                    tlist=tlist, args={"_step_func_coeff":True})
+    assert_equal(qobjevo.ops[0].get_coeff(2.0), coeff1[0])
+    assert_equal(qobjevo.ops[0].get_coeff(7.0), coeff1[5])
+    assert_equal(qobjevo.ops[0].get_coeff(5.0001), coeff1[3])
+    assert_equal(qobjevo.ops[0].get_coeff(3.9999), coeff1[1])
+
+    assert_equal(qobjevo.ops[1].get_coeff(2.0), coeff2[0])
+    assert_equal(qobjevo.ops[1].get_coeff(7.0), coeff2[5])
+    assert_equal(qobjevo.ops[1].get_coeff(5.0001), coeff2[3])
+    assert_equal(qobjevo.ops[1].get_coeff(3.9999), coeff2[1])
+
+    qobjevo.compile()
+    assert_equal(qobjevo.coeff_get(2.0), [coeff1[0], coeff2[0]])
+    assert_equal(qobjevo.coeff_get(7.0), [coeff1[5], coeff2[5]])
+    assert_equal(qobjevo.coeff_get(4.0001), [coeff1[2], coeff2[2]])
+    assert_equal(qobjevo.coeff_get(3.9999), [coeff1[1], coeff2[1]])
+
+    # non-uniform t
+    tlist = np.array([1, 2, 4, 5, 6, 8], dtype=float)
+    qobjevo = QobjEvo([[sigmaz(), coeff1], [sigmax(), coeff2]],
+        tlist=tlist, args={"_step_func_coeff":True})
+    assert_equal(qobjevo.ops[0].get_coeff(1.0), coeff1[0])
+    assert_equal(qobjevo.ops[0].get_coeff(8.0), coeff1[5])
+    assert_equal(qobjevo.ops[0].get_coeff(3.9999), coeff1[1])
+    assert_equal(qobjevo.ops[0].get_coeff(4.23), coeff1[2])
+    assert_equal(qobjevo.ops[0].get_coeff(1.23), coeff1[0])
+
+    assert_equal(qobjevo.ops[1].get_coeff(1.0), coeff2[0])
+    assert_equal(qobjevo.ops[1].get_coeff(8.0), coeff2[5])
+    assert_equal(qobjevo.ops[1].get_coeff(6.7), coeff2[4])
+    assert_equal(qobjevo.ops[1].get_coeff(7.9999), coeff2[4])
+    assert_equal(qobjevo.ops[1].get_coeff(3.9999), coeff2[1])
+
+    qobjevo.compile()
+    assert_equal(qobjevo.coeff_get(1.0), [coeff1[0], coeff2[0]])
+    assert_equal(qobjevo.coeff_get(3.999), [coeff1[1], coeff2[1]])
+    assert_equal(qobjevo.coeff_get(6.3), [coeff1[4], coeff2[4]])
+    assert_equal(qobjevo.coeff_get(1.0001), [coeff1[0], coeff2[0]])
+
+
 def test_QobjEvo_copy():
     "QobjEvo copy"
     tlist = np.linspace(0,1,300)

--- a/qutip/tests/test_qobjevo.py
+++ b/qutip/tests/test_qobjevo.py
@@ -388,6 +388,36 @@ def test_QobjEvo_compress():
     _assert_qobj_almost_eq(td_obj_2(t), td_obj_1(t))
 
 
+def test_QobjEvo_shift():
+    """QobjEvo _shift time"""
+    tlist = np.linspace(0, 1, 300)
+    td_obj_1 = QobjEvo(_random_QobjEvo((1,1), [0,0], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_1s = td_obj_1.copy()
+    td_obj_1s._shift()
+    td_obj_2 = QobjEvo(_random_QobjEvo((1,1), [1,1], tlist=tlist),
+                       args={"w1":1, "w2":2}, tlist=tlist)
+    td_obj_2s = td_obj_2.copy()
+    td_obj_2s._shift()
+
+    _assert_qobj_almost_eq(td_obj_1(0),td_obj_1s(1, args={"_t0":-1}))
+    _assert_qobj_almost_eq(td_obj_2(0),td_obj_2s(1, args={"_t0":-1}))
+    td_obj_1s.arguments({"_t0":-1})
+    td_obj_2s.arguments({"_t0":-1})
+    _assert_qobj_almost_eq(td_obj_1(0),td_obj_1s(1))
+    _assert_qobj_almost_eq(td_obj_2(0),td_obj_2s(1))
+    td_obj_1s.compile()
+    td_obj_2s.compile()
+    _assert_qobj_almost_eq(td_obj_1(0),td_obj_1s(1))
+    _assert_qobj_almost_eq(td_obj_2(0),td_obj_2s(1))
+    _assert_qobj_almost_eq(td_obj_1(0),td_obj_1s(2, args={"_t0":-2}))
+    _assert_qobj_almost_eq(td_obj_2(0),td_obj_2s(2, args={"_t0":-2}))
+    td_obj_1s.arguments({"_t0":-2})
+    td_obj_2s.arguments({"_t0":-2})
+    _assert_qobj_almost_eq(td_obj_1(0),td_obj_1s(2))
+    _assert_qobj_almost_eq(td_obj_2(0),td_obj_2s(2))
+
+
 def test_QobjEvo_apply():
     "QobjEvo apply"
     def multiply(qobj,b,factor = 3.):

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,8 @@ cy_exts = ['spmatfuncs', 'math', 'spconvert', 'spmath',
 # Extra link args
 _link_flags = []
 
-# If on Win and Python version >= 3.5 and not in MSYS2 (i.e. Visual studio compile)
+# If on Win and Python version >= 3.5 and not in MSYS2
+# (i.e. Visual studio compile)
 if (sys.platform == 'win32'
     and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35
     and os.environ.get('MSYSTEM') is None):
@@ -173,21 +174,22 @@ else:
 EXT_MODULES =[]
 # Add Cython files from qutip/cy
 for ext in cy_exts:
-    _mod = Extension('qutip.cy.'+ext,
-            sources = ['qutip/cy/'+ext+'.pyx', 'qutip/cy/src/zspmv.cpp'],
-            include_dirs = [np.get_include()],
-            extra_compile_args=_compiler_flags,
-            extra_link_args=_link_flags,
-            language='c++')
+    _mod = Extension('qutip.cy.' + ext,
+                     sources=['qutip/cy/' + ext +
+                              '.pyx', 'qutip/cy/src/zspmv.cpp'],
+                     include_dirs=[np.get_include()],
+                     extra_compile_args=_compiler_flags,
+                     extra_link_args=_link_flags,
+                     language='c++')
     EXT_MODULES.append(_mod)
 
 # Add Cython files from qutip/control
 _mod = Extension('qutip.control.cy_grape',
-            sources = ['qutip/control/cy_grape.pyx'],
-            include_dirs = [np.get_include()],
-            extra_compile_args=_compiler_flags,
-            extra_link_args=_link_flags,
-            language='c++')
+                 sources=['qutip/control/cy_grape.pyx'],
+                 include_dirs=[np.get_include()],
+                 extra_compile_args=_compiler_flags,
+                 extra_link_args=_link_flags,
+                 language='c++')
 EXT_MODULES.append(_mod)
 
 
@@ -202,47 +204,47 @@ if "--with-openmp" in sys.argv:
         omp_flags = ['-fopenmp']
         omp_args = omp_flags
     _mod = Extension('qutip.cy.openmp.parfuncs',
-            sources = ['qutip/cy/openmp/parfuncs.pyx',
-                       'qutip/cy/openmp/src/zspmv_openmp.cpp'],
-            include_dirs = [np.get_include()],
-            extra_compile_args=_compiler_flags+omp_flags,
-            extra_link_args=omp_args+_link_flags,
-            language='c++')
+                     sources=['qutip/cy/openmp/parfuncs.pyx',
+                              'qutip/cy/openmp/src/zspmv_openmp.cpp'],
+                     include_dirs=[np.get_include()],
+                     extra_compile_args=_compiler_flags+omp_flags,
+                     extra_link_args=omp_args+_link_flags,
+                     language='c++')
     EXT_MODULES.append(_mod)
     # Add benchmark pyx
     _mod = Extension('qutip.cy.openmp.benchmark',
-            sources = ['qutip/cy/openmp/benchmark.pyx'],
-            include_dirs = [np.get_include()],
-            extra_compile_args=_compiler_flags,
-            extra_link_args=_link_flags,
-            language='c++')
+                     sources=['qutip/cy/openmp/benchmark.pyx'],
+                     include_dirs=[np.get_include()],
+                     extra_compile_args=_compiler_flags,
+                     extra_link_args=_link_flags,
+                     language='c++')
     EXT_MODULES.append(_mod)
 
     # Add brtools_omp
     _mod = Extension('qutip.cy.openmp.br_omp',
-            sources = ['qutip/cy/openmp/br_omp.pyx'],
-            include_dirs = [np.get_include()],
-            extra_compile_args=_compiler_flags,
-            extra_link_args=_link_flags,
-            language='c++')
+                     sources=['qutip/cy/openmp/br_omp.pyx'],
+                     include_dirs=[np.get_include()],
+                     extra_compile_args=_compiler_flags,
+                     extra_link_args=_link_flags,
+                     language='c++')
     EXT_MODULES.append(_mod)
 
     # Add omp_sparse_utils
     _mod = Extension('qutip.cy.openmp.omp_sparse_utils',
-            sources = ['qutip/cy/openmp/omp_sparse_utils.pyx'],
-            include_dirs = [np.get_include()],
-            extra_compile_args=_compiler_flags+omp_flags,
-            extra_link_args=omp_args+_link_flags,
-            language='c++')
+                     sources=['qutip/cy/openmp/omp_sparse_utils.pyx'],
+                     include_dirs=[np.get_include()],
+                     extra_compile_args=_compiler_flags+omp_flags,
+                     extra_link_args=omp_args+_link_flags,
+                     language='c++')
     EXT_MODULES.append(_mod)
 
     # Add cqobjevo_omp
     _mod = Extension('qutip.cy.openmp.cqobjevo_omp',
-            sources = ['qutip/cy/openmp/cqobjevo_omp.pyx'],
-            include_dirs = [np.get_include()],
-            extra_compile_args=_compiler_flags+omp_flags,
-            extra_link_args=omp_args,
-            language='c++')
+                     sources=['qutip/cy/openmp/cqobjevo_omp.pyx'],
+                     include_dirs=[np.get_include()],
+                     extra_compile_args=_compiler_flags+omp_flags,
+                     extra_link_args=omp_args,
+                     language='c++')
     EXT_MODULES.append(_mod)
 
 
@@ -254,30 +256,29 @@ if "CFLAGS" in cfg_vars:
 
 
 # Setup commands go here
-setup(
-    name = NAME,
-    version = FULLVERSION,
-    packages = PACKAGES,
-    include_package_data=True,
-    include_dirs = INCLUDE_DIRS,
-    # headers = HEADERS,
-    ext_modules = cythonize(EXT_MODULES),
-    cmdclass = {'build_ext': build_ext},
-    author = AUTHOR,
-    author_email = AUTHOR_EMAIL,
-    license = LICENSE,
-    description = DESCRIPTION,
-    long_description = LONG_DESCRIPTION,
-    keywords = KEYWORDS,
-    url = URL,
-    classifiers = CLASSIFIERS,
-    platforms = PLATFORMS,
-    requires = REQUIRES,
-    extras_require = EXTRAS_REQUIRE,
-    package_data = PACKAGE_DATA,
-    zip_safe = False,
-    install_requires=INSTALL_REQUIRES,
-    **EXTRA_KWARGS
+setup(name = NAME,
+      version = FULLVERSION,
+      packages = PACKAGES,
+      include_package_data=True,
+      include_dirs = INCLUDE_DIRS,
+      # headers = HEADERS,
+      ext_modules = cythonize(EXT_MODULES),
+      cmdclass = {'build_ext': build_ext},
+      author = AUTHOR,
+      author_email = AUTHOR_EMAIL,
+      license = LICENSE,
+      description = DESCRIPTION,
+      long_description = LONG_DESCRIPTION,
+      keywords = KEYWORDS,
+      url = URL,
+      classifiers = CLASSIFIERS,
+      platforms = PLATFORMS,
+      requires = REQUIRES,
+      extras_require = EXTRAS_REQUIRE,
+      package_data = PACKAGE_DATA,
+      zip_safe = False,
+      install_requires=INSTALL_REQUIRES,
+      **EXTRA_KWARGS
 )
 _cite = """\
 ==============================================================================

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ from Cython.Distutils import build_ext
 # all information about QuTiP goes here
 MAJOR = 4
 MINOR = 4
-MICRO = 0
+MICRO = 1
 ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 REQUIRES = ['numpy (>=1.12)', 'scipy (>=1.0)', 'cython (>=0.21)']
@@ -146,15 +146,18 @@ if os.path.exists('qutip/version.py'):
 write_version_py()
 
 # Add Cython extensions here
-cy_exts = ['spmatfuncs', 'stochastic', 'sparse_utils', 'graph_utils', 'interpolate',
-           'spmath', 'heom', 'math', 'spconvert', 'ptrace', 'checks', 'brtools', 'mcsolve',
-           'brtools_checks', 'br_tensor', 'inter', 'cqobjevo', 'cqobjevo_factor', 'piqs']
+cy_exts = ['spmatfuncs', 'math', 'spconvert', 'spmath',
+           'sparse_utils', 'graph_utils', 'interpolate', 'ptrace',
+           'inter', 'cqobjevo', 'cqobjevo_factor',
+           'stochastic', 'brtools', 'mcsolve', 'br_tensor', 'piqs', 'heom',
+           'brtools_checks', 'checks']
 
 # Extra link args
 _link_flags = []
 
 # If on Win and Python version >= 3.5 and not in MSYS2 (i.e. Visual studio compile)
-if (sys.platform == 'win32' and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35
+if (sys.platform == 'win32'
+    and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35
     and os.environ.get('MSYSTEM') is None):
     _compiler_flags = ['/w', '/Ox']
 # Everything else


### PR DESCRIPTION
Proposal for 4.4.1 Mostly to fix the bugs reported since 4.4.0's release but include small improvements.

Bug Fixes
-------------

- Fixed the pickling but that made solver unable to run in parallel on Windows. (Thank **lrunze** for reporting)
- Removed warning when mesolve fall back on sesolve (by **Michael Goerz**).
- Fixed dimension check and confusing documentation in random ket (by **Yariv Yanay**).
- Fixed Qobj isherm not working after using Qobj.permute. (Thank **llorz1207** for reporting)
- Correlation functions call now properly handle multiple time dependant functions. (Thank **taw181** for reporting)
- Removed mutable default values in mesolve/sesolve (by **Michael Goerz**)
- Fixed simdiag bug (Thank **Croydon-Brixton** for reporting)
- Better support of constant QobjEvo. (by **Boxi Li**)

Improvements
------------------

- QobjEvo do not need to start from 0 anymore. (by **Eric Giguere**)
- Add a quantum object purity function. (by **Nathan Shammah** and **Shahnawaz Ahmed**)
- Add step function interpolation for array time-coefficient. (by **Boxi Li**)
