### PR TITLE
Remove duplicated test runners

### DIFF
--- a/qutip/testing.py
+++ b/qutip/testing.py
@@ -31,18 +31,15 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 from qutip.about import about
-from qutip import settings
+from qutip import settings as qset
 
 def run():
     """
-    Run the nose test scripts for QuTiP.
+    Run the test scripts for QuTiP.
     """
     # Call about to get all version info printed with tests
     about()
     import pytest
-    # runs tests in qutip.tests module only
-    pytest.main(["--verbosity=1",
-                "--disable-pytest-warnings", "--pyargs", "qutip"])
     real_num_cpu = qset.num_cpus
     real_thresh = qset.openmp_thresh
     if qset.has_openmp:
@@ -50,10 +47,11 @@ def run():
         # Make sure the openmp version of the functions are tested.
         qset.num_cpus = 2
         qset.openmp_thresh = 100
-    import nose
-    # runs tests in qutip.tests module only
-    nose.run(defaultTest="qutip.tests", argv=['nosetests', '-v'])
 
+    pytest.main(["--verbosity=1",
+                "--disable-pytest-warnings", "--pyargs", "qutip"])
+
+    # Restore previous settings
     if qset.has_openmp:
         qset.num_cpus = real_num_cpu
         qset.openmp_thresh = real_thresh

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -34,8 +34,6 @@
 import scipy.sparse as sp
 import scipy.linalg as la
 import numpy as np
-from numpy.testing import (assert_equal, assert_, assert_almost_equal,
-                            run_module_suite)
 
 from qutip.qobj import Qobj
 from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
@@ -48,55 +46,28 @@ from qutip.superop_reps import to_super, to_choi, to_chi
 from qutip.tensor import tensor, super_tensor, composite
 
 from operator import add, mul, truediv, sub
-from functools import partial
-from contextlib import contextmanager
+import pytest
+
 
 def _random_not_singular(N):
     """
     return a N*N complex array with determinant not 0.
     """
-    data = np.zeros((1,1))
+    data = np.zeros((1, 1))
     while np.linalg.det(data) == 0:
         data = np.random.random((N, N)) + \
                1j * np.random.random((N, N)) - (0.5 + 0.5j)
     return data
 
-@contextmanager
-def expect_exception(ex_class):
-    """
-    Context manager that raises an AssertionError if its body
-    does not raise a particular class of exception.
-    """
-    ex_name = getattr(ex_class, '__name__', str(ex_class))
 
-    try:
-        yield
-    except ex_class:
-        pass
-    except Exception as other_ex:
-        raise AssertionError(
-            "Expected {}, but {} was raised.".format(
-                ex_name, getattr(type(other_ex), '__name__', str(type(other_ex)))
-            )
-        )
-    else:
-        raise AssertionError("Expected {}, but nothing was raised.".format(ex_name))
-
-def test_expect_exception():
-    with expect_exception(ValueError):
-        raise ValueError
-
-    with expect_exception(AssertionError):
-        with expect_exception(ValueError):
-            pass
-
-def assert_hermicity(oper, hermicity, msg=""):
+def assert_hermicity(oper, hermicity):
     # Check the cached isherm, if any exists.
-    assert_(oper.isherm == hermicity, msg)
+    assert oper.isherm == hermicity
     # Force a reset of the cached value for isherm.
     oper._isherm = None
     # Force a recalculation of isherm.
-    assert_(oper.isherm == hermicity, msg)
+    assert oper.isherm == hermicity
+
 
 def test_QobjData():
     "Qobj data"
@@ -104,27 +75,27 @@ def test_QobjData():
     data1 = _random_not_singular(N)
     q1 = Qobj(data1)
     # check if data is a csr_matrix if originally array
-    assert_equal(sp.isspmatrix_csr(q1.data), True)
+    assert sp.isspmatrix_csr(q1.data)
     # check if dense ouput is equal to original data
-    assert_(np.all(q1.data.todense() - np.matrix(data1) == 0))
+    assert np.all(q1.data.todense() - np.matrix(data1) == 0)
 
     data2 = _random_not_singular(N)
     data2 = sp.csr_matrix(data2)
     q2 = Qobj(data2)
     # check if data is a csr_matrix if originally csr_matrix
-    assert_equal(sp.isspmatrix_csr(q2.data), True)
+    assert sp.isspmatrix_csr(q2.data)
 
     data3 = 1
     q3 = Qobj(data3)
     # check if data is a csr_matrix if originally int
-    assert_equal(sp.isspmatrix_csr(q3.data), True)
+    assert sp.isspmatrix_csr(q3.data)
 
     data4 = _random_not_singular(N)
     data4 = np.matrix(data4)
     q4 = Qobj(data4)
     # check if data is a csr_matrix if originally csr_matrix
-    assert_equal(sp.isspmatrix_csr(q4.data), True)
-    assert_(np.all(q4.data.todense() - np.matrix(data4) == 0))
+    assert sp.isspmatrix_csr(q4.data)
+    assert np.all(q4.data.todense() - np.matrix(data4) == 0)
 
 
 def test_QobjType():
@@ -133,97 +104,97 @@ def test_QobjType():
 
     ket_data = np.random.random((N, 1))
     ket_qobj = Qobj(ket_data)
-    assert_equal(ket_qobj.type, 'ket')
-    assert_(ket_qobj.isket)
+    assert ket_qobj.type == 'ket'
+    assert ket_qobj.isket
 
     bra_data = np.random.random((1, N))
     bra_qobj = Qobj(bra_data)
-    assert_equal(bra_qobj.type, 'bra')
-    assert_(bra_qobj.isbra)
+    assert bra_qobj.type == 'bra'
+    assert bra_qobj.isbra
 
     oper_data = np.random.random((N, N))
     oper_qobj = Qobj(oper_data)
-    assert_equal(oper_qobj.type, 'oper')
-    assert_(oper_qobj.isoper)
+    assert oper_qobj.type == 'oper'
+    assert oper_qobj.isoper
 
     N = 9
     super_data = np.random.random((N, N))
     super_qobj = Qobj(super_data, dims=[[[3]], [[3]]])
-    assert_equal(super_qobj.type, 'super')
-    assert_(super_qobj.issuper)
+    assert super_qobj.type == 'super'
+    assert super_qobj.issuper
 
     operket_qobj = operator_to_vector(oper_qobj)
