### PR TITLE
Allow general callable objects to define a time-dependent Hamiltonian

### DIFF
--- a/qutip/rhs_generate.py
+++ b/qutip/rhs_generate.py
@@ -284,6 +284,8 @@ def _td_format_check(H, c_ops, solver='me'):
                     if isinstance(c_ops[k][1], (FunctionType,
                                                 BuiltinFunctionType, partial)):
                         c_func.append(k)
+                    elif hasattr(c_ops[k][1], '__call__'):
+                        c_func.append(k)
                     elif isinstance(c_ops[k][1], str):
                         c_str.append(k)
                     elif isinstance(c_ops[k][1], Cubic_Spline):


### PR DESCRIPTION
While solving some time-dependent Hamiltonians, I decided to refactor the list-style definition of my Hamiltonian and completely get rid of all ```partial``` calls which made my code much cleaner. In particular, I implemented a small class to construct the time-dependent components that go into the Hamiltonian and overwrote the ```__call__``` method to make my class object directly callable by Qutip.

However, this was rejected by Qutip as an "Incorrect Hamiltonian specification" due to the format check. Since, as far as I know, subclassing the built-in FunctionType ```function``` is not possible in Python, and subclasses of FunctionType would not be accepted by Qutip either (_td_format_check calls ```isinstance``` and not ```issubclass```), I  suggest that Qutip also accepts general objects which have the ```__call__``` attribute defined.

Changes: Update ```_td_format_check``` by one extra condition to allow any object with attribute ```__call__``` in the definition of a Hamiltonian.