### PR TITLE
Remove unnecessary circular call in qeye

### DIFF
--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -454,7 +454,7 @@ shape = [3, 3], type = oper, isHerm = True
 
     """
     if isinstance(N, list):
-        return tensor(*[identity(n) for n in N])
+        return tensor(*[qeye(n) for n in N])
     N = int(N)
     if N < 0:
         raise ValueError("N must be integer N>=0")


### PR DESCRIPTION
Hello,

There is currently a circular function call in the tensor produce part of `qeye()` - the list comprehension calls `identity()` for each element of the space, which is just a pass-through back to `qeye()`, rather than explicitly recursing.  I've just made the recursion explicit.

Also, as it stands, the "list of ints" argument will accept arbitrarily-nested lists of integers, and silently flatten it out.  Is it worth adding an error check to catch what is (presumably) user error?