### PR TITLE
Implicit tensor product for qeye, qzero and basis.

### DIFF
--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -440,7 +440,8 @@ def _implicit_tensor_dimensions(dimensions):
     size = 1
     for dimension in dimensions:
         if not isinstance(dimension, numbers.Integral):
-            raise TypeError("'dimensions' must be an integer or list of integers.")
+            message = "'dimensions' must be an integer or list of integers."
+            raise TypeError(message)
         if dimension < 0:
             raise ValueError("All dimensions must be integers >= 0")
         size *= dimension
@@ -493,13 +494,15 @@ def qeye(dimensions):
     Examples
     --------
     >>> qeye(3)
-    Quantum object: dims = [[3], [3]], shape = (3, 3), type = oper, isherm = True
+    Quantum object: dims = [[3], [3]], shape = (3, 3), type = oper, \
+isherm = True
     Qobj data =
     [[ 1.  0.  0.]
      [ 0.  1.  0.]
      [ 0.  0.  1.]]
     >>> qeye([2,2])
-    Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True
+    Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, \
+isherm = True
     Qobj data =
     [[1. 0. 0. 0.]
      [0. 1. 0. 0.]

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -42,6 +42,7 @@ __all__ = ['jmat', 'spin_Jx', 'spin_Jy', 'spin_Jz', 'spin_Jm', 'spin_Jp',
            'qutrit_ops', 'qdiags', 'phase', 'qzero', 'enr_destroy',
            'enr_identity', 'charge', 'tunneling']
 
+import numbers
 import numpy as np
 import scipy
 import scipy.sparse as sp
@@ -422,17 +423,64 @@ shape = [4, 4], type = oper, isHerm = False
     return qo.dag()
 
 
-#
-# QEYE returns identity operator for an N dimensional space
-# a = qeye(N), N is integer & N>0
-#
-def qeye(N):
+def _implicit_tensor_dimensions(dimensions):
     """
-    Identity operator
+    Total flattened size and operator dimensions for operator creation routines
+    that automatically perform tensor products.
+
+    Returns
+    -------
+    size : int
+        Dimension of backing matrix required to represent operator.
+    dimensions : list
+        Dimension list in the form required by ``Qobj`` creation.
+    """
+    if not isinstance(dimensions, list):
+        dimensions = [dimensions]
+    size = 1
+    for dimension in dimensions:
+        if not isinstance(dimension, numbers.Integral):
+            raise TypeError("'dimensions' must be an integer or list of integers.")
+        if dimension < 0:
+            raise ValueError("All dimensions must be integers >= 0")
+        size *= dimension
+    return size, [dimensions, dimensions.copy()]
+
+
+def qzero(dimensions):
+    """
+    Zero operator.
 
     Parameters
     ----------
-    N : int or list of ints
+    dimensions : int or list of ints
+        Dimension of Hilbert space. If provided as a list of ints,
+        then the dimension is the product over this list, but the
+        ``dims`` property of the new Qobj are set to this list.
+
+    Returns
+    -------
+    qzero : qobj
+        Zero operator Qobj.
+
+    """
+    size, dimensions = _implicit_tensor_dimensions(dimensions)
+    # A sparse matrix with no data is equal to a zero matrix.
+    return Qobj(fast_csr_matrix(shape=(size, size), dtype=complex),
+                dims=dimensions, isherm=True)
+
+
+#
+# QEYE returns identity operator for a Hilbert space with dimensions dims.
+# a = qeye(N), N is integer or list of integers & all elements >= 0
+#
+def qeye(dimensions):
+    """
+    Identity operator.
+
+    Parameters
+    ----------
+    dimensions : int or list of ints
         Dimension of Hilbert space. If provided as a list of ints,
         then the dimension is the product over this list, but the
         ``dims`` property of the new Qobj are set to this list.
@@ -445,28 +493,31 @@ def qeye(N):
     Examples
     --------
     >>> qeye(3)
-    Quantum object: dims = [[3], [3]], \
-shape = [3, 3], type = oper, isHerm = True
+    Quantum object: dims = [[3], [3]], shape = (3, 3), type = oper, isherm = True
     Qobj data =
     [[ 1.  0.  0.]
      [ 0.  1.  0.]
      [ 0.  0.  1.]]
+    >>> qeye([2,2])
+    Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True
+    Qobj data =
+    [[1. 0. 0. 0.]
+     [0. 1. 0. 0.]
+     [0. 0. 1. 0.]
+     [0. 0. 0. 1.]]
 
     """
-    if isinstance(N, list):
-        return tensor(*[identity(n) for n in N])
-    N = int(N)
-    if N < 0:
-        raise ValueError("N must be integer N>=0")
-    return Qobj(fast_identity(N), isherm=True, isunitary=True)
+    size, dimensions = _implicit_tensor_dimensions(dimensions)
+    return Qobj(fast_identity(size),
+                dims=dimensions, isherm=True, isunitary=True)
 
 
-def identity(N):
+def identity(dims):
     """Identity operator. Alternative name to :func:`qeye`.
 
     Parameters
     ----------
-    N : int or list of ints
+    dims : int or list of ints
         Dimension of Hilbert space. If provided as a list of ints,
         then the dimension is the product over this list, but the
         ``dims`` property of the new Qobj are set to this list.
@@ -476,7 +527,7 @@ def identity(N):
     oper : qobj
         Identity operator Qobj.
     """
-    return qeye(N)
+    return qeye(dims)
 
 
 def position(N, offset=0):
@@ -785,32 +836,6 @@ def phase(N, phi0=0):
                        for kk in phim])
     ops = np.array([np.outer(st, st.conj()) for st in states])
     return Qobj(np.sum(ops, axis=0))
