### PR TITLE
QobjEvo no longer require cython for string coefficient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ stage_generic_linux: &stage_generic_linux
     - cd qutip_testing
   # command to run tests
   script:
+    - conda list
     - python -m qutip.about
     - nosetests --verbosity=2 --with-coverage --cover-package=qutip qutip
   install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,24 @@ stage_linux_37: &stage_linux_37
   dist: xenial
   python: 3.7
 
+stage_linux_37_no_cython: &stage_linux_37_no_cython
+  <<: *stage_generic_linux
+  name: "Python 3.7 no cython"
+  dist: xenial
+  python: 3.7
+  install:
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda info -a
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+    - source activate test-environment
+    - conda install nomkl blas=*=openblas numpy scipy nose cython
+    - python setup.py install
+    - conda uninstall cython
+
 stage_linux_37_openblas: &stage_linux_37_openblas
   <<: *stage_generic_linux
   name: "Python 3.7 OpenBLAS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ stage_generic_linux: &stage_generic_linux
     - cd qutip_testing
   # command to run tests
   script:
-    - conda list
     - python -m qutip.about
     - nosetests --verbosity=2 --with-coverage --cover-package=qutip qutip
   install:
@@ -50,9 +49,10 @@ stage_linux_37_no_cython: &stage_linux_37_no_cython
     - conda info -a
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
     - source activate test-environment
-    - conda install nomkl blas=*=openblas numpy scipy nose cython
+    - conda install -c conda-forge nomkl blas=*=openblas numpy scipy nose cython
+    - conda list
     - python setup.py install
-    - conda uninstall cython
+    - conda uninstall cython --no-update-dependencies
 
 stage_linux_37_openblas: &stage_linux_37_openblas
   <<: *stage_generic_linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,11 @@ stage_linux_37_no_cython: &stage_linux_37_no_cython
     - conda info -a
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
     - source activate test-environment
-    - conda install -c conda-forge nomkl blas=*=openblas numpy scipy nose cython
+    - conda install -c conda-forge nomkl blas=*=openblas numpy scipy nose
+    - conda install -c conda-forge cython --freeze-installed
     - conda list
     - python setup.py install
-    - conda uninstall cython --no-update-dependencies
+    - conda uninstall cython
 
 stage_linux_37_openblas: &stage_linux_37_openblas
   <<: *stage_generic_linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,8 @@ jobs:
     - stage: test
       <<: *stage_linux_37_omp
     - stage: test
+      <<: *stage_linux_37_no_cython
+    - stage: test
       <<: *stage_linux_37_openblas
     - stage: test
       <<: *stage_osx

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -99,6 +99,10 @@ try:
         print("QuTiP warning: old version of cython detected " +
               ("(%s), requiring %s." %
                (Cython.__version__, _cython_requirement)))
+    # Setup pyximport
+    import qutip.cy.pyxbuilder as pbldr
+    pbldr.install(setup_args={'include_dirs': [numpy.get_include()]})
+    del pbldr
 
 except Exception as e:
     print("QuTiP warning: Cython setup failed: " + str(e))
@@ -235,11 +239,6 @@ import distutils.sysconfig
 cfg_vars = distutils.sysconfig.get_config_vars()
 if "CFLAGS" in cfg_vars:
     cfg_vars["CFLAGS"] = cfg_vars["CFLAGS"].replace("-Wstrict-prototypes", "")
-
-# Setup pyximport
-import qutip.cy.pyxbuilder as pbldr
-pbldr.install(setup_args={'include_dirs': [numpy.get_include()]})
-del pbldr
 
 # -----------------------------------------------------------------------------
 # Load user configuration if present: override defaults.

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -53,7 +53,7 @@ except:
 # if the requirements aren't fulfilled
 #
 
-numpy_requirement = "1.8.0"
+numpy_requirement = "1.12.0"
 try:
     import numpy
     if _version2int(numpy.__version__) < _version2int(numpy_requirement):
@@ -63,7 +63,7 @@ try:
 except:
     warnings.warn("numpy not found.")
 
-scipy_requirement = "0.15.0"
+scipy_requirement = "1.0.0"
 try:
     import scipy
     if _version2int(scipy.__version__) < _version2int(scipy_requirement):
@@ -103,9 +103,8 @@ try:
     import qutip.cy.pyxbuilder as pbldr
     pbldr.install(setup_args={'include_dirs': [numpy.get_include()]})
     del pbldr
-
 except Exception as e:
-    print("QuTiP warning: Cython setup failed: " + str(e))
+    pass
 else:
     del Cython
 

--- a/qutip/cy/br_codegen.py
+++ b/qutip/cy/br_codegen.py
@@ -59,6 +59,11 @@ class BR_Codegen(object):
                 omp_thresh=None,
                 omp_threads=None,
                 atol=None):
+        try:
+            import cython
+        except (ImportError, ModuleNotFoundError):
+            raise ModuleNotFoundError("Cython is needed for "
+                                      "time-depdendent brmesolve")
         import sys
         import os
         sys.path.append(os.getcwd())

--- a/qutip/cy/pyxbuilder.py
+++ b/qutip/cy/pyxbuilder.py
@@ -31,22 +31,29 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 import sys, os
-import pyximport
-from pyximport import install
+try:
+    import pyximport
+    from pyximport import install
 
-old_get_distutils_extension = pyximport.pyximport.get_distutils_extension
+    old_get_distutils_extension = pyximport.pyximport.get_distutils_extension
 
