### PR TITLE
Qobj inverse and inproved ptrace

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -62,7 +62,8 @@ from qutip.cy.ptrace import _ptrace
 from qutip.permute import _permute
 from qutip.sparse import (sp_eigs, sp_expm, sp_fro_norm, sp_max_norm,
                           sp_one_norm, sp_L2_norm)
-from qutip.dimensions import type_from_dims, enumerate_flat, collapse_dims_super
+from qutip.dimensions import (type_from_dims, enumerate_flat,
+                              collapse_dims_super)
 from qutip.cy.spmath import (zcsr_transpose, zcsr_adjoint, zcsr_isherm,
                             zcsr_trace, zcsr_proj, zcsr_inner)
 from qutip.cy.spmatfuncs import zcsr_mat_elem
@@ -74,7 +75,7 @@ elif sys.version_info.major < 3:
     from itertools import izip_longest
     zip_longest = izip_longest
 
-#OPENMP stuff
+# OPENMP stuff
 from qutip.cy.openmp.utilities import use_openmp
 if settings.has_openmp:
     from qutip.cy.openmp.omp_sparse_utils import omp_tidyup
@@ -321,12 +322,12 @@ class Qobj(object):
             inpt = np.array([[0]])
             _tmp = sp.csr_matrix(inpt, dtype=complex, copy=copy)
             self._data = fast_csr_matrix((_tmp.data, _tmp.indices, _tmp.indptr),
-                                        shape = _tmp.shape)
+                                        shape=_tmp.shape)
             self.dims = [[int(inpt.shape[0])], [int(inpt.shape[1])]]
 
         if type == 'super':
             # Type is not super, i.e. dims not explicitly passed, but oper shape
-            if dims== [[], []] and self.shape[0] == self.shape[1]:
+            if dims == [[], []] and self.shape[0] == self.shape[1]:
                 sub_shape = np.sqrt(self.shape[0])
                 # check if root of shape is int
                 if (sub_shape % 1) != 0:
@@ -351,7 +352,7 @@ class Qobj(object):
 
     def get_data(self):
         return self._data
-    #Here we perfrom a check of the csr matrix type during setting of Q.data
+    # Here we perfrom a check of the csr matrix type during setting of Q.data
     def set_data(self, data):
         if not isinstance(data, fast_csr_matrix):
             raise TypeError('Qobj data must be in fast_csr format.')
@@ -548,7 +549,7 @@ class Qobj(object):
                 raise TypeError("Incompatible Qobj shapes")
 
         elif isinstance(other, np.ndarray):
-            if other.dtype=='object':
+            if other.dtype == 'object':
                 return np.array([self * item for item in other],
                                 dtype=object)
             else:
@@ -585,7 +586,7 @@ class Qobj(object):
         MULTIPLICATION with Qobj on RIGHT [ ex. 4*Qobj ]
         """
         if isinstance(other, np.ndarray):
-            if other.dtype=='object':
+            if other.dtype == 'object':
                 return np.array([item * self for item in other],
                                             dtype=object)
             else:
@@ -1017,16 +1018,15 @@ class Qobj(object):
             Projection operator.
         """
         if self.isket:
-            _out = zcsr_proj(self.data,1)
-            _dims = [self.dims[0],self.dims[0]]
+            _out = zcsr_proj(self.data, 1)
+            _dims = [self.dims[0], self.dims[0]]
         elif self.isbra:
-            _out = zcsr_proj(self.data,0)
-            _dims = [self.dims[1],self.dims[1]]
+            _out = zcsr_proj(self.data, 0)
+            _dims = [self.dims[1], self.dims[1]]
         else:
             raise TypeError('Projector can only be formed from a bra or ket.')
 
-        return Qobj(_out,dims=_dims)
-
+        return Qobj(_out, dims=_dims)
 
     def tr(self):
         """Trace of a quantum object.
@@ -1201,7 +1201,6 @@ class Qobj(object):
         else:
             raise TypeError('Invalid operand for matrix square root')
 
-
     def cosm(self):
         """Cosine of a quantum operator.
 
@@ -1223,7 +1222,7 @@ class Qobj(object):
 
         """
         if self.dims[0][0] == self.dims[1][0]:
-             return 0.5 * ((1j * self).expm() + (-1j * self).expm())
+            return 0.5 * ((1j * self).expm() + (-1j * self).expm())
         else:
             raise TypeError('Invalid operand for matrix square root')
 
@@ -1248,7 +1247,7 @@ class Qobj(object):
 
         """
         if self.dims[0][0] == self.dims[1][0]:
-             return -0.5j * ((1j * self).expm() - (-1j * self).expm())
+            return -0.5j * ((1j * self).expm() - (-1j * self).expm())
         else:
             raise TypeError('Invalid operand for matrix square root')
 
@@ -1384,14 +1383,14 @@ class Qobj(object):
 
         """
         if self.data.nnz:
-            #This does the tidyup and returns True if
-            #The sparse data needs to be shortened
+            # This does the tidyup and returns True if
+            # The sparse data needs to be shortened
             if use_openmp() and self.data.nnz > 500:
-                if omp_tidyup(self.data.data,atol,self.data.nnz,
+                if omp_tidyup(self.data.data,atol, self.data.nnz,
                             settings.num_cpus):
                             self.data.eliminate_zeros()
             else:
-                if cy_tidyup(self.data.data,atol,self.data.nnz):
+                if cy_tidyup(self.data.data,atol, self.data.nnz):
                     self.data.eliminate_zeros()
             return self
         else:
@@ -1567,10 +1566,10 @@ class Qobj(object):
 
         else:
             if bra.isbra and ket.isket:
-                return zcsr_mat_elem(self.data,bra.data,ket.data,1)
+                return zcsr_mat_elem(self.data, bra.data, ket.data, 1)
 
             elif bra.isket and ket.isket:
-                return zcsr_mat_elem(self.data,bra.data,ket.data,0)
+                return zcsr_mat_elem(self.data, bra.data, ket.data, 0)
             else:
                 err = "Can only calculate matrix elements for bra"
                 err += " and ket vectors."
@@ -1613,8 +1612,8 @@ class Qobj(object):
                 if other.isket:
                     return zcsr_inner(self.data, other.data, 1)
                 elif other.isbra:
-                    #Since we deal mainly with ket vectors, the bra-bra combo
-                    #is not common, and not optimized.
+                    # Since we deal mainly with ket vectors, the bra-bra combo
+                    # is not common, and not optimized.
                     return zcsr_inner(self.data, other.dag().data, 1)
                 elif other.isoper:
                     return (qutip.states.ket2dm(self).dag() * other).tr()
@@ -2179,12 +2178,15 @@ def ptrace(Q, sel):
 
 
 def _ptrace_dense(Q, sel):
-    rd = Q.dims[0]
+    rd = np.asarray(Q.dims[0], dtype=np.int32).ravel()
     nd = len(rd)
+    if not isinstance(sel, (list, np.ndarray)):
+        sel = [sel]
     sel = list(np.sort(sel))
-    dkeep = (np.array(rd)[sel]).tolist()
+    dkeep = (rd[sel]).tolist()
     qtrace = list(set(np.arange(nd)) - set(sel))
-    dtrace = (np.array(rd)[qtrace]).tolist()
+    dtrace = (rd[qtrace]).tolist()
+    rd = list(rd)
     if isket(Q):
         vmat = (Q.full()
                 .reshape(rd)

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1252,7 +1252,7 @@ class Qobj(object):
         else:
             raise TypeError('Invalid operand for matrix square root')
 
-    def inv(self, sparse=None):
+    def inv(self, sparse=False):
         """Matrix inverse of a quantum operator
 
         Operator must be square.
@@ -1269,9 +1269,6 @@ class Qobj(object):
         """
         if self.shape[0] != self.shape[1]:
             raise TypeError('Invalid operand for matrix inverse')
-        if sparse is None:
-            if (self.data.nnz / (self.shape[0] * self.shape[1]) >= 0.1:
-                sparse = False
         if sparse:
             inv_mat = sp.linalg.inv(sp.csc_matrix(self.data))
         else:
@@ -1341,7 +1338,9 @@ class Qobj(object):
 
         """
         if sparse is None:
-            if (self.data.nnz / (self.shape[0] * self.shape[1]) >= 0.1:
+            if self.isket:
+                sparse = False
+            elif (self.data.nnz / (self.shape[0] * self.shape[1])) >= 0.1:
                 sparse = False
         if sparse:
             q = Qobj()
@@ -2182,7 +2181,7 @@ def ptrace(Q, sel):
 def _ptrace_dense(Q, sel):
     rd = Q.dims[0]
     nd = len(rd)
-    sel = list(sort(sel))
+    sel = list(np.sort(sel))
     dkeep = (np.array(rd)[sel]).tolist()
     qtrace = list(set(np.arange(nd)) - set(sel))
     dtrace = (np.array(rd)[qtrace]).tolist()
@@ -2190,17 +2189,17 @@ def _ptrace_dense(Q, sel):
         vmat = (Q.full()
                 .reshape(rd)
                 .transpose(sel + qtrace)
-                .reshape([prod(dkeep), prod(dtrace)]))
+                .reshape([np.prod(dkeep), np.prod(dtrace)]))
         rhomat = vmat.dot(vmat.conj().T)
     else:
         rhomat = np.trace(Q.full()
                           .reshape(rd + rd)
                           .transpose(qtrace + [nd + q for q in qtrace] +
                                      sel + [nd + q for q in sel])
-                          .reshape([prod(dtrace),
-                                    prod(dtrace),
-                                    prod(dkeep),
-                                    prod(dkeep)]))
+                          .reshape([np.prod(dtrace),
+                                    np.prod(dtrace),
+                                    np.prod(dkeep),
+                                    np.prod(dkeep)]))
     return Qobj(rhomat, dims=[dkeep, dkeep])
 
 

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -2180,8 +2180,10 @@ def ptrace(Q, sel):
 def _ptrace_dense(Q, sel):
     rd = np.asarray(Q.dims[0], dtype=np.int32).ravel()
     nd = len(rd)
-    if not isinstance(sel, (list, np.ndarray)):
-        sel = [sel]
+    if isinstance(sel, int):
+        sel = np.array([sel])
+    else:
+        sel = np.asarray(sel)
     sel = list(np.sort(sel))
     dkeep = (rd[sel]).tolist()
     qtrace = list(set(np.arange(nd)) - set(sel))

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -212,7 +212,8 @@ def _rand_herm_dense(N, density, pos_def):
         M[col, row] = 0
         M[row, col] = 0
     if pos_def:
-        M.setdiag(np.abs(M.diagonal())+np.sqrt(2)*N)
+        as_vec = M.ravel()
+        M[::N+1] = (np.abs(M.diagonal())+np.sqrt(2)*N)
     return M
 
 

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -217,34 +217,6 @@ def _rand_herm_dense(N, density, pos_def):
     return M
 
 