-    assert_(operket_qobj.isoperket)
-    operbra_qobj = operket_qobj.dag()
-    assert_(operbra_qobj.isoperbra)
+    assert operket_qobj.isoperket
+    assert operket_qobj.dag().isoperbra
 
 
-def test_QobjHerm():
-    "Qobj Hermicity"
-    N = 10
-    data = _random_not_singular(N)
-    q = Qobj(data)
-    assert_equal(q.isherm, False)
+class TestQobjHermicity:
+    def test_standard(self):
+        base = _random_not_singular(10)
+        assert not Qobj(base).isherm
+        assert Qobj(base + base.conj().T).isherm
 
-    data = data + data.conj().T
-    q = Qobj(data)
-    assert_(q.isherm)
+        q_a = destroy(5)
+        assert not q_a.isherm
 
-    q_a = destroy(5)
-    assert_(not q_a.isherm)
+        q_ad = create(5)
+        assert not q_ad.isherm
 
-    q_ad = create(5)
-    assert_(not q_ad.isherm)
+    def test_addition(self):
+        q_a, q_ad = destroy(5), create(5)
 
-    # test addition of two nonhermitian operators adding up to a hermitian one
-    q_x = q_a + q_ad
-    assert_hermicity(q_x, True)
+        # test addition of two nonhermitian operators adding up to be hermitian
+        q_x = q_a + q_ad
+        assert_hermicity(q_x, True)
 
-    # test addition of one hermitan and one nonhermitian operator
-    q = q_x + q_a
-    assert_hermicity(q, False)
+        # test addition of one hermitan and one nonhermitian operator
+        q = q_x + q_a
+        assert_hermicity(q, False)
 
-    # test addition of two hermitan operators
-    q = q_x + q_x
-    assert_hermicity(q, True)
+        # test addition of two hermitan operators
+        q = q_x + q_x
+        assert_hermicity(q, True)
 
-    # Test multiplication of two Hermitian operators.
-    # This results in a skew-Hermitian operator, so
-    # we're checking here that __mul__ doesn't set wrong
-    # metadata.
-    q = sigmax() * sigmay()
-    assert_hermicity(q, False, "Expected iZ = X * Y to be skew-Hermitian.")
-    # Similarly, we need to check that -Z = X * iY is correctly
-    # identified as Hermitian.
-    q = sigmax() * (1j * sigmay())
-    assert_hermicity(q, True, "Expected -Z = X * iY to be Hermitian.")
+    def test_multiplication(self):
+        # Test multiplication of two Hermitian operators.  This results in a
+        # skew-Hermitian operator, so we're checking here that __mul__ doesn't
+        # set wrong metadata.
+        q = sigmax() * sigmay()
+        assert_hermicity(q, False)
+        # Similarly, we need to check that -Z = X * iY is correctly identified
+        # as Hermitian.
+        q = sigmax() * (1j * sigmay())
+        assert_hermicity(q, True)
 
-def assert_unitarity(oper, unitarity, msg=""):
+
+def assert_unitarity(oper, unitarity):
     # Check the cached isunitary, if any exists.
-    assert_(oper.isunitary == unitarity, msg)
+    assert oper.isunitary == unitarity
     # Force a reset of the cached value for isunitary.
     oper._isunitary = None
     # Force a recalculation of isunitary.
-    assert_(oper.isunitary == unitarity, msg)
+    assert oper.isunitary == unitarity
+
 
 def test_QobjUnitaryOper():
     "Qobj unitarity"
     # Check some standard operators
     Sx = sigmax()
     Sy = sigmay()
-    assert_unitarity(qeye(4), True, "qeye(4) should be unitary.")
-    assert_unitarity(Sx, True, "sigmax() should be unitary.")
-    assert_unitarity(Sy, True, "sigmax() should be unitary.")
-    assert_unitarity(sigmam(), False, "sigmam() should NOT be unitary.")
-    assert_unitarity(destroy(10), False, "destroy(10) should NOT be unitary.")
+    assert_unitarity(qeye(4), True)
+    assert_unitarity(Sx, True)
+    assert_unitarity(Sy, True)
+    assert_unitarity(sigmam(), False)
+    assert_unitarity(destroy(10), False)
     # Check multiplcation of unitary is unitary
-    assert_unitarity(Sx*Sy, True, "sigmax()*sigmay() should be unitary.")
+    assert_unitarity(Sx*Sy, True)
     # Check some other operations clear unitarity
-    assert_unitarity(Sx+Sy, False, "sigmax()+sigmay() should NOT be unitary.")
-    assert_unitarity(4*Sx, False, "4*sigmax() should NOT be unitary.")
-    assert_unitarity(Sx*4, False, "sigmax()*4 should NOT be unitary.")
-    assert_unitarity(4+Sx, False, "4+sigmax() should NOT be unitary.")
-    assert_unitarity(Sx+4, False, "sigmax()+4 should NOT be unitary.")
+    assert_unitarity(Sx+Sy, False)
+    assert_unitarity(4*Sx, False)
+    assert_unitarity(Sx*4, False)
+    assert_unitarity(4+Sx, False)
+    assert_unitarity(Sx+4, False)
+
 
 def test_QobjDimsShape():
     "Qobj shape"
@@ -231,23 +202,21 @@ def test_QobjDimsShape():
     data = _random_not_singular(N)
 
     q1 = Qobj(data)
-    assert_equal(q1.dims, [[10], [10]])
-    assert_equal(q1.shape, [10, 10])
+    assert q1.dims == [[10], [10]]
+    assert q1.shape == (10, 10)
 
-    data = np.random.random(
-        (N, 1)) + 1j * np.random.random((N, 1)) - (0.5 + 0.5j)
+    data = np.random.random((N, 1)) + 1j*np.random.random((N, 1)) - (0.5+0.5j)
 
     q1 = Qobj(data)
-    assert_equal(q1.dims, [[10], [1]])
-    assert_equal(q1.shape, [10, 1])
+    assert q1.dims == [[10], [1]]
+    assert q1.shape == (10, 1)
 
-    N = 4
-
-    data = _random_not_singular(N)
+    data = _random_not_singular(4)
 
     q1 = Qobj(data, dims=[[2, 2], [2, 2]])
