### PR TITLE
name collision fix for parallel propagator

### DIFF
--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -54,14 +54,15 @@ def _import_str(code, basefilename, obj_name, cythonfile=False):
     Import 'obj_name' defined in 'code'.
     Using a temporary file starting by 'basefilename'.
     """
-    filename = basefilename + str(hash(code))[1:6]
+    filename = (basefilename + str(hash(code))[1:4] + 
+                str(os.getpid()) + time.strftime("%M%S"))
     tries = 0
     import_list = []
     ext = ".pyx" if cythonfile else ".py"
     if os.getcwd() not in sys.path:
         sys.path.insert(0, os.getcwd())
     while not import_list and tries < 3:
-        try_file = filename + time.strftime("%d%H%M%S") + str(tries)
+        try_file = filename + str(tries)
         file_ = open(try_file+ext, "w")
         file_.writelines(code)
         file_.close()

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -54,7 +54,7 @@ def _import_str(code, basefilename, obj_name, cythonfile=False):
     Import 'obj_name' defined in 'code'.
     Using a temporary file starting by 'basefilename'.
     """
-    filename = (basefilename + str(hash(code))[1:4] + 
+    filename = (basefilename + str(hash(code))[1:4] +
                 str(os.getpid()) + time.strftime("%M%S"))
     tries = 0
     import_list = []


### PR DESCRIPTION
Should fix tests/test_propagator.py::testPropHOStrTd sometime failing, ran it 100 times with the patch without error.
Cause: compiling the same string by multiple process at once resulted in them writing temp files with the same filename, resulting in a race condition and random fails. Not sure why it was not caught before.
@nathanshammah, @ajgpitch  