-
-
-def qzero(N):
-    """
-    Zero operator
-
-    Parameters
-    ----------
-    N : int or list of ints
-        Dimension of Hilbert space. If provided as a list of ints,
-        then the dimension is the product over this list, but the
-        ``dims`` property of the new Qobj are set to this list.
-
-    Returns
-    -------
-    qzero : qobj
-        Zero operator Qobj.
-
-    """
-
-    if isinstance(N, list):
-        return tensor(*[qzero(n) for n in N])
-    N = int(N)
-    if (not isinstance(N, (int, np.integer))) or N < 0:
-        raise ValueError("N must be integer N>=0")
-    return Qobj(sp.csr_matrix((N, N), dtype=complex), isherm=True)
 
 
 def enr_destroy(dims, excitations):

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -48,7 +48,7 @@ import scipy
 import scipy.sparse as sp
 from qutip.qobj import Qobj
 from qutip.fastsparse import fast_csr_matrix, fast_identity
-from qutip.dimensions import flatten, type_from_dims
+from qutip.dimensions import flatten
 
 #
 # Spin operators
@@ -450,11 +450,7 @@ def _implicit_tensor_dimensions(dimensions):
     flat = flatten(dimensions)
     if not all(isinstance(x, numbers.Integral) and x >= 0 for x in flat):
         raise ValueError("All dimensions must be integers >= 0")
-    dimensions = [dimensions, dimensions]
-    if type_from_dims(dimensions) not in ['oper', 'super']:
-        raise TypeError("`dimensions` must be a valid single dimension of a "
-                        "'oper' or 'super' Qobj.")
-    return np.prod(flat), dimensions
+    return np.prod(flat), [dimensions, dimensions]
 
 
 def qzero(dimensions):

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -73,6 +73,7 @@ def _promote_to_zero_list(arg, length):
         return arg
     raise TypeError("Dimensions must be an integer or list of integers.")
 
