### PR TITLE
Faster omp bench

### DIFF
--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -251,7 +251,7 @@ has_rc, rc_file = qutip.configrc.has_qutip_rc()
 if qutip.settings.has_openmp and (not has_rc):
     qutip.configrc.generate_qutiprc()
     has_rc, rc_file = qutip.configrc.has_qutip_rc()
-    if has_rc and qutip.settings.num_cpus >= 1:
+    if has_rc and qutip.settings.num_cpus > 1:
         from qutip.cy.openmp.bench_openmp import calculate_openmp_thresh
         #bench OPENMP
         print('Calibrating OPENMP threshold...')
@@ -260,7 +260,7 @@ if qutip.settings.has_openmp and (not has_rc):
 # Make OPENMP if has_rc but 'openmp_thresh' not in keys
 elif qutip.settings.has_openmp and has_rc:
     has_omp_key = qutip.configrc.has_rc_key(rc_file, 'openmp_thresh')
-    if not has_omp_key and qutip.settings.num_cpus >= 1:
+    if not has_omp_key and qutip.settings.num_cpus > 1:
         from qutip.cy.openmp.bench_openmp import calculate_openmp_thresh
         print('Calibrating OPENMP threshold...')
         thrsh = calculate_openmp_thresh()

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -249,19 +249,19 @@ has_rc, rc_file = qutip.configrc.has_qutip_rc()
 
 # Make qutiprc and benchmark OPENMP if has_rc = False
 if qutip.settings.has_openmp and (not has_rc):
-    from qutip.cy.openmp.bench_openmp import calculate_openmp_thresh
-    #bench OPENMP
-    print('Calibrating OPENMP threshold...')
-    thrsh = calculate_openmp_thresh()
     qutip.configrc.generate_qutiprc()
     has_rc, rc_file = qutip.configrc.has_qutip_rc()
-    if has_rc:
+    if has_rc and qutip.settings.num_cpus >= 1:
+        from qutip.cy.openmp.bench_openmp import calculate_openmp_thresh
+        #bench OPENMP
+        print('Calibrating OPENMP threshold...')
+        thrsh = calculate_openmp_thresh()
         qutip.configrc.write_rc_key(rc_file, 'openmp_thresh', thrsh)
 # Make OPENMP if has_rc but 'openmp_thresh' not in keys
 elif qutip.settings.has_openmp and has_rc:
-    from qutip.cy.openmp.bench_openmp import calculate_openmp_thresh
     has_omp_key = qutip.configrc.has_rc_key(rc_file, 'openmp_thresh')
-    if not has_omp_key:
+    if not has_omp_key and qutip.settings.num_cpus >= 1:
+        from qutip.cy.openmp.bench_openmp import calculate_openmp_thresh
         print('Calibrating OPENMP threshold...')
         thrsh = calculate_openmp_thresh()
         qutip.configrc.write_rc_key(rc_file, 'openmp_thresh', thrsh)

--- a/qutip/testing.py
+++ b/qutip/testing.py
@@ -31,6 +31,7 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 from qutip.about import about
+from qutip import settings
 
 def run():
     """
@@ -38,6 +39,18 @@ def run():
     """
     # Call about to get all version info printed with tests
     about()
+    real_num_cpu = qset.num_cpus
+    real_thresh  = qset.openmp_thresh
+    if qset.has_openmp:
+        # For test with openmp
+        # make sure the openmp version of the function is tested.
+        # For travis which VMs have only 1 cpu.
+        qset.num_cpus = 2
+        qset.openmp_thresh = 100
     import nose
     # runs tests in qutip.tests module only
     nose.run(defaultTest="qutip.tests", argv=['nosetests', '-v'])
+
+    if qset.has_openmp:
+        qset.num_cpus = real_num_cpu
+        qset.openmp_thresh = real_thresh

--- a/qutip/testing.py
+++ b/qutip/testing.py
@@ -40,7 +40,7 @@ def run():
     # Call about to get all version info printed with tests
     about()
     real_num_cpu = qset.num_cpus
-    real_thresh  = qset.openmp_thresh
+    real_thresh = qset.openmp_thresh
     if qset.has_openmp:
         # For travis which VMs have only 1 cpu.
         # Make sure the openmp version of the functions are tested.

--- a/qutip/testing.py
+++ b/qutip/testing.py
@@ -42,9 +42,8 @@ def run():
     real_num_cpu = qset.num_cpus
     real_thresh  = qset.openmp_thresh
     if qset.has_openmp:
-        # For test with openmp
-        # make sure the openmp version of the function is tested.
         # For travis which VMs have only 1 cpu.
+        # Make sure the openmp version of the functions are tested.
         qset.num_cpus = 2
         qset.openmp_thresh = 100
     import nose


### PR DESCRIPTION
Openmp test on travis tend to hang at the calibration step.
The calibration function compute the matrix vector product with increasing size until the parallel version is faster or it give up. But on Travis, there is only 1 cpu, so the speed up is never observed and the calibration does not give up searching quickly enough. (Over 10min)

In this PR:
- Skip calibration if only 1 cpu.
- Faster calibration by skipping some of the later size and testing only up to 100000 elements. (threshold around 1000 on my cpus)
- Settings used in tests are fixed to use omp if compiled with it, even if slower. (thresh hold at 100)