-def _rand_herm_exact_density(N, density):
-    # less clean and slower (2x)
-    # However will get the desired density within 1 elements
-    row_idx = []
-    col_idx = []
-    nnz = 0
-    num_elems = np.int(np.round(N * N * density))
-    num_elems = max([num_elems, 1])
-    num_elems = min([num_elems, N * N])
-    for index in np.random.permutation(N*N):
-        row, col = divmod(index, N)
-        if row >= col:
-            nnz += 2
-            row_idx.append(row)
-            col_idx.append(col)
-        if row == col:
-            nnz -= 1
-        if nnz >= num_elems:
-            break
-    num_valid = len(row_idx)
-    data = (2 * np.random.rand(num_valid) - 1) + \
-           (2 * np.random.rand(num_valid) - 1) * 1j
-    M = sp.coo_matrix((data, (row_idx,col_idx)),
-                      dtype=complex, shape=(N,N)).tocsr()
-    M = 0.5 * (M + M.conj().transpose())
-    return M
-
-
 def rand_unitary(N, density=0.75, dims=None, seed=None):
     """Creates a random NxN sparse unitary quantum object.
 

--- a/qutip/tests/test_ptrace.py
+++ b/qutip/tests/test_ptrace.py
@@ -35,76 +35,144 @@ from qutip import *
 from qutip.legacy.ptrace import _ptrace as _pt
 
 def test_ptrace_rand():
-    'ptrace : randomized tests'
-    for k in range(10):
+    'ptrace : randomized tests, sparse'
+    for k in range(5):
         A = tensor(rand_ket(5), rand_ket(2), rand_ket(3))
-        B = A.ptrace([1,2])
+        B = A.ptrace([1,2], True)
         bdat,bd,bs = _pt(A, [1,2])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
-        
-        B = A.ptrace([0,2])
+
+        B = A.ptrace([0,2], True)
         bdat,bd,bs = _pt(A, [0,2])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
-        
-        B = A.ptrace([0,1])
+
+        B = A.ptrace([0,1], True)
         bdat,bd,bs = _pt(A, [0,1])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
 
-
-    for k in range(10):
+    for k in range(5):
         A = tensor(rand_dm(2), thermal_dm(10,1), rand_unitary(3))
-        B = A.ptrace([1,2])
+        B = A.ptrace([1,2], True)
         bdat,bd,bs = _pt(A, [1,2])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
-        
-        B = A.ptrace([0,2])
+
+        B = A.ptrace([0,2], True)
         bdat,bd,bs = _pt(A, [0,2])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
-        
-        B = A.ptrace([0,1])
+
+        B = A.ptrace([0,1], True)
         bdat,bd,bs = _pt(A, [0,1])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
-        
-        
-    for k in range(10):
+
+    for k in range(5):
         A = tensor(rand_ket(2),rand_ket(2),rand_ket(2),
                     rand_ket(2),rand_ket(2),rand_ket(2))
-        B = A.ptrace([3,2])
+        B = A.ptrace([3,2], True)
         bdat,bd,bs = _pt(A, [3,2])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
-        
-        B = A.ptrace([0,2])
+
+        B = A.ptrace([0,2], True)
         bdat,bd,bs = _pt(A, [0,2])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
-        
-        B = A.ptrace([0,1])
+
+        B = A.ptrace([0,1], True)
         bdat,bd,bs = _pt(A, [0,1])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
-        
 
-
-    for k in range(10):
+    for k in range(5):
         A = rand_dm(64,0.5,dims=[[4,4,4],[4,4,4]])
-        B = A.ptrace([0])
+        B = A.ptrace([0], True)
         bdat,bd,bs = _pt(A, [0])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
-        
-        B = A.ptrace([1])
+
+        B = A.ptrace([1], True)
         bdat,bd,bs = _pt(A, [1])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)
-        
-        B = A.ptrace([0,2])
+
+        B = A.ptrace([0,2], True)
+        bdat,bd,bs = _pt(A, [0,2])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+
+def test_ptrace_rand():
+    'ptrace : randomized tests, dense'
+    for k in range(5):
+        A = tensor(rand_ket(5), rand_ket(2), rand_ket(3))
+        B = A.ptrace([1,2], False)
+        bdat,bd,bs = _pt(A, [1,2])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+        B = A.ptrace([0,2], False)
+        bdat,bd,bs = _pt(A, [0,2])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+        B = A.ptrace([0,1], False)
+        bdat,bd,bs = _pt(A, [0,1])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+    for k in range(5):
+        A = tensor(rand_dm(2), thermal_dm(10,1), rand_unitary(3))
+        B = A.ptrace([1,2], False)
+        bdat,bd,bs = _pt(A, [1,2])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+        B = A.ptrace([0,2], False)
+        bdat,bd,bs = _pt(A, [0,2])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+        B = A.ptrace([0,1], False)
+        bdat,bd,bs = _pt(A, [0,1])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+    for k in range(5):
+        A = tensor(rand_ket(2),rand_ket(2),rand_ket(2),
+                    rand_ket(2),rand_ket(2),rand_ket(2))
+        B = A.ptrace([3,2], False)
+        bdat,bd,bs = _pt(A, [3,2])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+        B = A.ptrace([0,2], False)
+        bdat,bd,bs = _pt(A, [0,2])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+        B = A.ptrace([0,1], False)
+        bdat,bd,bs = _pt(A, [0,1])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+    for k in range(5):
+        A = rand_dm(64,0.5,dims=[[4,4,4],[4,4,4]])
+        B = A.ptrace([0], False)
+        bdat,bd,bs = _pt(A, [0])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+        B = A.ptrace([1], False)
+        bdat,bd,bs = _pt(A, [1])
+        C = Qobj(bdat,dims=bd)
+        assert_(B==C)
+
+        B = A.ptrace([0,2], False)
         bdat,bd,bs = _pt(A, [0,2])
         C = Qobj(bdat,dims=bd)
         assert_(B==C)

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -51,6 +51,16 @@ from operator import add, mul, truediv, sub
 from functools import partial
 from contextlib import contextmanager
 
+def _random_not_singular(N):
+    """
+    return a N*N complex array with determinant not 0.
+    """
+    data = np.zeros((1,1))
+    while np.linalg.det(data) == 0:
+        data = np.random.random((N, N)) + \
+               1j * np.random.random((N, N)) - (0.5 + 0.5j)
+    return data
+
 @contextmanager
 def expect_exception(ex_class):
     """