-def new_get_distutils_extension(modname, pyxfilename, language_level=None):
-    extension_mod, setup_args = old_get_distutils_extension(modname, pyxfilename, language_level)
-    extension_mod.language='c++'
-    # If on Win and Python version >= 3.5 and not in MSYS2 (i.e. Visual studio compile)
-    if sys.platform == 'win32' and int(str(sys.version_info[0])+str(sys.version_info[1])) >= 35 and os.environ.get('MSYSTEM') is None:
-        extension_mod.extra_compile_args = ['/w', '/O1']
-    else:
-        extension_mod.extra_compile_args = ['-w', '-O1']
-        if sys.platform == 'darwin':
-            extension_mod.extra_compile_args.append('-mmacosx-version-min=10.9')
-            extension_mod.extra_link_args = ['-mmacosx-version-min=10.9']
-    return extension_mod,setup_args
+    def new_get_distutils_extension(modname, pyxfilename, language_level=None):
+        extension_mod, setup_args = old_get_distutils_extension(modname,
+                                                                pyxfilename,
+                                                                language_level)
+        extension_mod.language='c++'
+        # If on Win and Python version >= 3.5 and not in MSYS2 (i.e. Visual studio compile)
+        if sys.platform == 'win32' and int(str(sys.version_info[0])+
+                                           str(sys.version_info[1])) >= 35 and \
+                                           os.environ.get('MSYSTEM') is None:
+            extension_mod.extra_compile_args = ['/w', '/O1']
+        else:
+            extension_mod.extra_compile_args = ['-w', '-O1']
+            if sys.platform == 'darwin':
+                extension_mod.extra_compile_args.append('-mmacosx-version-min=10.9')
+                extension_mod.extra_link_args = ['-mmacosx-version-min=10.9']
+        return extension_mod,setup_args
 
-pyximport.pyximport.get_distutils_extension = new_get_distutils_extension
+    pyximport.pyximport.get_distutils_extension = new_get_distutils_extension
+except:
+    pass

--- a/qutip/cy/pyxbuilder.py
+++ b/qutip/cy/pyxbuilder.py
@@ -42,18 +42,21 @@ try:
                                                                 pyxfilename,
                                                                 language_level)
         extension_mod.language='c++'
-        # If on Win and Python version >= 3.5 and not in MSYS2 (i.e. Visual studio compile)
-        if sys.platform == 'win32' and int(str(sys.version_info[0])+
-                                           str(sys.version_info[1])) >= 35 and \
-                                           os.environ.get('MSYSTEM') is None:
+        # If on Win and Python version >= 3.5 and not in MSYS2
+        # (i.e. Visual studio compile)
+        if sys.platform == 'win32' and \
+                int(str(sys.version_info[0]) +
+                    str(sys.version_info[1])) >= 35 and \
+                os.environ.get('MSYSTEM') is None:
             extension_mod.extra_compile_args = ['/w', '/O1']
         else:
             extension_mod.extra_compile_args = ['-w', '-O1']
             if sys.platform == 'darwin':
-                extension_mod.extra_compile_args.append('-mmacosx-version-min=10.9')
+                extension_mod.extra_compile_args.append(
+                                                '-mmacosx-version-min=10.9')
                 extension_mod.extra_link_args = ['-mmacosx-version-min=10.9']
         return extension_mod,setup_args
 
     pyximport.pyximport.get_distutils_extension = new_get_distutils_extension
-except:
+except Exception:
     pass

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -68,7 +68,7 @@ if sys.platform == 'win32':
 try:
     import cython
     use_cython = [True]
-except e:
+except:
     use_cython = [False]
 
 def proj(x):

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -71,11 +71,13 @@ try:
 except:
     use_cython = [False]
 
+
 def proj(x):
     if np.isfinite(x):
         return (x)
     else:
         return np.inf + 0j * np.imag(x)