-    assert_equal(q1.dims, [[2, 2], [2, 2]])
-    assert_equal(q1.shape, [4, 4])
+    assert q1.dims == [[2, 2], [2, 2]]
+    assert q1.shape == (4, 4)
+
 
 def test_QobjMulNonsquareDims():
     """
@@ -261,27 +230,27 @@ def test_QobjMulNonsquareDims():
     q1.dims[0].append(1)
     q2 = Qobj(data)
 
-    assert_equal((q1 * q2).dims, [[2, 1], [2]])
-    assert_equal((q2 * q1.dag()).dims, [[2], [2, 1]])
+    assert (q1 * q2).dims == [[2, 1], [2]]
+    assert (q2 * q1.dag()).dims == [[2], [2, 1]]
 
     # Note that this is [[2], [2]] instead of [[2, 1], [2, 1]],
     # as matching dimensions of 1 are implicitly partial traced out.
     # (See #331.)
-    assert_equal((q1 * q2 * q1.dag()).dims, [[2], [2]])
+    assert (q1 * q2 * q1.dag()).dims == [[2], [2]]
 
     # Because of the above, we also need to check for extra indices
     # that aren't of length 1.
-    q1 = Qobj([[ 1.+0.j,  0.+0.j],
-         [ 0.+0.j,  1.+0.j],
-         [ 0.+0.j,  1.+0.j],
-         [ 1.+0.j,  0.+0.j],
-         [ 0.+0.j,  0.-1.j],
-         [ 0.+1.j,  0.+0.j],
-         [ 1.+0.j,  0.+0.j],
-         [ 0.+0.j, -1.+0.j]
-     ], dims=[[4, 2], [2]])
+    q1 = Qobj([[1.+0.j,  0.+0.j],
+               [0.+0.j,  1.+0.j],
+               [0.+0.j,  1.+0.j],
+               [1.+0.j,  0.+0.j],
+               [0.+0.j,  0.-1.j],
+               [0.+1.j,  0.+0.j],
+               [1.+0.j,  0.+0.j],
+               [0.+0.j, -1.+0.j]],
+              dims=[[4, 2], [2]])
+    assert (q1 * q2 * q1.dag()).dims == [[4, 2], [4, 2]]
 
-    assert_equal((q1 * q2 * q1.dag()).dims, [[4, 2], [4, 2]])
 
 def test_QobjAddition():
     "Qobj addition"
@@ -300,14 +269,14 @@ def test_QobjAddition():
     q4_isherm = q4.isherm
     q4._type = None
     q4._isherm = None  # clear cached values
-    assert_equal(q4_type, q4.type)
-    assert_equal(q4_isherm, q4.isherm)
+    assert q4_type == q4.type
+    assert q4_isherm == q4.isherm
 
     # check elementwise addition/subtraction
-    assert_(q3 == q4)
+    assert q3 == q4
 
     # check that addition is commutative
-    assert_(q1 + q2 == q2 + q1)
+    assert q1 + q2 == q2 + q1
 
     data = np.random.random((5, 5))
     q = Qobj(data)
@@ -316,8 +285,8 @@ def test_QobjAddition():
     x2 = 5 + q
 
     data = data + np.eye(5) * 5
-    assert_(np.all(x1.data.todense() - np.matrix(data) == 0))
-    assert_(np.all(x2.data.todense() - np.matrix(data) == 0))
+    assert np.all(x1.data.todense() - np.matrix(data) == 0)
+    assert np.all(x2.data.todense() - np.matrix(data) == 0)
 
     data = np.random.random((5, 5))
     q = Qobj(data)
@@ -325,8 +294,8 @@ def test_QobjAddition():
     x4 = data + q
 
     data = 2.0 * data
-    assert_(np.all(x3.data.todense() - np.matrix(data) == 0))
-    assert_(np.all(x4.data.todense() - np.matrix(data) == 0))
+    assert np.all(x3.data.todense() - np.matrix(data) == 0)
+    assert np.all(x4.data.todense() - np.matrix(data) == 0)
 
 
 def test_QobjSubtraction():
@@ -340,12 +309,12 @@ def test_QobjSubtraction():
     q3 = q1 - q2
     data3 = data1 - data2
 
-    assert_(np.all(q3.data.todense() - np.matrix(data3) == 0))
+    assert np.all(q3.data.todense() - np.matrix(data3) == 0)
 
     q4 = q2 - q1
     data4 = data2 - data1
 
-    assert_(np.all(q4.data.todense() - np.matrix(data4) == 0))
+    assert np.all(q4.data.todense() - np.matrix(data4) == 0)
 
 
 def test_QobjMultiplication():
@@ -361,7 +330,7 @@ def test_QobjMultiplication():
 
     q4 = q1 * q2
 
-    assert_(q3 == q4)
+    assert q3 == q4
 
 
 def test_QobjDivision():
@@ -370,7 +339,7 @@ def test_QobjDivision():
     q = Qobj(data)
     randN = 10 * np.random.random()
     q = q / randN
-    assert_(np.allclose(q.data.todense(), np.matrix(data) / randN))
+    assert np.allclose(q.data.todense(), np.matrix(data) / randN)
 
 
 def test_QobjPower():
@@ -379,10 +348,10 @@ def test_QobjPower():
     q = Qobj(data)
 
     q2 = q ** 2
-    assert_((q2.data.todense() - np.matrix(data) ** 2 < 1e-12).all())
+    assert (q2.data.todense() - np.matrix(data)**2 < 1e-12).all()
 
     q3 = q ** 3
-    assert_((q3.data.todense() - np.matrix(data) ** 3 < 1e-12).all())
+    assert (q3.data.todense() - np.matrix(data)**3 < 1e-12).all()
 
 
 def test_QobjNeg():
@@ -390,9 +359,9 @@ def test_QobjNeg():
     data = _random_not_singular(5)
     q = Qobj(data)
     x = -q
-    assert_(np.all(x.data.todense() + np.matrix(data) == 0))
-    assert_equal(q.isherm, x.isherm)
-    assert_equal(q.type, x.type)
+    assert np.all(x.data.todense() + np.matrix(data) == 0)
+    assert q.isherm == x.isherm
+    assert q.type == x.type
 
 
 def test_QobjEquals():
@@ -400,80 +369,80 @@ def test_QobjEquals():
     data = _random_not_singular(5)
     q1 = Qobj(data)
     q2 = Qobj(data)
-    assert_(q1 == q2)
+    assert q1 == q2
 
     q1 = Qobj(data)
     q2 = Qobj(-data)
-    assert_(q1 != q2)
+    assert q1 != q2
 
 
 def test_QobjGetItem():
     "Qobj getitem"
     data = _random_not_singular(5)
     q = Qobj(data)
-    assert_equal(q[0, 0], data[0, 0])
-    assert_equal(q[-1, 2], data[-1, 2])
+    assert q[0, 0] == data[0, 0]
+    assert q[-1, 2] == data[-1, 2]
 
 
 def test_CheckMulType():
     "Qobj multiplication type"
-
     # ket-bra and bra-ket multiplication
     psi = basis(5)
     dm = psi * psi.dag()
-    assert_(dm.isoper)
-    assert_(dm.isherm)
+    assert dm.isoper
+    assert dm.isherm
 
     nrm = psi.dag() * psi
-    assert_equal(np.prod(nrm.shape), 1)
-    assert_((abs(nrm) == 1)[0, 0])
+    assert np.prod(nrm.shape) == 1
+    assert abs(nrm)[0, 0] == 1
 
     # operator-operator multiplication
     H1 = rand_herm(3)
     H2 = rand_herm(3)
     out = H1 * H2
-    assert_(out.isoper)
+    assert out.isoper
     out = H1 * H1
-    assert_(out.isoper)
-    assert_(out.isherm)
+    assert out.isoper
+    assert out.isherm
     out = H2 * H2
-    assert_(out.isoper)
-    assert_(out.isherm)
+    assert out.isoper
+    assert out.isherm
 
     U = rand_unitary(5)
     out = U.dag() * U
-    assert_(out.isoper)
-    assert_(out.isherm)
+    assert out.isoper
+    assert out.isherm
 
     N = num(5)
 
     out = N * N
-    assert_(out.isoper)
-    assert_(out.isherm)
+    assert out.isoper
+    assert out.isherm
 
     # operator-ket and bra-operator multiplication
     op = sigmax()
     ket1 = basis(2)
     ket2 = op * ket1
-    assert_(ket2.isket)
+    assert ket2.isket
 
     bra1 = basis(2).dag()
     bra2 = bra1 * op
-    assert_(bra2.isbra)
+    assert bra2.isbra
 
-    assert_(bra2.dag() == ket2)
+    assert bra2.dag() == ket2
 
     # superoperator-operket and operbra-superoperator multiplication
     sop = to_super(sigmax())
     opket1 = operator_to_vector(fock_dm(2))
     opket2 = sop * opket1
-    assert(opket2.isoperket)
+    assert opket2.isoperket
 
     opbra1 = operator_to_vector(fock_dm(2)).dag()
     opbra2 = opbra1 * sop
-    assert(opbra2.isoperbra)
+    assert opbra2.isoperbra
 
-    assert_(opbra2.dag() == opket2)
+    assert opbra2.dag() == opket2
+
 
 def test_Qobj_Spmv():
     "Qobj mult ndarray right"
@@ -481,7 +450,7 @@ def test_Qobj_Spmv():
     b = rand_ket(5).full()
     C = A*b
     D = A.full().dot(b)
-    assert_(np.all((C-D)<1e-14))
+    assert np.all((C-D) < 1e-14)
 
 
 def test_QobjConjugate():
@@ -489,10 +458,10 @@ def test_QobjConjugate():
     data = _random_not_singular(5)
     A = Qobj(data)
     B = A.conj()
-    assert_(np.all(B.data.todense() - np.matrix(data.conj()) == 0))
-    assert_equal(A.isherm, B.isherm)
-    assert_equal(A.type, B.type)
-    assert_equal(A.superrep, B.superrep)
+    assert np.all(B.data.todense() - np.matrix(data.conj()) == 0)
+    assert A.isherm == B.isherm
+    assert A.type == B.type
+    assert A.superrep == B.superrep
 
 
 def test_QobjDagger():
@@ -500,10 +469,10 @@ def test_QobjDagger():
     data = _random_not_singular(5)
     A = Qobj(data)
     B = A.dag()
-    assert_(np.all(B.data.todense() - np.matrix(data.conj().T) == 0))
-    assert_equal(A.isherm, B.isherm)
-    assert_equal(A.type, B.type)
-    assert_equal(A.superrep, B.superrep)
+    assert np.all(B.data.todense() - np.matrix(data.conj().T) == 0)
+    assert A.isherm == B.isherm
+    assert A.type == B.type
+    assert A.superrep == B.superrep
 
 
 def test_QobjDiagonals():
@@ -511,7 +480,7 @@ def test_QobjDiagonals():
     data = _random_not_singular(5)
     A = Qobj(data)
     b = A.diag()
-    assert_(np.all(b - np.diag(data) == 0))
+    assert np.all(b - np.diag(data) == 0)
 
 
 def test_QobjEigenEnergies():
@@ -519,17 +488,17 @@ def test_QobjEigenEnergies():
     data = np.eye(5)
     A = Qobj(data)
     b = A.eigenenergies()
-    assert_(np.all(b - np.ones(5) == 0))
+    assert np.all(b - np.ones(5) == 0)
 
     data = np.diag(np.arange(10))
     A = Qobj(data)
     b = A.eigenenergies()
-    assert_(np.all(b - np.arange(10) == 0))
+    assert np.all(b - np.arange(10) == 0)
 
     data = np.diag(np.arange(10))
     A = 5 * Qobj(data)
     b = A.eigenenergies()
-    assert_(np.all(b - 5 * np.arange(10) == 0))
+    assert np.all(b - 5 * np.arange(10) == 0)
 
 
 def test_QobjEigenStates():
@@ -537,12 +506,12 @@ def test_QobjEigenStates():
     data = np.eye(5)
     A = Qobj(data)
     b, c = A.eigenstates()
-    assert_(np.all(b - np.ones(5) == 0))
+    assert np.all(b - np.ones(5) == 0)
 
     kets = [basis(5, k) for k in range(5)]
 
     for k in range(5):
-        assert_(c[k] == kets[k])
+        assert c[k] == kets[k]
 
 
 def test_QobjExpm():
@@ -550,7 +519,7 @@ def test_QobjExpm():
     data = _random_not_singular(15)
     A = Qobj(data)
     B = A.expm()
-    assert_((B.data.todense() - np.matrix(la.expm(data)) < 1e-10).all())
+    assert (B.data.todense() - np.matrix(la.expm(data)) < 1e-10).all()
 
 
 def test_QobjExpmExplicitlySparse():
@@ -558,14 +527,14 @@ def test_QobjExpmExplicitlySparse():
     data = _random_not_singular(15)
     A = Qobj(data)
     B = A.expm(method='sparse')
-    assert_((B.data.todense() - np.matrix(la.expm(data)) < 1e-10).all())
+    assert (B.data.todense() - np.matrix(la.expm(data)) < 1e-10).all()
 
 
 def test_QobjExpmZeroOper():
     "Qobj expm zero_oper (#493)"
-    A = Qobj(np.zeros((5,5), dtype=complex))
+    A = Qobj(np.zeros((5, 5), dtype=complex))
     B = A.expm()
-    assert_(B == qeye(5))
+    assert B == qeye(5)
 
 
 def test_Qobj_sqrtm():
@@ -573,7 +542,7 @@ def test_Qobj_sqrtm():
     data = _random_not_singular(5)
     A = Qobj(data)
     B = A.sqrtm()
-    assert_(A == B * B)
+    assert A == B * B
 
 
 def test_Qobj_inv():
@@ -581,11 +550,11 @@ def test_Qobj_inv():
     data = _random_not_singular(5)
     A = Qobj(data)
     B = A.inv()
-    assert_(qeye(5) == A * B)
-    assert_(qeye(5) == B * A)
+    assert qeye(5) == A * B
+    assert qeye(5) == B * A
     B = A.inv(sparse=True)
-    assert_(qeye(5) == A * B)
-    assert_(qeye(5) == B * A)
+    assert qeye(5) == A * B
+    assert qeye(5) == B * A
 
 
 def test_QobjFull():
@@ -593,7 +562,7 @@ def test_QobjFull():
     data = _random_not_singular(15)
     A = Qobj(data)
     b = A.full()
-    assert_(np.all(b - data == 0))
+    assert np.all(b - data == 0)
 
 
 def test_QobjNorm():
@@ -602,35 +571,35 @@ def test_QobjNorm():
     N = 20
     x = np.random.random(N) + 1j * np.random.random(N)
     A = Qobj(x)
-    assert_equal(np.abs(A.norm() - la.norm(A.data.data, 2)) < 1e-12, True)
+    assert np.abs(A.norm() - la.norm(A.data.data, 2)) < 1e-12
     # vector max (inf) norm test
-    assert_equal(
-        np.abs(A.norm('max') - la.norm(A.data.data, np.inf)) < 1e-12, True)
+    assert np.abs(A.norm('max') - la.norm(A.data.data, np.inf)) < 1e-12
     # operator frobius norm
     x = np.random.random((N, N)) + 1j * np.random.random((N, N))
     A = Qobj(x)
-    assert_equal(
-        np.abs(A.norm('fro') - la.norm(A.full(), 'fro')) < 1e-12, True)
+    assert np.abs(A.norm('fro') - la.norm(A.full(), 'fro')) < 1e-12
     # operator trace norm
     a = rand_herm(10, 0.25)
-    assert_almost_equal(a.norm(), (a*a.dag()).sqrtm().tr().real)
+    assert np.allclose(a.norm(), (a*a.dag()).sqrtm().tr().real)
     b = rand_herm(10, 0.25) - 1j*rand_herm(10, 0.25)
-    assert_almost_equal(b.norm(), (b*b.dag()).sqrtm().tr().real)
+    assert np.allclose(b.norm(), (b*b.dag()).sqrtm().tr().real)
+
 
 def test_QobjPurity():
     "Tests the purity method of `Qobj`"
     psi = basis(2, 1)
     # check purity of pure ket state
-    assert_almost_equal(psi.purity(), 1)
+    assert np.allclose(psi.purity(), 1)
     # check purity of pure ket state (superposition)
     psi2 = basis(2, 0)
     psi_tot = (psi+psi2).unit()
-    assert_almost_equal(psi_tot.purity(), 1)
+    assert np.allclose(psi_tot.purity(), 1)
     # check purity of density matrix of pure state
-    assert_almost_equal(ket2dm(psi_tot).purity(), 1)
+    assert np.allclose(ket2dm(psi_tot).purity(), 1)
     # check purity of maximally mixed density matrix
-    rho_mixed = (ket2dm(psi)+ket2dm(psi2)).unit()
-    assert_almost_equal(rho_mixed.purity(), 0.5)
+    rho_mixed = (ket2dm(psi) + ket2dm(psi2)).unit()
+    assert np.allclose(rho_mixed.purity(), 0.5)
+
 
 def test_QobjPermute():
     "Qobj permute"
@@ -639,54 +608,55 @@ def test_QobjPermute():
     C = basis(4, 2)
     psi = tensor(A, B, C)
     psi2 = psi.permute([2, 0, 1])
-    assert_(psi2 == tensor(C, A, B))
+    assert psi2 == tensor(C, A, B)
 
     psi_bra = psi.dag()
     psi2_bra = psi_bra.permute([2, 0, 1])
-    assert_(psi2_bra == tensor(C, A, B).dag())
+    assert psi2_bra == tensor(C, A, B).dag()
 
     A = fock_dm(3, 0)
     B = fock_dm(5, 4)
     C = fock_dm(4, 2)
     rho = tensor(A, B, C)
     rho2 = rho.permute([2, 0, 1])
-    assert_(rho2 == tensor(C, A, B))
+    assert rho2 == tensor(C, A, B)
 
-    for ii in range(3):
+    for _ in range(3):
         A = rand_ket(3)
         B = rand_ket(4)
         C = rand_ket(5)
         psi = tensor(A, B, C)
         psi2 = psi.permute([1, 0, 2])
-        assert_(psi2 == tensor(B, A, C))
+        assert psi2 == tensor(B, A, C)
 
         psi_bra = psi.dag()
         psi2_bra = psi_bra.permute([1, 0, 2])
-        assert_(psi2_bra == tensor(B, A, C).dag())
+        assert psi2_bra == tensor(B, A, C).dag()
 
-    for ii in range(3):
+    for _ in range(3):
         A = rand_dm(3)
         B = rand_dm(4)
         C = rand_dm(5)
         rho = tensor(A, B, C)
         rho2 = rho.permute([1, 0, 2])
-        assert_(rho2 == tensor(B, A, C))
+        assert rho2 == tensor(B, A, C)
 
         rho_vec = operator_to_vector(rho)
-        rho2_vec = rho_vec.permute([[1, 0, 2],[4,3,5]])
-        assert_(rho2_vec == operator_to_vector(tensor(B, A, C)))
+        rho2_vec = rho_vec.permute([[1, 0, 2], [4, 3, 5]])
+        assert rho2_vec == operator_to_vector(tensor(B, A, C))
 
         rho_vec_bra = operator_to_vector(rho).dag()
-        rho2_vec_bra = rho_vec_bra.permute([[1, 0, 2],[4,3,5]])
-        assert_(rho2_vec_bra == operator_to_vector(tensor(B, A, C)).dag())
+        rho2_vec_bra = rho_vec_bra.permute([[1, 0, 2], [4, 3, 5]])
+        assert rho2_vec_bra == operator_to_vector(tensor(B, A, C)).dag()
 
-    for ii in range(3):
+    for _ in range(3):
         super_dims = [3, 5, 4]
-        U = rand_unitary(np.prod(super_dims), density=0.02, dims=[super_dims, super_dims])
-        Unew = U.permute([2,1,0])
+        U = rand_unitary(np.prod(super_dims), density=0.02,
+                         dims=[super_dims, super_dims])
+        Unew = U.permute([2, 1, 0])
         S_tens = to_super(U)
         S_tens_new = to_super(Unew)
-        assert_(S_tens_new == S_tens.permute([[2,1,0],[5,4,3]]))
+        assert S_tens_new == S_tens.permute([[2, 1, 0], [5, 4, 3]])
 
 
 def test_KetType():
@@ -694,17 +664,17 @@ def test_KetType():
 
     psi = basis(2, 1)
 
-    assert_(psi.isket)
-    assert_(not psi.isbra)
-    assert_(not psi.isoper)
-    assert_(not psi.issuper)
+    assert psi.isket
+    assert not psi.isbra
+    assert not psi.isoper
+    assert not psi.issuper
 
     psi = tensor(basis(2, 1), basis(2, 0))
 
-    assert_(psi.isket)
-    assert_(not psi.isbra)
-    assert_(not psi.isoper)
-    assert_(not psi.issuper)
+    assert psi.isket
+    assert not psi.isbra
+    assert not psi.isoper
+    assert not psi.issuper
 
 
 def test_BraType():
@@ -712,17 +682,17 @@ def test_BraType():
 
     psi = basis(2, 1).dag()
 
-    assert_equal(psi.isket, False)
-    assert_equal(psi.isbra, True)
-    assert_equal(psi.isoper, False)
-    assert_equal(psi.issuper, False)
+    assert not psi.isket
+    assert psi.isbra
+    assert not psi.isoper
+    assert not psi.issuper
 
     psi = tensor(basis(2, 1).dag(), basis(2, 0).dag())
 
-    assert_equal(psi.isket, False)
-    assert_equal(psi.isbra, True)
-    assert_equal(psi.isoper, False)
-    assert_equal(psi.issuper, False)
+    assert not psi.isket
+    assert psi.isbra
+    assert not psi.isoper
+    assert not psi.issuper
 
 
 def test_OperType():
@@ -731,10 +701,10 @@ def test_OperType():
     psi = basis(2, 1)
     rho = psi * psi.dag()
 
-    assert_equal(rho.isket, False)
-    assert_equal(rho.isbra, False)
-    assert_equal(rho.isoper, True)
-    assert_equal(rho.issuper, False)
+    assert not rho.isket
+    assert not rho.isbra
+    assert rho.isoper
+    assert not rho.issuper
 
 
 def test_SuperType():
@@ -745,38 +715,38 @@ def test_SuperType():
 
     sop = spre(rho)
 
-    assert_equal(sop.isket, False)
-    assert_equal(sop.isbra, False)
-    assert_equal(sop.isoper, False)
-    assert_equal(sop.issuper, True)
+    assert not sop.isket
+    assert not sop.isbra
+    assert not sop.isoper
+    assert sop.issuper
 
     sop = spost(rho)
 
-    assert_equal(sop.isket, False)
-    assert_equal(sop.isbra, False)
-    assert_equal(sop.isoper, False)
-    assert_equal(sop.issuper, True)
+    assert not sop.isket
+    assert not sop.isbra
+    assert not sop.isoper
+    assert sop.issuper
 
 
-def test_dag_preserves_superrep():
+@pytest.mark.parametrize("dimension", [2, 4, 8])
+@pytest.mark.parametrize("conversion", [to_super, to_choi, to_chi])
+def test_dag_preserves_superrep(dimension, conversion):
     """
     Checks that dag() preserves superrep.
     """
-
-    def case(qobj):
-        orig_superrep = qobj.superrep
-        assert_equal(qobj.dag().superrep, orig_superrep)
-
-    for dim in (2, 4, 8):
-        qobj = rand_super_bcsz(dim)
-        yield case, to_super(qobj)
-        # These two shouldn't even do anything, since qobj
-        # is Hermicity-preserving.
-        yield case, to_choi(qobj)
-        yield case, to_chi(qobj)
+    qobj = conversion(rand_super_bcsz(dimension))
+    assert qobj.superrep == qobj.dag().superrep
 
 
-def test_arithmetic_preserves_superrep():
+@pytest.mark.parametrize("superrep", ["super", "choi", "chi"])
+@pytest.mark.parametrize("operation,check_op,check_scalar",
+                         [(add, True, True),
+                          (sub, True, True),
+                          (mul, True, True),
+                          (truediv, False, True),
+                          (tensor, True, False)])
+def test_arithmetic_preserves_superrep(superrep,
+                                       operation, check_op, check_scalar):
     """
     Checks that binary ops preserve 'superrep'.
 