+
 def basis(dimensions, n=None, offset=None):
     """Generates the vector representation of a Fock state.
 
@@ -85,8 +86,8 @@ def basis(dimensions, n=None, offset=None):
     n : int or list of ints, optional (default 0 for all dimensions)
         Integer corresponding to desired number state, defaults to 0 for all
         dimensions if omitted.  The shape must match ``dimensions``, e.g. if
-        ``dimensions`` is a list, then ``n`` must either be omitted or a list of
-        equal length.
+        ``dimensions`` is a list, then ``n`` must either be omitted or a list
+        of equal length.
 
     offset : int or list of ints, optional (default 0 for all dimensions)
         The lowest number state that is included in the finite number state
@@ -135,8 +136,8 @@ def basis(dimensions, n=None, offset=None):
     if not isinstance(dimensions, list):
         dimensions = [dimensions]
     n_dimensions = len(dimensions)
-    ns = [m - off for m, off in zip(_promote_to_zero_list(n, n_dimensions),
-                                    _promote_to_zero_list(offset,n_dimensions))]
+    ns = [m-off for m, off in zip(_promote_to_zero_list(n, n_dimensions),
+                                  _promote_to_zero_list(offset, n_dimensions))]
     if any((not isinstance(x, numbers.Integral)) or x < 0 for x in dimensions):
         raise ValueError("All dimensions must be >= 0.")
     if not all(0 <= n < dimension for n, dimension in zip(ns, dimensions)):
@@ -151,6 +152,7 @@ def basis(dimensions, n=None, offset=None):
     ptr = np.array([0]*(location+1) + [1]*(size-location), dtype=np.int32)
     return Qobj(fast_csr_matrix((data, ind, ptr), shape=(size, 1)),
                 dims=[dimensions, [1]*n_dimensions], isherm=False)
+
 
 def qutrit_basis():
     """Basis states for a three level system (qutrit)
@@ -315,8 +317,8 @@ def fock_dm(dimensions, n=None, offset=None):
     n : int or list of ints, optional (default 0 for all dimensions)
         Integer corresponding to desired number state, defaults to 0 for all
         dimensions if omitted.  The shape must match ``dimensions``, e.g. if
-        ``dimensions`` is a list, then ``n`` must either be omitted or a list of
-        equal length.
+        ``dimensions`` is a list, then ``n`` must either be omitted or a list
+        of equal length.
 
     offset : int or list of ints, optional (default 0 for all dimensions)
         The lowest number state that is included in the finite number state
@@ -357,8 +359,8 @@ def fock(dimensions, n=None, offset=None):
     n : int or list of ints, optional (default 0 for all dimensions)
         Integer corresponding to desired number state, defaults to 0 for all
         dimensions if omitted.  The shape must match ``dimensions``, e.g. if
-        ``dimensions`` is a list, then ``n`` must either be omitted or a list of
-        equal length.
+        ``dimensions`` is a list, then ``n`` must either be omitted or a list
+        of equal length.
 
     offset : int or list of ints, optional (default 0 for all dimensions)
         The lowest number state that is included in the finite number state

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -40,6 +40,7 @@ __all__ = ['basis', 'qutrit_basis', 'coherent', 'coherent_dm', 'fock_dm',
            'ghz_state', 'enr_state_dictionaries', 'enr_fock',
            'enr_thermal_dm']
 
+import numbers
 import numpy as np
 from numpy import arange, conj, prod
 import scipy.sparse as sp
@@ -51,21 +52,45 @@ from qutip.tensor import tensor
 from qutip.fastsparse import fast_csr_matrix
 
 
