### PR TITLE
fix dims incongruence in `propagator`

### DIFF
--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -158,7 +158,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                     u[:, n, k] = output[n].states[k].full().T
         else:
             if unitary_mode == 'single':
-                output = sesolve(H, qeye(H.dims[0]), tlist, [], args, options,
+                output = sesolve(H, qeye(dims[0]), tlist, [], args, options,
                                  _safe_mode=False)
                 if len(tlist) == 2:
                     return output.states[-1]

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -158,7 +158,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                     u[:, n, k] = output[n].states[k].full().T
         else:
             if unitary_mode == 'single':
-                output = sesolve(H, qeye(N), tlist, [], args, options,
+                output = sesolve(H, qeye(H.dims[0]), tlist, [], args, options,
                                  _safe_mode=False)
                 if len(tlist) == 2:
                     return output.states[-1]

--- a/qutip/tests/test_propagator.py
+++ b/qutip/tests/test_propagator.py
@@ -35,7 +35,7 @@ import numpy as np
 from numpy.testing import assert_, assert_equal, run_module_suite
 from qutip import *
 
-    
+
 def testPropHO():
     "Propagator: HO ('single mode')"
     a = destroy(5)
@@ -120,6 +120,12 @@ def testPropHOSteadyPar():
     rho_prop = propagator_steadystate(U)
     rho_ss = steadystate(H,c_op_list)
     assert_(np.abs((rho_prop-rho_ss).full()).max() < 1e-4)
+
+def testPropHDims():
+    "Propagator: preserve H dims (unitary_mode='single', parallel=False)"
+    H = tensor([qeye(2),qeye(2)])
+    U = propagator(H,1, unitary_mode='single')
+    assert_equal(U.dims,H.dims)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Solves #1152, in which it is found that the `propagator` gives the wrong dimensions when it is run for `unitary_mode= single` and `parallel=False`. 

The problem was arising in line 161 of `qutip.propagator`, [here](https://github.com/qutip/qutip/blob/89ddbf4d2c238cba880bb40acdc448fc1c7c951e/qutip/propagator.py#L161), 
```
            if unitary_mode == 'single':
                output = sesolve(H, qeye(N), tlist, [], args, options,
                                 _safe_mode=False)
```
the `qeye(N)` resets the dimensions of `H`, which up to then retains the correct Hilbert space structure, `dims`.  Now they are set by `H.dims[0]` in the state. 