### PR TITLE
FIX: sesolve average states

### DIFF
--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -1118,16 +1118,18 @@ def general_stochastic(state0, times, d1, d2, e_ops=[], m_ops=[],
 
         msg_d1 = ("d1 must return an 1d numpy array with the same number "
                   "of elements as the initial state as a vector.")
-        if not isinstance(out_d1, np.ndarray) or out_d1.ndim != 1:
-            raise ValueError(msg_d1)
-        if out_d1.shape[0] != l_vec or len(out_d1.shape) != 1:
+        if not isinstance(out_d1, np.ndarray):
+            raise TypeError(msg_d1)
+        if (out_d1.ndim != 1
+                or out_d1.shape[0] != l_vec or len(out_d1.shape) != 1):
             raise ValueError(msg_d1)
 
         msg_d2 = ("Safety check: d2 must return a 2d numpy array "
                   "with the shape (len_d2, len(state0_vec) ).")
-        if not isinstance(out_d2, np.ndarray) or out_d2.ndim != 2:
-            raise ValueError(msg_d2)
-        if out_d2.shape[1] != l_vec and out_d2.shape[0] != len_d2:
+        if not isinstance(out_d2, np.ndarray):
+            raise TypeError(msg_d2)
+        if (out_d2.ndim != 2
+                or out_d2.shape[1] != l_vec or out_d2.shape[0] != len_d2):
             raise ValueError(msg_d2)
         if out_d1.dtype != np.dtype('complex128') or \
            out_d2.dtype != np.dtype('complex128'):

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -1314,9 +1314,12 @@ def _sesolve_generic(sso, options, progress_bar):
             paths_expect.append(result[3])
         res.runs_expect = np.stack(paths_expect)
 
-    # average density matrices (vectorized)
+    # average density matrices (vectorized maybe)
     # ajgpitch 2019-10-25: np.any(res.states) seems to error
     # I guess there may be a potential exception if there are no states?
+    # store individual trajectory states
+    res.traj_states = res.states
+    res.avg_states = None
     if options.average_states and options.store_states:
         avg_states_list = []
         for n in range(len(res.times)):
@@ -1325,7 +1328,8 @@ def _sesolve_generic(sso, options, progress_bar):
                 state = Qobj(np.sum(tslot_states),
                              dims=res.states[0][n].dims).unit()
                 avg_states_list.append(state)
-        res.states = avg_states_list
+        # store average states
+        res.states = res.avg_states = avg_states_list
 
     # average
     res.expect = res.expect / nt

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -1097,7 +1097,8 @@ def general_stochastic(state0, times, d1, d2, e_ops=[], m_ops=[],
     sso.d1 = d1
     sso.d2 = d2
     if _safe_mode:
-        # This state0_vec is computed as mat2vec(state0.full()).ravel() in the sso init.
+        # This state0_vec is computed as mat2vec(state0.full()).ravel()
+        # in the sso init.
         state0_vec = sso.rho0
         l_vec = state0_vec.shape[0]
         try:
@@ -1131,7 +1132,7 @@ def general_stochastic(state0, times, d1, d2, e_ops=[], m_ops=[],
         if out_d1.dtype != np.dtype('complex128') or \
            out_d2.dtype != np.dtype('complex128'):
             raise ValueError("Safety check: d1 and d2 must return " +
-                            "complex numpy array.")
+                             "complex numpy array.")
         msg_e_ops = ("Safety check: The shape of the e_ops "
                      "does not fit the intial state.")
         for op in sso.e_ops:
@@ -1327,8 +1328,8 @@ def _sesolve_generic(sso, options, progress_bar):
 
     # convert complex data to real if hermitian
     res.expect = [np.real(res.expect[n, :])
-                   if e.isherm else res.expect[n, :]
-                   for n, e in enumerate(sso.e_ops)]
+                  if e.isherm else res.expect[n, :]
+                  for n, e in enumerate(sso.e_ops)]
 
     return res
 

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -322,31 +322,41 @@ class StochasticSolverOptions:
         # Cast to QobjEvo so the code has only one version for both the
         # constant and time-dependent case.
         self.me = me
+
         if H is not None:
+            msg = "The Hamiltonian format is not valid. "
             try:
                 self.H = QobjEvo(H, args=args, tlist=times)
+            except Exception as e:
+                raise ValueError(msg + str(e)) from e
             except:
-                raise Exception("The hamiltonian format is not valid")
+                raise ValueError(msg)
         else:
             self.H = H
 
         if sc_ops:
+            msg = ("The sc_ops format is not valid. Options are "
+                   "[ Qobj / QobjEvo / [Qobj, coeff]]. ")
             try:
                 self.sc_ops = [QobjEvo(op, args=args, tlist=times)
                                for op in sc_ops]
+            except Exception as e:
+                raise ValueError(msg + str(e)) from e
             except:
-                raise Exception("The sc_ops format is not valid.\n" +
-                                "[ Qobj / QobjEvo / [Qobj,coeff]]")
+                raise ValueError(msg)
         else:
             self.sc_ops = sc_ops
 
         if c_ops:
+            msg = ("The c_ops format is not valid. Options are "
+                   "[ Qobj / QobjEvo / [Qobj, coeff]]. ")
             try:
                 self.c_ops = [QobjEvo(op, args=args, tlist=times)
                               for op in c_ops]
+            except Exception as e:
+                raise ValueError(msg + str(e)) from e
             except:
-                raise Exception("The c_ops format is not valid.\n" +
-                                "[ Qobj / QobjEvo / [Qobj,coeff]]")
+                raise ValueError(msg)
         else:
             self.c_ops = c_ops
 
@@ -393,8 +403,8 @@ class StochasticSolverOptions:
             noise = np.array(noise)
             if len(noise.shape) == 1:
                 if noise.shape[0] < ntraj:
-                    raise Exception("'noise' does not have enought seeds" +
-                                    "len(noise) >= ntraj")
+                    raise ValueError("'noise' does not have enought seeds " +
+                                     "len(noise) >= ntraj")
                 # numpy seed must be between 0 and 2**32-1
                 # 'u4': unsigned 32bit int
                 self.noise = noise.astype("u4")
@@ -404,19 +414,16 @@ class StochasticSolverOptions:
                 # taylor case not included
                 dw_len = (2 if method == "heterodyne" else 1)
                 dw_len_str = (" * 2" if method == "heterodyne" else "")
+                msg = "Incorrect shape for 'noise': "
                 if noise.shape[0] < ntraj:
-                    raise Exception("'noise' does not have the right shape" +
-                                    "shape[0] >= ntraj")
+                    raise ValueError(msg + "shape[0] >= ntraj")
                 if noise.shape[1] < len(times):
-                    raise Exception("'noise' does not have the right shape" +
-                                    "shape[1] >= len(times)")
+                    raise ValueError(msg + "shape[1] >= len(times)")
                 if noise.shape[2] < nsubsteps:
-                    raise Exception("'noise' does not have the right shape" +
-                                    "shape[2] >= nsubsteps")
+                    raise ValueError(msg + "shape[2] >= nsubsteps")
                 if noise.shape[3] < len(self.sc_ops) * dw_len:
-                    raise Exception("'noise' does not have the right shape: " +
-                                    "shape[3] >= len(self.sc_ops)" +
-                                    dw_len_str)
+                    raise ValueError(msg + "shape[3] >= len(self.sc_ops)" +
+                                     dw_len_str)
                 self.noise_type = 1
                 self.noise = noise
 
@@ -462,7 +469,7 @@ class StochasticSolverOptions:
             self.solver_code = 120
             self.solver = 'rouchon'
             if not all((op.const for op in self.sc_ops)):
-                raise Exception("Rouchon only work with constant sc_ops")
+                raise ValueError("Rouchon only works with constant sc_ops")
         elif self.solver in ['platen15', 'explicit1.5', 'explicit15', 150]:
             self.solver_code = 150
             self.solver = 'explicit1.5'
@@ -478,15 +485,16 @@ class StochasticSolverOptions:
             if not len(self.sc_ops) == 1 or \
                     not self.sc_ops[0].const or \
                     not self.method == "homodyne":
-                raise Exception("Taylor2.0 only work with 1 constant sc_ops " +
-                                "and for homodyne method")
+                raise ValueError("Taylor2.0 only works with 1 constant " +
+                                "sc_ops and for homodyne method")
         else:
-            raise Exception("The solver should be one of " +
-                            "[None, 'euler-maruyama', 'platen', 'pc-euler', " +
-                            "'pc-euler-imp', 'milstein', 'milstein-imp', " +
-                            "'rouchon', " +
-                            "'taylor1.5', 'taylor1.5-imp', 'explicit1.5' " +
-                            "'taylor2.0']")
+            raise ValueError((
+                    "The solver should be one of "
+                    "[None, 'euler-maruyama', 'platen', 'pc-euler', "
+                    "'pc-euler-imp', 'milstein', 'milstein-imp', "
+                    "'rouchon', "
+                    "'taylor1.5', 'taylor1.5-imp', 'explicit1.5' "
+                    "'taylor2.0']"))
 
 
 class StochasticSolverOptionsPhoto(StochasticSolverOptions):


### PR DESCRIPTION
When using the `average_states` solver option `general_stochastic` seemed to error when summing the timeslot states. This PR provides a fix for this.

Also included is some hopefully more succinct messages from the safety checks in `general_stochastic`.