-def basis(N, n=0, offset=0):
+def _promote_to_zero_list(arg, length):
+    """
+    Ensure `arg` is a list of length `length`.  If `arg` is None it is promoted
+    to `[0]*length`.  All other inputs are checked that they match the correct
+    form.
+
+    Returns
+    -------
+    list_ : list
+        A list of integers of length `length`.
+    """
+    if arg is None:
+        arg = [0]*length
+    elif not isinstance(arg, list):
+        arg = [arg]
+    if not len(arg) == length:
+        raise ValueError("All list inputs must be the same length.")
+    if all(isinstance(x, numbers.Integral) for x in arg):
+        return arg
+    raise TypeError("Dimensions must be an integer or list of integers.")
+
+def basis(dimensions, n=None, offset=None):
     """Generates the vector representation of a Fock state.
 
     Parameters
     ----------
-    N : int
-        Number of Fock states in Hilbert space.
+    dimensions : int or list of ints
+        Number of Fock states in Hilbert space.  If a list, then the resultant
+        object will be a tensor product over spaces with those dimensions.
 
-    n : int
-        Integer corresponding to desired number state, defaults
-        to 0 if omitted.
+    n : int or list of ints, optional (default 0 for all dimensions)
+        Integer corresponding to desired number state, defaults to 0 for all
+        dimensions if omitted.  The shape must match ``dimensions``, e.g. if
+        ``dimensions`` is a list, then ``n`` must either be omitted or a list of
+        equal length.
 
-    offset : int (default 0)
+    offset : int or list of ints, optional (default 0 for all dimensions)
         The lowest number state that is included in the finite number state
-        representation of the state.
+        representation of the state in the relevant dimension.
 
     Returns
     -------
@@ -75,17 +100,28 @@ def basis(N, n=0, offset=0):
     Examples
     --------
     >>> basis(5,2)
-    Quantum object: dims = [[5], [1]], shape = [5, 1], type = ket
+    Quantum object: dims = [[5], [1]], shape = (5, 1), type = ket
     Qobj data =
     [[ 0.+0.j]
      [ 0.+0.j]
      [ 1.+0.j]
      [ 0.+0.j]
      [ 0.+0.j]]
+    >>> basis([2,2,2], [0,1,0])
+    Quantum object: dims = [[2, 2, 2], [1, 1, 1]], shape = (8, 1), type = ket
+    Qobj data =
+    [[0.]
+     [0.]
+     [1.]
+     [0.]
+     [0.]
+     [0.]
+     [0.]
+     [0.]]
+
 
     Notes
     -----
-
     A subtle incompatibility with the quantum optics toolbox: In QuTiP::
 
         basis(N, 0) = ground state
@@ -95,21 +131,26 @@ def basis(N, n=0, offset=0):
         basis(N, 1) = ground state
 
     """
-    if (not isinstance(N, (int, np.integer))) or N < 0:
-        raise ValueError("N must be integer N >= 0")
-
-    if (not isinstance(n, (int, np.integer))) or n < offset:
-        raise ValueError("n must be integer n >= 0")
-
-    if n - offset > (N - 1):  # check if n is within bounds
-        raise ValueError("basis vector index need to be in n <= N-1")
-
+    # Promote all parameters to lists to simplify later logic.
+    if not isinstance(dimensions, list):
+        dimensions = [dimensions]
+    n_dimensions = len(dimensions)
+    ns = [m - off for m, off in zip(_promote_to_zero_list(n, n_dimensions),
+                                    _promote_to_zero_list(offset,n_dimensions))]
+    if any((not isinstance(x, numbers.Integral)) or x < 0 for x in dimensions):
+        raise ValueError("All dimensions must be >= 0.")
+    if not all(0 <= n < dimension for n, dimension in zip(ns, dimensions)):
+        raise ValueError("All basis indices must be "
+                         "`offset <= n < dimension+offset`.")
+    location, size = 0, 1
+    for m, dimension in zip(reversed(ns), reversed(dimensions)):
+        location += m*size
+        size *= dimension
     data = np.array([1], dtype=complex)
     ind = np.array([0], dtype=np.int32)