@@ -785,42 +755,23 @@ def test_arithmetic_preserves_superrep():
         The random superoperators are not chosen in a way that reflects the
         structure of that superrep, but are simply random matrices.
     """
-
     dims = [[[2], [2]], [[2], [2]]]
     shape = (4, 4)
+    S1 = Qobj(np.random.random(shape), superrep=superrep, dims=dims)
+    S2 = Qobj(np.random.random(shape), superrep=superrep, dims=dims)
+    x = np.random.random()
 
-    def check(superrep, operation, chk_op, chk_scalar):
-        S1 = Qobj(np.random.random(shape), superrep=superrep, dims=dims)
-        S2 = Qobj(np.random.random(shape), superrep=superrep, dims=dims)
-        x = np.random.random()
+    check_list = []
+    if check_op:
+        check_list.append(operation(S1, S2))
+    if check_scalar:
+        check_list.append(operation(S1, x))
+    if check_op and check_scalar:
+        check_list.append(operation(x, S2))
 
-        check_list = []
-        if chk_op:
-            check_list.append(operation(S1, S2))
-        if chk_scalar:
-            check_list.append(operation(S1, x))
-        if chk_op and chk_scalar:
-            check_list.append(operation(x, S2))
-
-        for S in check_list:
-            assert_equal(S.type, "super",
-                         "Operator {} did not preserve type='super'.".format(
-                             operation)
-                         )
-            assert_equal(S.superrep, superrep,
-                         "Operator {} did not preserve superrep={}.".format(
-                             operation, superrep)
-                         )
-
-    for superrep in ['super', 'choi', 'chi']:
-        for operation, chk_op, chk_scalar in [
-                (add, True, True),
-                (sub, True, True),
-                (mul, True, True),
-                (truediv, False, True),
-                (tensor, True, False)
-        ]:
-            yield check, superrep, operation, chk_op, chk_scalar
+    for S in check_list:
+        assert S.type == "super"
+        assert S.superrep == superrep
 
 
 def test_isherm_skew():
@@ -829,9 +780,9 @@ def test_isherm_skew():
     """
     iH = 1j * rand_herm(5)
 