@@ -91,16 +101,14 @@ def assert_hermicity(oper, hermicity, msg=""):
 def test_QobjData():
     "Qobj data"
     N = 10
-    data1 = np.random.random(
-        (N, N)) + 1j * np.random.random((N, N)) - (0.5 + 0.5j)
+    data1 = _random_not_singular(N)
     q1 = Qobj(data1)
     # check if data is a csr_matrix if originally array
     assert_equal(sp.isspmatrix_csr(q1.data), True)
     # check if dense ouput is equal to original data
     assert_(np.all(q1.data.todense() - np.matrix(data1) == 0))
 
-    data2 = np.random.random(
-        (N, N)) + 1j * np.random.random((N, N)) - (0.5 + 0.5j)
+    data2 = _random_not_singular(N)
     data2 = sp.csr_matrix(data2)
     q2 = Qobj(data2)
     # check if data is a csr_matrix if originally csr_matrix
@@ -111,8 +119,7 @@ def test_QobjData():
     # check if data is a csr_matrix if originally int
     assert_equal(sp.isspmatrix_csr(q3.data), True)
 
-    data4 = np.random.random(
-        (N, N)) + 1j * np.random.random((N, N)) - (0.5 + 0.5j)
+    data4 = _random_not_singular(N)
     data4 = np.matrix(data4)
     q4 = Qobj(data4)
     # check if data is a csr_matrix if originally csr_matrix
@@ -154,8 +161,7 @@ def test_QobjType():
 def test_QobjHerm():
     "Qobj Hermicity"
     N = 10
-    data = np.random.random(
-        (N, N)) + 1j * np.random.random((N, N)) - (0.5 + 0.5j)
+    data = _random_not_singular(N)
     q = Qobj(data)
     assert_equal(q.isherm, False)
 
@@ -222,8 +228,7 @@ def test_QobjUnitaryOper():
 def test_QobjDimsShape():
     "Qobj shape"
     N = 10
-    data = np.random.random(
-        (N, N)) + 1j * np.random.random((N, N)) - (0.5 + 0.5j)
+    data = _random_not_singular(N)
 
     q1 = Qobj(data)
     assert_equal(q1.dims, [[10], [10]])
@@ -238,8 +243,7 @@ def test_QobjDimsShape():
 
     N = 4
 
-    data = np.random.random(
-        (N, N)) + 1j * np.random.random((N, N)) - (0.5 + 0.5j)
+    data = _random_not_singular(N)
 
     q1 = Qobj(data, dims=[[2, 2], [2, 2]])
     assert_equal(q1.dims, [[2, 2], [2, 2]])
@@ -327,12 +331,10 @@ def test_QobjAddition():
 
 def test_QobjSubtraction():
     "Qobj subtraction"
-    data1 = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data1 = _random_not_singular(5)
     q1 = Qobj(data1)
 
-    data2 = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data2 = _random_not_singular(5)
     q2 = Qobj(data2)
 
     q3 = q1 - q2
@@ -364,8 +366,7 @@ def test_QobjMultiplication():
 
 def test_QobjDivision():
     "Qobj division"
-    data = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data = _random_not_singular(5)
     q = Qobj(data)
     randN = 10 * np.random.random()
     q = q / randN
@@ -374,8 +375,7 @@ def test_QobjDivision():
 
 def test_QobjPower():
     "Qobj power"
-    data = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data = _random_not_singular(5)
     q = Qobj(data)
 
     q2 = q ** 2
@@ -387,8 +387,7 @@ def test_QobjPower():
 
 def test_QobjNeg():
     "Qobj negation"
-    data = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data = _random_not_singular(5)
     q = Qobj(data)
     x = -q
     assert_(np.all(x.data.todense() + np.matrix(data) == 0))
@@ -398,8 +397,7 @@ def test_QobjNeg():
 
 def test_QobjEquals():
     "Qobj equals"
-    data = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data = _random_not_singular(5)
     q1 = Qobj(data)
     q2 = Qobj(data)
     assert_(q1 == q2)
@@ -411,8 +409,7 @@ def test_QobjEquals():
 
 def test_QobjGetItem():
     "Qobj getitem"