-    ptr = np.array([0]*((n - offset)+1)+[1]*(N-(n-offset)),dtype=np.int32)
-
-    return Qobj(fast_csr_matrix((data,ind,ptr), shape=(N,1)), isherm=False)
-
+    ptr = np.array([0]*(location+1) + [1]*(size-location), dtype=np.int32)
+    return Qobj(fast_csr_matrix((data, ind, ptr), shape=(size, 1)),
+                dims=[dimensions, [1]*n_dimensions], isherm=False)
 
 def qutrit_basis():
     """Basis states for a three level system (qutrit)
@@ -260,18 +301,26 @@ shape = [3, 3], type = oper, isHerm = True
             "The method option can only take values 'operator' or 'analytic'")
 
 
-def fock_dm(N, n=0, offset=0):
+def fock_dm(dimensions, n=None, offset=None):
     """Density matrix representation of a Fock state
 
     Constructed via outer product of :func:`qutip.states.fock`.
 
     Parameters
     ----------
-    N : int
-        Number of Fock states in Hilbert space.
+    dimensions : int or list of ints
+        Number of Fock states in Hilbert space.  If a list, then the resultant
+        object will be a tensor product over spaces with those dimensions.
 
-    n : int
-        ``int`` for desired number state, defaults to 0 if omitted.
+    n : int or list of ints, optional (default 0 for all dimensions)
+        Integer corresponding to desired number state, defaults to 0 for all
+        dimensions if omitted.  The shape must match ``dimensions``, e.g. if
+        ``dimensions`` is a list, then ``n`` must either be omitted or a list of
+        equal length.
+
+    offset : int or list of ints, optional (default 0 for all dimensions)
+        The lowest number state that is included in the finite number state
+        representation of the state in the relevant dimension.
 
     Returns
     -------
@@ -289,23 +338,32 @@ shape = [3, 3], type = oper, isHerm = True
       [ 0.+0.j  0.+0.j  0.+0.j]]
 
     """
-    psi = basis(N, n, offset=offset)
+    psi = basis(dimensions, n, offset=offset)
 
     return psi * psi.dag()
 
 
-def fock(N, n=0, offset=0):
+def fock(dimensions, n=None, offset=None):
     """Bosonic Fock (number) state.
 
     Same as :func:`qutip.states.basis`.
 
     Parameters
     ----------
-    N : int
-        Number of states in the Hilbert space.
+    dimensions : int or list of ints
+        Number of Fock states in Hilbert space.  If a list, then the resultant
+        object will be a tensor product over spaces with those dimensions.
 
-    n : int
-        ``int`` for desired number state, defaults to 0 if omitted.
+    n : int or list of ints, optional (default 0 for all dimensions)
+        Integer corresponding to desired number state, defaults to 0 for all
+        dimensions if omitted.  The shape must match ``dimensions``, e.g. if
+        ``dimensions`` is a list, then ``n`` must either be omitted or a list of
+        equal length.
+
+    offset : int or list of ints, optional (default 0 for all dimensions)
+        The lowest number state that is included in the finite number state
+        representation of the state in the relevant dimension.
+
 
     Returns
     -------
@@ -322,7 +380,7 @@ def fock(N, n=0, offset=0):
      [ 1.+0.j]]
 
     """
-    return basis(N, n, offset=offset)
+    return basis(dimensions, n, offset=offset)
 
 
 def thermal_dm(N, n, method='operator'):
@@ -459,7 +517,7 @@ shape = [3, 3], type = oper, isHerm = True
 #
 # projection operator
 #
-def projection(N, n, m, offset=0):
+def projection(N, n, m, offset=None):
     """The projection operator that projects state :math:`|m>` on state :math:`|n>`.
 
     Parameters

--- a/qutip/tests/test_operators.py
+++ b/qutip/tests/test_operators.py
@@ -130,8 +130,8 @@ def test_create():
         (qutip.qzero, lambda x: np.zeros((x, x), dtype=complex)),
         (qutip.qeye, lambda x: np.eye(x, dtype=complex)),
     ])
-def test_simple_operator_creation(to_test, expected):
-    dimension = 5
+@pytest.mark.parametrize("dimension", [1, 5, 100])
+def test_simple_operator_creation(to_test, expected, dimension):
     qobj = to_test(dimension)
     assert np.allclose(qobj.full(), expected(dimension))
 