+
 
 str_env = {
     "sin": np.sin,
@@ -106,6 +108,7 @@ str_env = {
     "proj": proj,
     "np": np,
     "spe": scipy.special}
+
 
 class _file_list:
     """

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -126,7 +126,7 @@ class _file_list:
             try:
                 os.remove(file_)
                 to_del.append(i)
-            except:
+            except Exception:
                 if not os.path.isfile(file_):
                     to_del.append(i)
 

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -610,8 +610,7 @@ class QobjEvo:
                     expect_op = QobjEvo(self.args[key], copy=False)
                 if update:
                     for ops in self.dynamics_args:
-                        if ops[0] == name:
-                            ops = (name, what, expect_op)
+                        ops = (name, what, expect_op) if ops[0] == name else ops
                 else:
                     self.dynamics_args += [(name, what, expect_op)]
                     if name not in self.args:

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -43,7 +43,7 @@ import time
 
 def delay(filename):
     if not os.access(filename, os.R_OK):
-        time.sleep(0.01)
+        time.sleep(0.05)
 
 
 def _compile_str_single(string, args):
@@ -73,7 +73,7 @@ def f(double t, args):
         if name in string:
             Code += "    " + name + " = args['" + name + "']\n"
     Code += "    return " + string + "\n"
-    filename = "td_Qobj_single_str" + str(hash(Code))[1:]
+    filename = "td_Qobj_single_str" + str(hash(Code))[1:10]
     file = open(filename+".pyx", "w")
     file.writelines(Code)
     file.close()
@@ -91,7 +91,7 @@ def _compiled_coeffs(ops, args, dyn_args, tlist):
     need compilation.
     """
     code = _make_code_4_cimport(ops, args, dyn_args, tlist)
-    filename = "cqobjevo_compiled_coeff_"+str(hash(code))[1:]
+    filename = "cqobjevo_compiled_coeff_"+str(hash(code))[1:10]
     file_ = open(filename+".pyx", "w")
     file_.writelines(code)
     file_.close()

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -47,6 +47,8 @@ def make_file_code(code):
     file_num = str(make_file_code.file_num)
     make_file_code.file_num += 1
     return now + uniq + file_num
+
+
 make_file_code.file_num = 0
 
 
@@ -100,7 +102,7 @@ def _compiled_coeffs(ops, args, dyn_args, tlist):
     need compilation.
     """
     code = _make_code_4_cimport(ops, args, dyn_args, tlist)
-    filename = "cqobjevo_compiled_coeff_" + make_file_code(Code)
+    filename = "cqobjevo_compiled_coeff_" + make_file_code(code)
     file_ = open(filename+".pyx", "w")
     file_.writelines(code)
     file_.close()
@@ -292,7 +294,7 @@ def _compiled_coeffs_python(ops, args, dyn_args, tlist):
     need compilation.
     """
     code = _make_code_4_python_import(ops, args, dyn_args, tlist)
-    filename = "qobjevo_compiled_coeff_" + make_file_code(Code)
+    filename = "qobjevo_compiled_coeff_" + make_file_code(code)
     file_ = open(filename+".py", "w")
     file_.writelines(code)
     file_.close()

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -40,6 +40,7 @@ import numpy as np
 from qutip.cy.inter import _prep_cubic_spline
 import time
 
+
 def _compile_str_single(string, args):
     """Create and import a cython compiled function from text
     """

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -273,6 +273,7 @@ include """ + _include_string + "\n\n"
 
     return code
 
+
 def _compiled_coeffs_python(ops, args, dyn_args, tlist):
     """Create and import a cython compiled class for coeff that
     need compilation.
@@ -292,6 +293,7 @@ def _compiled_coeffs_python(ops, args, dyn_args, tlist):
     coeff_obj = import_list[0]
 
     return coeff_obj, code, filename+".py"
+
 
 code_python_pre = """
 # This file is generated automatically by QuTiP.
@@ -381,6 +383,7 @@ code_python_post = """
         return self.args
 
 """
+
 
 def _make_code_4_python_import(ops, args, dyn_args, tlist):
     code = code_python_pre

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -43,7 +43,6 @@ from qutip.cy.inter import _prep_cubic_spline
 def _compile_str_single(string, args):
     """Create and import a cython compiled function from text
     """
-    import os
     _cython_path = os.path.dirname(os.path.abspath(__file__)).replace(
                     "\\", "/")
     _include_string = "'"+_cython_path + "/cy/complex_math.pxi'"
@@ -107,7 +106,6 @@ def _make_code_4_cimport(ops, args, dyn_args, tlist):
     Create the code for a CoeffFunc cython class the wraps
     the string coefficients, array_like coefficients and Cubic_Spline.
     """
-    import os
     _cython_path = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
     _include_string = "'"+_cython_path + "/cy/complex_math.pxi'"
 

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -41,6 +41,13 @@ from qutip.cy.inter import _prep_cubic_spline
 import time
 
 
+def _try_remove(filename):
+    try:
+        os.remove(filename)
+    except Exception:
+        pass
+
+
 def import_str(code, basefilename, obj_name, cythonfile=False):
     filename = basefilename + str(hash(code))[1:6]
     tries = 0
@@ -62,10 +69,7 @@ def import_str(code, basefilename, obj_name, cythonfile=False):
         except (ModuleNotFoundError, ImportError):
             time.sleep(0.05)
             tries += 1
-            try:
-                os.remove(try_file+ext)
-            except Exception:
-                pass
+            _try_remove(try_file+ext)
     if not import_list:
         raise Exception("Could not convert string to importable function, "
                         "tmpfile:" + try_file + ext)

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -38,7 +38,7 @@ cy/codegen.py does the same thing for specific solver
 import os
 import numpy as np
 from qutip.cy.inter import _prep_cubic_spline
-
+import time
 
 def _compile_str_single(string, args):
     """Create and import a cython compiled function from text
@@ -87,9 +87,11 @@ def _compiled_coeffs(ops, args, dyn_args, tlist):
     code = _make_code_4_cimport(ops, args, dyn_args, tlist)
     filename = "cqobjevo_compiled_coeff_"+str(hash(code))[1:]
 
-    file = open(filename+".pyx", "w")
-    file.writelines(code)
-    file.close()
+    file_ = open(filename+".pyx", "w")
+    file_.writelines(code)
+    file_.close()
+    if not os.access(filename+".pyx", os.R_OK):
+        time.sleep(0.01)
     import_list = []
 
     import_code = compile('from ' + filename + ' import CompiledStrCoeff\n' +
@@ -280,9 +282,12 @@ def _compiled_coeffs_python(ops, args, dyn_args, tlist):
     code = _make_code_4_python_import(ops, args, dyn_args, tlist)
     filename = "qobjevo_compiled_coeff_"+str(hash(code))[1:]
 
-    file = open(filename+".py", "w")
-    file.writelines(code)
-    file.close()
+    file_ = open(filename+".py", "w")
+    file_.writelines(code)
+    file_.close()
+    if not os.access(filename+".py", os.R_OK):
+        time.sleep(0.01)
+
     import_list = []
 
     import_code = compile('from ' + filename + ' import _UnitedStrCaller\n' +

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -41,6 +41,11 @@ from qutip.cy.inter import _prep_cubic_spline
 import time
 
 
+def delay(filename):
+    if not os.access(filename, os.R_OK):
+        time.sleep(0.01)
+
+
 def _compile_str_single(string, args):
     """Create and import a cython compiled function from text
     """
@@ -87,14 +92,11 @@ def _compiled_coeffs(ops, args, dyn_args, tlist):
     """
     code = _make_code_4_cimport(ops, args, dyn_args, tlist)
     filename = "cqobjevo_compiled_coeff_"+str(hash(code))[1:]
-
     file_ = open(filename+".pyx", "w")
     file_.writelines(code)
     file_.close()
-    if not os.access(filename+".pyx", os.R_OK):
-        time.sleep(0.01)
+    delay(filename+".pyx")
     import_list = []
-
     import_code = compile('from ' + filename + ' import CompiledStrCoeff\n' +
                           "import_list.append(CompiledStrCoeff)",
                           '<string>', 'exec')
@@ -282,15 +284,11 @@ def _compiled_coeffs_python(ops, args, dyn_args, tlist):
     """
     code = _make_code_4_python_import(ops, args, dyn_args, tlist)
     filename = "qobjevo_compiled_coeff_"+str(hash(code))[1:]
-
     file_ = open(filename+".py", "w")
     file_.writelines(code)
     file_.close()
-    if not os.access(filename+".py", os.R_OK):
-        time.sleep(0.01)
-
+    delay(filename+".py")
     import_list = []
-
     import_code = compile('from ' + filename + ' import _UnitedStrCaller\n' +
                           "import_list.append(_UnitedStrCaller)",
                           '<string>', 'exec')

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -48,7 +48,11 @@ def _try_remove(filename):
         pass
 
 
-def import_str(code, basefilename, obj_name, cythonfile=False):
+def _import_str(code, basefilename, obj_name, cythonfile=False):
+    """
+    Import 'obj_name' defined in 'code'.
+    Using a temporary file starting by 'basefilename'.
+    """
     filename = basefilename + str(hash(code))[1:6]
     tries = 0
     import_list = []
@@ -105,7 +109,7 @@ def f(double t, args):
             Code += "    " + name + " = args['" + name + "']\n"
     Code += "    return " + string + "\n"
 
-    return import_str(Code, "td_Qobj_single_str", "f", True)
+    return _import_str(Code, "td_Qobj_single_str", "f", True)
 
 
 def _compiled_coeffs(ops, args, dyn_args, tlist):
@@ -113,7 +117,7 @@ def _compiled_coeffs(ops, args, dyn_args, tlist):
     need compilation.
     """
     code = _make_code_4_cimport(ops, args, dyn_args, tlist)
-    coeff_obj, filename = import_str(code, "cqobjevo_compiled_coeff_",
+    coeff_obj, filename = _import_str(code, "cqobjevo_compiled_coeff_",
                                      "CompiledStrCoeff", True)
     return coeff_obj(ops, args, tlist, dyn_args), code, filename
 
@@ -295,7 +299,7 @@ def _compiled_coeffs_python(ops, args, dyn_args, tlist):
     need compilation.
     """
     code = _make_code_4_python_import(ops, args, dyn_args, tlist)
-    coeff_obj, filename = import_str(code, "qobjevo_compiled_coeff_",
+    coeff_obj, filename = _import_str(code, "qobjevo_compiled_coeff_",
                                      "_UnitedStrCaller", False)
     return coeff_obj, code, filename
 

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -59,14 +59,8 @@ def import_str(code, basefilename, obj_name, cythonfile=False):
                                   "import_list.append(" + obj_name + ")",
                                   '<string>', 'exec')
             exec(import_code, locals())
-        except ModuleNotFoundError:
-            time.sleep(0.2)
-            tries += 1
-            try:
-                os.remove(try_file+ext)
-            except Exception:
-                pass
-        except ImportError:
+        except (ModuleNotFoundError, ImportError):
+            time.sleep(0.05)
             tries += 1
             try:
                 os.remove(try_file+ext)

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -299,6 +299,7 @@ code_python_pre = """
 import numpy as np
 import scipy.special as spe
 import scipy
+from qutip.qobjevo import _UnitedFuncCaller
 
 def proj(x):
     if np.isfinite(x):
@@ -332,7 +333,7 @@ abs = np.abs
 norm = lambda x: np.abs(x)**2
 arg = np.angle
 
-class _UnitedStrCaller:
+class _UnitedStrCaller(_UnitedFuncCaller):
     def __init__(self, funclist, args, dynamics_args, cte):
         self.funclist = funclist
         self.args = args

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -118,7 +118,7 @@ def _compiled_coeffs(ops, args, dyn_args, tlist):
     """
     code = _make_code_4_cimport(ops, args, dyn_args, tlist)
     coeff_obj, filename = _import_str(code, "cqobjevo_compiled_coeff_",
-                                     "CompiledStrCoeff", True)
+                                      "CompiledStrCoeff", True)
     return coeff_obj(ops, args, tlist, dyn_args), code, filename
 
 
@@ -300,7 +300,7 @@ def _compiled_coeffs_python(ops, args, dyn_args, tlist):
     """
     code = _make_code_4_python_import(ops, args, dyn_args, tlist)
     coeff_obj, filename = _import_str(code, "qobjevo_compiled_coeff_",
-                                     "_UnitedStrCaller", False)
+                                      "_UnitedStrCaller", False)
     return coeff_obj, code, filename
 
 

--- a/qutip/rhs_generate.py
+++ b/qutip/rhs_generate.py
@@ -309,15 +309,16 @@ def _td_format_check(H, c_ops, solver='me'):
 
     # check to see if Cython is installed and version is high enough.
     if len(h_str) > 0 or len(c_str) > 0:
-        try:
-            import Cython
-        except:
-            raise Exception(
-                "Unable to load Cython. Use Python function format.")
-        else:
-            if Cython.__version__ < '0.21':
-                raise Exception("Cython version (%s) is too old. Upgrade to " +
-                                "version 0.21+" % Cython.__version__)
+        pass
+        #try:
+        #    import Cython
+        #except:
+        #    raise Exception(
+        #        "Unable to load Cython. Use Python function format.")
+        #else:
+        #    if Cython.__version__ < '0.21':
+        #        raise Exception("Cython version (%s) is too old. Upgrade to " +
+        #                        "version 0.21+" % Cython.__version__)
 
     # If only time-dependence is in Objects, then prefer string based format
     if (len(h_func) + len(c_func) + len(h_str) + len(c_str)) == 0:

--- a/qutip/rhs_generate.py
+++ b/qutip/rhs_generate.py
@@ -317,8 +317,8 @@ def _td_format_check(H, c_ops, solver='me'):
         #        "Unable to load Cython. Use Python function format.")
         #else:
         #    if Cython.__version__ < '0.21':
-        #        raise Exception("Cython version (%s) is too old. Upgrade to " +
-        #                        "version 0.21+" % Cython.__version__)
+        #        raise Exception("Cython version (%s) is too old. Upgrade to" +
+        #                        " version 0.21+" % Cython.__version__)
 
     # If only time-dependence is in Objects, then prefer string based format
     if (len(h_func) + len(c_func) + len(h_str) + len(c_str)) == 0:

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -33,14 +33,22 @@
 
 import numpy as np
 from numpy.testing import assert_, run_module_suite, assert_allclose
+import unittest
 from qutip import *
 
+try:
+    import Cython
+except:
+    Cython_OK = False
+else:
+    Cython_OK = _version2int(Cython.__version__) >= _version2int('0.14')
 
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_basic():
     """
     td_brmesolve: passes all brmesolve tests
     """
-    
+
     # Test #1
     delta = 0.0 * 2 * np.pi
     epsilon = 0.5 * 2 * np.pi
@@ -58,7 +66,7 @@ def test_td_brmesolve_basic():
         diff = abs(res_me.expect[idx] - res_brme.expect[idx]).max()
         assert_(diff < 1e-2)
 
-    
+
     # Test #2
     delta = 0.0 * 2 * np.pi
     epsilon = 0.5 * 2 * np.pi
@@ -130,7 +138,7 @@ def test_td_brmesolve_basic():
 
     aop_str = "(({0} + 1) * {1})*(w>=0) + (({0}+1)*{1}*exp(w / {2}))*(w<0)" \
         .format(n_th,kappa,w_th)
-    
+
     c_ops = [np.sqrt(kappa * (n_th + 1)) * a, np.sqrt(kappa * n_th) * a.dag()]
     a_ops = [[a + a.dag(),aop_str]]
     e_ops = [a.dag() * a, a + a.dag()]
@@ -170,7 +178,7 @@ def test_td_brmesolve_basic():
 
     diff = abs(n_me - n_brme).max()
     assert_(diff < 1e-2)
-    
+
     # Test #7
     N = 10
     kappa = 0.05
@@ -195,7 +203,7 @@ def test_td_brmesolve_basic():
         diff = abs(res_me.expect[idx] - res_brme.expect[idx]).max()
         assert_(diff < 5e-2)  # accept 5% error
 
-
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_aop():
     """
     td_brmesolve: time-dependent a_ops
@@ -213,7 +221,7 @@ def test_td_brmesolve_aop():
     avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
     assert_(avg_diff < 1e-6)
 
-
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_aop_tuple1():
     """
     td_brmesolve: time-dependent a_ops tuple of strings
@@ -231,7 +239,7 @@ def test_td_brmesolve_aop_tuple1():
     avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
     assert_(avg_diff < 1e-6)
 
-
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_aop_tuple2():
     """
     td_brmesolve: time-dependent a_ops tuple interp
@@ -250,7 +258,7 @@ def test_td_brmesolve_aop_tuple2():
     avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
     assert_(avg_diff < 1e-5)
 
-
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_aop_tuple3():
     """
     td_brmesolve: time-dependent a_ops & c_ops interp
@@ -270,7 +278,7 @@ def test_td_brmesolve_aop_tuple3():
     avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
     assert_(avg_diff < 1e-5)
 
-    
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_nonherm_eops():
     """
     td_brmesolve: non-Hermitian e_ops check
@@ -286,7 +294,7 @@ def test_td_brmesolve_nonherm_eops():
     br = brmesolve(H2,psi0,tlist,a_ops=[],e_ops=[a],progress_bar=True)
     assert_(np.max(np.abs(me.expect[0]-br.expect[0])) < 1e-4)
 
-    
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_states():
     """
     td_brmesolve: states check
@@ -300,10 +308,10 @@ def test_td_brmesolve_states():
     tlist = np.linspace(0,10,10)
     me = mesolve(H,psi0,tlist,c_ops=[],e_ops=[],progress_bar=True)
     br = brmesolve(H2,psi0,tlist,a_ops=[],e_ops=[],progress_bar=True)
-    assert_(np.max([np.abs((me.states[kk]-br.states[kk]).full()).max() 
+    assert_(np.max([np.abs((me.states[kk]-br.states[kk]).full()).max()
                 for kk in range(len(tlist))]) < 1e-5)
 
-
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_split_ops1():
     """
     td_brmesolve: split ops #1
@@ -319,7 +327,7 @@ def test_td_brmesolve_split_ops1():
     H2 = [[w0 * a.dag() * a + g * (a + a.dag()),'1']]
     psi0 = ket2dm((basis(N, 4) + basis(N, 2) + basis(N, 0)).unit())
     c_ops = [np.sqrt(kappa) * a, np.sqrt(kappa) * a]
-    a_ops = [[ (a, a.dag()), ('{0} * (w >= 0)'.format(kappa), '1', '1') ] , 
+    a_ops = [[ (a, a.dag()), ('{0} * (w >= 0)'.format(kappa), '1', '1') ] ,
                 [a+a.dag(), '{0} * (w >= 0)'.format(kappa)]]
     e_ops = [a.dag() * a, a + a.dag()]
 
@@ -329,7 +337,8 @@ def test_td_brmesolve_split_ops1():
     for idx, e in enumerate(e_ops):
         diff = abs(res_me.expect[idx] - res_brme.expect[idx]).max()
         assert_(diff < 1e-2)
-    
+
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_split_ops2():
     """
     td_brmesolve: split ops #2
@@ -345,7 +354,7 @@ def test_td_brmesolve_split_ops2():
     H2 = [[w0 * a.dag() * a + g * (a + a.dag()),'1']]
     psi0 = ket2dm((basis(N, 4) + basis(N, 2) + basis(N, 0)).unit())
     c_ops = [np.sqrt(kappa) * a, np.sqrt(4*kappa) * a]
-    a_ops = [[a+a.dag(), '{0} * (w >= 0)'.format(kappa)], [ (a, a.dag(), a, a.dag()), 
+    a_ops = [[a+a.dag(), '{0} * (w >= 0)'.format(kappa)], [ (a, a.dag(), a, a.dag()),
                     ('{0} * (w >= 0)'.format(kappa), '1', '1', '1', '1') ]]
 
     e_ops = [a.dag() * a, a + a.dag()]
@@ -356,7 +365,7 @@ def test_td_brmesolve_split_ops2():
         diff = abs(res_me.expect[idx] - res_brme.expect[idx]).max()
         assert_(diff < 1e-2)
 
-
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_split_ops3():
     """
     td_brmesolve: split ops, Cubic_Spline td-terms
@@ -371,10 +380,10 @@ def test_td_brmesolve_split_ops3():
     H = w0 * a.dag() * a + g * (a + a.dag())
     H2 = [[w0 * a.dag() * a + g * (a + a.dag()),'1']]
     psi0 = ket2dm((basis(N, 4) + basis(N, 2) + basis(N, 0)).unit())
-    
+
     S1 = Cubic_Spline(times[0],times[-1], np.ones_like(times))
     S2 = Cubic_Spline(times[0],times[-1], np.ones_like(times))
-    
+
     c_ops = [np.sqrt(kappa) * a, np.sqrt(kappa) * a, np.sqrt(kappa) * a]
     a_ops = [ [a+a.dag(), '{0} * (w >= 0)'.format(kappa)],  [ (a, a.dag()), ('{0} * (w >= 0)'.format(kappa), S1, S2) ]]
     c_ops_br = [np.sqrt(kappa) * a]
@@ -387,7 +396,7 @@ def test_td_brmesolve_split_ops3():
         diff = abs(res_me.expect[idx] - res_brme.expect[idx]).max()
         assert_(diff < 1e-2)
 
-
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_split_ops4():
     """
     td_brmesolve: split ops, multiple
@@ -418,6 +427,7 @@ def test_td_brmesolve_split_ops4():
         diff = abs(res_me.expect[idx] - res_brme.expect[idx]).max()
         assert_(diff < 1e-2)
 
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_td_brmesolve_args():
     """
     td_brmesolve: Hamiltonian args

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -35,6 +35,7 @@ import numpy as np
 from numpy.testing import assert_, run_module_suite, assert_allclose
 import unittest
 from qutip import *
+from qutip import _version2int
 
 try:
     import Cython

--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -33,7 +33,6 @@
 import numpy as np
 import scipy.linalg as la
 from numpy.testing import assert_equal, assert_, run_module_suite
-import unittest
 from qutip import *
 import qutip.settings as qset
 from qutip.superoperator import mat2vec

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -53,7 +53,7 @@ except:
     Cython_OK = False
 else:
     Cython_OK = _version2int(Cython.__version__) >= _version2int('0.14')
-
+Cython_OK = True
 
 def test_compare_solvers_coherent_state_legacy():
     """
@@ -260,7 +260,7 @@ def test_spectrum_espi():
     assert_(max(abs(spec1 - spec2)) < 1e-3)
 
 
-@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
+#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_H_str_list_td_corr():
     """
     correlation: comparing TLS emission corr., H td (str-list td format)
@@ -296,7 +296,7 @@ def test_H_str_list_td_corr():
     assert_(abs(g20-0.59) < 1e-2)
 
 
-@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
+#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_H_np_list_td_corr():
     """
     correlation: comparing TLS emission corr., H td (np-list td format)
@@ -412,7 +412,7 @@ def test_H_fn_td_corr():
     assert_(abs(g20-0.59) < 1e-2)
 
 
-@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
+#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_c_ops_str_list_td_corr():
     """
     correlation: comparing 3LS emission corr., c_ops td (str-list td format)
@@ -456,7 +456,7 @@ def test_c_ops_str_list_td_corr():
     assert_(abs(gab - 0.185) < 1e-2)
 
 
-@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
+#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_np_str_list_td_corr():
     """
     correlation: comparing 3LS emission corr., c_ops td (np-list td format)
@@ -545,7 +545,7 @@ def test_c_ops_fn_list_td_corr():
     assert_(abs(gab - 0.185) < 1e-2)
 
 
-@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
+#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_str_list_td_corr():
     """
     correlation: comparing TLS emission corr. (str-list td format)
@@ -584,7 +584,7 @@ def test_str_list_td_corr():
     assert_(abs(g20 - 0.85) < 1e-2)
 
 
-@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
+#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_np_list_td_corr():
     """
     correlation: comparing TLS emission corr. (np-list td format)
@@ -683,7 +683,7 @@ def test_fn_list_td_corr():
     H1 = [[(sm + sm.dag()), step_func], [qeye(2), inv_step_func]]
 
     H2 = [[qeye(2), inv_step_func], [(sm + sm.dag()), step_func]]
-    
+
     tlist = np.linspace(0, 5, 6)
     corr1 = correlation_2op_2t(H1, fock(2, 0), tlist, tlist, [sm],
                                sm.dag(), sm, args=args)

--- a/qutip/tests/test_graph.py
+++ b/qutip/tests/test_graph.py
@@ -33,7 +33,6 @@
 import os
 import numpy as np
 from numpy.testing import run_module_suite, assert_equal
-import unittest
 import scipy.sparse as sp
 from scipy.sparse.csgraph import breadth_first_order as BFO
 

--- a/qutip/tests/test_interpolate.py
+++ b/qutip/tests/test_interpolate.py
@@ -35,6 +35,7 @@ import scipy.interpolate as sint
 from numpy.testing import assert_, assert_equal, run_module_suite
 import unittest
 from qutip import *
+from qutip import _version2int
 
 try:
     import Cython

--- a/qutip/tests/test_interpolate.py
+++ b/qutip/tests/test_interpolate.py
@@ -33,9 +33,16 @@
 import numpy as np
 import scipy.interpolate as sint
 from numpy.testing import assert_, assert_equal, run_module_suite
+import unittest
 from qutip import *
 
-    
+try:
+    import Cython
+except:
+    Cython_OK = False
+else:
+    Cython_OK = _version2int(Cython.__version__) >= _version2int('0.14')
+
 def testInterpolate1():
     "Interpolate: Sine + noise (array)"
     x = np.linspace(0,2*np.pi,200)
@@ -252,7 +259,7 @@ def test_interpolate_evolve11():
     out2 = mesolve(H2, psi0, tlist, [], [a.dag()*a]).expect[0]
     assert_(np.max(np.abs(out1-out2)) < 1e-4)
 
-
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_interpolate_brevolve1():
     """
     Interpolate: brmesolve str + interp (real)
@@ -269,7 +276,7 @@ def test_interpolate_brevolve1():
     out2 = brmesolve(H2, psi0, tlist, a_ops=[], e_ops=[a.dag()*a]).expect[0]
     assert_(np.max(np.abs(out1-out2)) < 1e-4)
 
-
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_interpolate_brevolve2():
     """
     Interpolate: brmesolve str + interp (complex)
@@ -286,6 +293,7 @@ def test_interpolate_brevolve2():
     out2 = brmesolve(H2, psi0, tlist, a_ops=[], e_ops=[a.dag()*a]).expect[0]
     assert_(np.max(np.abs(out1-out2)) < 1e-4)
 
+@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
 def test_interpolate_brevolve3():
     """
     Interpolate: brmesolve c_op as interp (str)

--- a/qutip/tests/test_mcsolve.py
+++ b/qutip/tests/test_mcsolve.py
@@ -198,7 +198,7 @@ def test_MCCollapseTimesOperators():
     result = mcsolve(H, psi0, times, c_ops, [], ntraj=1)
     assert_(len(result.col_times[0]) > 0)
     assert_(len(result.col_which) == len(result.col_times))
-    assert_(set(result.col_which[0]) == {0, 1})
+    assert_(all([col in [0, 1] for col in result.col_which[0]]))
 
 
 def test_MCSimpleConst():
@@ -306,8 +306,9 @@ def test_MCSimpleConstFunc():
     assert_equal(avg_diff < mc_error, True)
 
 
-@unittest.skipIf(_version2int(Cython.__version__) < _version2int('0.14') or
-                 Cython_found == 0, 'Cython not found or version too low.')
+#@unittest.skipIf(Cython_found == 0 or
+#                 _version2int(Cython.__version__) < _version2int('0.14'),
+#                 'Cython not found or version too low.')
 def test_MCSimpleConstStr():
     "Monte-carlo: Collapse terms constant (str format)"
     N = 10  # number of basis states to consider
@@ -343,8 +344,9 @@ def test_MCTDFunc():
     assert_equal(diff < error, True)
 
 
-@unittest.skipIf(_version2int(Cython.__version__) < _version2int('0.14') or
-                 Cython_found == 0, 'Cython not found or version too low.')
+#@unittest.skipIf(Cython_found == 0 or
+#                 _version2int(Cython.__version__) < _version2int('0.14'),
+#                 'Cython not found or version too low.')
 def test_TDStr():
     "Monte-carlo: Time-dependent H (str format)"
     error = 5e-2
@@ -534,7 +536,7 @@ def test_mc_ntraj_list():
 
 def test_mc_functd_sum():
     "Monte-carlo: Test for #490"
-    psi0 = (basis(2,0) + basis(2,1)).unit()   
+    psi0 = (basis(2,0) + basis(2,1)).unit()
     H0 = sigmax()
     H1 = sigmay()
     H2 = sigmaz()

--- a/qutip/tests/test_qobjevo.py
+++ b/qutip/tests/test_qobjevo.py
@@ -123,22 +123,33 @@ def test_QobjEvo_call():
         op.compile()
         assert_equal(_sp_eq(op(t, data=1) , O_target1.data), True)
         assert_equal(len((op(t) - O_target1).tidyup(1e-10).data.data),0)
+        op.compiled = ""
 
         op.compile(dense=1)
         assert_equal(_sp_eq(op(t, data=1) , O_target1.data), True)
         assert_equal(len((op(t) - O_target1).tidyup(1e-10).data.data),0)
+        op.compiled = ""
 
         op.compile(matched=1)
         assert_equal(_sp_eq(op(t, data=1) , O_target1.data), True)
         assert_equal(len((op(t) - O_target1).tidyup(1e-10).data.data),0)
+        op.compiled = ""
 
         op.compile(omp=2)
         assert_equal(_sp_eq(op(t, data=1) , O_target1.data), True)
         assert_equal(len((op(t) - O_target1).tidyup(1e-10).data.data),0)
+        op.compiled = ""
 
         op.compile(matched=1, omp=2)
         assert_equal(_sp_eq(op(t, data=1) , O_target1.data), True)
         assert_equal(len((op(t) - O_target1).tidyup(1e-10).data.data),0)
+        op.compiled = ""
+
+        op.use_cython = False
+        op.compile()
+        assert_equal(_sp_eq(op(t, data=1) , O_target1.data), True)
+        assert_equal(len((op(t) - O_target1).tidyup(1e-10).data.data),0)
+        op.compiled = ""
 
 
 def test_QobjEvo_call_args():
@@ -204,7 +215,7 @@ def test_QobjEvo_step_coeff():
     coeff2 = np.random.rand(6) + np.random.rand(6) * 1.j
     # uniform t
     tlist = np.array([2, 3, 4, 5, 6, 7], dtype=float)
-    qobjevo = QobjEvo([[sigmaz(), coeff1], [sigmax(), coeff2]], 
+    qobjevo = QobjEvo([[sigmaz(), coeff1], [sigmax(), coeff2]],
                     tlist=tlist, args={"_step_func_coeff":True})
     assert_equal(qobjevo.ops[0].get_coeff(2.0), coeff1[0])
     assert_equal(qobjevo.ops[0].get_coeff(7.0), coeff1[5])
@@ -710,6 +721,7 @@ def test_QobjEvo_safepickle():
     #used in parallel_map
     import pickle
     from qutip.qobjevo import safePickle
+    old_set = safePickle[0]
     safePickle[0] = True
     tlist = np.linspace(0,1,300)
     args={"w1":1, "w2":2}
@@ -742,6 +754,7 @@ def test_QobjEvo_safepickle():
     td_pick = pickle.loads(pickled)
     # Check for ct_cqobjevo
     assert_equal(td_obj_m(t) == td_pick(t), True)
+    safePickle[0] = old_set
 
 
 def test_QobjEvo_superoperator():

--- a/qutip/tests/test_qobjevo.py
+++ b/qutip/tests/test_qobjevo.py
@@ -211,6 +211,7 @@ def test_QobjEvo_call_args():
 
 
 def test_QobjEvo_step_coeff():
+    "QobjEvo step interpolation"
     coeff1 = np.random.rand(6)
     coeff2 = np.random.rand(6) + np.random.rand(6) * 1.j
     # uniform t

--- a/qutip/tests/test_qobjevo.py
+++ b/qutip/tests/test_qobjevo.py
@@ -53,13 +53,10 @@ def _rand_cqobjevo(N=5):
     tlist=np.linspace(0,10,10001)
     tlistlog=np.logspace(-3,1,10001)
     O0, O1, O2 = rand_herm(N), rand_herm(N), rand_herm(N)
-
     cte = [QobjEvo([O0])]
-
     wargs = [QobjEvo([O0,[O1,_f1],[O2,_f2]], args={"w1":1,"w2":2}),
              QobjEvo([O0,[O1,"sin(w1*t)"],[O2,"cos(w2*t)"]],
                      args={"w1":1,"w2":2})]
-
     nargs = [QobjEvo([O0,[O1,np.sin(tlist)],[O2,np.cos(2*tlist)]],tlist=tlist),
              QobjEvo([O0,[O1,np.sin(tlistlog)],[O2,np.cos(2*tlistlog)]],
                      tlist=tlistlog),
@@ -78,12 +75,10 @@ def _random_QobjEvo(shape=(1,1), ops=[0,0,0], cte=True, tlist=None):
     """Create a list to make a QobjEvo with up to 3 coefficients"""
     if tlist is None:
         tlist = np.linspace(0,1,301)
-
     Qobj_list = []
     if cte:
         Qobj_list.append(Qobj(np.random.random(shape) + \
                               1j*np.random.random(shape)))
-
     coeff =  [[_f1, "sin(w1*t)",    np.sin(tlist),
                     Cubic_Spline(0,1,np.sin(tlist))],
               [_f2, "cos(w2*t)",    np.cos(tlist),

--- a/qutip/tests/test_stochastic_se.py
+++ b/qutip/tests/test_stochastic_se.py
@@ -39,8 +39,8 @@ from qutip import (ssesolve, destroy, coherent, mesolve, fock, qeye,
 def f(t, args):
     return args["a"] * t
 
-def test_smesolve_homodyne_methods():
-    "Stochastic: smesolve: homodyne methods with single jump operator"
+def test_ssesolve_homodyne_methods():
+    "Stochastic: ssesolve: homodyne methods with single jump operator"
 
     def arccoth(x):
         return 0.5*np.log((1.+x)/(x-1.))
@@ -85,13 +85,13 @@ def test_smesolve_homodyne_methods():
                         ['taylor2.0', 5e-4]]
     for n_method in list_methods_tol:
         sol = ssesolve(H, rho0, tlist, sc_op, e_op,
-                       nsubsteps=Nsub, method='homodyne', solver = n_method[0])
+                       nsubsteps=Nsub, method='homodyne', solver=n_method[0])
         sol2 = ssesolve(H, rho0, tlist, sc_op, e_op, store_measurement=0,
-                       nsubsteps=Nsub, method='homodyne', solver = n_method[0],
+                       nsubsteps=Nsub, method='homodyne', solver=n_method[0],
                        noise = sol.noise)
         sol3 = ssesolve(H, rho0, tlist, sc_op, e_op,
-                        nsubsteps=Nsub*5, method='homodyne',
-                        solver = n_method[0], tol=1e-8)
+                        nsubsteps=Nsub*10, method='homodyne',
+                        solver=n_method[0], tol=1e-8)
         err = 1/T * np.sum(np.abs(y_an - \
                     (sol.expect[1]-sol.expect[0]*sol.expect[0].conj())))*ddt
         err3 = 1/T * np.sum(np.abs(y_an - \
@@ -100,7 +100,7 @@ def test_smesolve_homodyne_methods():
         assert_(err < n_method[1])
         # 5* more substep should decrease the error
         assert_(err3 < err)
-        # just to check that noise is not affected by smesolve
+        # just to check that noise is not affected by ssesolve
         assert_(np.all(sol.noise == sol2.noise))
         assert_(np.all(sol.expect[0] == sol2.expect[0]))
 


### PR DESCRIPTION
Added the option to import string to python instead of compiling to cython for QobjEvo.
This is default if no cython, or set manually if cython available. `QobjEvoInstance.use_cython = False`
Added test and updated docstring.
Work in parallel.
Did not do any benchmark yet.