-    assert_(not iH.isherm)
-    assert_((iH * iH).isherm)
-    assert_(tensor(iH, iH).isherm)
+    assert not iH.isherm
+    assert (iH * iH).isherm
+    assert tensor(iH, iH).isherm
 
 
 def test_super_tensor_operket():
@@ -855,8 +806,8 @@ def test_super_tensor_property():
 
     S_supertens = super_tensor(to_super(U1), to_super(U2))
 
-    assert_(S_tens == S_supertens)
-    assert_equal(S_supertens.superrep, 'super')
+    assert S_tens == S_supertens
+    assert S_supertens.superrep == 'super'
 
 
 def test_composite_oper():
@@ -871,10 +822,10 @@ def test_composite_oper():
     S3 = rand_super(4)
     S4 = rand_super(7)
 
-    assert_(composite(U1, U2) == tensor(U1, U2))
-    assert_(composite(S3, S4) == super_tensor(S3, S4))
-    assert_(composite(U1, S4) == super_tensor(S1, S4))
-    assert_(composite(S3, U2) == super_tensor(S3, S2))
+    assert composite(U1, U2) == tensor(U1, U2)
+    assert composite(S3, S4) == super_tensor(S3, S4)
+    assert composite(U1, S4) == super_tensor(S1, S4)
+    assert composite(S3, U2) == super_tensor(S3, S2)
 
 
 def test_composite_vec():