@@ -141,6 +141,9 @@ def test_simple_operator_creation(to_test, expected):
         2,
         [2],
         [2, 3, 4],
+        1,
+        [1],
+        [1, 1],
     ])
 def test_implicit_tensor_creation(to_test, dimensions):
     implicit = to_test(dimensions)

--- a/qutip/tests/test_operators.py
+++ b/qutip/tests/test_operators.py
@@ -34,7 +34,7 @@
 import numpy as np
 from numpy.testing import assert_equal, run_module_suite
 
-from qutip import (jmat, basis, destroy, create, displace, qeye, 
+from qutip import (jmat, basis, destroy, create, displace, qzero, qeye,
                     num, squeeze, charge, tunneling)
 
 
@@ -123,10 +123,23 @@ def test_create():
     assert_equal(np.allclose(matrix3, c3.full()), True)
 
 
+def test_qzero():
+    "Zero operator"
+    zero5 = qzero(5)
+    assert_equal(np.allclose(zero5.full(), np.zeros((5,5), dtype=complex)), True)
+
+
+def test_qzero_dims():
+    "Zero operator (array input)"
+    zero24 = qzero([2, 3, 4])
+    assert_equal(np.allclose(zero24.full(), np.zeros((24,24), dtype=complex)), True)
+    assert_equal(zero24.dims, [[2, 3, 4], [2, 3, 4]])
+
+
 def test_qeye():
     "Identity operator"
-    eye3 = qeye(5)
-    assert_equal(np.allclose(eye3.full(), np.eye(5, dtype=complex)), True)
+    eye5 = qeye(5)
+    assert_equal(np.allclose(eye5.full(), np.eye(5, dtype=complex)), True)
 
 
 def test_qeye_dims():

--- a/qutip/tests/test_states.py
+++ b/qutip/tests/test_states.py
@@ -31,9 +31,39 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+import pytest
+import numpy as np
 from numpy.testing import assert_, run_module_suite
+import qutip
 from qutip import (expect, destroy, coherent, coherent_dm, thermal_dm,
-                    fock_dm, triplet_states)
+                   fock_dm, triplet_states)
+
+
+@pytest.mark.parametrize("size, n", [(2, 0), (2, 1), (100, 99)])
+def test_basis_simple(size, n):
+    qobj = qutip.basis(size, n)
+    numpy = np.zeros((size, 1), dtype=complex)
+    numpy[n, 0] = 1
+    assert np.array_equal(qobj.full(), numpy)
+
+
+@pytest.mark.parametrize("to_test", [qutip.basis, qutip.fock, qutip.fock_dm])
+@pytest.mark.parametrize("size, n", [([2, 2], [0, 1]), ([2, 3, 4], [1, 2, 0])])
+def test_implicit_tensor_basis_like(to_test, size, n):
+    implicit = to_test(size, n)
+    explicit = qutip.tensor(*[to_test(ss, nn) for ss, nn in zip(size, n)])
+    assert implicit == explicit
+
+
+@pytest.mark.parametrize("size, n, m", [
+        ([2, 2], [0, 0], [1, 1]),
+        ([2, 3, 4], [1, 2, 0], [0, 1, 3]),
+    ])
+def test_implicit_tensor_projection(size, n, m):
+    implicit = qutip.projection(size, n, m)
+    explicit = qutip.tensor(*[qutip.projection(ss, nn, mm)
+                              for ss, nn, mm in zip(size, n, m)])
+    assert implicit == explicit
 
 
 class TestStates:


### PR DESCRIPTION
This makes the additions referred to in #363.  As `fock`, `fock_dm` and `projection` are thin passes-through to `basis`, the automatic tensor-producting applies to them too.

`qeye` and `qzero` are reworked to remove all calls to `tensor`, and instead just build their underlying matrix and override the `dims` when converting to a `Qobj`.  The new functionality in `basis` also follows a similar form.

This deprecates my previous pull request #1157, since the recursive call is entirely removed.