-    data = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data = _random_not_singular(5)
     q = Qobj(data)
     assert_equal(q[0, 0], data[0, 0])
     assert_equal(q[-1, 2], data[-1, 2])
@@ -489,8 +486,7 @@ def test_Qobj_Spmv():
 
 def test_QobjConjugate():
     "Qobj conjugate"
-    data = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data = _random_not_singular(5)
     A = Qobj(data)
     B = A.conj()
     assert_(np.all(B.data.todense() - np.matrix(data.conj()) == 0))
@@ -501,8 +497,7 @@ def test_QobjConjugate():
 
 def test_QobjDagger():
     "Qobj adjoint (dagger)"
-    data = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data = _random_not_singular(5)
     A = Qobj(data)
     B = A.dag()
     assert_(np.all(B.data.todense() - np.matrix(data.conj().T) == 0))
@@ -513,8 +508,7 @@ def test_QobjDagger():
 
 def test_QobjDiagonals():
     "Qobj diagonals"
-    data = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data = _random_not_singular(5)
     A = Qobj(data)
     b = A.diag()
     assert_(np.all(b - np.diag(data) == 0))
@@ -553,8 +547,7 @@ def test_QobjEigenStates():
 
 def test_QobjExpm():
     "Qobj expm (dense)"
-    data = np.random.random(
-        (15, 15)) + 1j * np.random.random((15, 15)) - (0.5 + 0.5j)
+    data = _random_not_singular(15)
     A = Qobj(data)
     B = A.expm()
     assert_((B.data.todense() - np.matrix(la.expm(data)) < 1e-10).all())
@@ -562,8 +555,7 @@ def test_QobjExpm():
 
 def test_QobjExpmExplicitlySparse():
     "Qobj expm (sparse)"
-    data = np.random.random(
-        (15, 15)) + 1j * np.random.random((15, 15)) - (0.5 + 0.5j)
+    data = _random_not_singular(15)
     A = Qobj(data)
     B = A.expm(method='sparse')
     assert_((B.data.todense() - np.matrix(la.expm(data)) < 1e-10).all())
@@ -578,17 +570,27 @@ def test_QobjExpmZeroOper():
 
 def test_Qobj_sqrtm():
     "Qobj sqrtm"
-    data = np.random.random(
-        (5, 5)) + 1j * np.random.random((5, 5)) - (0.5 + 0.5j)
+    data = _random_not_singular(5)
     A = Qobj(data)
     B = A.sqrtm()
     assert_(A == B * B)
 
 
+def test_Qobj_inv():
+    "Qobj inv"
+    data = _random_not_singular(5)
+    A = Qobj(data)
+    B = A.inv()
+    assert_(qeye(5) == A * B)
+    assert_(qeye(5) == B * A)
+    B = A.inv(sparse=True)
+    assert_(qeye(5) == A * B)
+    assert_(qeye(5) == B * A)
+
+
 def test_QobjFull():
     "Qobj full"
-    data = np.random.random(
-        (15, 15)) + 1j * np.random.random((15, 15)) - (0.5 + 0.5j)
+    data = _random_not_singular(15)
     A = Qobj(data)
     b = A.full()
     assert_(np.all(b - data == 0))
@@ -622,12 +624,12 @@ def test_QobjPurity():
     assert_almost_equal(psi.purity(), 1)
     # check purity of pure ket state (superposition)
     psi2 = basis(2, 0)
-    psi_tot = (psi+psi2).unit() 
+    psi_tot = (psi+psi2).unit()
     assert_almost_equal(psi_tot.purity(), 1)
-    # check purity of density matrix of pure state 
+    # check purity of density matrix of pure state
     assert_almost_equal(ket2dm(psi_tot).purity(), 1)
     # check purity of maximally mixed density matrix
-    rho_mixed = (ket2dm(psi)+ket2dm(psi2)).unit() 
+    rho_mixed = (ket2dm(psi)+ket2dm(psi2)).unit()
     assert_almost_equal(rho_mixed.purity(), 0.5)
 
 def test_QobjPermute():


### PR DESCRIPTION
2 improvement to Qobj:
- `inv` method. (close #1102)
- faster `ptrace` using dense matrix (taken from #1076)
Both dense and sparse method are kept. Default is use sparse method when the matrix density in under 10%.

 `inv` method also has a sparse and dense version, but sparse is almost always slower.

Some improvement to random Qobj to remove edge case.

Tests are updated.


(Not merge ready yet.)