@@ -889,61 +840,47 @@ def test_composite_vec():
     r3 = operator_to_vector(rand_dm(3))
     r4 = operator_to_vector(rand_dm(4))
 
-    assert_(composite(k1, k2) == tensor(k1, k2))
-    assert_(composite(r3, r4) == super_tensor(r3, r4))
-    assert_(composite(k1, r4) == super_tensor(r1, r4))
-    assert_(composite(r3, k2) == super_tensor(r3, r2))
+    assert composite(k1, k2) == tensor(k1, k2)
+    assert composite(r3, r4) == super_tensor(r3, r4)
+    assert composite(k1, r4) == super_tensor(r1, r4)
+    assert composite(r3, k2) == super_tensor(r3, r2)
 
 # TODO: move out to a more appropriate module.
 
-def has_description(case):
-    """
-    Decorates a test case such that it takes an argument describing
-    that case, such that failure logs are usefully formatted.
-    """
-    # See https://code.google.com/archive/p/python-nose/issues/244#c1
-    # for why this works.
 
-    def make_case(description):
-        partial_case = partial(case)
-        partial_case.description = description
-        return partial_case
-    return make_case
+def trunc_neg_case(qobj, method, expected=None):
+    pos_qobj = qobj.trunc_neg(method=method)
+    assert all(energy > -1e-8 for energy in pos_qobj.eigenenergies())
+    assert np.allclose(pos_qobj.tr(), 1)
+    if expected is not None:
+        test_array = pos_qobj.data.todense()
+        exp_array = expected.data.todense()
+        assert np.allclose(test_array, exp_array)
 
