### PR TITLE
Activate Python 3.8 builds on Linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,4 +151,6 @@ jobs:
     - stage: test
       <<: *stage_linux_37_openblas
     - stage: test
+      <<: *stage_linux_38
+    - stage: test
       <<: *stage_osx


### PR DESCRIPTION
Python 3.8 was released awhile ago, so I thought I'd try activate its travis build and see if it passes.