### PR TITLE
Remove wrong shebangs

### DIFF
--- a/qutip/control/cy_grape.pyx
+++ b/qutip/control/cy_grape.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/br_tensor.pyx
+++ b/qutip/cy/br_tensor.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/brtools.pyx
+++ b/qutip/cy/brtools.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/brtools_checks.pyx
+++ b/qutip/cy/brtools_checks.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/checks.pyx
+++ b/qutip/cy/checks.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/cqobjevo.pxd
+++ b/qutip/cy/cqobjevo.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/cqobjevo.pyx
+++ b/qutip/cy/cqobjevo.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # distutils: language = c++
 # This file is part of QuTiP: Quantum Toolbox in Python.

--- a/qutip/cy/cqobjevo_factor.pxd
+++ b/qutip/cy/cqobjevo_factor.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 cimport numpy as np
 

--- a/qutip/cy/cqobjevo_factor.pyx
+++ b/qutip/cy/cqobjevo_factor.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/graph_utils.pyx
+++ b/qutip/cy/graph_utils.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/heom.pyx
+++ b/qutip/cy/heom.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/inter.pxd
+++ b/qutip/cy/inter.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/inter.pyx
+++ b/qutip/cy/inter.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/interpolate.pxd
+++ b/qutip/cy/interpolate.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/interpolate.pyx
+++ b/qutip/cy/interpolate.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/math.pxd
+++ b/qutip/cy/math.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/math.pyx
+++ b/qutip/cy/math.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/mcsolve.pyx
+++ b/qutip/cy/mcsolve.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 ## cython: profile=True
 ## cython: linetrace=True

--- a/qutip/cy/openmp/benchmark.pyx
+++ b/qutip/cy/openmp/benchmark.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/openmp/br_omp.pxd
+++ b/qutip/cy/openmp/br_omp.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/openmp/br_omp.pyx
+++ b/qutip/cy/openmp/br_omp.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/openmp/cqobjevo_omp.pyx
+++ b/qutip/cy/openmp/cqobjevo_omp.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # distutils: language = c++
 # This file is part of QuTiP: Quantum Toolbox in Python.

--- a/qutip/cy/openmp/omp_sparse_utils.pyx
+++ b/qutip/cy/openmp/omp_sparse_utils.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/openmp/parfuncs.pxd
+++ b/qutip/cy/openmp/parfuncs.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/openmp/parfuncs.pyx
+++ b/qutip/cy/openmp/parfuncs.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/piqs.pyx
+++ b/qutip/cy/piqs.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/ptrace.pyx
+++ b/qutip/cy/ptrace.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/sparse_structs.pxd
+++ b/qutip/cy/sparse_structs.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/sparse_utils.pyx
+++ b/qutip/cy/sparse_utils.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/spconvert.pxd
+++ b/qutip/cy/spconvert.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/spconvert.pyx
+++ b/qutip/cy/spconvert.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/spmatfuncs.pxd
+++ b/qutip/cy/spmatfuncs.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/spmatfuncs.pyx
+++ b/qutip/cy/spmatfuncs.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/spmath.pxd
+++ b/qutip/cy/spmath.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/spmath.pyx
+++ b/qutip/cy/spmath.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #

--- a/qutip/cy/stochastic.pyx
+++ b/qutip/cy/stochastic.pyx
@@ -1,4 +1,3 @@
-#!python
 #cython: language_level=3
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #


### PR DESCRIPTION
Fix unnecessary shebangs in `.pyx` and `.pxd` files by removing them.

related to #1059
ref :https://github.com/qutip/qutip/pull/1070