-def test_trunc_neg():
-    """
-    Test Qobj: Checks trunc_neg in several different cases.
-    """
 
-    @has_description
-    def case(qobj, method, expected=None):
-        pos_qobj = qobj.trunc_neg(method=method)
-        assert(all([energy > -1e-8 for energy in pos_qobj.eigenenergies()]))
-        assert_almost_equal(pos_qobj.tr(), 1)
+class TestTruncNeg:
+    """Test Qobj.trunc_neg for several different cases."""
+    def test_positive_operator(self):
+        trunc_neg_case(rand_dm(5), 'clip')
+        trunc_neg_case(rand_dm(5), 'sgs')
 
-        if expected is not None:
-            assert_almost_equal(pos_qobj.data.todense(), expected.data.todense())
+    def test_diagonal_operator(self):
+        to_test = Qobj(np.diag([1.1, 0, -0.1]))
+        expected = Qobj(np.diag([1.0, 0.0, 0.0]))
+        trunc_neg_case(to_test, 'clip', expected)
+        trunc_neg_case(to_test, 'sgs', expected)
 
-    for method in ('clip', 'sgs'):
-        # Make sure that it works for operators that are already positive.
-        yield case("Test Qobj: trunc_neg works for positive opers."), \
-            rand_dm(5), method
-        # Make sure that it works for a diagonal matrix.
-        yield case("Test Qobj: trunc_neg works for diagonal opers."), \
-            Qobj(np.diag([1.1, -0.1])), method, Qobj(np.diag([1.0, 0.0]))
-        # Make sure that it works for a non-diagonal matrix.
+    def test_nondiagonal_operator(self):
         U = rand_unitary(3)
-        yield case("Test Qobj: trunc_neg works for non-diagonal opers."), \
-            U * Qobj(np.diag([1.1, 0, -0.1])) * U.dag(), \
-            method, \
-            U * Qobj(np.diag([1.0, 0.0, 0.0])) * U.dag()
+        to_test = U * Qobj(np.diag([1.1, 0, -0.1])) * U.dag()
+        expected = U * Qobj(np.diag([1.0, 0.0, 0.0])) * U.dag()
+        trunc_neg_case(to_test, 'clip', expected)
+        trunc_neg_case(to_test, 'sgs', expected)
 
-    # Check the test case in SGS.
-    yield (
-        case("Test Qobj: trunc_neg works for SGS known-good test case."),
-        Qobj(np.diag([3. / 5, 1. / 2, 7. / 20, 1. / 10, -11. / 20])), 'sgs',
-        Qobj(np.diag([9. / 20, 7. / 20, 1. / 5, 0, 0]))
-    )
+    def test_sgs_known_good(self):
+        trunc_neg_case(Qobj(np.diag([3./5, 1./2, 7./20, 1./10, -11./20])),
+                       'sgs',
+                       Qobj(np.diag([9./20, 7./20, 1./5, 0, 0])))
 
 
 def test_cosm():
@@ -956,7 +893,7 @@ def test_cosm():
 
     C = la.cosm(A.full())
 
-    assert_(np.all((B-C)< 1e-14))
+    assert np.all((B-C) < 1e-14)
 
 
 def test_sinm():
@@ -969,51 +906,42 @@ def test_sinm():
 
     C = la.sinm(A.full())
 
-    assert_(np.all((B-C)< 1e-14))
+    assert np.all((B-C) < 1e-14)
 
 
-
-def test_dual_channel():
+@pytest.mark.parametrize("sub_dimensions", ([2], [2, 2], [2, 3], [3, 5, 2]))
+def test_dual_channel(sub_dimensions, n_trials=50):
     """
     Qobj: dual_chan() preserves inner products with arbitrary density ops.
     """
+    S = rand_super_bcsz(np.prod(sub_dimensions))
+    S.dims = [[sub_dimensions, sub_dimensions],
+              [sub_dimensions, sub_dimensions]]
+    S = to_super(S)
+    left_dims, right_dims = S.dims
 
