### PR TITLE
explicitly set pointer to NULL in spconvert

### DIFF
--- a/qutip/cy/spconvert.pyx
+++ b/qutip/cy/spconvert.pyx
@@ -300,3 +300,4 @@ def cy_index_permute(int [::1] idx_arr,
             idx_arr[ii] = idx
     finally:
         free(multi_idx)
+        multi_idx = NULL


### PR DESCRIPTION
This is a real shot in the dark, but it appears to have fixed an issue with lots of random malloc errors popping up on the mac platform (see #1120 and other recent discussions on the google group. It appears this is literally the only call to `free()` in all of qutip so perhaps there is a better way to do low-level memory work? I only know enough C to be dangerous, and found a random hint about setting pointers to NULL after freeing them. I gave it a shot and no longer see the issue on my mac when running py2.7.