-    def case(S, n_trials=50):
-        S = to_super(S)
-        left_dims, right_dims = S.dims
+    # Assume for the purposes of the test that S maps square operators to
+    # square operators.
+    in_dim = np.prod(right_dims[0])
+    out_dim = np.prod(left_dims[0])
 
-        # Assume for the purposes of the test that S maps square operators to square operators.
-        in_dim = np.prod(right_dims[0])
-        out_dim = np.prod(left_dims[0])
+    S_dual = to_super(S.dual_chan())
 
-        S_dual = to_super(S.dual_chan())
+    primals = []
+    duals = []
 
-        primals = []
-        duals = []
+    for _ in [None]*n_trials:
+        X = rand_dm_ginibre(out_dim)
+        X.dims = left_dims
+        X = operator_to_vector(X)
+        Y = rand_dm_ginibre(in_dim)
+        Y.dims = right_dims
+        Y = operator_to_vector(Y)
 
-        for idx_trial in range(n_trials):
-            X = rand_dm_ginibre(out_dim)
-            X.dims = left_dims
-            X = operator_to_vector(X)
-            Y = rand_dm_ginibre(in_dim)
-            Y.dims = right_dims
-            Y = operator_to_vector(Y)
+        primals.append((X.dag() * S * Y)[0, 0])
+        duals.append((X.dag() * S_dual.dag() * Y)[0, 0])
 
-            primals.append((X.dag() * S * Y)[0, 0])
-            duals.append((X.dag() * S_dual.dag() * Y)[0, 0])
-
-        np.testing.assert_array_almost_equal(primals, duals)
-
-    for subdims in [
-        [2],
-        [2, 2],
-        [2, 3],
-        [3, 5, 2]
-    ]:
-        dim = np.prod(subdims)
-        S = rand_super_bcsz(dim)
-        S.dims = [[subdims, subdims], [subdims, subdims]]
-        yield case, S
+    np.testing.assert_array_almost_equal(primals, duals)
 
 
 def test_call():
@@ -1030,7 +958,7 @@ def test_call():
     assert U(psi) == U * psi
 
     # Case 1: oper(oper). Should raise TypeError.
-    with expect_exception(TypeError):
+    with pytest.raises(TypeError):
         U(rho)
 
     # Case 2: super(ket).
@@ -1040,79 +968,77 @@ def test_call():
     assert S(rho) == vector_to_operator(S * operator_to_vector(rho))
 
     # Case 4: super(super). Should raise TypeError.
-    with expect_exception(TypeError):
+    with pytest.raises(TypeError):
         S(S)
+
 
 def test_matelem():
     """
     Test Qobj: Compute matrix elements
     """
-    for kk in range(10):
+    for _ in range(10):
         N = 20
-        H = rand_herm(N,0.2)
+        H = rand_herm(N, 0.2)
 
-        L = rand_ket(N,0.3)
+        L = rand_ket(N, 0.3)
         Ld = L.dag()
-        R = rand_ket(N,0.3)
+        R = rand_ket(N, 0.3)
 
-        ans = (Ld*H*R).tr()
+        ans = (Ld * H * R).tr()
 
-        #bra-ket
-        out1 = H.matrix_element(Ld,R)
-        #ket-ket
-        out2 = H.matrix_element(Ld,R)
+        # bra-ket
+        out1 = H.matrix_element(Ld, R)
+        # ket-ket
+        out2 = H.matrix_element(Ld, R)
 
-        assert_(abs(ans-out1) < 1e-14)
-        assert_(abs(ans-out2) < 1e-14)
+        assert abs(ans-out1) < 1e-14
+        assert abs(ans-out2) < 1e-14
 
 
 def test_projection():
     """
     Test Qobj: Projection operator
     """
-    for kk in range(10):
+    for _ in range(10):
         N = 5
-        K = tensor(rand_ket(N,0.75),rand_ket(N,0.75))
+        K = tensor(rand_ket(N, 0.75), rand_ket(N, 0.75))
         B = K.dag()
 
-        ans = K*K.dag()
+        ans = K * K.dag()
 
         out1 = K.proj()
         out2 = B.proj()
 
-        assert_(out1==ans)
-        assert_(out2==ans)
+        assert out1 == ans
+        assert out2 == ans
 
 
 def test_overlap():
     """
     Test Qobj: Overlap (inner product)
     """
-    for kk in range(10):
+    for _ in range(10):
         N = 10
-        A = rand_ket(N,0.75)
+        A = rand_ket(N, 0.75)
         Ad = A.dag()
-        B = rand_ket(N,0.75)
+        B = rand_ket(N, 0.75)
         Bd = B.dag()
 
-        ans = (A.dag()*B).tr()
+        ans = (A.dag() * B).tr()
 
-        assert_almost_equal(A.overlap(B), ans)
-        assert_almost_equal(Ad.overlap(B), ans)
-        assert_almost_equal(Ad.overlap(Bd), ans)
-        assert_almost_equal(A.overlap(Bd), np.conj(ans))
+        assert np.allclose(A.overlap(B), ans)
+        assert np.allclose(Ad.overlap(B), ans)
+        assert np.allclose(Ad.overlap(Bd), ans)
+        assert np.allclose(A.overlap(Bd), np.conj(ans))
 
 
 def test_unit():
     """
     Test Qobj: unit
     """
-    psi = 10*np.random.randn()*basis(2,0)-10*np.random.randn()*1j*basis(2,1)
+    psi = (10*np.random.randn()*basis(2, 0)
+           - 10j*np.random.randn()*basis(2, 1))
     psi2 = psi.unit()
     psi.unit(inplace=True)
-    assert_(psi == psi2)
-    assert_almost_equal(np.linalg.norm(psi.full()), 1.0)
-
-
-if __name__ == "__main__":
-    run_module_suite()
+    assert psi == psi2
+    assert np.allclose(np.linalg.norm(psi.full()), 1.0)

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,9 @@ import sys
 # If the user doesn't have, then that's OK, we'll just skip unit tests.
 try:
     from setuptools import setup, Extension
-    TEST_SUITE = 'nose.collector'
-    TESTS_REQUIRE = ['nose']
     EXTRA_KWARGS = {
-        'test_suite': TEST_SUITE,
-        'tests_require': TESTS_REQUIRE
+        'setup_require': ['pytest-runner'],
+        'tests_require': ['pytest']
     }
 except:
     from distutils.core import setup


### PR DESCRIPTION
Removes the `nose` test runners found in `qutip.testing.run()` in #1158.

This isn't ready to be merged yet, I think - there's still references to `nose` in `setup.py`, and a comment in `test_qobj.py`, the context of which suggests that the tests are organised specifically for `nose`.  I'm not familiar enough with the differences between `nose`, `pytest` and `unittest` to know how much of a problem the latter is, though.