### PR TITLE
Convert tests to pytest

### DIFF
--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -50,9 +50,24 @@ def _add_repeats_if_marked(metafunc):
                              ids=["rep({})".format(x+1) for x in range(count)])
 
 
+def _skip_cython_tests_if_unavailable(item):
+    """
+    Skip the current test item if Cython is unavailable for import, or isn't a
+    high enough version.
+    """
+    if item.get_closest_marker("requires_cython"):
+        # importorskip rather than mark.skipif because this way we get pytest's
+        # version-handling semantics.
+        pytest.importorskip('Cython', minversion='0.14')
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_generate_tests(metafunc):
     _add_repeats_if_marked(metafunc)
+
+
+def pytest_runtest_setup(item):
+    _skip_cython_tests_if_unavailable(item)
 
 
 @pytest.fixture

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -32,8 +32,10 @@
 ###############################################################################
 
 import pytest
+import functools
 import os
 import tempfile
+import numpy as np
 
 
 def _add_repeats_if_marked(metafunc):
@@ -68,6 +70,106 @@ def pytest_generate_tests(metafunc):
 
 def pytest_runtest_setup(item):
     _skip_cython_tests_if_unavailable(item)
+
+
+def _patched_build_err_msg(arrays, err_msg, header='Items are not equal:',
+                           verbose=True, names=('ACTUAL', 'DESIRED'),
+                           precision=8):
+    """
+    Taken almost verbatim from `np.testing._private.utils`, except this version
+    doesn't truncate output if it's longer than three lines.
+
+    LICENCE
+    -------
+    Copyright (c) 2005-2020, NumPy Developers.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    - Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    - Neither the name of the NumPy Developers nor the names of any
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+    """
+    msg = ['\n' + header]
+    if err_msg:
+        if err_msg.find('\n') == -1 and len(err_msg) < 79-len(header):
+            msg = [msg[0] + ' ' + err_msg]
+        else:
+            msg.append(err_msg)
+    if verbose:
+        for i, a in enumerate(arrays):
+            if isinstance(a, np.ndarray):
+                # precision argument is only needed if the objects are ndarrays
+                r_func = functools.partial(np.core.array_repr,
+                                           precision=precision)
+            else:
+                r_func = repr
+
+            try:
+                # [diff] Remove truncation threshold from array output.
+                with np.printoptions(threshold=np.inf):
+                    r = r_func(a)
+            except Exception as exc:
+                r = '[repr failed for <{}>: {}]'.format(type(a).__name__, exc)
+            # [diff] The original truncates the output to 3 lines here.
+            msg.append(' %s: %s' % (names[i], r))
+    return '\n'.join(msg)
+
+
+# Find the private module used by numpy to store its testing utility functions
+# so that we can monkeypatch the error messages to be more verbose.  QuTiP
+# supports numpy from 1.12 upwards, so we have to search.
+_numpy_private_utils_paths = [
+    ['_private', 'utils'],    # 1.15.0 <= x
+    ['nose_tools', 'utils'],  # 1.14.0 <= x < 1.15.0
+    ['utils'],                # 1.14.0 > x
+]
+for possible_path in _numpy_private_utils_paths:
+    try:
+        module = np.testing
+        for submodule in possible_path:
+            module = getattr(module, submodule)
+        _numpy_private_utils = module
+        break
+    except NameError:
+        pass
+else:
+    # If we can't locate it for some reason, then we don't attempt to patch.
+    _numpy_private_utils = None
+
+if _numpy_private_utils is not None:
+    @pytest.fixture(autouse=True)
+    def do_not_truncate_numpy_output(monkeypatch):
+        """
+        Monkeypatch the internal numpy function used for printing arrays so
+        that we get full output that isn't cut off after three lines.
+        """
+        with monkeypatch.context() as patch:
+            patch.setattr(np.testing._private.utils, "build_err_msg",
+                          _patched_build_err_msg)
+            # Yield inside context manager just to minimize the amount of time
+            # we've monkeypatched such a core library (and a private function!)
+            yield
 
 
 @pytest.fixture

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -81,7 +81,6 @@ def in_temporary_directory():
     previous_dir = os.getcwd()
     with tempfile.TemporaryDirectory() as temporary_dir:
         os.chdir(temporary_dir)
-        print(temporary_dir)
         yield
         # pytest should catch exceptions occuring in functions using the
         # fixture, so this should always be called.  We want it here rather

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -31,6 +31,9 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+import pytest
+
+
 def _add_repeats_if_marked(metafunc):
     """
     If the metafunc is marked with the 'repeat' mark, then add the requisite
@@ -45,5 +48,6 @@ def _add_repeats_if_marked(metafunc):
                              ids=["rep({})".format(x+1) for x in range(count)])
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_generate_tests(metafunc):
     _add_repeats_if_marked(metafunc)

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -32,6 +32,8 @@
 ###############################################################################
 
 import pytest
+import os
+import tempfile
 
 
 def _add_repeats_if_marked(metafunc):
@@ -51,3 +53,29 @@ def _add_repeats_if_marked(metafunc):
 @pytest.hookimpl(trylast=True)
 def pytest_generate_tests(metafunc):
     _add_repeats_if_marked(metafunc)
+
+
+@pytest.fixture
+def in_temporary_directory():
+    """
+    Creates a temporary directory for the lifetime of the fixture and changes
+    into it.  All relative paths used will be in the temporary directory, and
+    everything will automatically be cleaned up at the end of the fixture's
+    life.
+    """
+    previous_dir = os.getcwd()
+    with tempfile.TemporaryDirectory() as temporary_dir:
+        os.chdir(temporary_dir)
+        print(temporary_dir)
+        yield
+        # pytest should catch exceptions occuring in functions using the
+        # fixture, so this should always be called.  We want it here rather
+        # than outside to prevent the case of the directory failing to be
+        # removed because it is 'busy'.
+        os.chdir(previous_dir)
+
+
+@pytest.fixture
+def tmpfile():
+    with tempfile.NamedTemporaryFile() as file:
+        yield file

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -31,67 +31,19 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-import pytest
-import numpy as np
-import scipy.sparse
-import qutip
-from qutip.fastsparse import fast_csr_matrix
-from qutip.cy.checks import (_test_sorting, _test_coo2csr_inplace_struct,
-                             _test_csr2coo_struct, _test_coo2csr_struct)
-from qutip.random_objects import rand_jacobi_rotation
+def _add_repeats_if_marked(metafunc):
+    """
+    If the metafunc is marked with the 'repeat' mark, then add the requisite
+    number of repeats via parametrisation.
+    """
+    marker = metafunc.definition.get_closest_marker('repeat')
+    if marker:
+        count = marker.args[0]
+        metafunc.fixturenames.append('_repeat_count')
+        metafunc.parametrize('_repeat_count',
+                             range(count),
+                             ids=["rep({})".format(x+1) for x in range(count)])
 
 
-def _unsorted_csr(N, density=0.5):
-    M = scipy.sparse.diags(np.arange(N), 0, dtype=complex, format='csr')
-    nvals = N**2 * density
-    while M.nnz < 0.95*nvals:
-        M = rand_jacobi_rotation(M)
-    M = M.tocsr()
-    return fast_csr_matrix((M.data, M.indices, M.indptr), shape=M.shape)
-
-
-def sparse_arrays_equal(a, b):
-    return not (a != b).data.any()
-
-
-@pytest.mark.repeat(20)
-def test_coo2csr_struct():
-    "Cython structs : COO to CSR"
-    A = qutip.rand_dm(5, 0.5).data
-    assert sparse_arrays_equal(A, _test_coo2csr_struct(A.tocoo()))
-
-
-@pytest.mark.repeat(20)
-def test_indices_sort():
-    "Cython structs : sort CSR indices inplace"
-    A = _unsorted_csr(10, 0.25)
-    B = A.copy()
-    B.sort_indices()
-    _test_sorting(A)
-    assert np.all(A.data == B.data)
-    assert np.all(A.indices == B.indices)
-
-
-@pytest.mark.repeat(20)
-def test_coo2csr_inplace_nosort():
-    "Cython structs : COO to CSR inplace (no sort)"
-    A = qutip.rand_dm(5, 0.5).data
-    B = _test_coo2csr_inplace_struct(A.tocoo(), sorted=0)
-    assert sparse_arrays_equal(A, B)
-
-
-@pytest.mark.repeat(20)
-def test_coo2csr_inplace_sort():
-    "Cython structs : COO to CSR inplace (sorted)"
-    A = qutip.rand_dm(5,0.5).data
-    B = _test_coo2csr_inplace_struct(A.tocoo(), sorted=1)
-    assert sparse_arrays_equal(A, B)
-
-
-@pytest.mark.repeat(20)
-def test_csr2coo():
-    "Cython structs : CSR to COO"
-    A = qutip.rand_dm(5, 0.5).data
-    B = A.tocoo()
-    C = _test_csr2coo_struct(A)
-    assert sparse_arrays_equal(B, C)
+def pytest_generate_tests(metafunc):
+    _add_repeats_if_marked(metafunc)

--- a/qutip/tests/pytest.ini
+++ b/qutip/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow

--- a/qutip/tests/pytest.ini
+++ b/qutip/tests/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     slow
     repeat(n): Repeat the given test 'n' times.
+    requires_cython: Mark that the given test requires Cython to be installed.

--- a/qutip/tests/pytest.ini
+++ b/qutip/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow
+    repeat(n): Repeat the given test 'n' times.

--- a/qutip/tests/pytest.ini
+++ b/qutip/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 markers =
-    slow
+    slow: Mark a test as taking a long time to run, and so can be skipped with `pytest -m "not slow"`.
     repeat(n): Repeat the given test 'n' times.
-    requires_cython: Mark that the given test requires Cython to be installed.
+    requires_cython: Mark that the given test requires Cython to be installed.  Such tests will be skipped if Cython is not available.

--- a/qutip/tests/test_brmesolve.py
+++ b/qutip/tests/test_brmesolve.py
@@ -47,11 +47,16 @@ _x_a_op = [qutip.sigmax(), lambda w: _simple_qubit_gamma * (w >= 0)]
 
 
 @pytest.mark.parametrize("me_c_ops, brme_c_ops, brme_a_ops", [
-        ([_m_c_op],          [],        [_x_a_op]),
-        ([_m_c_op],          [_m_c_op], []),
-        ([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op]),
-    ])
+    pytest.param([_m_c_op], [], [_x_a_op], id="me collapse-br coupling"),
+    pytest.param([_m_c_op], [_m_c_op], [], id="me collapse-br collapse"),
+    pytest.param([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op],
+                 id="me collapse-br collapse-br coupling"),
+])
 def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
+    """
+    Test that the BR solver handles collapse and coupling operators correctly
+    relative to the standard ME solver.
+    """
     delta = 0.0 * 2*np.pi
     epsilon = 0.5 * 2*np.pi
     e_ops = pauli_spin_operators()

--- a/qutip/tests/test_brmesolve.py
+++ b/qutip/tests/test_brmesolve.py
@@ -67,7 +67,7 @@ def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
     brme = qutip.brmesolve(H, psi0, times,
                            brme_a_ops, e_ops, brme_c_ops).expect
     for me_expectation, brme_expectation in zip(me, brme):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
 
 def _harmonic_oscillator_spectrum_frequency(n_th, w0, kappa):
@@ -110,12 +110,12 @@ def test_harmonic_oscillator(n_th):
     me = qutip.mesolve(H, psi0, times, c_ops, e_ops)
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
     num = qutip.num(N)
     me_num = qutip.expect(num, me.states)
     brme_num = qutip.expect(num, brme.states)
-    assert np.allclose(me_num, brme_num, atol=1e-2)
+    np.testing.assert_allclose(me_num, brme_num, atol=1e-2)
 
 
 def test_jaynes_cummings_zero_temperature():
@@ -141,7 +141,7 @@ def test_jaynes_cummings_zero_temperature():
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
         # Accept 5% error.
-        assert np.allclose(me_expectation, brme_expectation, atol=5e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=5e-2)
 
 
 def test_pull_572_error():
@@ -180,7 +180,7 @@ def test_pull_572_error():
     # Solution of the master equation
     times = np.linspace(0, 10./gamma3, 1000)
     sol = qutip.bloch_redfield_solve(R, ekets, ini, times, [proj_up1])
-    assert np.allclose(sol[0], np.ones_like(times))
+    np.testing.assert_allclose(sol[0], np.ones_like(times))
 
 
 def test_solver_accepts_list_hamiltonian():
@@ -198,4 +198,4 @@ def test_solver_accepts_list_hamiltonian():
     me = qutip.mesolve(H, psi0, times, c_ops=c_ops, e_ops=e_ops).expect
     brme = qutip.brmesolve(H, psi0, times, [], e_ops, c_ops).expect
     for me_expectation, brme_expectation in zip(me, brme):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-8)

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -42,9 +42,10 @@ else:
     cython_version = qutip._version2int(Cython.__version__)
     Cython_OK = cython_version >= qutip._version2int('0.14')
 
-pytestmark = pytest.mark.skipif(not Cython_OK,
-                                reason="Cython not found, or version too low.",
-                                allow_module_level=True)
+pytestmark = [pytest.mark.skipif(not Cython_OK,
+                                 reason="Cython not found or version too low.",
+                                 allow_module_level=True),
+              pytest.mark.usefixtures("in_temporary_directory")]
 
 
 def pauli_spin_operators():

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -39,6 +39,9 @@ pytest.importorskip('Cython', minversion="0.14",
 
 pytestmark = [pytest.mark.usefixtures("in_temporary_directory")]
 
+# A lot of this module is direct duplication of test_brmesolve.py, but using
+# string time dependence rather than functional.
+
 
 def pauli_spin_operators():
     return [qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()]
@@ -52,11 +55,16 @@ _x_a_op = [qutip.sigmax(), '{0} * (w >= 0)'.format(_simple_qubit_gamma)]
 
 @pytest.mark.slow
 @pytest.mark.parametrize("me_c_ops, brme_c_ops, brme_a_ops", [
-        ([_m_c_op],          [],        [_x_a_op]),
-        ([_m_c_op],          [_m_c_op], []),
-        ([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op]),
-    ])
+    pytest.param([_m_c_op], [], [_x_a_op], id="me collapse-br coupling"),
+    pytest.param([_m_c_op], [_m_c_op], [], id="me collapse-br collapse"),
+    pytest.param([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op],
+                 id="me collapse-br collapse-br coupling"),
+])
 def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
+    """
+    Test that the BR solver handles collapse and coupling operators correctly
+    relative to the standard ME solver.
+    """
     delta = 0.0 * 2*np.pi
     epsilon = 0.5 * 2*np.pi
     e_ops = pauli_spin_operators()

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -34,18 +34,10 @@ import pytest
 import numpy as np
 import qutip
 
-try:
-    import Cython
-except ImportError:
-    Cython_OK = False
-else:
-    cython_version = qutip._version2int(Cython.__version__)
-    Cython_OK = cython_version >= qutip._version2int('0.14')
+pytest.importorskip('Cython', minversion="0.14",
+                    reason="Suitable Cython not found.")
 
-pytestmark = [pytest.mark.skipif(not Cython_OK,
-                                 reason="Cython not found or version too low.",
-                                 allow_module_level=True),
-              pytest.mark.usefixtures("in_temporary_directory")]
+pytestmark = [pytest.mark.usefixtures("in_temporary_directory")]
 
 
 def pauli_spin_operators():

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -75,7 +75,7 @@ def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
     brme = qutip.brmesolve([[H, '1']], psi0, times,
                            brme_a_ops, e_ops, brme_c_ops).expect
     for me_expectation, brme_expectation in zip(me, brme):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
 
 def _harmonic_oscillator_spectrum_frequency(n_th, w0, kappa):
@@ -117,12 +117,12 @@ def test_harmonic_oscillator(n_th):
     me = qutip.mesolve(H, psi0, times, c_ops, e_ops)
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
     num = qutip.num(N)
     me_num = qutip.expect(num, me.states)
     brme_num = qutip.expect(num, brme.states)
-    assert np.allclose(me_num, brme_num, atol=1e-2)
+    np.testing.assert_allclose(me_num, brme_num, atol=1e-2)
 
 
 @pytest.mark.slow
@@ -146,7 +146,7 @@ def test_jaynes_cummings_zero_temperature():
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
         # Accept 5% error.
-        assert np.allclose(me_expectation, brme_expectation, atol=5e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=5e-2)
 
 
 def _mixed_string(kappa, _):
@@ -208,7 +208,7 @@ def test_nonhermitian_e_ops():
     times = np.linspace(0, 10, 10)
     me = qutip.mesolve(H, psi0, times, c_ops=[], e_ops=[a]).expect[0]
     brme = qutip.brmesolve(H_brme, psi0, times, a_ops=[], e_ops=[a]).expect[0]
-    assert np.allclose(me, brme, atol=1e-4)
+    np.testing.assert_allclose(me, brme, atol=1e-4)
 
 
 @pytest.mark.slow
@@ -288,7 +288,7 @@ def test_split_operators_maintain_answer(collapse_operators):
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops, brme_c_ops)
 
     for me_expect, brme_expect in zip(me.expect, brme.expect):
-        assert np.allclose(me_expect, brme_expect, atol=1e-2)
+        np.testing.assert_allclose(me_expect, brme_expect, atol=1e-2)
 
 
 @pytest.mark.slow

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -34,10 +34,10 @@ import pytest
 import numpy as np
 import qutip
 
-pytest.importorskip('Cython', minversion="0.14",
-                    reason="Suitable Cython not found.")
-
-pytestmark = [pytest.mark.usefixtures("in_temporary_directory")]
+pytestmark = [
+    pytest.mark.requires_cython,
+    pytest.mark.usefixtures("in_temporary_directory"),
+]
 
 # A lot of this module is direct duplication of test_brmesolve.py, but using
 # string time dependence rather than functional.

--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -52,8 +52,8 @@ def test_zheevr():
         our_evals = np.zeros(dimension, dtype=np.float64)
         our_evecs = _test_zheevr(H.full('F'), our_evals)
         scipy_evals, scipy_evecs = scipy.linalg.eigh(H.full())
-        assert np.allclose(scipy_evals, our_evals)
-        assert np.allclose(scipy_evecs, our_evecs)
+        np.testing.assert_allclose(scipy_evals, our_evals, atol=1e-12)
+        np.testing.assert_allclose(scipy_evecs, our_evecs, atol=1e-12)
 
 
 @pytest.mark.parametrize("operator", [
@@ -72,7 +72,7 @@ def test_dense_operator_to_eigbasis(operator):
         basis_zheevr = _test_zheevr(H.full('F'), _eigenvalues)
         calculated = _test_dense_to_eigbasis(operator.full('F'), basis_zheevr,
                                              dimension, qutip.settings.atol)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_vec_to_eigbasis():
@@ -85,7 +85,7 @@ def test_vec_to_eigbasis():
         target = qutip.mat2vec(R.transform(basis).full()).ravel()
         flat_vector = qutip.mat2vec(R.full()).ravel()
         calculated = _test_vec_to_eigbasis(H.full('F'), flat_vector)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_eigvec_to_fockbasis():
@@ -101,7 +101,7 @@ def test_eigvec_to_fockbasis():
         flat_eigenvectors = qutip.mat2vec(R.transform(basis).full()).ravel()
         calculated = _test_eigvec_to_fockbasis(flat_eigenvectors, evecs_zheevr,
                                                dimension)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_vector_roundtrip():
@@ -110,7 +110,8 @@ def test_vector_roundtrip():
     for _ in range(50):
         H = qutip.rand_herm(dimension, 0.5).full('F')
         vector = qutip.mat2vec(qutip.rand_dm(dimension, 0.5).full()).ravel()
-        assert np.allclose(vector, _test_vector_roundtrip(H, vector))
+        np.testing.assert_allclose(vector, _test_vector_roundtrip(H, vector),
+                                   atol=1e-12)
 
 
 def test_diag_liou_mult():
@@ -123,7 +124,7 @@ def test_diag_liou_mult():
         calculated = np.zeros_like(coefficients)
         target = L.data.dot(coefficients)
         _test_diag_liou_mult(evals, coefficients, calculated, dimension)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_cop_super_mult():
@@ -140,7 +141,7 @@ def test_cop_super_mult():
         _eigenvalues = np.empty((dimension,), dtype=np.float64)
         _cop_super_mult(a.full('F'), _test_zheevr(H.full('F'), _eigenvalues),
                         vec, 1, calculated, dimension, qutip.settings.atol)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 @pytest.mark.parametrize("secular",
@@ -165,4 +166,4 @@ def test_br_term_mult(secular):
         calculated = np.zeros_like(target)
         _test_br_term_mult(time, operator.full('F'), evecs, evals, vec,
                            calculated, secular, 0.1, atol)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=atol)

--- a/qutip/tests/test_control_pulseoptim.py
+++ b/qutip/tests/test_control_pulseoptim.py
@@ -43,987 +43,405 @@
 Tests for main control.pulseoptim methods
 Some associated objects also tested.
 """
-from __future__ import division
 
+import pytest
+import collections
 import os
-import uuid
-import shutil
+import pathlib
+import tempfile
 import numpy as np
-from numpy.testing import (
-    assert_, assert_almost_equal, run_module_suite, assert_equal)
-from scipy.optimize import check_grad
+import scipy.optimize
 
-from qutip import Qobj, identity, sigmax, sigmay, sigmaz, tensor
-from qutip.qip.operations.gates import hadamard_transform
+import qutip
+from qutip.control import pulseoptim as cpo
 from qutip.qip.algorithms import qft
-import qutip.control.optimconfig as optimconfig
-import qutip.control.dynamics as dynamics
-import qutip.control.termcond as termcond
-import qutip.control.optimizer as optimizer
-import qutip.control.stats as stats
-import qutip.control.pulsegen as pulsegen
-import qutip.control.errors as errors
-import qutip.control.loadparams as loadparams
-import qutip.control.pulseoptim as cpo
-import qutip.control.symplectic as sympl
+from qutip.qip.operations.gates import hadamard_transform
+import qutip.control.loadparams
 
-class TestPulseOptim:
-    """
-    A test class for the QuTiP functions for generating quantum gates
-    """
+_sx = qutip.sigmax()
+_sy = qutip.sigmay()
+_sz = qutip.sigmaz()
+_sp = qutip.sigmap()
+_sm = qutip.sigmam()
+_si = qutip.identity(2)
+_project_0 = qutip.basis(2, 0).proj()
+_hadamard = hadamard_transform(1)
 
-    def setUp(self):
-        # list of file paths to be removed after test
-        self.tmp_files = []
-        # list of folder paths to be removed after test
-        self.tmp_dirs = []
+_System = collections.namedtuple('_System',
+                                 ['system', 'controls', 'initial', 'target',
+                                  'kwargs'])
 
-    def tearDown(self):
-        for f in self.tmp_files:
-            try:
-                os.remove(f)
-            except:
-                pass
+_hadamard_kwargs = {'num_tslots': 10, 'evo_time': 10, 'gen_stats': True,
+                    'init_pulse_type': 'LIN', 'fid_err_targ': 1e-10,
+                    'dyn_type': 'UNIT'}
+hadamard = _System(system=_sz,
+                   controls=[_sx],
+                   initial=_si,
+                   target=_hadamard,
+                   kwargs=_hadamard_kwargs)
 
-        for d in self.tmp_dirs:
-            shutil.rmtree(d, ignore_errors=True)
+_qft_system = 0.5 * sum(qutip.tensor(op, op) for op in (_sx, _sy, _sz))
+_qft_controls = [0.5*qutip.tensor(_sx, _si), 0.5*qutip.tensor(_sy, _si),
+                 0.5*qutip.tensor(_si, _sx), 0.5*qutip.tensor(_si, _sy)]
+_qft_kwargs = {'num_tslots': 10, 'evo_time': 10, 'gen_stats': True,
+               'init_pulse_type': 'LIN', 'fid_err_targ': 1e-9,
+               'dyn_type': 'UNIT'}
+qft = _System(system=_qft_system,
+              controls=_qft_controls,
+              initial=qutip.identity([2, 2]),
+              target=qft.qft(2),
+              kwargs=_qft_kwargs)
+
+# Arbitrary coupling constants.
+_ising_system = (0.9*qutip.tensor(_sx, _si) + 0.7*qutip.tensor(_si, _sx)
+                 + 0.8*qutip.tensor(_sz, _si) + 0.9*qutip.tensor(_si, _sz))
+_ising_kwargs = {'num_tslots': 10, 'evo_time': 18, 'init_pulse_type': 'LIN',
+                 'fid_err_targ': 1e-10, 'dyn_type': 'UNIT'}
+ising = _System(system=_ising_system,
+                controls=[qutip.tensor(_sz, _sz)],
+                initial=qutip.basis([2, 2], [0, 0]),
+                target=qutip.basis([2, 2], [1, 1]),
+                kwargs=_ising_kwargs)
+
+_l_adc_system = 0.1 * (2*qutip.tensor(_sm, _sp.dag())
+                       - qutip.tensor(_project_0, _si)
+                       - qutip.tensor(_si, _project_0.dag()))
+_l_adc_controls = [1j * (qutip.tensor(_si, _sz) - qutip.tensor(_sz, _si)),
+                   1j * (qutip.tensor(_si, _sx) - qutip.tensor(_sx, _si))]
+_l_adc_kwargs = {'num_tslots': 10, 'evo_time': 5, 'init_pulse_type': 'LIN',
+                 'max_iter': 200, 'fid_err_targ': 1e-1, 'gen_stats': True}
+l_adc = _System(system=_l_adc_system,
+                controls=_l_adc_controls,
+                initial=qutip.identity([2, 2]),
+                target=hadamard_transform(2),
+                kwargs=_l_adc_kwargs)
+
+_g1, _g2 = 1.0, 0.2
+_A_rotate = qutip.qdiags([[1, 1, 0, 0]], [0])
+_A_squeeze = 0.4 * qutip.qdiags([[1, -1, 0, 0]], [0])
+_A_target = qutip.qdiags([[1, 1], [1, 1]], [2, -2])
+_Omega = qutip.Qobj(qutip.control.symplectic.calc_omega(2))
+_sympl_system = qutip.qdiags([[1, 1, 1, 1], [_g1, _g2], [_g1, _g2]],
+                             [0, 2, -2])
+_sympl_target = (-0.5 * _A_target * _Omega * np.pi).expm()
+_sympl_kwargs = {'num_tslots': 20, 'evo_time': 10, 'fid_err_targ': 1e-3,
+                 'max_iter': 200, 'dyn_type': 'SYMPL',
+                 'init_pulse_type': 'ZERO', 'gen_stats': True}
+symplectic = _System(system=_sympl_system,
+                     controls=[_A_rotate, _A_squeeze],
+                     initial=qutip.identity(4),
+                     target=_sympl_target,
+                     kwargs=_sympl_kwargs)
 
 
-    def test_01_1_unitary_hadamard(self):
-        """
-        control.pulseoptim: Hadamard gate with linear initial pulses
-        assert that goal is achieved and fidelity error is below threshold
-        """
-        # Hadamard
-        H_d = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
+@pytest.fixture(params=[
+    pytest.param(None, id="default propagation"),
+    pytest.param({'oper_dtype': qutip.Qobj}, id="Qobj propagation"),
+])
+def propagation(request):
+    return {'dyn_params': request.param}
 
-        n_ts = 10
-        evo_time = 10
 
-        # Run the optimisation
-        result = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_(result.goal_achieved, msg="Hadamard goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result.termination_reason, result.fid_err))
-        assert_almost_equal(result.fid_err, 0.0, decimal=10,
-                            err_msg="Hadamard infidelity too high")
+@pytest.fixture(params=[
+    pytest.param(hadamard, id="Hadamard gate"),
+    pytest.param(qft, id="QFT"),
+    pytest.param(ising, id="Ising state-to-state"),
+    pytest.param(l_adc, id="Lindbladian amplitude damping channel"),
+    pytest.param(symplectic, id="Symplectic coupled oscillators"),
+])
+def system(request):
+    return request.param
 
-    def test_01_2_unitary_hadamard_no_stats(self):
-        """
-        control.pulseoptim: Hadamard gate with linear initial pulses (no stats)
-        assert that goal is achieved
-        """
-        # Hadamard
-        H_d = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
 
-        n_ts = 10
-        evo_time = 10
+def _optimize_pulse(system):
+    result = cpo.optimize_pulse(system.system, system.controls,
+                                system.initial, system.target,
+                                **system.kwargs)
+    error = " ".join(["Infidelity: {:7.4e}".format(result.fid_err),
+                      "reason:", result.termination_reason])
+    assert result.goal_achieved, error
+    return result
 
-        # Run the optimisation
-        #Try without stats
-        result = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=False)
-        assert_(result.goal_achieved, msg="Hadamard goal not achieved "
-                                            "(no stats). "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result.termination_reason, result.fid_err))
 
-    def test_01_3_unitary_hadamard_tau(self):
-        """
-        control.pulseoptim: Hadamard gate with linear initial pulses (tau)
-        assert that goal is achieved
-        """
-        # Hadamard
-        H_d = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
+def _merge_kwargs(system, kwargs):
+    out = system.kwargs.copy()
+    out.update(kwargs)
+    return system._replace(kwargs=out)
 
-        # Run the optimisation
-        #Try setting timeslots with tau array
-        tau = np.arange(1.0, 10.0, 1.0)
-        result = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        tau=tau,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=False)
-        assert_(result.goal_achieved, msg="Hadamard goal not achieved "
-                                            "(tau as timeslots). "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result.termination_reason, result.fid_err))
 
-    def test_01_4_unitary_hadamard_qobj(self):
-        """
-        control.pulseoptim: Hadamard gate with linear initial pulses (Qobj)
-        assert that goal is achieved
-        """
-        # Hadamard
-        H_d = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
+class TestOptimization:
+    def test_basic_optimization(self, system, propagation):
+        system = _merge_kwargs(system, propagation)
+        result = _optimize_pulse(system)
+        assert result.fid_err < system.kwargs['fid_err_targ']
 
-        n_ts = 10
-        evo_time = 10
+    def test_object_oriented_approach_and_gradient(self, system, propagation):
+        system = _merge_kwargs(system, propagation)
+        base = _optimize_pulse(system)
+        optimizer = cpo.create_pulse_optimizer(system.system, system.controls,
+                                               system.initial, system.target,
+                                               **system.kwargs)
+        init_amps = np.array([optimizer.pulse_generator.gen_pulse()
+                              for _ in system.controls]).T
+        optimizer.dynamics.initialize_controls(init_amps)
+        # Check the gradient numerically.
+        func = optimizer.fid_err_func_wrapper
+        grad = optimizer.fid_err_grad_wrapper
+        loc = optimizer.dynamics.ctrl_amps.flatten()
+        assert abs(scipy.optimize.check_grad(func, grad, loc)) < 1e-5,\
+            "Gradient outside tolerance."
+        result = optimizer.run_optimization()
+        tol = system.kwargs['fid_err_targ']
+        assert abs(result.fid_err-base.fid_err) < tol,\
+            "Direct and indirect methods produce different results."
 
-        # Run the optimisation
-        #Try with Qobj propagation
-        result = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        dyn_params={'oper_dtype':Qobj},
-                        gen_stats=True)
-        assert_(result.goal_achieved, msg="Hadamard goal not achieved "
-                                            "(Qobj propagation). "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result.termination_reason, result.fid_err))
+    @pytest.mark.parametrize("kwargs", [
+        pytest.param({'gen_stats': False}, id="no stats"),
+        pytest.param({'num_tslots': None, 'evo_time': None,
+                      'tau': np.arange(1, 10, 1, dtype=np.float64)},
+                     id="tau array")
+    ])
+    def test_modified_optimization(self, propagation, kwargs):
+        system = _merge_kwargs(hadamard, kwargs)
+        self.test_basic_optimization(system, propagation)
 
-    def test_01_5_unitary_hadamard_oo(self):
-        """
-        control.pulseoptim: Hadamard gate with linear initial pulses (OO)
-        assert that goal is achieved and pulseoptim method achieves
-        same result as OO method
-        """
-        # Hadamard
-        H_d = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
+    def test_optimizer_bounds(self):
+        bound = 1.0
+        kwargs = {'amp_lbound': -bound, 'amp_ubound': bound}
+        system = _merge_kwargs(qft, kwargs)
+        result = _optimize_pulse(system)
+        assert np.all(result.final_amps >= -bound)
+        assert np.all(result.final_amps <= bound)
 
-        n_ts = 10
-        evo_time = 10
-
-        # Run the optimisation
-        optim = cpo.create_pulse_optimizer(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        dyn_type='UNIT',
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        dyn = optim.dynamics
-
-        init_amps = optim.pulse_generator.gen_pulse().reshape([-1, 1])
-        dyn.initialize_controls(init_amps)
-
-        result_oo = optim.run_optimization()
-
-        # Run the pulseoptim func
-        result_po = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-
-        assert_almost_equal(result_oo.fid_err, result_po.fid_err, decimal=10,
-                            err_msg="OO and pulseoptim methods produce "
-                                    "different results for Hadamard")
-
-    def test_01_6_unitary_hadamard_grad(self):
-        """
-        control.pulseoptim: Hadamard gate gradient check
-        assert that gradient approx and exact gradient match in tolerance
-        """
-        # Hadamard
-        H_d = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
-
-        n_ts = 10
-        evo_time = 10
-
-        # Create the optim objects
-        optim = cpo.create_pulse_optimizer(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        dyn_type='UNIT',
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        dyn = optim.dynamics
-
-        init_amps = optim.pulse_generator.gen_pulse().reshape([-1, 1])
-        dyn.initialize_controls(init_amps)
-
-        # Check the exact gradient
-        func = optim.fid_err_func_wrapper
-        grad = optim.fid_err_grad_wrapper
-        x0 = dyn.ctrl_amps.flatten()
-        grad_diff = check_grad(func, grad, x0)
-        assert_almost_equal(grad_diff, 0.0, decimal=6,
-                            err_msg="Unitary gradient outside tolerance")
-
-    def test_02_1_qft(self):
-        """
-        control.pulseoptim: QFT gate with linear initial pulses
-        assert that goal is achieved and fidelity error is below threshold
-        """
-        Sx = sigmax()
-        Sy = sigmay()
-        Sz = sigmaz()
-        Si = 0.5*identity(2)
-
-        H_d = 0.5*(tensor(Sx, Sx) + tensor(Sy, Sy) + tensor(Sz, Sz))
-        H_c = [tensor(Sx, Si), tensor(Sy, Si), tensor(Si, Sx), tensor(Si, Sy)]
-        U_0 = identity(4)
-        # Target for the gate evolution - Quantum Fourier Transform gate
-        U_targ = qft.qft(2)
-
-        n_ts = 10
-        evo_time = 10
-
-        result = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-9,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-
-        assert_(result.goal_achieved, msg="QFT goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result.termination_reason, result.fid_err))
-        assert_almost_equal(result.fid_err, 0.0, decimal=7,
-                            err_msg="QFT infidelity too high")
-
-        # check bounds
-        result2 = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-9,
-                        amp_lbound=-1.0, amp_ubound=1.0,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_((result2.final_amps >= -1.0).all() and
-                    (result2.final_amps <= 1.0).all(),
-                    msg="Amplitude bounds exceeded for QFT")
-
-    def test_02_2_qft_bounds(self):
-        """
-        control.pulseoptim: QFT gate with linear initial pulses (bounds)
-        assert that amplitudes remain in bounds
-        """
-        Sx = sigmax()
-        Sy = sigmay()
-        Sz = sigmaz()
-        Si = 0.5*identity(2)
-
-        H_d = 0.5*(tensor(Sx, Sx) + tensor(Sy, Sy) + tensor(Sz, Sz))
-        H_c = [tensor(Sx, Si), tensor(Sy, Si), tensor(Si, Sx), tensor(Si, Sy)]
-        U_0 = identity(4)
-        # Target for the gate evolution - Quantum Fourier Transform gate
-        U_targ = qft.qft(2)
-
-        n_ts = 10
-        evo_time = 10
-
-        result = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-9,
-                        amp_lbound=-1.0, amp_ubound=1.0,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_((result.final_amps >= -1.0).all() and
-                    (result.final_amps <= 1.0).all(),
-                    msg="Amplitude bounds exceeded for QFT")
-
-    def test_03_dumping(self):
-        """
-        control: data dumping
-        Dump out processing data, check file counts
-        """
-        self.setUp()
-        N_EXP_OPTIMDUMP_FILES = 10
-        N_EXP_DYNDUMP_FILES = 49
-
-        # Hadamard
-        H_d = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
-
-        n_ts = 1000
-        evo_time = 4
-
-        dump_folder = str(uuid.uuid4())
-        qtrl_dump_dir = os.path.expanduser(os.path.join('~', dump_folder))
-        self.tmp_dirs.append(qtrl_dump_dir)
-        optim_dump_dir = os.path.join(qtrl_dump_dir, 'optim')
-        dyn_dump_dir = os.path.join(qtrl_dump_dir, 'dyn')
-        result = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-9,
-                        init_pulse_type='LIN',
-                        optim_params={'dumping':'FULL', 'dump_to_file':True,
-                                    'dump_dir':optim_dump_dir},
-                        dyn_params={'dumping':'FULL', 'dump_to_file':True,
-                                    'dump_dir':dyn_dump_dir},
-                        gen_stats=True)
-
-        # check dumps were generated
-        optim = result.optimizer
-        dyn = optim.dynamics
-        assert_(optim.dump is not None, msg='optimizer dump not created')
-        assert_(dyn.dump is not None, msg='dynamics dump not created')
-
-        # Count files that were output
-        nfiles = len(os.listdir(optim.dump.dump_dir))
-        assert_(nfiles == N_EXP_OPTIMDUMP_FILES,
-                msg="{} optimizer dump files generated, {} expected".format(
-                    nfiles, N_EXP_OPTIMDUMP_FILES))
-
-        nfiles = len(os.listdir(dyn.dump.dump_dir))
-        assert_(nfiles == N_EXP_DYNDUMP_FILES,
-                msg="{} dynamics dump files generated, {} expected".format(
-                    nfiles, N_EXP_DYNDUMP_FILES))
-
-        # dump all to specific file stream
-        fpath = os.path.expanduser(os.path.join('~', str(uuid.uuid4())))
-        self.tmp_files.append(fpath)
-        with open(fpath, 'wb') as f:
-            optim.dump.writeout(f)
-
-        assert_(os.stat(fpath).st_size > 0,
-                msg="Nothing written to optimizer dump file")
-
-        fpath = os.path.expanduser(os.path.join('~', str(uuid.uuid4())))
-        self.tmp_files.append(fpath)
-        with open(fpath, 'wb') as f:
-            dyn.dump.writeout(f)
-        assert_(os.stat(fpath).st_size > 0,
-                msg="Nothing written to dynamics dump file")
-        self.tearDown()
-
-    def test_04_unitarity(self):
-        """
-        control: unitarity checking (via dump)
-        Dump out processing data and use to check unitary evolution
-        """
-
-        # Hadamard
-        H_d = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
-
-        n_ts = 1000
-        evo_time = 4
-
-        result = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-9,
-                        init_pulse_type='LIN',
-                        dyn_params={'dumping':'FULL'},
-                        gen_stats=True)
-
-        # check dumps were generated
-        optim = result.optimizer
-        dyn = optim.dynamics
-        assert_(dyn.dump is not None, msg='dynamics dump not created')
-
+    def test_unitarity_via_dump(self):
+        kwargs = {'num_tslots': 1000, 'evo_time': 4, 'fid_err_targ': 1e-9,
+                  'dyn_params': {'dumping': 'FULL'}}
+        system = _merge_kwargs(hadamard, kwargs)
+        result = _optimize_pulse(system)
+        dynamics = result.optimizer.dynamics
+        assert dynamics.dump is not None, "Dynamics dump not created"
         # Use the dump to check unitarity of all propagators and evo_ops
-        dyn.unitarity_tol = 1e-14
-        nu_prop = 0
-        nu_fwd_evo = 0
-        nu_onto_evo = 0
-        for d in dyn.dump.evo_dumps:
-            for k in range(dyn.num_tslots):
-                if not dyn._is_unitary(d.prop[k]): nu_prop += 1
-                if not dyn._is_unitary(d.fwd_evo[k]): nu_fwd_evo += 1
-                if not dyn._is_unitary(d.onto_evo[k]): nu_onto_evo += 1
-        assert_(nu_prop==0,
-                msg="{} propagators found to be non-unitary".format(nu_prop))
-        assert_(nu_fwd_evo==0,
-                msg="{} fwd evo ops found to be non-unitary".format(
-                                                                nu_fwd_evo))
-        assert_(nu_onto_evo==0,
-                msg="{} onto evo ops found to be non-unitary".format(
-                                                                nu_onto_evo))
+        dynamics.unitarity_tol = 1e-14
+        for item, description in [('prop', 'propagators'),
+                                  ('fwd_evo', 'forward evolution operators'),
+                                  ('onto_evo', 'onto evolution operators')]:
+            non_unitary = sum(not dynamics._is_unitary(x)
+                              for dump in dynamics.dump.evo_dumps
+                              for x in getattr(dump, item))
+            assert non_unitary == 0, "Found non-unitary " + description + "."
 
-    def test_05_1_state_to_state(self):
-        """
-        control.pulseoptim: state-to-state transfer
-        linear initial pulse used
-        assert that goal is achieved
-        """
-        # 2 qubits with Ising interaction
-        # some arbitary coupling constants
-        alpha = [0.9, 0.7]
-        beta  = [0.8, 0.9]
-        Sx = sigmax()
-        Sz = sigmaz()
-        H_d = (alpha[0]*tensor(Sx,identity(2)) +
-              alpha[1]*tensor(identity(2),Sx) +
-              beta[0]*tensor(Sz,identity(2)) +
-              beta[1]*tensor(identity(2),Sz))
-        H_c = [tensor(Sz,Sz)]
-
-        q1_0 = q2_0 = Qobj([[1], [0]])
-        q1_T = q2_T = Qobj([[0], [1]])
-
-        psi_0 = tensor(q1_0, q2_0)
-        psi_T = tensor(q1_T, q2_T)
-
-        n_ts = 10
-        evo_time = 18
-
-        # Run the optimisation
-        result = cpo.optimize_pulse_unitary(H_d, H_c, psi_0, psi_T,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_(result.goal_achieved, msg="State-to-state goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result.termination_reason, result.fid_err))
-        assert_almost_equal(result.fid_err, 0.0, decimal=10,
-                            err_msg="Hadamard infidelity too high")
-
-    def test_05_2_state_to_state_qobj(self):
-        """
-        control.pulseoptim: state-to-state transfer (Qobj)
-        linear initial pulse used
-        assert that goal is achieved
-        """
-        # 2 qubits with Ising interaction
-        # some arbitary coupling constants
-        alpha = [0.9, 0.7]
-        beta  = [0.8, 0.9]
-        Sx = sigmax()
-        Sz = sigmaz()
-        H_d = (alpha[0]*tensor(Sx,identity(2)) +
-              alpha[1]*tensor(identity(2),Sx) +
-              beta[0]*tensor(Sz,identity(2)) +
-              beta[1]*tensor(identity(2),Sz))
-        H_c = [tensor(Sz,Sz)]
-
-        q1_0 = q2_0 = Qobj([[1], [0]])
-        q1_T = q2_T = Qobj([[0], [1]])
-
-        psi_0 = tensor(q1_0, q2_0)
-        psi_T = tensor(q1_T, q2_T)
-
-        n_ts = 10
-        evo_time = 18
-
-        #Try with Qobj propagation
-        result = cpo.optimize_pulse_unitary(H_d, H_c, psi_0, psi_T,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        dyn_params={'oper_dtype':Qobj},
-                        gen_stats=True)
-        assert_(result.goal_achieved, msg="State-to-state goal not achieved "
-                    "(Qobj propagation)"
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result.termination_reason, result.fid_err))
-
-    def test_06_lindbladian(self):
-        """
-        control.pulseoptim: amplitude damping channel
-        Lindbladian dynamics
-        assert that fidelity error is below threshold
-        """
-
-        Sx = sigmax()
-        Sz = sigmaz()
-        Si = identity(2)
-
-        Sd = Qobj(np.array([[0, 1], [0, 0]]))
-        Sm = Qobj(np.array([[0, 0], [1, 0]]))
-        Sd_m = Qobj(np.array([[1, 0], [0, 0]]))
-
-        gamma = 0.1
-        L0_Ad = gamma*(2*tensor(Sm, Sd.trans()) -
-                    (tensor(Sd_m, Si) + tensor(Si, Sd_m.trans())))
-        LC_x = -1j*(tensor(Sx, Si) - tensor(Si, Sx))
-        LC_z = -1j*(tensor(Sz, Si) - tensor(Si, Sz))
-
-        drift = L0_Ad
-        ctrls = [LC_z, LC_x]
-        n_ctrls = len(ctrls)
-        initial = tensor(Si, Si)
-        had_gate = hadamard_transform(1)
-        target_DP = tensor(had_gate, had_gate)
-
-        n_ts = 10
-        evo_time = 5
-
-        result = cpo.optimize_pulse(drift, ctrls, initial, target_DP,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-3,
-                        max_iter=200,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_(result.fid_err < 0.1,
-                msg="Fidelity higher than expected")
-
-        # Repeat with Qobj propagation
-        result = cpo.optimize_pulse(drift, ctrls, initial, target_DP,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-3,
-                        max_iter=200,
-                        init_pulse_type='LIN',
-                        dyn_params={'oper_dtype':Qobj},
-                        gen_stats=True)
-        assert_(result.fid_err < 0.1,
-                msg="Fidelity higher than expected (Qobj propagation)")
-
-        # Check same result is achieved using the create objects method
-        optim = cpo.create_pulse_optimizer(drift, ctrls,
-                        initial, target_DP,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-3,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        dyn = optim.dynamics
-
-        p_gen = optim.pulse_generator
-        init_amps = np.zeros([n_ts, n_ctrls])
-        for j in range(n_ctrls):
-            init_amps[:, j] = p_gen.gen_pulse()
-        dyn.initialize_controls(init_amps)
-
-        # Check the exact gradient
-        func = optim.fid_err_func_wrapper
-        grad = optim.fid_err_grad_wrapper
-        x0 = dyn.ctrl_amps.flatten()
-        grad_diff = check_grad(func, grad, x0)
-        assert_almost_equal(grad_diff, 0.0, decimal=7,
-                            err_msg="Frechet gradient outside tolerance")
-
-        result2 = optim.run_optimization()
-        assert_almost_equal(result.fid_err, result2.fid_err, decimal=3,
-                            err_msg="Direct and indirect methods produce "
-                                    "different results for ADC")
-
-    def test_07_symplectic(self):
-        """
-        control.pulseoptim: coupled oscillators (symplectic dynamics)
-        assert that fidelity error is below threshold
-        """
-        g1 = 1.0
-        g2 = 0.2
-        A0 = Qobj(np.array([[1, 0, g1, 0],
-                           [0, 1, 0, g2],
-                           [g1, 0, 1, 0],
-                           [0, g2, 0, 1]]))
-        A_rot = Qobj(np.array([
-                            [1, 0, 0, 0],
-                            [0, 1, 0, 0],
-                            [0, 0, 0, 0],
-                            [0, 0, 0, 0]
-                            ]))
-
-        A_sqz = Qobj(0.4*np.array([
-                            [1, 0, 0, 0],
-                            [0, -1, 0, 0],
-                            [0, 0, 0, 0],
-                            [0, 0, 0, 0]
-                            ]))
-
-        A_c = [A_rot, A_sqz]
-        n_ctrls = len(A_c)
-        initial = identity(4)
-        A_targ = Qobj(np.array([
-                        [0, 0, 1, 0],
-                        [0, 0, 0, 1],
-                        [1, 0, 0, 0],
-                        [0, 1, 0, 0]
-                        ]))
-        Omg = Qobj(sympl.calc_omega(2))
-        S_targ = (-A_targ*Omg*np.pi/2.0).expm()
-
-        n_ts = 20
+    def test_crab(self, propagation):
+        tol = 1e-5
         evo_time = 10
-
-        result = cpo.optimize_pulse(A0, A_c, initial, S_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-3,
-                        max_iter=200,
-                        dyn_type='SYMPL',
-                        init_pulse_type='ZERO',
-                        gen_stats=True)
-        assert_(result.goal_achieved, msg="Symplectic goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result.termination_reason, result.fid_err))
-        assert_almost_equal(result.fid_err, 0.0, decimal=2,
-                            err_msg="Symplectic infidelity too high")
-
-        # Repeat with Qobj integration
-        resultq = cpo.optimize_pulse(A0, A_c, initial, S_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-3,
-                        max_iter=200,
-                        dyn_type='SYMPL',
-                        init_pulse_type='ZERO',
-                        dyn_params={'oper_dtype':Qobj},
-                        gen_stats=True)
-        assert_(resultq.goal_achieved, msg="Symplectic goal not achieved "
-                                        "(Qobj integration). "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    resultq.termination_reason, result.fid_err))
-
-        # Check same result is achieved using the create objects method
-        optim = cpo.create_pulse_optimizer(A0, list(A_c),
-                        initial, S_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-3,
-                        dyn_type='SYMPL',
-                        init_pulse_type='ZERO',
-                        gen_stats=True)
-        dyn = optim.dynamics
-
-        p_gen = optim.pulse_generator
-        init_amps = np.zeros([n_ts, n_ctrls])
-        for j in range(n_ctrls):
-            init_amps[:, j] = p_gen.gen_pulse()
-        dyn.initialize_controls(init_amps)
-
-        # Check the exact gradient
-        func = optim.fid_err_func_wrapper
-        grad = optim.fid_err_grad_wrapper
-        x0 = dyn.ctrl_amps.flatten()
-        grad_diff = check_grad(func, grad, x0)
-        assert_almost_equal(grad_diff, 0.0, decimal=5,
-                            err_msg="Frechet gradient outside tolerance "
-                                    "(SYMPL)")
-
-        result2 = optim.run_optimization()
-        assert_almost_equal(result.fid_err, result2.fid_err, decimal=6,
-                            err_msg="Direct and indirect methods produce "
-                                    "different results for Symplectic")
-
-    def test_08_crab(self):
-        """
-        control.pulseoptim: Hadamard gate using CRAB algorithm
-        Apply guess and ramping pulse
-        assert that goal is achieved and fidelity error is below threshold
-        assert that starting amplitude is zero
-        """
-        # Hadamard
-        H_d = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
-
-        n_ts = 12
-        evo_time = 10
-
-        # Run the optimisation
-        result = cpo.opt_pulse_crab_unitary(H_d, H_c, U_0, U_targ,
-                n_ts, evo_time,
-                fid_err_targ=1e-5,
-                alg_params={'crab_pulse_params':{'randomize_coeffs':False,
-                                                 'randomize_freqs':False}},
-                init_coeff_scaling=0.5,
-                guess_pulse_type='GAUSSIAN',
-                guess_pulse_params={'variance':0.1*evo_time},
-                guess_pulse_scaling=1.0, guess_pulse_offset=1.0,
-                amp_lbound=None, amp_ubound=None,
-                ramping_pulse_type='GAUSSIAN_EDGE',
-                ramping_pulse_params={'decay_time':evo_time/100.0},
-                gen_stats=True)
-        assert_(result.goal_achieved, msg="Hadamard goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result.termination_reason, result.fid_err))
-        assert_almost_equal(result.fid_err, 0.0, decimal=3,
-                            err_msg="Hadamard infidelity too high")
-        assert_almost_equal(result.final_amps[0, 0], 0.0, decimal=3,
-                            err_msg="lead in amplitude not zero")
-        # Repeat with Qobj integration
-        result = cpo.opt_pulse_crab_unitary(H_d, H_c, U_0, U_targ,
-                n_ts, evo_time,
-                fid_err_targ=1e-5,
-                alg_params={'crab_pulse_params':{'randomize_coeffs':False,
-                                                 'randomize_freqs':False}},
-                dyn_params={'oper_dtype':Qobj},
-                init_coeff_scaling=0.5,
-                guess_pulse_type='GAUSSIAN',
-                guess_pulse_params={'variance':0.1*evo_time},
-                guess_pulse_scaling=1.0, guess_pulse_offset=1.0,
-                amp_lbound=None, amp_ubound=None,
-                ramping_pulse_type='GAUSSIAN_EDGE',
-                ramping_pulse_params={'decay_time':evo_time/100.0},
-                gen_stats=True)
-        assert_(result.goal_achieved, msg="Hadamard goal not achieved"
-                                        "(Qobj integration). "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result.termination_reason, result.fid_err))
-
-    def test_09_load_params(self):
-        """
-        control.pulseoptim: Hadamard gate (loading config from file)
-        compare with result produced by pulseoptim method
-        """
-        H_d = sigmaz()
-        H_c = sigmax()
-
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
-
-        cfg = optimconfig.OptimConfig()
-        cfg.param_fname = "Hadamard_params.ini"
-        cfg.param_fpath = os.path.join(os.path.dirname(__file__),
-                                           cfg.param_fname)
-        cfg.pulse_type = "ZERO"
-        loadparams.load_parameters(cfg.param_fpath, config=cfg)
-
-        dyn = dynamics.DynamicsUnitary(cfg)
-        dyn.target = U_targ
-        dyn.initial = U_0
-        dyn.drift_dyn_gen = H_d
-        dyn.ctrl_dyn_gen = [H_c]
-        loadparams.load_parameters(cfg.param_fpath, dynamics=dyn)
-        dyn.init_timeslots()
-        n_ts = dyn.num_tslots
-        n_ctrls = dyn.num_ctrls
-
-        pgen = pulsegen.create_pulse_gen(pulse_type=cfg.pulse_type, dyn=dyn)
-        loadparams.load_parameters(cfg.param_fpath, pulsegen=pgen)
-
-        tc = termcond.TerminationConditions()
-        loadparams.load_parameters(cfg.param_fpath, term_conds=tc)
-
-        if cfg.optim_method == 'BFGS':
-            optim = optimizer.OptimizerBFGS(cfg, dyn)
-        elif cfg.optim_method == 'FMIN_L_BFGS_B':
-            optim = optimizer.OptimizerLBFGSB(cfg, dyn)
-        elif cfg.optim_method is None:
-            raise errors.UsageError("Optimisation algorithm must be specified "
-                                    "via 'optim_method' parameter")
-        else:
-            optim = optimizer.Optimizer(cfg, dyn)
-            optim.method = cfg.optim_method
-        loadparams.load_parameters(cfg.param_fpath, optim=optim)
-
-        sts = stats.Stats()
-        dyn.stats = sts
-        optim.stats = sts
-        optim.config = cfg
-        optim.dynamics = dyn
-        optim.pulse_generator = pgen
-        optim.termination_conditions = tc
-
-        init_amps = np.zeros([n_ts, n_ctrls])
-        for j in range(n_ctrls):
-            init_amps[:, j] = pgen.gen_pulse()
-        dyn.initialize_controls(init_amps)
-        result = optim.run_optimization()
-
-        result2 = cpo.optimize_pulse_unitary(H_d, list([H_c]), U_0, U_targ,
-                        6, 6, fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        amp_lbound=-1.0, amp_ubound=1.0,
-                        gen_stats=True)
-
-        assert_almost_equal(result.final_amps, result2.final_amps, decimal=5,
-                            err_msg="Pulses do not match")
+        result = cpo.opt_pulse_crab_unitary(
+            hadamard.system, hadamard.controls,
+            hadamard.initial, hadamard.target,
+            num_tslots=12, evo_time=evo_time, fid_err_targ=tol,
+            **propagation,
+            alg_params={'crab_pulse_params': {'randomize_coeffs': False,
+                                              'randomize_freqs': False}},
+            init_coeff_scaling=0.5,
+            guess_pulse_type='GAUSSIAN',
+            guess_pulse_params={'variance': evo_time * 0.1},
+            guess_pulse_scaling=1.0,
+            guess_pulse_offset=1.0,
+            amp_lbound=None,
+            amp_ubound=None,
+            ramping_pulse_type='GAUSSIAN_EDGE',
+            ramping_pulse_params={'decay_time': evo_time * 0.01},
+            gen_stats=True)
+        error = " ".join(["Infidelity: {:7.4e}".format(result.fid_err),
+                          "reason:", result.termination_reason])
+        assert result.goal_achieved, error
+        assert abs(result.fid_err) < tol
+        assert abs(result.final_amps[0, 0]) < tol, "Lead-in amplitude nonzero."
 
 
-    def test_10_init_pulse_params(self):
-        """
-        control.pulsegen: Check periodic control functions
-        """
+def _load_configuration(path):
+    configuration = qutip.control.optimconfig.OptimConfig()
+    configuration.param_fname = path.name
+    configuration.param_fpath = str(path)
+    configuration.pulse_type = "ZERO"
+    qutip.control.loadparams.load_parameters(str(path), config=configuration)
+    return configuration
 
-        def count_waves(n_ts, evo_time, ptype, freq=None, num_waves=None):
 
-            # Any dyn config will do
-            #Hadamard
-            H_d = sigmaz()
-            H_c = [sigmax()]
-            U_0 = identity(2)
-            U_targ = hadamard_transform(1)
+def _load_dynamics(path, system, configuration, stats):
+    dynamics = qutip.control.dynamics.DynamicsUnitary(configuration)
+    dynamics.drift_dyn_gen = system.system
+    dynamics.ctrl_dyn_gen = system.controls
+    dynamics.initial = system.initial
+    dynamics.target = system.target
+    qutip.control.loadparams.load_parameters(str(path), dynamics=dynamics)
+    dynamics.init_timeslots()
+    dynamics.stats = stats
+    return dynamics
 
-            pulse_params = {}
-            if freq is not None:
-                pulse_params['freq'] = freq
-            if num_waves is not None:
-                pulse_params['num_waves'] = num_waves
 
-            optim = cpo.create_pulse_optimizer(H_d, H_c, U_0, U_targ,
-                                        n_ts, evo_time,
-                                        dyn_type='UNIT',
-                                        init_pulse_type=ptype,
-                                        init_pulse_params=pulse_params,
-                                        gen_stats=False)
-            pgen = optim.pulse_generator
-            pulse = pgen.gen_pulse()
+def _load_pulse_generator(path, configuration, dynamics):
+    pulse_generator = qutip.control.pulsegen.create_pulse_gen(
+            pulse_type=configuration.pulse_type,
+            dyn=dynamics)
+    qutip.control.loadparams.load_parameters(str(path),
+                                             pulsegen=pulse_generator)
+    return pulse_generator
 
-            # count number of waves
-            zero_cross = pulse[0:-2]*pulse[1:-1] < 0
 
-            return (sum(zero_cross) + 1) / 2
+def _load_termination_conditions(path):
+    conditions = qutip.control.termcond.TerminationConditions()
+    qutip.control.loadparams.load_parameters(str(path), term_conds=conditions)
+    return conditions
 
-        n_ts = 1000
-        evo_time = 10
 
-        ptypes = ['SINE', 'SQUARE', 'TRIANGLE', 'SAW']
-        numws = [1, 5, 10, 100]
-        freqs = [0.1, 1, 10, 20]
+def _load_optimizer(path, configuration, dynamics, pulse_generator,
+                    termination_conditions, stats):
+    method = configuration.optim_method
+    if method is None:
+        raise qutip.control.errors.UsageError(
+            "Optimization algorithm must be specified using the 'optim_method'"
+            " parameter.")
+    known = {'BFGS': 'OptimizerBFGS', 'FMIN_L_BFGS_B': 'OptimizerLBFGSB'}
+    constructor = getattr(qutip.control.optimizer,
+                          known.get(method, 'Optimizer'))
+    optimizer = constructor(configuration, dynamics)
+    optimizer.method = method
+    qutip.control.loadparams.load_parameters(str(path), optim=optimizer)
+    optimizer.config = configuration
+    optimizer.dynamics = dynamics
+    optimizer.pulse_generator = pulse_generator
+    optimizer.termination_conditions = termination_conditions
+    optimizer.stats = stats
+    return optimizer
 
-        for ptype in ptypes:
-            for freq in freqs:
-                exp_num_waves = evo_time*freq
-                fnd_num_waves = count_waves(n_ts, evo_time, ptype, freq=freq)
-#                print("Found {} waves for pulse type '{}', "
-#                    "freq {}".format(fnd_num_waves, ptype, freq))
-                assert_equal(exp_num_waves, fnd_num_waves, err_msg=
-                    "Number of waves incorrect for pulse type '{}', "
-                    "freq {}".format(ptype, freq))
 
-            for num_waves in numws:
-                exp_num_waves = num_waves
-                fnd_num_waves = count_waves(n_ts, evo_time, ptype,
-                                            num_waves=num_waves)
-#                print("Found {} waves for pulse type '{}', "
-#                    "num_waves {}".format(fnd_num_waves, ptype, num_waves))
-                assert_equal(exp_num_waves, fnd_num_waves, err_msg=
-                    "Number of waves incorrect for pulse type '{}', "
-                    "num_waves {}".format(ptype, num_waves))
+class TestFileIO:
+    def test_load_parameters_from_file(self):
+        system = hadamard
+        path = pathlib.Path(__file__).parent / "Hadamard_params.ini"
+        stats = qutip.control.stats.Stats()
+        configuration = _load_configuration(path)
+        dynamics = _load_dynamics(path, system, configuration, stats)
+        pulse_generator = _load_pulse_generator(path, configuration, dynamics)
+        termination_conditions = _load_termination_conditions(path)
+        optimizer = _load_optimizer(path,
+                                    configuration,
+                                    dynamics,
+                                    pulse_generator,
+                                    termination_conditions,
+                                    stats)
+        init_amps = np.array([optimizer.pulse_generator.gen_pulse()
+                              for _ in system.controls]).T
+        optimizer.dynamics.initialize_controls(init_amps)
+        result = optimizer.run_optimization()
 
-    def test_11_time_dependent_drift(self):
-        """
-        control.pulseoptim: Hadamard gate with fixed and time varying drift
-        assert that goal is achieved for both and that different control
-        pulses are produced (only) when they should be
-        """
-        # Hadamard
-        H_0 = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
+        kwargs = {'num_tslots': 6, 'evo_time': 6, 'fid_err_targ': 1e-10,
+                  'init_pulse_type': 'LIN', 'dyn_type': 'UNIT',
+                  'amp_lbound': -1, 'amp_ubound': 1,
+                  'gen_stats': True}
+        target = _optimize_pulse(system._replace(kwargs=kwargs))
+        assert np.allclose(result.final_amps, target.final_amps, atol=1e-5)
 
-        n_ts = 20
-        evo_time = 10
+    def test_dumping_to_files(self, tmpdir):
+        N_OPTIMDUMP_FILES = 10
+        N_DYNDUMP_FILES = 49
+        dumping = {'dumping': 'FULL', 'dump_to_file': True}
+        kwargs = {'num_tslots': 1_000, 'evo_time': 4, 'fid_err_targ': 1e-9,
+                  'optim_params': {'dump_dir': str(tmpdir/'optim'), **dumping},
+                  'dyn_params': {'dump_dir': str(tmpdir / 'dyn'), **dumping}}
+        system = _merge_kwargs(hadamard, kwargs)
+        result = _optimize_pulse(system)
 
-        drift_amps_flat = np.ones([n_ts], dtype=float)
-        dript_amps_step = [np.round(float(k)/n_ts) for k in range(n_ts)]
+        # Check dumps were generated and have the right number of files.
+        assert result.optimizer.dump is not None
+        assert result.optimizer.dynamics.dump is not None
+        assert (len(os.listdir(result.optimizer.dump.dump_dir))
+                == N_OPTIMDUMP_FILES)
+        assert (len(os.listdir(result.optimizer.dynamics.dump.dump_dir))
+                == N_DYNDUMP_FILES)
 
-        # Run the optimisations
-        result_fixed = cpo.optimize_pulse_unitary(H_0, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_(result_fixed.goal_achieved,
-                    msg="Fixed drift goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result_fixed.termination_reason, result_fixed.fid_err))
+        # Dump all to specific file stream.
+        for dump, type_ in [(result.optimizer.dump, 'optimizer'),
+                            (result.optimizer.dynamics.dump, 'dynamics')]:
+            with tempfile.NamedTemporaryFile() as file:
+                dump.writeout(file)
+                assert os.stat(file.name).st_size > 0,\
+                    " ".join(["Empty", type_, "file."])
 
-        H_d = [drift_amps_flat[k]*H_0 for k in range(n_ts)]
-        result_flat = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_(result_flat.goal_achieved, msg="Flat drift goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result_flat.termination_reason, result_flat.fid_err))
 
-        # Check fixed and flat produced the same pulse
-        assert_almost_equal(result_fixed.final_amps, result_flat.final_amps,
-                            decimal=9,
-                            err_msg="Flat and fixed drift result in "
-                                    "different control pules")
+@pytest.fixture(params=[pytest.param(x, id=x.lower())
+                        for x in ['SINE', 'SQUARE', 'TRIANGLE', 'SAW']])
+def pulse_type(request):
+    return request.param
 
-        H_d = [dript_amps_step[k]*H_0 for k in range(n_ts)]
-        result_step = cpo.optimize_pulse_unitary(H_d, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_(result_step.goal_achieved, msg="Step drift goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result_step.termination_reason, result_step.fid_err))
 
-        # Check step and flat produced different results
-        assert_(np.any(
-            np.abs(result_flat.final_amps - result_step.final_amps) > 1e-3),
-                            msg="Flat and step drift result in "
-                                    "the same control pules")
+def _count_waves(system):
+    optimizer = cpo.create_pulse_optimizer(system.system, system.controls,
+                                           system.initial, system.target,
+                                           **system.kwargs)
+    pulse = optimizer.pulse_generator.gen_pulse()
+    zero_crossings = pulse[0:-2]*pulse[1:-1] < 0
+    return (sum(zero_crossings) + 1) // 2
 
-    def test_12_time_dependent_ctrls(self):
-        """
-        control.pulseoptim: Hadamard gate with fixed and time varying ctrls
-        assert that goal is achieved for both and that different control
-        pulses are produced (only) when they should be.
-        """
-        # Hadamard
-        H_0 = sigmaz()
-        H_c = [sigmax()]
-        U_0 = identity(2)
-        U_targ = hadamard_transform(1)
 
-        n_ts = 20
-        evo_time = 10
+class TestPeriodicControlFunction:
+    num_tslots = 1_000
+    evo_time = 10
 
-        # Run the optimisations
-        result_fixed = cpo.optimize_pulse_unitary(H_0, H_c, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_(result_fixed.goal_achieved,
-                    msg="Fixed ctrls goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result_fixed.termination_reason, result_fixed.fid_err))
+    @pytest.mark.parametrize('n_waves', [1, 5, 10, 100])
+    def test_number_of_waves(self, pulse_type, n_waves):
+        kwargs = {'num_tslots': self.num_tslots, 'evo_time': self.evo_time,
+                  'init_pulse_type': pulse_type,
+                  'init_pulse_params': {'num_waves': n_waves},
+                  'gen_stats': False}
+        system = _merge_kwargs(hadamard, kwargs)
+        assert _count_waves(system) == n_waves
 
-        H_c_t = []
-        for k in range(n_ts):
-            H_c_t.append([sigmax()])
-        result_tdcs = cpo.optimize_pulse_unitary(H_0, H_c_t, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_(result_tdcs.goal_achieved,
-                msg="td same ctrl goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result_tdcs.termination_reason, result_tdcs.fid_err))
+    @pytest.mark.parametrize('frequency', [0.1, 1, 10, 20])
+    def test_frequency(self, pulse_type, frequency):
+        kwargs = {'num_tslots': self.num_tslots, 'evo_time': self.evo_time,
+                  'init_pulse_type': pulse_type,
+                  'init_pulse_params': {'freq': frequency},
+                  'fid_err_targ': 1e-5,
+                  'gen_stats': False}
+        system = _merge_kwargs(hadamard, kwargs)
+        assert _count_waves(system) == self.evo_time*frequency
 
-        # Check fixed and same produced the same pulse
-        assert_almost_equal(result_fixed.final_amps, result_tdcs.final_amps,
-                            decimal=9,
-                            err_msg="same and fixed ctrls result in "
-                                    "different control pules")
 
-        H_c_t = []
-        for k in range(n_ts):
-            if k % 3 == 0:
-                H_c_t.append([sigmax()])
-            else:
-                H_c_t.append([identity(2)])
-        result_tdcv = cpo.optimize_pulse_unitary(H_0, H_c_t, U_0, U_targ,
-                        n_ts, evo_time,
-                        fid_err_targ=1e-10,
-                        init_pulse_type='LIN',
-                        gen_stats=True)
-        assert_(result_tdcv.goal_achieved,
-                msg="true td ctrls goal not achieved. "
-                    "Terminated due to: {}, with infidelity: {}".format(
-                    result_tdcv.termination_reason, result_tdcv.fid_err))
+class TestTimeDependence:
+    def test_drift(self):
+        num_tslots = 20
+        system = _merge_kwargs(hadamard, {'num_tslots': num_tslots,
+                                          'evo_time': 10})
+        result_fixed = _optimize_pulse(system)
+        system_flat = system._replace(system=[system.system]*num_tslots)
+        result_flat = _optimize_pulse(system_flat)
+        step = [0.0]*(num_tslots//2) + [1.0]*(num_tslots//2)
+        system_step = system._replace(system=[x*system.system for x in step])
+        result_step = _optimize_pulse(system_step)
+        assert np.allclose(result_fixed.final_amps, result_flat.final_amps,
+                           rtol=1e-9),\
+            "Flat and fixed drifts result in different control pulses."
+        assert np.any((result_flat.final_amps-result_step.final_amps) > 1e-3),\
+            "Flat and step drights result in the same control pulses."
 
-        # Check that identity control tslots don't vary
+    def test_controls_all_time_slots_equal_to_no_time_dependence(self):
+        num_tslots = 20
+        system = _merge_kwargs(hadamard, {'num_tslots': num_tslots,
+                                          'evo_time': 10,
+                                          'fid_err_targ': 1e-10})
+        result_single = _optimize_pulse(system)
+        system_vary = system._replace(controls=[[_sx]]*num_tslots)
+        result_vary = _optimize_pulse(system_vary)
+        assert np.allclose(result_single.final_amps, result_vary.final_amps,
+                           atol=1e-9)
 
-        for k in range(n_ts):
-            if k % 3 != 0:
-                assert_almost_equal(result_tdcv.initial_amps[k, 0],
-                                    result_tdcv.final_amps[k, 0],
-                                    decimal=9,
-                                    err_msg=("timeslot {} amps should remain "
-                                            "fixed").format(k))
-
-if __name__ == "__main__":
-    run_module_suite()
-
+    def test_controls_identity_operators_ignored(self):
+        num_tslots = 20
+        controls = [[_sx] if k % 3 else [_si] for k in range(num_tslots)]
+        system = _merge_kwargs(hadamard, {'num_tslots': num_tslots,
+                                          'evo_time': 10})
+        system = system._replace(controls=controls)
+        result = _optimize_pulse(system)
+        for k in range(0, num_tslots, 3):
+            assert np.allclose(result.initial_amps[k], result.final_amps[k],
+                               rtol=1e-9)

--- a/qutip/tests/test_control_pulseoptim.py
+++ b/qutip/tests/test_control_pulseoptim.py
@@ -376,7 +376,8 @@ class TestFileIO:
                   'amp_lbound': -1, 'amp_ubound': 1,
                   'gen_stats': True}
         target = _optimize_pulse(system._replace(kwargs=kwargs))
-        assert np.allclose(result.final_amps, target.final_amps, atol=1e-5)
+        np.testing.assert_allclose(result.final_amps, target.final_amps,
+                                   atol=1e-5)
 
     @pytest.mark.usefixtures("in_temporary_directory")
     def test_dumping_to_files(self):
@@ -461,9 +462,9 @@ class TestTimeDependence:
         step = [0.0]*(num_tslots//2) + [1.0]*(num_tslots//2)
         system_step = system._replace(system=[x*system.system for x in step])
         result_step = _optimize_pulse(system_step)
-        assert np.allclose(result_fixed.final_amps, result_flat.final_amps,
-                           rtol=1e-9),\
-            "Flat and fixed drifts result in different control pulses."
+        np.testing.assert_allclose(result_fixed.final_amps,
+                                   result_flat.final_amps,
+                                   rtol=1e-9)
         assert np.any((result_flat.final_amps-result_step.final_amps) > 1e-3),\
             "Flat and step drights result in the same control pulses."
 
@@ -479,8 +480,9 @@ class TestTimeDependence:
         result_single = _optimize_pulse(system)
         system_vary = system._replace(controls=[[_sx]]*num_tslots)
         result_vary = _optimize_pulse(system_vary)
-        assert np.allclose(result_single.final_amps, result_vary.final_amps,
-                           atol=1e-9)
+        np.testing.assert_allclose(result_single.final_amps,
+                                   result_vary.final_amps,
+                                   atol=1e-9)
 
     def test_controls_identity_operators_ignored(self):
         """
@@ -495,5 +497,6 @@ class TestTimeDependence:
         system = system._replace(controls=controls)
         result = _optimize_pulse(system)
         for k in range(0, num_tslots, 3):
-            assert np.allclose(result.initial_amps[k], result.final_amps[k],
-                               rtol=1e-9)
+            np.testing.assert_allclose(result.initial_amps[k],
+                                       result.final_amps[k],
+                                       rtol=1e-9)

--- a/qutip/tests/test_control_pulseoptim.py
+++ b/qutip/tests/test_control_pulseoptim.py
@@ -341,13 +341,14 @@ class TestFileIO:
         target = _optimize_pulse(system._replace(kwargs=kwargs))
         assert np.allclose(result.final_amps, target.final_amps, atol=1e-5)
 
-    def test_dumping_to_files(self, tmpdir):
+    @pytest.mark.usefixtures("in_temporary_directory")
+    def test_dumping_to_files(self):
         N_OPTIMDUMP_FILES = 10
         N_DYNDUMP_FILES = 49
         dumping = {'dumping': 'FULL', 'dump_to_file': True}
         kwargs = {'num_tslots': 1_000, 'evo_time': 4, 'fid_err_targ': 1e-9,
-                  'optim_params': {'dump_dir': str(tmpdir/'optim'), **dumping},
-                  'dyn_params': {'dump_dir': str(tmpdir / 'dyn'), **dumping}}
+                  'optim_params': {'dump_dir': 'optim', **dumping},
+                  'dyn_params': {'dump_dir': 'dyn', **dumping}}
         system = _merge_kwargs(hadamard, kwargs)
         result = _optimize_pulse(system)
 

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -36,6 +36,8 @@ import functools
 import numpy as np
 import qutip
 
+pytestmark = [pytest.mark.usefixtures("in_temporary_directory")]
+
 _equivalence_dimension = 20
 _equivalence_fock = qutip.fock(_equivalence_dimension, 1)
 _equivalence_coherent = qutip.coherent_dm(_equivalence_dimension, 2)

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -32,651 +32,205 @@
 ###############################################################################
 
 import pytest
+import functools
 import numpy as np
+import qutip
 
-from qutip import _version2int
-from numpy import trapz, linspace, pi
-from numpy.testing import run_module_suite, assert_
-import unittest
-import warnings
+_equivalence_dimension = 20
+_equivalence_fock = qutip.fock(_equivalence_dimension, 1)
+_equivalence_coherent = qutip.coherent_dm(_equivalence_dimension, 2)
 
-from qutip import (correlation, destroy, coherent_dm, correlation_2op_2t,
-                   fock, correlation_2op_1t, tensor, qeye, spectrum_ss,
-                   spectrum_pi, correlation_ss, spectrum_correlation_fft,
-                   spectrum, correlation_3op_2t, mesolve, Options,
-                   Cubic_Spline)
 
-# find Cython if it exists
-try:
-    import Cython
-except:
-    Cython_OK = False
-else:
-    Cython_OK = _version2int(Cython.__version__) >= _version2int('0.14')
-Cython_OK = True
-
-def test_compare_solvers_coherent_state_legacy():
-    """
-    correlation: legacy me and es for oscillator in coherent initial state
-    """
-    N = 20
-    a = destroy(N)
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.parametrize(["solver", "start", "legacy"], [
+    pytest.param("es", _equivalence_coherent, False, id="es"),
+    pytest.param("es", _equivalence_coherent, True, id="es-legacy"),
+    pytest.param("es", None, False, id="es-steady state"),
+    pytest.param("es", None, True, id="es-steady state-legacy"),
+    pytest.param("mc", _equivalence_fock, False, id="mc",
+                 marks=pytest.mark.slow),
+])
+def test_correlation_solver_equivalence(solver, start, legacy):
+    a = qutip.destroy(_equivalence_dimension)
     H = a.dag() * a
     G1 = 0.75
-    n_th = 2.00
-    c_ops = [np.sqrt(G1 * (1 + n_th)) * a, np.sqrt(G1 * n_th) * a.dag()]
-    rho0 = coherent_dm(N, np.sqrt(4.0))
-    taulist = np.linspace(0, 5.0, 100)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        corr1 = correlation(H, rho0, None, taulist, c_ops, a.dag(), a,
-                            solver="me")
-        corr2 = correlation(H, rho0, None, taulist, c_ops, a.dag(), a,
-                            solver="es")
-
-    assert_(max(abs(corr1 - corr2)) < 1e-4)
-
-
-def test_compare_solvers_coherent_state_mees():
-    """
-    correlation: comparing me and es for oscillator in coherent initial state
-    """
-    N = 20
-    a = destroy(N)
-    H = a.dag() * a
-    G1 = 0.75
-    n_th = 2.00
-    c_ops = [np.sqrt(G1 * (1 + n_th)) * a, np.sqrt(G1 * n_th) * a.dag()]
-    rho0 = coherent_dm(N, np.sqrt(4.0))
-
-    taulist = np.linspace(0, 5.0, 100)
-    corr1 = correlation_2op_2t(H, rho0, None, taulist, c_ops, a.dag(), a,
-                               solver="me")
-    corr2 = correlation_2op_2t(H, rho0, None, taulist, c_ops, a.dag(), a,
-                               solver="es")
-
-    assert_(max(abs(corr1 - corr2)) < 1e-4)
+    n_th = 2
+    c_ops = [np.sqrt(G1 * (n_th+1)) * a,
+             np.sqrt(G1 * n_th) * a.dag()]
+    times = np.linspace(0, 5, 101)
+    # Massively relax the tolerance for the Monte-Carlo approach to avoid a
+    # long simulation time.
+    tol = 0.25 if solver == "mc" else 1e-4
+    correlation = (qutip.correlation if legacy
+                   else qutip.correlation_2op_2t)
+    base = correlation(H, start, None, times, c_ops, a.dag(), a, solver="me")
+    cmp = correlation(H, start, None, times, c_ops, a.dag(), a, solver=solver)
+    assert np.allclose(base, cmp, atol=tol)
 
 
-@pytest.mark.slow
-def test_compare_solvers_coherent_state_memc():
-    """
-    correlation: comparing me and mc for driven oscillator in fock state
-    """
-    N = 2
-    a = destroy(N)
-    H = a.dag() * a + a + a.dag()
-    G1 = 0.75
-    n_th = 2.00
-    c_ops = [np.sqrt(G1 * (1 + n_th)) * a, np.sqrt(G1 * n_th) * a.dag()]
-    psi0 = fock(N, 1)
-
-    taulist = np.linspace(0, 1.0, 3)
-    corr1 = correlation_2op_2t(H, psi0, [0, 0.5], taulist, c_ops, a.dag(), a,
-                               solver="me")
-    corr2 = correlation_2op_2t(H, psi0, [0, 0.5], taulist, c_ops, a.dag(), a,
-                               solver="mc")
-
-    # pretty lax criterion, but would otherwise require a quite long simulation
-    # time
-    assert_(abs(corr1 - corr2).max() < 0.25)
+def _spectrum_wrapper(spectrum):
+    frequencies = 2*np.pi * np.linspace(0.5, 1.5, 101)
+    @functools.wraps(spectrum)
+    def out(H, c_ops, a, b):
+        return spectrum(H, frequencies, c_ops, a, b), frequencies
+    return out
 
 
-def test_compare_solvers_steadystate_legacy():
-    """
-    correlation: legacy me and es for oscillator in steady-state
-    """
-    N = 20
-    a = destroy(N)
-    H = a.dag() * a
-    G1 = 0.75
-    n_th = 2.00
-    c_ops = [np.sqrt(G1 * (1 + n_th)) * a, np.sqrt(G1 * n_th) * a.dag()]
-
-    taulist = np.linspace(0, 5.0, 100)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        corr1 = correlation(H, None, None, taulist, c_ops, a.dag(), a,
-                            solver="me")
-        corr2 = correlation(H, None, None, taulist, c_ops, a.dag(), a,
-                            solver="es")
-
-    assert_(max(abs(corr1 - corr2)) < 1e-4)
+def _spectrum_fft(H, c_ops, a, b):
+    times = np.linspace(0, 100, 2500)
+    correlation = qutip.correlation_ss(H, times, c_ops, a, b)
+    frequencies, spectrum = qutip.spectrum_correlation_fft(times, correlation)
+    return spectrum, frequencies
 
 
-def test_compare_solvers_steadystate():
-    """
-    correlation: comparing me and es for oscillator in steady-state
-    """
-    N = 20
-    a = destroy(N)
-    H = a.dag() * a
-    G1 = 0.75
-    n_th = 2.00
-    c_ops = [np.sqrt(G1 * (1 + n_th)) * a, np.sqrt(G1 * n_th) * a.dag()]
-
-    taulist = np.linspace(0, 5.0, 100)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        corr1 = correlation_2op_1t(H, None, taulist, c_ops, a.dag(), a,
-                                   solver="me")
-        corr2 = correlation_2op_1t(H, None, taulist, c_ops, a.dag(), a,
-                                   solver="es")
-
-    assert_(max(abs(corr1 - corr2)) < 1e-4)
-
-
-def test_spectrum_espi_legacy():
-    """
-    correlation: legacy spectrum from es and pi methods
-    """
-    # use JC model
-    N = 4
-    wc = wa = 1.0 * 2 * np.pi
-    g = 0.1 * 2 * np.pi
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.parametrize("spectrum", [
+    pytest.param(_spectrum_fft, id="fft"),
+    pytest.param(_spectrum_wrapper(qutip.spectrum_ss), id="es-legacy"),
+    pytest.param(_spectrum_wrapper(qutip.spectrum_pi), id="pi-legacy"),
+])
+def test_spectrum_solver_equivalence_to_es(spectrum):
+    # Jaynes--Cummings model.
+    dimension = 4
+    wc = wa = 1.0 * 2*np.pi
+    g = 0.1 * 2*np.pi
     kappa = 0.75
     gamma = 0.25
     n_th = 0.01
 
-    a = tensor(destroy(N), qeye(2))
-    sm = tensor(qeye(N), destroy(2))
-    H = wc * a.dag() * a + wa * sm.dag() * sm + \
-        g * (a.dag() * sm + a * sm.dag())
-    c_ops = [np.sqrt(kappa * (1 + n_th)) * a,
+    a = qutip.tensor(qutip.destroy(dimension), qutip.qeye(2))
+    sm = qutip.tensor(qutip.qeye(dimension), qutip.sigmam())
+    H = wc*a.dag()*a + wa*sm*sm.dag() + g*(a.dag()*sm.dag() + a*sm)
+    c_ops = [np.sqrt(kappa * (n_th+1)) * a,
              np.sqrt(kappa * n_th) * a.dag(),
-             np.sqrt(gamma) * sm]
+             np.sqrt(gamma) * sm.dag()]
 
-    wlist = 2 * np.pi * np.linspace(0.5, 1.5, 100)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        spec1 = spectrum_ss(H, wlist, c_ops, a.dag(), a)
-        spec2 = spectrum_pi(H, wlist, c_ops, a.dag(), a)
-
-    assert_(max(abs(spec1 - spec2)) < 1e-3)
+    test, frequencies = spectrum(H, c_ops, a.dag(), a)
+    base = qutip.spectrum(H, frequencies, c_ops, a.dag(), a, solver="es")
+    assert np.allclose(base, test, atol=1e-3)
 
 
-def test_spectrum_esfft():
+def _trapz_2d(z, xy):
+    dx = xy[1] - xy[0]
+    return dx*dx * np.trapz(np.trapz(z, axis=0))
+
+
+def _n_correlation(times, n_expectation):
+    interp = qutip.Cubic_Spline(times[0], times[-1], n_expectation)
+    n = interp(np.concatenate([times, times[1:] + times[-1]]))
+    return np.array([[n[t] * n[t+tau] for tau in range(times.shape[0])]
+                     for t in range(times.shape[0])])
+
+
+def _coefficient_function(t, args):
+    t_off, tp = args['t_off'], args['tp']
+    return np.exp(-(t-t_off)*(t-t_off) / (2*tp*tp))
+
+
+_coefficient_string = "exp(-(t-t_off)**2 / (2 * tp*tp))"
+
+
+def _h_qobj_function(t, args):
+    return args['H0'] * _coefficient_function(t, args)
+
+
+# 2LS and 3LS stand for two- and three-level system respectively.
+
+_2ls_args = {'H0': 2*qutip.sigmax(), 't_off': 1, 'tp': 0.5}
+_2ls_times = np.linspace(0, 5, 51)
+_3ls_args = {'t_off': 2, 'tp': 1}
+_3ls_times = np.linspace(0, 6, 20)
+
+
+def _2ls_g2_0(H, c_ops):
+    sp = qutip.sigmap()
+    start = qutip.basis(2, 0)
+    times = _2ls_times
+    correlation = qutip.correlation_3op_2t(H, start, times, times, [sp],
+                                           sp.dag(), sp.dag()*sp, sp,
+                                           args=_2ls_args)
+    n_expectation = qutip.mesolve(H, start, times, [sp] + c_ops,
+                                  e_ops=[qutip.num(2)],
+                                  args=_2ls_args).expect[0]
+    integral_correlation = _trapz_2d(np.real(correlation), times)
+    integral_n_expectation = np.trapz(n_expectation, times)
+    # Factor of two from negative time correlations.
+    return 2 * integral_correlation / integral_n_expectation**2
+
+
+@pytest.fixture(params=[
+    pytest.param(_coefficient_string, id="string"),
+    pytest.param(_coefficient_function(_2ls_times, _2ls_args), id="numpy"),
+    pytest.param(_coefficient_function, id="function"),
+])
+def dependence_2ls(request):
+    return request.param
+
+
+class TestTimeDependence:
     """
-    correlation: comparing spectrum from es and fft methods
+    Test correlations with time-dependent operators using a two-level system
+    (2LS) or a three-level system (3LS).
     """
-    # use JC model
-    N = 4
-    wc = wa = 1.0 * 2 * np.pi
-    g = 0.1 * 2 * np.pi
-    kappa = 0.75
-    gamma = 0.25
-    n_th = 0.01
-
-    a = tensor(destroy(N), qeye(2))
-    sm = tensor(qeye(N), destroy(2))
-    H = wc * a.dag() * a + wa * sm.dag() * sm + \
-        g * (a.dag() * sm + a * sm.dag())
-    c_ops = [np.sqrt(kappa * (1 + n_th)) * a,
-             np.sqrt(kappa * n_th) * a.dag(),
-             np.sqrt(gamma) * sm]
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        tlist = np.linspace(0, 100, 2500)
-        corr = correlation_ss(H, tlist, c_ops, a.dag(), a)
-        wlist1, spec1 = spectrum_correlation_fft(tlist, corr)
-        spec2 = spectrum_ss(H, wlist1, c_ops, a.dag(), a)
-
-    assert_(max(abs(spec1 - spec2)) < 1e-3)
-
-
-def test_spectrum_espi():
-    """
-    correlation: comparing spectrum from es and pi methods
-    """
-    # use JC model
-    N = 4
-    wc = wa = 1.0 * 2 * np.pi
-    g = 0.1 * 2 * np.pi
-    kappa = 0.75
-    gamma = 0.25
-    n_th = 0.01
-
-    a = tensor(destroy(N), qeye(2))
-    sm = tensor(qeye(N), destroy(2))
-    H = wc * a.dag() * a + wa * sm.dag() * sm + \
-        g * (a.dag() * sm + a * sm.dag())
-    c_ops = [np.sqrt(kappa * (1 + n_th)) * a,
-             np.sqrt(kappa * n_th) * a.dag(),
-             np.sqrt(gamma) * sm]
-
-    wlist = 2 * pi * np.linspace(0.5, 1.5, 100)
-    spec1 = spectrum(H, wlist, c_ops, a.dag(), a, solver='es')
-    spec2 = spectrum(H, wlist, c_ops, a.dag(), a, solver='pi')
-
-    assert_(max(abs(spec1 - spec2)) < 1e-3)
-
-
-#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
-def test_H_str_list_td_corr():
-    """
-    correlation: comparing TLS emission corr., H td (str-list td format)
-    """
-    # calculate emission zero-delay second order correlation, g2[0], for TLS
-    # with following parameters:
-    #   gamma = 1, omega = 2, tp = 0.5
-    # Then: g2(0)~0.57
-    sm = destroy(2)
-    args = {"t_off": 1, "tp": 0.5}
-    H = [[2 * (sm+sm.dag()), "exp(-(t-t_off)**2 / (2*tp**2))"]]
-    tlist = np.linspace(0, 5, 50)
-    corr = correlation_3op_2t(H, fock(2, 0), tlist, tlist, [sm],
-                              sm.dag(), sm.dag() * sm, sm, args=args)
-    # integrate w/ 2D trapezoidal rule
-    dt = (tlist[-1]-tlist[0]) / (np.shape(tlist)[0]-1)
-    s1 = corr[0, 0] + corr[-1, 0] + corr[0, -1] + corr[-1, -1]
-    s2 = sum(corr[1:-1, 0]) + sum(corr[1:-1, -1]) + \
-        sum(corr[0, 1:-1]) + sum(corr[-1, 1:-1])
-    s3 = sum(corr[1:-1, 1:-1])
-
-    exp_n_in = np.trapz(
-        mesolve(
-            H, fock(2, 0), tlist, [sm], [sm.dag()*sm], args=args
-        ).expect[0], tlist
-    )
-    # factor of 2 from negative time correlations
-    g20 = abs(
-        sum(0.5*dt**2*(s1 + 2*s2 + 4*s3)) / exp_n_in**2
-    )
-
-    assert_(abs(g20-0.59) < 1e-2)
-
-
-#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
-def test_H_np_list_td_corr():
-    """
-    correlation: comparing TLS emission corr., H td (np-list td format)
-    """
-    #from qutip.rhs_generate import rhs_clear
-
-    #rhs_clear()
-
-    # calculate emission zero-delay second order correlation, g2[0], for TLS
-    # with following parameters:
-    #   gamma = 1, omega = 2, tp = 0.5
-    # Then: g2(0)~0.57
-    sm = destroy(2)
-    tp = 0.5
-    t_off = 1
-    tlist = np.linspace(0, 5, 50)
-    H = [[2 * (sm + sm.dag()), np.exp(-(tlist - t_off) ** 2 / (2 * tp ** 2))]]
-    corr = correlation_3op_2t(H, fock(2, 0), tlist, tlist, [sm],
-                              sm.dag(), sm.dag() * sm, sm)
-    # integrate w/ 2D trapezoidal rule
-    dt = (tlist[-1] - tlist[0]) / (np.shape(tlist)[0] - 1)
-    s1 = corr[0, 0] + corr[-1, 0] + corr[0, -1] + corr[-1, -1]
-    s2 = sum(corr[1:-1, 0]) + sum(corr[1:-1, -1]) + \
-         sum(corr[0, 1:-1]) + sum(corr[-1, 1:-1])
-    s3 = sum(corr[1:-1, 1:-1])
-
-    exp_n_in = np.trapz(
-        mesolve(
-            H, fock(2, 0), tlist, [sm], [sm.dag() * sm]
-        ).expect[0], tlist
-    )
-    # factor of 2 from negative time correlations
-    g20 = abs(
-        sum(0.5 * dt ** 2 * (s1 + 2 * s2 + 4 * s3)) / exp_n_in ** 2
-    )
-
-    assert_(abs(g20 - 0.59) < 1e-2)
-
-
-def test_H_fn_list_td_corr():
-    """
-    correlation: comparing TLS emission corr., H td (fn-list td format)
-    """
-    # calculate emission zero-delay second order correlation, g2[0], for TLS
-    # with following parameters:
-    #   gamma = 1, omega = 2, tp = 0.5
-    # Then: g2(0)~0.57
-    sm = destroy(2)
-    args = {"t_off": 1, "tp": 0.5}
-    H = [[2 * (sm+sm.dag()),
-          lambda t, args: np.exp(-(t-args["t_off"])**2 / (2*args["tp"]**2))]]
-    tlist = linspace(0, 5, 50)
-    corr = correlation_3op_2t(H, fock(2, 0), tlist, tlist, [sm],
-                              sm.dag(), sm.dag() * sm, sm, args=args)
-    # integrate w/ 2D trapezoidal rule
-    dt = (tlist[-1]-tlist[0]) / (np.shape(tlist)[0]-1)
-    s1 = corr[0, 0] + corr[-1, 0] + corr[0, -1] + corr[-1, -1]
-    s2 = sum(corr[1:-1, 0]) + sum(corr[1:-1, -1]) + \
-        sum(corr[0, 1:-1]) + sum(corr[-1, 1:-1])
-    s3 = sum(corr[1:-1, 1:-1])
-
-    exp_n_in = np.trapz(
-        mesolve(
-            H, fock(2, 0), tlist, [sm], [sm.dag()*sm], args=args
-        ).expect[0], tlist
-    )
-    # factor of 2 from negative time correlations
-    g20 = abs(
-        sum(0.5*dt**2*(s1 + 2*s2 + 4*s3)) / exp_n_in**2
-    )
-
-    assert_(abs(g20-0.59) < 1e-2)
-
-
-def test_H_fn_td_corr():
-    """
-    correlation: comparing TLS emission corr., H td (fn td format)
-    """
-    # calculate emission zero-delay second order correlation, g2[0], for TLS
-    # with following parameters:
-    #   gamma = 1, omega = 2, tp = 0.5
-    # Then: g2(0)~0.57
-    sm = destroy(2)
-
-    def H_func(t, args):
-        return 2 * args["H0"] * np.exp(-2 * (t-1)**2)
-
-    tlist = linspace(0, 5, 50)
-    corr = correlation_3op_2t(H_func, fock(2, 0), tlist, tlist,
-                              [sm], sm.dag(), sm.dag() * sm, sm,
-                              args={"H0": sm+sm.dag()})
-    # integrate w/ 2D trapezoidal rule
-    dt = (tlist[-1]-tlist[0]) / (np.shape(tlist)[0]-1)
-    s1 = corr[0, 0] + corr[-1, 0] + corr[0, -1] + corr[-1, -1]
-    s2 = sum(corr[1:-1, 0]) + sum(corr[1:-1, -1]) +\
-        sum(corr[0, 1:-1]) + sum(corr[-1, 1:-1])
-    s3 = sum(corr[1:-1, 1:-1])
-
-    exp_n_in = trapz(
-        mesolve(
-            H_func, fock(2, 0), tlist, [sm], [sm.dag()*sm],
-            args={"H0": sm+sm.dag()}
-        ).expect[0], tlist
-    )
-    # factor of 2 from negative time correlations
-    g20 = abs(
-        sum(0.5*dt**2*(s1 + 2*s2 + 4*s3)) / exp_n_in**2
-    )
-
-    assert_(abs(g20-0.59) < 1e-2)
-
-
-#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
-@pytest.mark.slow
-def test_c_ops_str_list_td_corr():
-    """
-    correlation: comparing 3LS emission corr., c_ops td (str-list td format)
-    """
-    # calculate zero-delay HOM cross-correlation, for incoherently pumped
-    # 3LS ladder system g2ab[0]
-    # with following parameters:
-    #   gamma = 1, 99% initialized, tp = 0.5
-    # Then: g2ab(0)~0.185
-    tlist = np.linspace(0, 6, 20)
-    ket0 = fock(3, 0)
-    ket1 = fock(3, 1)
-    ket2 = fock(3, 2)
-    sm01 = ket0 * ket1.dag()
-    sm12 = ket1 * ket2.dag()
-    psi0 = fock(3, 2)
-
-    tp = 1
-    # define "pi" pulse as when 99% of population has been transferred
-    Om = np.sqrt(-np.log(1e-2) / (tp * np.sqrt(np.pi)))
-    c_ops = [sm01,
-             [sm12 * Om, "exp(-(t - t_off) ** 2 / (2 * tp ** 2))"]]
-    args = {"tp": tp, "t_off": 2}
-    H = qeye(3) * 0
-    # HOM cross-correlation depends on coherences (g2[0]=0)
-    c1 = correlation_2op_2t(H, psi0, tlist, tlist, c_ops,
-                            sm01.dag(), sm01, args=args)
-    c2 = correlation_2op_2t(H, psi0, tlist, tlist, c_ops,
-                            sm01.dag(), sm01, args=args, reverse=True)
-    n = mesolve(
-        H, psi0, tlist, c_ops, [sm01.dag() * sm01], args=args
-    ).expect[0]
-    n_f = Cubic_Spline(tlist[0], tlist[-1], n)
-    corr_ab = - c1 * c2 + np.array(
-        [[n_f(t) * n_f(t + tau) for tau in tlist]
-         for t in tlist])
-    dt = tlist[1] - tlist[0]
-    gab = abs(np.trapz(np.trapz(corr_ab, axis=0))) * dt ** 2
-
-    assert_(abs(gab - 0.185) < 1e-2)
-
-
-#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
-@pytest.mark.slow
-def test_np_str_list_td_corr():
-    """
-    correlation: comparing 3LS emission corr., c_ops td (np-list td format)
-    """
-    # calculate zero-delay HOM cross-correlation, for incoherently pumped
-    # 3LS ladder system g2ab[0]
-    # with following parameters:
-    #   gamma = 1, 99% initialized, tp = 0.5
-    # Then: g2ab(0)~0.185
-    tlist = np.linspace(0, 6, 20)
-    ket0 = fock(3, 0)
-    ket1 = fock(3, 1)
-    ket2 = fock(3, 2)
-    sm01 = ket0 * ket1.dag()
-    sm12 = ket1 * ket2.dag()
-    psi0 = fock(3, 2)
-
-    tp = 1
-    t_off = 2
-    # define "pi" pulse as when 99% of population has been transferred
-    Om = np.sqrt(-np.log(1e-2) / (tp * np.sqrt(np.pi)))
-    c_ops = [sm01,
-             [sm12 * Om, np.exp(-(tlist - t_off) ** 2 / (2 * tp ** 2))]]
-    H = qeye(3) * 0
-    # HOM cross-correlation depends on coherences (g2[0]=0)
-    c1 = correlation_2op_2t(H, psi0, tlist, tlist, c_ops,
-                            sm01.dag(), sm01)
-    c2 = correlation_2op_2t(H, psi0, tlist, tlist, c_ops,
-                            sm01.dag(), sm01, reverse=True)
-    n = mesolve(
-        H, psi0, tlist, c_ops, [sm01.dag() * sm01]
-    ).expect[0]
-    n_f = Cubic_Spline(tlist[0], tlist[-1], n)
-    corr_ab = - c1 * c2 + np.array(
-        [[n_f(t) * n_f(t + tau) for tau in tlist]
-         for t in tlist])
-    dt = tlist[1] - tlist[0]
-    gab = abs(np.trapz(np.trapz(corr_ab, axis=0))) * dt ** 2
-
-    assert_(abs(gab - 0.185) < 1e-2)
-
-
-def test_c_ops_fn_list_td_corr():
-    """
-    correlation: comparing 3LS emission corr., c_ops td (fn-list td format)
-    """
-    # calculate zero-delay HOM cross-correlation, for incoherently pumped
-    # 3LS ladder system g2ab[0]
-    # with following parameters:
-    #   gamma = 1, 99% initialized, tp = 0.5
-    # Then: g2ab(0)~0.185
-    tlist = np.linspace(0, 6, 20)
-    ket0 = fock(3, 0)
-    ket1 = fock(3, 1)
-    ket2 = fock(3, 2)
-    sm01 = ket0 * ket1.dag()
-    sm12 = ket1 * ket2.dag()
-    psi0 = fock(3, 2)
-
-    tp = 1
-    # define "pi" pulse as when 99% of population has been transferred
-    Om = np.sqrt(-np.log(1e-2) / (tp * np.sqrt(np.pi)))
-    c_ops = [sm01,
-             [sm12 * Om,
-              lambda t, args:
-                    np.exp(-(t - args["t_off"]) ** 2 / (2 * args["tp"] ** 2))]]
-    args = {"tp": tp, "t_off": 2}
-    H = qeye(3) * 0
-    # HOM cross-correlation depends on coherences (g2[0]=0)
-    c1 = correlation_2op_2t(H, psi0, tlist, tlist, c_ops,
-                            sm01.dag(), sm01, args=args)
-    c2 = correlation_2op_2t(H, psi0, tlist, tlist, c_ops,
-                            sm01.dag(), sm01, args=args, reverse=True)
-    n = mesolve(
-        H, psi0, tlist, c_ops, [sm01.dag() * sm01], args=args
-    ).expect[0]
-    n_f = Cubic_Spline(tlist[0], tlist[-1], n)
-    corr_ab = - c1 * c2 + np.array(
-        [[n_f(t) * n_f(t + tau) for tau in tlist]
-         for t in tlist])
-    dt = tlist[1] - tlist[0]
-    gab = abs(np.trapz(np.trapz(corr_ab, axis=0))) * dt ** 2
-
-    assert_(abs(gab - 0.185) < 1e-2)
-
-
-#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
-@pytest.mark.slow
-def test_str_list_td_corr():
-    """
-    correlation: comparing TLS emission corr. (str-list td format)
-    """
-    # both H and c_ops are time-dependent
-
-    # calculate emission zero-delay second order correlation, g2[0], for TLS
-    # with following parameters:
-    #   gamma = 1, omega = 2, tp = 0.5
-    # Then: g2(0)~0.85
-    sm = destroy(2)
-    args = {"t_off": 1, "tp": 0.5}
-    tlist = np.linspace(0, 5, 50)
-    H = [[2 * (sm + sm.dag()), "exp(-(t-t_off)**2 / (2*tp**2))"]]
-    c_ops = [sm, [sm.dag() * sm * 2, "exp(-(t-t_off)**2 / (2*tp**2))"]]
-    corr = correlation_3op_2t(H, fock(2, 0), tlist, tlist, [sm],
-                              sm.dag(), sm.dag() * sm, sm, args=args)
-    # integrate w/ 2D trapezoidal rule
-    dt = (tlist[-1] - tlist[0]) / (np.shape(tlist)[0] - 1)
-    s1 = corr[0, 0] + corr[-1, 0] + corr[0, -1] + corr[-1, -1]
-    s2 = sum(corr[1:-1, 0]) + sum(corr[1:-1, -1]) + \
-         sum(corr[0, 1:-1]) + sum(corr[-1, 1:-1])
-    s3 = sum(corr[1:-1, 1:-1])
-
-    exp_n_in = np.trapz(
-        mesolve(
-            H, fock(2, 0), tlist, c_ops, [sm.dag() * sm], args=args
-        ).expect[0], tlist
-    )
-    # factor of 2 from negative time correlations
-    g20 = abs(
-        sum(0.5 * dt ** 2 * (s1 + 2 * s2 + 4 * s3)) / exp_n_in ** 2
-    )
-
-    assert_(abs(g20 - 0.85) < 1e-2)
-
-
-#@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
-def test_np_list_td_corr():
-    """
-    correlation: comparing TLS emission corr. (np-list td format)
-    """
-    # both H and c_ops are time-dependent
-
-    # calculate emission zero-delay second order correlation, g2[0], for TLS
-    # with following parameters:
-    #   gamma = 1, omega = 2, tp = 0.5
-    # Then: g2(0)~0.85
-    sm = destroy(2)
-    t_off = 1
-    tp = 0.5
-    tlist = np.linspace(0, 5, 50)
-    H = [[2 * (sm + sm.dag()), np.exp(-(tlist-t_off)**2 / (2*tp**2))]]
-    c_ops = [sm, [sm.dag() * sm * 2, np.exp(-(tlist-t_off)**2 / (2*tp**2))]]
-    corr = correlation_3op_2t(H, fock(2, 0), tlist, tlist, [sm],
-                              sm.dag(), sm.dag() * sm, sm)
-    # integrate w/ 2D trapezoidal rule
-    dt = (tlist[-1] - tlist[0]) / (np.shape(tlist)[0] - 1)
-    s1 = corr[0, 0] + corr[-1, 0] + corr[0, -1] + corr[-1, -1]
-    s2 = sum(corr[1:-1, 0]) + sum(corr[1:-1, -1]) + \
-         sum(corr[0, 1:-1]) + sum(corr[-1, 1:-1])
-    s3 = sum(corr[1:-1, 1:-1])
-
-    exp_n_in = np.trapz(
-        mesolve(
-            H, fock(2, 0), tlist, c_ops, [sm.dag() * sm]
-        ).expect[0], tlist
-    )
-    # factor of 2 from negative time correlations
-    g20 = abs(
-        sum(0.5 * dt ** 2 * (s1 + 2 * s2 + 4 * s3)) / exp_n_in ** 2
-    )
-
-    assert_(abs(g20 - 0.85) < 1e-2)
-
-
-def test_fn_list_td_corr():
-    """
-    correlation: comparing TLS emission corr. (fn-list td format)
-    """
-    # both H and c_ops are time-dependent
-
-    # calculate emission zero-delay second order correlation, g2[0], for TLS
-    # with following parameters:
-    #   gamma = 1, omega = 2, tp = 0.5
-    # Then: g2(0)~0.85
-    sm = destroy(2)
-    args = {"t_off": 1, "tp": 0.5}
-    H = [[2 * (sm + sm.dag()),
-          lambda t, args:
-                np.exp(-(t - args["t_off"]) ** 2 / (2 * args["tp"] ** 2))]]
-    c_ops = [sm, [sm.dag() * sm * 2,
-                  lambda t, args:
-                    np.exp(-(t - args["t_off"]) ** 2 / (2 * args["tp"] ** 2))]]
-    tlist = np.linspace(0, 5, 50)
-    corr = correlation_3op_2t(H, fock(2, 0), tlist, tlist, [sm],
-                              sm.dag(), sm.dag() * sm, sm, args=args)
-    # integrate w/ 2D trapezoidal rule
-    dt = (tlist[-1] - tlist[0]) / (np.shape(tlist)[0] - 1)
-    s1 = corr[0, 0] + corr[-1, 0] + corr[0, -1] + corr[-1, -1]
-    s2 = sum(corr[1:-1, 0]) + sum(corr[1:-1, -1]) + \
-         sum(corr[0, 1:-1]) + sum(corr[-1, 1:-1])
-    s3 = sum(corr[1:-1, 1:-1])
-
-    exp_n_in = np.trapz(
-        mesolve(
-            H, fock(2, 0), tlist, c_ops, [sm.dag() * sm], args=args
-        ).expect[0], tlist
-    )
-    # factor of 2 from negative time correlations
-    g20 = abs(
-        sum(0.5 * dt ** 2 * (s1 + 2 * s2 + 4 * s3)) / exp_n_in ** 2
-    )
-
-    assert_(abs(g20 - 0.85) < 1e-2)
-
-
-def test_fn_list_td_corr2():
-    """
-    correlation: multi time-dependent factor
-    """
-    # test for bug of issue #1048
-    sm = destroy(2)
-    args = {}
-
-    def step_func(t, args={}):
-        return np.arctan(t-2)/np.pi + 0.5
-
-    def inv_step_func(t, args={}):
-        return np.arctan(-(t-2))/np.pi + 0.5
-
-    H1 = [[(sm + sm.dag()), step_func], [qeye(2), inv_step_func]]
-
-    H2 = [[qeye(2), inv_step_func], [(sm + sm.dag()), step_func]]
-
-    tlist = np.linspace(0, 5, 6)
-    corr1 = correlation_2op_2t(H1, fock(2, 0), tlist, tlist, [sm],
-                               sm.dag(), sm, args=args)
-    corr2 = correlation_2op_2t(H2, fock(2, 0), tlist, tlist, [sm],
-                               sm.dag(), sm, args=args)
-    assert_(np.sum(np.abs(corr1-corr2)) < 1e-5)
-
-
-if __name__ == "__main__":
-    run_module_suite()
+    def test_varying_coefficient_hamiltonian_2ls(self, dependence_2ls):
+        H = [[_2ls_args['H0'], dependence_2ls]]
+        assert abs(_2ls_g2_0(H, []) - 0.575) < 1e-2
+
+    def test_hamiltonian_from_function_2ls(self):
+        H = _h_qobj_function
+        assert abs(_2ls_g2_0(H, []) - 0.575) < 1e-2
+
+    @pytest.mark.slow
+    def test_varying_coefficient_hamiltonian_c_ops_2ls(self, dependence_2ls):
+        H = [[_2ls_args['H0'], dependence_2ls]]
+        c_ops = [[2*qutip.sigmam()*qutip.sigmap(), dependence_2ls]]
+        assert abs(_2ls_g2_0(H, c_ops) - 0.824) < 1e-2
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("dependence_3ls", [
+        pytest.param(_coefficient_string, id="string"),
+        pytest.param(_coefficient_function(_3ls_times, _3ls_args), id="numpy"),
+        pytest.param(_coefficient_function, id="function"),
+    ])
+    def test_coefficient_c_ops_3ls(self, dependence_3ls):
+        # Calculate zero-delay HOM cross-correlation for incoherently pumped
+        # three-level system, g2_ab[0] with gamma = 1.
+        dimension = 3
+        H = qutip.qzero(dimension)
+        start = qutip.basis(dimension, 2)
+        times = _3ls_times
+        project_0_1 = qutip.projection(dimension, 0, 1)
+        project_1_2 = qutip.projection(dimension, 1, 2)
+        population_1 = qutip.projection(dimension, 1, 1)
+        # Define the pi pulse to be when 99% of the population is transferred.
+        rabi = np.sqrt(-np.log(0.01) / (_3ls_args['tp']*np.sqrt(np.pi)))
+        c_ops = [project_0_1, [rabi*project_1_2, dependence_3ls]]
+        forwards = qutip.correlation_2op_2t(H, start, times, times, c_ops,
+                                            project_0_1.dag(), project_0_1,
+                                            args=_3ls_args)
+        backwards = qutip.correlation_2op_2t(H, start, times, times, c_ops,
+                                             project_0_1.dag(), project_0_1,
+                                             args=_3ls_args, reverse=True)
+        n_expect = qutip.mesolve(H, start, times, c_ops, args=_3ls_args,
+                                 e_ops=[population_1]).expect[0]
+        correlation_ab = -forwards*backwards + _n_correlation(times, n_expect)
+        g2_ab_0 = _trapz_2d(np.real(correlation_ab), times)
+        assert abs(g2_ab_0 - 0.185) < 1e-2
+
+
+def _step(t):
+    return np.arctan(t)/np.pi + 0.5
+
+
+def test_hamiltonian_order_unimportant():
+    # Testing for regression on issue 1048.
+    sp = qutip.sigmap()
+    H = [[qutip.sigmax(), lambda t, _: _step(t-2)],
+         [qutip.qeye(2), lambda t, _: _step(-(t-2))]]
+    start = qutip.basis(2, 0)
+    times = np.linspace(0, 5, 6)
+    forwards = qutip.correlation_2op_2t(H, start, times, times, [sp],
+                                        sp.dag(), sp)
+    backwards = qutip.correlation_2op_2t(H[::-1], start, times, times, [sp],
+                                         sp.dag(), sp)
+    assert np.allclose(forwards, backwards, atol=1e-6)

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -76,7 +76,7 @@ def test_correlation_solver_equivalence(solver, start, legacy):
     # to the "me" solver.
     base = correlation(H, start, None, times, c_ops, a.dag(), a, solver="me")
     cmp = correlation(H, start, None, times, c_ops, a.dag(), a, solver=solver)
-    assert np.allclose(base, cmp, atol=tol)
+    np.testing.assert_allclose(base, cmp, atol=tol)
 
 
 def _spectrum_wrapper(spectrum):
@@ -119,7 +119,7 @@ def test_spectrum_solver_equivalence_to_es(spectrum):
 
     test, frequencies = spectrum(H, c_ops, a.dag(), a)
     base = qutip.spectrum(H, frequencies, c_ops, a.dag(), a, solver="es")
-    assert np.allclose(base, test, atol=1e-3)
+    np.testing.assert_allclose(base, test, atol=1e-3)
 
 
 def _trapz_2d(z, xy):
@@ -250,4 +250,4 @@ def test_hamiltonian_order_unimportant():
                                         sp.dag(), sp)
     backwards = qutip.correlation_2op_2t(H[::-1], start, times, times, [sp],
                                          sp.dag(), sp)
-    assert np.allclose(forwards, backwards, atol=1e-6)
+    np.testing.assert_allclose(forwards, backwards, atol=1e-6)

--- a/qutip/tests/test_countstat.py
+++ b/qutip/tests/test_countstat.py
@@ -30,11 +30,9 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-import numpy as np
-from numpy.testing import assert_, assert_allclose, run_module_suite
 
-from qutip import (projection, sprepost, liouvillian, countstat_current,
-                   countstat_current_noise, steadystate)
+import numpy as np
+import qutip
 
 
 def test_dqd_current():
@@ -44,10 +42,10 @@ def test_dqd_current():
     L = 1
     R = 2
 
-    sz = projection(3, L, L) - projection(3, R, R)
-    sx = projection(3, L, R) + projection(3, R, L)
-    sR = projection(3, G, R)
-    sL = projection(3, G, L)
+    sz = qutip.projection(3, L, L) - qutip.projection(3, R, R)
+    sx = qutip.projection(3, L, R) + qutip.projection(3, R, L)
+    sR = qutip.projection(3, G, R)
+    sL = qutip.projection(3, G, L)
 
     w0 = 1
     tc = 0.6 * w0
@@ -56,41 +54,38 @@ def test_dqd_current():
     nth = 0.00
     eps_vec = np.linspace(-1.5*w0, 1.5*w0, 20)
 
-    J_ops = [GammaR * sprepost(sR, sR.dag())]
+    J_ops = [GammaR * qutip.sprepost(sR, sR.dag())]
 
     c_ops = [np.sqrt(GammaR * (1 + nth)) * sR,
              np.sqrt(GammaR * (nth)) * sR.dag(),
              np.sqrt(GammaL * (nth)) * sL,
-             np.sqrt(GammaL * (1 + nth)) * sL.dag(),
-             ]
+             np.sqrt(GammaL * (1 + nth)) * sL.dag()]
 
-    I = np.zeros(len(eps_vec))
-    S = np.zeros(len(eps_vec))
+    current = np.zeros(len(eps_vec))
+    noise = np.zeros(len(eps_vec))
 
     for n, eps in enumerate(eps_vec):
         H = (eps/2 * sz + tc * sx)
-        L = liouvillian(H, c_ops)
-        rhoss = steadystate(L)
-        I[n], S[n] = countstat_current_noise(L, [], rhoss=rhoss, J_ops=J_ops)
+        L = qutip.liouvillian(H, c_ops)
+        rhoss = qutip.steadystate(L)
+        current[n], noise[n] = qutip.countstat_current_noise(L, [],
+                                                             rhoss=rhoss,
+                                                             J_ops=J_ops)
 
-        I2 = countstat_current(L, rhoss=rhoss, J_ops=J_ops)
-        assert_(abs(I[n] - I2) < 1e-8)
+        current2 = qutip.countstat_current(L, rhoss=rhoss, J_ops=J_ops)
+        assert abs(current[n] - current2) < 1e-8
 
-        I2 = countstat_current(L, c_ops, J_ops=J_ops)
-        assert_(abs(I[n] - I2) < 1e-8)
+        current2 = qutip.countstat_current(L, c_ops, J_ops=J_ops)
+        assert abs(current[n] - current2) < 1e-8
 
-    Iref = tc**2 * GammaR / (tc**2 * (2 + GammaR/GammaL) +
-                             GammaR**2/4 + eps_vec**2)
-    Sref = 1 * Iref * (
-        1 - 8 * GammaL * tc**2 *
-        (4 * eps_vec**2 * (GammaR - GammaL) +
-         GammaR * (3 * GammaL * GammaR + GammaR**2 + 8*tc**2)) /
-        (4 * tc**2 * (2 * GammaL + GammaR) + GammaL * GammaR**2 +
-         4 * eps_vec**2 * GammaL)**2
+    current_target = (tc**2 * GammaR
+                      / (tc**2 * (2+GammaR/GammaL) + GammaR**2/4 + eps_vec**2))
+    noise_target = current_target * (
+        1 - (8*GammaL*tc**2*(4 * eps_vec**2 * (GammaR - GammaL)
+                             + GammaR*(3*GammaL*GammaR + GammaR**2 + 8*tc**2))
+             / (4*tc**2*(2*GammaL + GammaR) + GammaL*GammaR**2
+                + 4*eps_vec**2*GammaL)**2)
     )
 
-    assert_allclose(I, Iref, 1e-4)
-    assert_allclose(S, Sref, 1e-4)
-
-if __name__ == "__main__":
-    run_module_suite()
+    assert np.allclose(current, current_target, atol=1e-4)
+    assert np.allclose(noise, noise_target, atol=1e-4)

--- a/qutip/tests/test_countstat.py
+++ b/qutip/tests/test_countstat.py
@@ -87,5 +87,5 @@ def test_dqd_current():
                 + 4*eps_vec**2*GammaL)**2)
     )
 
-    assert np.allclose(current, current_target, atol=1e-4)
-    assert np.allclose(noise, noise_target, atol=1e-4)
+    np.testing.assert_allclose(current, current_target, atol=1e-4)
+    np.testing.assert_allclose(noise, noise_target, atol=1e-4)

--- a/qutip/tests/test_cy_structs.py
+++ b/qutip/tests/test_cy_structs.py
@@ -30,76 +30,70 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
+
 import numpy as np
-import scipy.sparse as sp
-from qutip import rand_dm
+import scipy.sparse
+import qutip
 from qutip.fastsparse import fast_csr_matrix
 from qutip.cy.checks import (_test_sorting, _test_coo2csr_inplace_struct,
-                            _test_csr2coo_struct, _test_coo2csr_struct)
+                             _test_csr2coo_struct, _test_coo2csr_struct)
 from qutip.random_objects import rand_jacobi_rotation
-from numpy.testing import assert_equal, assert_, run_module_suite
+
+
+def pytest_generate_tests(metafunc):
+    """Repeat all tests in the module."""
+    repeats = 20
+    metafunc.fixturenames.append("repeat_count")
+    metafunc.parametrize("repeat_count", [None]*repeats,
+                         ids=["random " + str(n+1) for n in range(repeats)])
+
 
 def _unsorted_csr(N, density=0.5):
-    N = np.arange(N)
-    M = sp.diags(N,0, dtype=complex, format='csr')
-    N = N.shape[0]
-    nvals = N**2*density
+    M = scipy.sparse.diags(np.arange(N), 0, dtype=complex, format='csr')
+    nvals = N**2 * density
     while M.nnz < 0.95*nvals:
         M = rand_jacobi_rotation(M)
     M = M.tocsr()
-    return fast_csr_matrix((M.data,M.indices,M.indptr),
-                            shape = M.shape)
+    return fast_csr_matrix((M.data, M.indices, M.indptr), shape=M.shape)
 
+
+def sparse_arrays_equal(a, b):
+    return not (a != b).data.any()
 
 
 def test_coo2csr_struct():
     "Cython structs : COO to CSR"
-    for k in range(20):
-        A = rand_dm(5,0.5).data
-        B = A.tocoo()
-        C = _test_coo2csr_struct(B)
-        assert_(not (A!=C).data.any())
-
+    A = qutip.rand_dm(5, 0.5).data
+    assert sparse_arrays_equal(A, _test_coo2csr_struct(A.tocoo()))
 
 
 def test_indices_sort():
     "Cython structs : sort CSR indices inplace"
-    for k in range(20):
-        A = _unsorted_csr(10,0.25)
-        B = A.copy()
-        B.sort_indices()
-        _test_sorting(A)
-        assert_(np.all(A.data == B.data))
-        assert_(np.all(A.indices == B.indices))
+    A = _unsorted_csr(10, 0.25)
+    B = A.copy()
+    B.sort_indices()
+    _test_sorting(A)
+    assert np.all(A.data == B.data)
+    assert np.all(A.indices == B.indices)
 
 
 def test_coo2csr_inplace_nosort():
     "Cython structs : COO to CSR inplace (no sort)"
-    for k in range(20):
-        A = rand_dm(5,0.5).data
-        B = A.tocoo()
-        C = _test_coo2csr_inplace_struct(B, sorted = 0)
-        assert_(not (A!=C).data.any())
+    A = qutip.rand_dm(5, 0.5).data
+    B = _test_coo2csr_inplace_struct(A.tocoo(), sorted=0)
+    assert sparse_arrays_equal(A, B)
 
 
 def test_coo2csr_inplace_sort():
     "Cython structs : COO to CSR inplace (sorted)"
-    for k in range(20):
-        A = rand_dm(5,0.5).data
-        B = A.tocoo()
-        C = _test_coo2csr_inplace_struct(B, sorted = 1)
-        assert_(not (A!=C).data.any())
+    A = qutip.rand_dm(5,0.5).data
+    B = _test_coo2csr_inplace_struct(A.tocoo(), sorted=1)
+    assert sparse_arrays_equal(A, B)
 
 
 def test_csr2coo():
     "Cython structs : CSR to COO"
-    for k in range(20):
-        A = rand_dm(5,0.5).data
-        B = A.tocoo()
-        C = _test_csr2coo_struct(A)
-        assert_(not (B!=C).data.any())
-
-
-
-if __name__ == "__main__":
-    run_module_suite()
+    A = qutip.rand_dm(5, 0.5).data
+    B = A.tocoo()
+    C = _test_csr2coo_struct(A)
+    assert sparse_arrays_equal(B, C)

--- a/qutip/tests/test_cy_structs.py
+++ b/qutip/tests/test_cy_structs.py
@@ -83,7 +83,7 @@ def test_coo2csr_inplace_nosort():
 @pytest.mark.repeat(20)
 def test_coo2csr_inplace_sort():
     "Cython structs : COO to CSR inplace (sorted)"
-    A = qutip.rand_dm(5,0.5).data
+    A = qutip.rand_dm(5, 0.5).data
     B = _test_coo2csr_inplace_struct(A.tocoo(), sorted=1)
     assert sparse_arrays_equal(A, B)
 

--- a/qutip/tests/test_eigenstates.py
+++ b/qutip/tests/test_eigenstates.py
@@ -92,10 +92,11 @@ def test_known_eigensystem(hamiltonian, eigenvalues, eigenstates):
     expected_order = np.argsort(eigenvalues)
     expected_vectors = [_canonicalise_eigenvector(eigenstates[i])
                         for i in expected_order]
-    assert np.allclose(test_values[test_order], eigenvalues[expected_order],
-                       atol=1e-10)
+    np.testing.assert_allclose(test_values[test_order],
+                               eigenvalues[expected_order],
+                               atol=1e-10)
     for test, expected in zip(test_vectors, expected_vectors):
-        assert np.allclose(test, expected, atol=1e-10)
+        np.testing.assert_allclose(test, expected, atol=1e-10)
 
 
 # Specify parametrisation over a random Hamiltonian by specifying the
@@ -109,6 +110,6 @@ def random_hamiltonian(request):
 
 def test_satisfy_eigenvalue_equation(random_hamiltonian):
     for eigenvalue, eigenstate in zip(*random_hamiltonian.eigenstates()):
-        assert np.allclose((random_hamiltonian * eigenstate).full(),
-                           (eigenvalue * eigenstate).full(),
-                           atol=1e-10)
+        np.testing.assert_allclose((random_hamiltonian * eigenstate).full(),
+                                   (eigenvalue * eigenstate).full(),
+                                   atol=1e-10)

--- a/qutip/tests/test_eigenstates.py
+++ b/qutip/tests/test_eigenstates.py
@@ -31,61 +31,82 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-from qutip import sigmax, sigmay, sigmaz, tensor, destroy, qeye
-from numpy import amax
-from numpy.testing import assert_equal, run_module_suite
-from numpy.random import rand
+import pytest
+import numpy as np
+import qutip
 
 
-def test_diagHamiltonian1():
+def _canonicalise_eigenvector(vec):
     """
-    Diagonalization of random two-level system
+    Normalise an eigenvector so that the first non-zero value is equal to one,
+    and the array is flattened.  Just normalising based on vector magnitude
+    isn't enough to fully fix the gauge because the vectors could still be
+    multiplied by a unit complex number.
     """
-
-    H = rand() * sigmax() + rand() * sigmay() +\
-        rand() * sigmaz()
-
-    evals, ekets = H.eigenstates()
-
-    for n in range(len(evals)):
-        # assert that max(H * ket - e * ket) is small
-        assert_equal(amax(
-            abs((H * ekets[n] - evals[n] * ekets[n]).full())) < 1e-10, True)
+    vec = vec.flatten()
+    nonzero = vec != 0
+    if not np.any(nonzero):
+        return vec
+    return vec / vec[np.argmax(nonzero)]
 
 
-def test_diagHamiltonian2():
-    """
-    Diagonalization of composite systems
-    """
+# Random diagonal Hamiltonian.
+_diagonal_dimension = 10
+_diagonal_eigenvalues = np.sort(np.random.rand(_diagonal_dimension))
+_diagonal_eigenstates = np.array([[0]*n + [1] + [0]*(_diagonal_dimension-n-1)
+                                  for n in range(_diagonal_dimension)])
+_diagonal_hamiltonian = qutip.qdiags(_diagonal_eigenvalues, 0)
 
-    H1 = rand() * sigmax() + rand() * sigmay() +\
-        rand() * sigmaz()
-    H2 = rand() * sigmax() + rand() * sigmay() +\
-        rand() * sigmaz()
-
-    H = tensor(H1, H2)
-
-    evals, ekets = H.eigenstates()
-
-    for n in range(len(evals)):
-        # assert that max(H * ket - e * ket) is small
-        assert_equal(amax(
-            abs((H * ekets[n] - evals[n] * ekets[n]).full())) < 1e-10, True)
-
-    N1 = 10
-    N2 = 2
-
-    a1 = tensor(destroy(N1), qeye(N2))
-    a2 = tensor(qeye(N1), destroy(N2))
-    H = rand() * a1.dag() * a1 + rand() * a2.dag() * a2 + \
-        rand() * (a1 + a1.dag()) * (a2 + a2.dag())
-    evals, ekets = H.eigenstates()
-
-    for n in range(len(evals)):
-        # assert that max(H * ket - e * ket) is small
-        assert_equal(amax(
-            abs((H * ekets[n] - evals[n] * ekets[n]).full())) < 1e-10, True)
+# Arbitrary known non-diagonal complex Hamiltonian.
+_nondiagonal_hamiltonian = qutip.Qobj(np.array([
+    [0.16252356,             0.27696416+0.0405202j,  0.19577420+0.07815636j],
+    [0.27696416-0.0405202j,  0.45859633,             0.36222915+0.17372725j],
+    [0.19577420-0.07815636j, 0.36222915-0.17372725j, 0.44149665]]))
+_nondiagonal_eigenvalues = np.array([
+    -0.022062710138316392, 0.08888141616526818, 0.995797833973048])
+_nondiagonal_eigenstates = np.array([
+    [-0.737511505546763, 0.5270680510449308-0.29398599661318j,
+     0.009793118179759598+0.3029065489313791j],
+    [0.5552814080417957, 0.23570050756381764 - 0.3577691669342573j,
+     -0.3741560255426259+0.6067259021655438j],
+    [-0.3843687514214284, -0.670810624386174+0.04723455831286158j,
+     -0.5593181579625106+0.2953063897306936j]])
 
 
-if __name__ == "__main__":
-    run_module_suite()
+@pytest.mark.parametrize(["hamiltonian", "eigenvalues", "eigenstates"], [
+    pytest.param(qutip.sigmaz(), [-1, 1], [[0, 1], [1, 0]], id="diagonal-2"),
+    pytest.param(_diagonal_hamiltonian, _diagonal_eigenvalues,
+                 _diagonal_eigenstates,
+                 id="diagonal-"+str(_diagonal_dimension)),
+    pytest.param(qutip.sigmax(), [-1, 1], [[-1, 1], [1, 1]], id="sigmax"),
+    pytest.param(_nondiagonal_hamiltonian, _nondiagonal_eigenvalues,
+                 _nondiagonal_eigenstates, id="non-diagonal"),
+])
+def test_known_eigensystem(hamiltonian, eigenvalues, eigenstates):
+    test_values, test_states = hamiltonian.eigenstates()
+    eigenvalues = np.array(eigenvalues)
+    eigenstates = np.array(eigenstates)
+    test_order = np.argsort(test_values)
+    test_vectors = [_canonicalise_eigenvector(test_states[i].full())
+                    for i in test_order]
+    expected_order = np.argsort(eigenvalues)
+    expected_vectors = [_canonicalise_eigenvector(eigenstates[i])
+                        for i in expected_order]
+    assert np.allclose(test_values[test_order], eigenvalues[expected_order],
+                       atol=1e-10)
+    for test, expected in zip(test_vectors, expected_vectors):
+        assert np.allclose(test, expected, atol=1e-10)
+
+
+@pytest.fixture(params=[pytest.param([5], id="simple"),
+                        pytest.param([5, 3, 4], id="tensor")])
+def random_hamiltonian(request):
+    dimensions = request.param
+    return qutip.tensor(*[qutip.rand_herm(dim) for dim in dimensions])
+
+
+def test_satisfy_eigenvalue_equation(random_hamiltonian):
+    for eigenvalue, eigenstate in zip(*random_hamiltonian.eigenstates()):
+        assert np.allclose((random_hamiltonian * eigenstate).full(),
+                           (eigenvalue * eigenstate).full(),
+                           atol=1e-10)

--- a/qutip/tests/test_eigenstates.py
+++ b/qutip/tests/test_eigenstates.py
@@ -98,6 +98,8 @@ def test_known_eigensystem(hamiltonian, eigenvalues, eigenstates):
         assert np.allclose(test, expected, atol=1e-10)
 
 
+# Specify parametrisation over a random Hamiltonian by specifying the
+# dimensions, rather than duplicating that logic.
 @pytest.fixture(params=[pytest.param([5], id="simple"),
                         pytest.param([5, 3, 4], id="tensor")])
 def random_hamiltonian(request):

--- a/qutip/tests/test_enr_state_operator.py
+++ b/qutip/tests/test_enr_state_operator.py
@@ -31,109 +31,107 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-from numpy.testing import assert_, run_module_suite
+import pytest
+import itertools
+import random
+import numpy as np
+import qutip
 
-from qutip import (destroy, enr_destroy, identity, tensor, enr_fock,
-                   enr_identity, enr_thermal_dm, thermal_dm,
-                   state_number_enumerate)
-
-
-def test_enr_destory_full():
-    "Excitation-number-restricted state-space: full state space"
-    a1, a2 = enr_destroy([4, 4], 4**2)
-    b1, b2 = tensor(destroy(4), identity(4)), tensor(identity(4), destroy(4))
-
-    assert_(a1 == b1)
-    assert_(a2 == b2)
-
-
-def test_enr_destory_single():
-    "Excitation-number-restricted state space: single excitations"
-    a1, a2 = enr_destroy([4, 4], 1)
-    assert_(a1.shape == (3, 3))
-
-    a1, a2, a3 = enr_destroy([4, 4, 4], 1)
-    assert_(a1.shape == (4, 4))
-
-    a1, a2, a3, a4 = enr_destroy([4, 4, 4, 4], 1)
-    assert_(a1.shape == (5, 5))
+def _n_enr_states(dimensions, n_excitations):
+    """
+    Calculate the total number of distinct ENR states for a given set of
+    subspaces.  This method is not intended to be fast or efficient, it's
+    intended to be obviously correct for testing purposes.
+    """
+    count = 0
+    for excitations in itertools.product(*map(range, dimensions)):
+        count += int(sum(excitations) <= n_excitations)
+    return count
 
 
-def test_enr_destory_double():
-    "Excitation-number-restricted state space: two excitations"
-    a1, a2 = enr_destroy([4, 4], 2)
-    assert_(a1.shape == (6, 6))
-
-    a1, a2, a3 = enr_destroy([4, 4, 4], 2)
-    assert_(a1.shape == (10, 10))
-
-    a1, a2, a3, a4 = enr_destroy([4, 4, 4, 4], 2)
-    assert_(a1.shape == (15, 15))
-
-
-def test_enr_fock_state():
-    "Excitation-number-restricted state space: fock states"
-    dims, excitations = [4, 4], 2
-
-    a1, a2 = enr_destroy(dims, excitations)
-
-    psi = enr_fock(dims, excitations, [0, 2])
-    assert_(abs((a1.dag()*a1).matrix_element(psi.dag(), psi) - 0) < 1e-10)
-    assert_(abs((a2.dag()*a2).matrix_element(psi.dag(), psi) - 2) < 1e-10)
-
-    psi = enr_fock(dims, excitations, [2, 0])
-    assert_(abs((a1.dag()*a1).matrix_element(psi.dag(), psi) - 2) < 1e-10)
-    assert_(abs((a2.dag()*a2).matrix_element(psi.dag(), psi) - 0) < 1e-10)
-
-    psi = enr_fock(dims, excitations, [1, 1])
-    assert_(abs((a1.dag()*a1).matrix_element(psi.dag(), psi) - 1) < 1e-10)
-    assert_(abs((a2.dag()*a2).matrix_element(psi.dag(), psi) - 1) < 1e-10)
+@pytest.fixture(params=[
+    pytest.param([4], id="single"),
+    pytest.param([4]*2, id="tensor-equal-2"),
+    pytest.param([4]*3, id="tensor-equal-3"),
+    pytest.param([4]*4, id="tensor-equal-4"),
+    pytest.param([2, 3, 4], id="tensor-not-equal"),
+])
+def dimensions(request):
+    return request.param
 
 
-def test_enr_identity():
-    "Excitation-number-restricted state space: identity operator"
-    dims, excitations = [4, 4], 2
-
-    i = enr_identity(dims, excitations)
-    assert_((i.diag() == 1).all())
-    assert_(i.dims[0] == dims)
-    assert_(i.dims[1] == dims)
+@pytest.fixture(params=[1, 2, 3, 1_000_000])
+def n_excitations(request):
+    return request.param
 
 
-def test_enr_thermal_dm1():
-    "Excitation-number-restricted state space: thermal density operator (I)"
-    dims, excitations = [3, 4, 5, 6], 3
+class TestOperator:
+    def test_no_restrictions(self, dimensions):
+        """
+        Test that the restricted-excitation operators are equal to the standard
+        operators when there aren't any restrictions.
+        """
+        test_operators = qutip.enr_destroy(dimensions, sum(dimensions))
+        a = [qutip.destroy(n) for n in dimensions]
+        iden = [qutip.qeye(n) for n in dimensions]
+        for i, test in enumerate(test_operators):
+            expected = qutip.tensor(iden[:i] + [a[i]] + iden[i+1:])
+            assert test == expected
+            assert test.dims == [dimensions, dimensions]
 
-    n_vec = [0.01, 0.05, 0.1, 0.15]
+    def test_space_size_reduction(self, dimensions, n_excitations):
+        test_operators = qutip.enr_destroy(dimensions, n_excitations)
+        expected_size = _n_enr_states(dimensions, n_excitations)
+        expected_shape = (expected_size, expected_size)
+        for test in test_operators:
+            assert test.shape == expected_shape
+            assert test.dims == [dimensions, dimensions]
 
-    rho = enr_thermal_dm(dims, excitations, n_vec)
-
-    rho_ref = tensor([thermal_dm(d, n_vec[idx])
-                      for idx, d in enumerate(dims)])
-    gonners = [idx for idx, state in enumerate(state_number_enumerate(dims))
-               if sum(state) > excitations]
-    rho_ref = rho_ref.eliminate_states(gonners)
-    rho_ref = rho_ref / rho_ref.tr()
-
-    assert_(abs((rho.data - rho_ref.data).data).max() < 1e-12)
-
-
-def test_enr_thermal_dm2():
-    "Excitation-number-restricted state space: thermal density operator (II)"
-    dims, excitations = [3, 4, 5], 2
-
-    n_vec = 0.1
-
-    rho = enr_thermal_dm(dims, excitations, n_vec)
-
-    rho_ref = tensor([thermal_dm(d, n_vec) for idx, d in enumerate(dims)])
-    gonners = [idx for idx, state in enumerate(state_number_enumerate(dims))
-               if sum(state) > excitations]
-    rho_ref = rho_ref.eliminate_states(gonners)
-    rho_ref = rho_ref / rho_ref.tr()
-
-    assert_(abs((rho.data - rho_ref.data).data).max() < 1e-12)
+    def test_identity(self, dimensions, n_excitations):
+        iden = qutip.enr_identity(dimensions, n_excitations)
+        expected_size = _n_enr_states(dimensions, n_excitations)
+        expected_shape = (expected_size, expected_size)
+        assert np.all(iden.diag() == 1)
+        assert np.all(iden.full() - np.diag(iden.diag()) == 0)
+        assert iden.shape == expected_shape
+        assert iden.dims == [dimensions, dimensions]
 
 
-if __name__ == "__main__":
-    run_module_suite()
+def test_fock_state(dimensions, n_excitations):
+    """
+    Test Fock state creation agrees with the number operators implied by the
+    existence of the ENR annihiliation operators.
+    """
+    number = [a.dag()*a for a in qutip.enr_destroy(dimensions, n_excitations)]
+    bases = list(qutip.state_number_enumerate(dimensions, n_excitations))
+    n_samples = min((len(bases), 5))
+    for basis in random.sample(bases, n_samples):
+        state = qutip.enr_fock(dimensions, n_excitations, basis)
+        for n, x in zip(number, basis):
+            assert abs(n.matrix_element(state.dag(), state)) - x < 1e-10
+
+
+def _reference_dm(dimensions, n_excitations, nbars):
+    if np.isscalar(nbars):
+        nbars = [nbars] * len(dimensions)
+    out = qutip.tensor([qutip.thermal_dm(dimension, nbar)
+                        for dimension, nbar in zip(dimensions, nbars)])
+    eliminate = [
+        i for i, state in enumerate(qutip.state_number_enumerate(dimensions))
+        if sum(state) > n_excitations]
+    out = out.eliminate_states(eliminate)
+    return out / out.tr()
+
+
+@pytest.mark.parametrize("nbar_type", ["scalar", "vector"])
+def test_thermal_dm(dimensions, n_excitations, nbar_type):
+    # Ensure that the average number of excitations over all the states is
+    # much less than the total number of allowed excitations.
+    if nbar_type == "scalar":
+        nbars = 0.1 * n_excitations / len(dimensions)
+    else:
+        nbars = np.random.rand(len(dimensions))
+        nbars = (0.1 * n_excitations) / np.sum(nbars)
+    test_dm = qutip.enr_thermal_dm(dimensions, n_excitations, nbars)
+    expect_dm = _reference_dm(dimensions, n_excitations, nbars)
+    assert np.allclose(test_dm.full(), expect_dm.full(), atol=1e-12)

--- a/qutip/tests/test_enr_state_operator.py
+++ b/qutip/tests/test_enr_state_operator.py
@@ -37,6 +37,7 @@ import random
 import numpy as np
 import qutip
 
+
 def _n_enr_states(dimensions, n_excitations):
     """
     Calculate the total number of distinct ENR states for a given set of

--- a/qutip/tests/test_enr_state_operator.py
+++ b/qutip/tests/test_enr_state_operator.py
@@ -113,6 +113,10 @@ def test_fock_state(dimensions, n_excitations):
 
 
 def _reference_dm(dimensions, n_excitations, nbars):
+    """
+    Get the reference density matrix using `Qobj.eliminate_states` explicitly,
+    to compare to the direct ENR construction.
+    """
     if np.isscalar(nbars):
         nbars = [nbars] * len(dimensions)
     out = qutip.tensor([qutip.thermal_dm(dimension, nbar)

--- a/qutip/tests/test_enr_state_operator.py
+++ b/qutip/tests/test_enr_state_operator.py
@@ -139,4 +139,4 @@ def test_thermal_dm(dimensions, n_excitations, nbar_type):
         nbars = (0.1 * n_excitations) / np.sum(nbars)
     test_dm = qutip.enr_thermal_dm(dimensions, n_excitations, nbars)
     expect_dm = _reference_dm(dimensions, n_excitations, nbars)
-    assert np.allclose(test_dm.full(), expect_dm.full(), atol=1e-12)
+    np.testing.assert_allclose(test_dm.full(), expect_dm.full(), atol=1e-12)

--- a/qutip/tests/test_entropy.py
+++ b/qutip/tests/test_entropy.py
@@ -31,117 +31,93 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-from __future__ import division
-
+import pytest
 import numpy as np
-from numpy.testing import assert_, assert_equal, run_module_suite
-
-from qutip import (basis, ket2dm, entropy_vn, entropy_linear, rand_ket,
-                   rand_dm, tensor, concurrence, entropy_mutual, ptrace,
-                   entropy_conditional, entangling_power)
-from qutip.qip.operations.gates import cnot, iswap, swap, berkeley, sqrtswap, swapalpha
+import qutip
 
 
-def test_EntropyVN():
-    "Entropy: von-Neumann entropy"
-    # verify that entropy_vn gives correct binary entropy
-    a = np.linspace(0, 1, 20)
-    for k in range(len(a)):
-        # a*|0><0|
-        x = a[k] * ket2dm(basis(2, 0))
-        # (1-a)*|1><1|
-        y = (1 - a[k]) * ket2dm(basis(2, 1))
-        rho = x + y
-        # Von-Neumann entropy (base 2) of rho
-        out = entropy_vn(rho, 2)
-        if k == 0 or k == 19:
-            assert_equal(out, -0.0)
-        else:
-            assert_(abs(-out - a[k] * np.log2(a[k])
-                        - (1. - a[k]) * np.log2((1. - a[k]))) < 1e-12)
+class TestVonNeumannEntropy:
+    @pytest.mark.parametrize("p", np.linspace(0, 1, 17))
+    def test_binary(self, p):
+        dm = qutip.qdiags([p, 1 - p], 0)
+        expected = 0 if p in [0, 1] else p*np.log2(p) + (1-p)*np.log2(1-p)
+        assert abs(-qutip.entropy_vn(dm, 2) - expected) < 1e-12
 
-    # test_ entropy_vn = 0 for pure state
-    psi = rand_ket(10)
-    assert_equal(abs(entropy_vn(psi)) <= 1e-13, True)
+    @pytest.mark.repeat(10)
+    def test_pure_state(self):
+        assert abs(qutip.entropy_vn(qutip.rand_ket(10))) < 1e-12
 
 
-def test_EntropyLinear():
-    "Entropy: Linear entropy"
-    # test_ entropy_vn = 0 for pure state
-    psi = rand_ket(10)
-    assert_equal(abs(entropy_linear(psi)) <= 1e-13, True)
+class TestLinearEntropy:
+    @pytest.mark.repeat(10)
+    def test_less_than_von_neumann(self):
+        dm = qutip.rand_dm(10)
+        assert qutip.entropy_linear(dm) <= qutip.entropy_vn(dm)
 
-    # test_ linear entropy always less than or equal to VN entropy
-    rhos = [rand_dm(6) for k in range(10)]
-    for k in rhos:
-        assert_equal(entropy_linear(k) <= entropy_vn(k), True)
-
-
-def test_EntropyConcurrence():
-    "Entropy: Concurrence"
-    # check concurrence = 1 for maximal entangled (Bell) state
-    bell = ket2dm(
-        (tensor(basis(2), basis(2)) + tensor(basis(2, 1), basis(2, 1))).unit())
-    assert_equal(abs(concurrence(bell) - 1.0) < 1e-15, True)
-
-    # check all concurrence values >=0
-    rhos = [rand_dm(4, dims=[[2, 2], [2, 2]]) for k in range(10)]
-    for k in rhos:
-        assert_equal(concurrence(k) >= 0, True)
+    @pytest.mark.repeat(10)
+    def test_pure_state(self):
+        assert abs(qutip.entropy_linear(qutip.rand_ket(10))) < 1e-12
 
 
-def test_EntropyMutual():
-    "Entropy: Mutual information"
-    # verify mutual information = S(A)+S(B) for pure state
-    rhos = [rand_dm(25, dims=[[5, 5], [5, 5]], pure=True) for k in range(10)]
+class TestConcurrence:
+    @pytest.mark.parametrize("dm", [
+        pytest.param(qutip.bell_state(x).proj(), id='bell'+x)
+        for x in ['00', '01', '10', '11']
+    ])
+    def test_maximally_entangled(self, dm):
+        assert abs(qutip.concurrence(dm) - 1) < 1e-12
 
-    for r in rhos:
-        assert_equal(abs(entropy_mutual(r, [0], [1]) - (
-            entropy_vn(ptrace(r, 0)) + entropy_vn(ptrace(r, 1)))) < 1e-13,
-            True)
-
-    # check component selection
-    rhos = [rand_dm(8, dims=[[2, 2, 2], [2, 2, 2]], pure=True)
-            for k in range(10)]
-
-    for r in rhos:
-        assert_equal(abs(entropy_mutual(r, [0, 2], [1]) - (entropy_vn(
-            ptrace(r, [0, 2])) + entropy_vn(ptrace(r, 1)))) < 1e-13, True)
+    @pytest.mark.repeat(10)
+    def test_nonzero(self):
+        dm = qutip.rand_dm(4, dims=[[2, 2], [2, 2]])
+        assert qutip.concurrence(dm) >= 0
 
 
-def test_EntropyConditional():
-    "Entropy: Conditional entropy"
-    # test_ S(A,B|C,D)<=S(A|C)+S(B|D)
-    rhos = [rand_dm(16, dims=[[2, 2, 2, 2], [2, 2, 2, 2]], pure=True)
-            for k in range(20)]
+@pytest.mark.repeat(10)
+class TestMutualInformation:
+    def test_pure_state_additive(self):
+        # Verify mutual information = S(A) + S(B) for pure states.
+        dm = qutip.rand_dm(25, dims=[[5, 5], [5, 5]], pure=True)
+        expect = (qutip.entropy_vn(dm.ptrace(0))
+                  + qutip.entropy_vn(dm.ptrace(1)))
+        assert abs(qutip.entropy_mutual(dm, [0], [1]) - expect) < 1e-13
 
-    for ABCD in rhos:
-        AC = ptrace(ABCD, [0, 2])
-        BD = ptrace(ABCD, [1, 3])
-        assert_equal(entropy_conditional(ABCD, [2, 3]) <= (
-            entropy_conditional(AC, 1) + entropy_conditional(BD, 1)), True)
-
-    # test_ S(A|B,C)<=S(A|B)
-    rhos = [rand_dm(8, dims=[[2, 2, 2], [2, 2, 2]], pure=True)
-            for k in range(20)]
-
-    for ABC in rhos:
-        AB = ptrace(ABC, [0, 1])
-        assert_equal(entropy_conditional(
-            ABC, [1, 2]) <= entropy_conditional(AB, 1), True)
+    def test_component_selection(self):
+        dm = qutip.rand_dm(8, dims=[[2, 2, 2], [2, 2, 2]], pure=True)
+        expect = (qutip.entropy_vn(dm.ptrace([0, 2]))
+                  + qutip.entropy_vn(dm.ptrace(1)))
+        assert abs(qutip.entropy_mutual(dm, [0, 2], [1]) - expect) < 1e-13
 
 
-def test_EntanglingPower():
-    "Entropy: Entangling power"
-    assert_(abs(entangling_power(cnot()) - 2/9) < 1e-12)
-    assert_(abs(entangling_power(iswap()) - 2/9) < 1e-12)
-    assert_(abs(entangling_power(berkeley()) - 2/9) < 1e-12)
-    assert_(abs(entangling_power(sqrtswap()) - 1/6) < 1e-12)
-    alpha = 2 * np.pi * np.random.rand()
-    assert_(abs(entangling_power(swapalpha(alpha))
-                - 1/6 * np.sin(np.pi * alpha) ** 2) < 1e-12)
-    assert_(abs(entangling_power(swap()) - 0) < 1e-12)
+@pytest.mark.repeat(20)
+class TestConditionalEntropy:
+    def test_inequality_3_qubits(self):
+        # S(A | B,C) <= S(A|B)
+        full = qutip.rand_dm(8, dims=[[2]*3]*2, pure=True)
+        ab = full.ptrace([0, 1])
+        assert (qutip.entropy_conditional(full, [1, 2])
+                <= qutip.entropy_conditional(ab, 1))
+
+    def test_triangle_inequality_4_qubits(self):
+        # S(A,B | C,D) <= S(A|C) + S(B|D)
+        full = qutip.rand_dm(16, dims=[[2]*4]*2, pure=True)
+        ac, bd = full.ptrace([0, 2]), full.ptrace([1, 3])
+        assert (qutip.entropy_conditional(full, [2, 3])
+                <= (qutip.entropy_conditional(ac, 1)
+                    + qutip.entropy_conditional(bd, 1)))
 
 
-if __name__ == "__main__":
-    run_module_suite()
+_alpha = 2*np.pi * np.random.rand()
+
+
+@pytest.mark.parametrize(["gate", "expected"], [
+    pytest.param(qutip.qip.operations.gates.cnot(), 2/9, id="CNOT"),
+    pytest.param(qutip.qip.operations.gates.iswap(), 2/9, id="ISWAP"),
+    pytest.param(qutip.qip.operations.gates.berkeley(), 2/9, id="Berkeley"),
+    pytest.param(qutip.qip.operations.gates.swap(), 0, id="SWAP"),
+    pytest.param(qutip.qip.operations.gates.sqrtswap(), 1/6, id="sqrt(SWAP)"),
+    pytest.param(qutip.qip.operations.gates.swapalpha(_alpha),
+                 np.sin(np.pi*_alpha)**2 / 6, id="SWAP(alpha)"),
+])
+def test_entangling_power(gate, expected):
+    assert abs(qutip.entangling_power(gate) - expected) < 1e-12

--- a/qutip/tests/test_expect.py
+++ b/qutip/tests/test_expect.py
@@ -31,151 +31,125 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+import pytest
+import collections
+import functools
 import numpy as np
-from numpy.testing import assert_, run_module_suite
+import qutip
 
-from qutip.operators import (num, destroy,
-                             sigmax, sigmay, sigmaz, sigmam, sigmap)
-from qutip.states import fock, fock_dm
-from qutip.expect import expect
-from qutip.mesolve import mesolve
-from qutip.random_objects import rand_herm, rand_ket
+_Case = collections.namedtuple('_Case', ['operator', 'state', 'expected'])
 
 
-class TestExpect:
-    """
-    A test class for the QuTiP function for calculating expectation values.
-    """
-
-    def testOperatorKet(self):
-        """
-        expect: operator and ket
-        """
-        N = 10
-        op_N = num(N)
-        op_a = destroy(N)
-        for n in range(N):
-            e = expect(op_N, fock(N, n))
-            assert_(e == n)
-            assert_(type(e) == float)
-            e = expect(op_a, fock(N, n))
-            assert_(e == 0)
-            assert_(type(e) == complex)
-
-    def testOperatorKetRand(self):
-        """
-        expect: rand operator & rand ket
-        """
-        for kk in range(20):
-            N = 20
-            H = rand_herm(N, 0.2)
-            psi = rand_ket(N,0.3)
-            out = expect(H,psi)
-            ans = (psi.dag()*H*psi).tr()
-            assert_(np.abs(out-ans) < 1e-14)
-    
-            G = rand_herm(N, 0.1)
-            out = expect(H+1j*G,psi)
-            ans = (psi.dag()*(H+1j*G)*psi).tr()
-            assert_(np.abs(out-ans) < 1e-14)
-    
-    def testOperatorDensityMatrix(self):
-        """
-        expect: operator and density matrix
-        """
-        N = 10
-        op_N = num(N)
-        op_a = destroy(N)
-        for n in range(N):
-            e = expect(op_N, fock_dm(N, n))
-            assert_(e == n)
-            assert_(type(e) == float)
-            e = expect(op_a, fock_dm(N, n))
-            assert_(e == 0)
-            assert_(type(e) == complex)
-
-    def testOperatorStateList(self):
-        """
-        expect: operator and state list
-        """
-        N = 10
-        op = num(N)
-
-        res = expect(op, [fock(N, n) for n in range(N)])
-        assert_(all(res == range(N)))
-        assert_(isinstance(res, np.ndarray) and res.dtype == np.float64)
-
-        res = expect(op, [fock_dm(N, n) for n in range(N)])
-        assert_(all(res == range(N)))
-        assert_(isinstance(res, np.ndarray) and res.dtype == np.float64)
-
-        op = destroy(N)
-
-        res = expect(op, [fock(N, n) for n in range(N)])
-        assert_(all(res == np.zeros(N)))
-        assert_(isinstance(res, np.ndarray) and res.dtype == np.complex128)
-
-        res = expect(op, [fock_dm(N, n) for n in range(N)])
-        assert_(all(res == np.zeros(N)))
-        assert_(isinstance(res, np.ndarray) and res.dtype == np.complex128)
-
-    def testOperatorListState(self):
-        """
-        expect: operator list and state
-        """
-        res = expect([sigmax(), sigmay(), sigmaz()], fock(2, 0))
-        assert_(len(res) == 3)
-        assert_(all(abs(res - [0, 0, 1]) < 1e-12))
-
-        res = expect([sigmax(), sigmay(), sigmaz()], fock_dm(2, 1))
-        assert_(len(res) == 3)
-        assert_(all(abs(res - [0, 0, -1]) < 1e-12))
-
-    def testOperatorListStateList(self):
-        """
-        expect: operator list and state list
-        """
-        operators = [sigmax(), sigmay(), sigmaz(), sigmam(), sigmap()]
-        states = [fock(2, 0), fock(2, 1), fock_dm(2, 0), fock_dm(2, 1)]
-        res = expect(operators, states)
-
-        assert_(len(res) == len(operators))
-
-        for r_idx, r in enumerate(res):
-
-            assert_(isinstance(r, np.ndarray))
-
-            if operators[r_idx].isherm:
-                assert_(r.dtype == np.float64)
-            else:
-                assert_(r.dtype == np.complex128)
-
-            for s_idx, s in enumerate(states):
-                assert_(r[s_idx] == expect(operators[r_idx], states[s_idx]))
-
-    def testExpectSolverCompatibility(self):
-        """
-        expect: operator list and state list
-        """
-        c_ops = [0.0001 * sigmaz()]
-        e_ops = [sigmax(), sigmay(), sigmaz(), sigmam(), sigmap()]
-        times = np.linspace(0, 10, 100)
-
-        res1 = mesolve(sigmax(), fock(2, 0), times, c_ops, e_ops)
-        res2 = mesolve(sigmax(), fock(2, 0), times, c_ops, [])
-
-        e1 = res1.expect
-        e2 = expect(e_ops, res2.states)
-
-        assert_(len(e1) == len(e2))
-
-        for n in range(len(e1)):
-            assert_(len(e1[n]) == len(e2[n]))
-            assert_(isinstance(e1[n], np.ndarray))
-            assert_(isinstance(e2[n], np.ndarray))
-            assert_(e1[n].dtype == e2[n].dtype)
-            assert_(all(abs(e1[n] - e2[n]) < 1e-12))
+def _case_to_dm(case):
+    return case._replace(state=[x.proj() for x in case.state])
 
 
-if __name__ == "__main__":
-    run_module_suite()
+def _unwrap(list_):
+    """Unwrap lists until we reach the first non-list element."""
+    out = list_
+    while isinstance(out, list):
+        out = out[0]
+    return out
+
+
+def _case_id(case):
+    op_part = 'qubit' if _unwrap(case.operator).dims[0][0] == 2 else 'basis'
+    state_part = 'ket' if _unwrap(case.state).dims[1][0] == 1 else 'dm'
+    return op_part + "-" + state_part
+
+
+# Store cases for the tests of known expectation value in broadcasted form,
+# because it's easier to unroll broadcasted objects than roll up flat ones.
+_dim = 5
+_num, _a = qutip.num(_dim), qutip.destroy(_dim)
+_sx, _sz, _sp = qutip.sigmax(), qutip.sigmaz(), qutip.sigmap()
+_known_fock = _Case([_num, _a],
+                    [qutip.fock(_dim, n) for n in range(_dim)],
+                    np.array([np.arange(_dim), np.zeros(_dim)]))
+_known_qubit = _Case([_sx, _sz, _sp],
+                     [qutip.basis(2, 0), qutip.basis(2, 1)],
+                     np.array([[0, 0], [1, -1], [0, 0]]))
+_known_cases = [_known_fock, _case_to_dm(_known_fock),
+                _known_qubit, _case_to_dm(_known_qubit)]
+
+
+class TestKnownExpectation:
+    def pytest_generate_tests(self, metafunc):
+        cases = _known_cases
+        op_name, state_name = 'operator', 'state'
+        if op_name not in metafunc.fixturenames:
+            op_name += 's'
+        else:
+            cases = [_Case(op, case.state, expected)
+                     for case in cases
+                     for op, expected in zip(case.operator, case.expected)]
+        if state_name not in metafunc.fixturenames:
+            state_name += 's'
+        else:
+            cases = [_Case(case.operator, state, expected)
+                     for case in cases
+                     for state, expected in zip(case.state, case.expected.T)]
+        metafunc.parametrize([op_name, state_name, 'expected'], cases,
+                             ids=[_case_id(case) for case in cases])
+
+    def test_operator_by_basis(self, operator, state, expected):
+        result = qutip.expect(operator, state)
+        assert result == expected
+        assert isinstance(result, float if operator.isherm else complex)
+
+    def test_broadcast_operator_list(self, operators, state, expected):
+        result = qutip.expect(operators, state)
+        expected_dtype = (np.float64 if all(op.isherm for op in operators)
+                          else np.complex128)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == expected_dtype
+        assert list(result) == list(expected)
+
+    def test_broadcast_state_list(self, operator, states, expected):
+        result = qutip.expect(operator, states)
+        expected_dtype = np.float64 if operator.isherm else np.complex128
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == expected_dtype
+        assert list(result) == list(expected)
+
+    def test_broadcast_both_lists(self, operators, states, expected):
+        result = qutip.expect(operators, states)
+        assert len(result) == len(operators)
+        for part, operator, expected_part in zip(result, operators, expected):
+            expected_dtype = np.float64 if operator.isherm else np.complex128
+            assert isinstance(part, np.ndarray)
+            assert part.dtype == expected_dtype
+            assert list(part) == list(expected_part)
+
+
+@pytest.mark.repeat(20)
+@pytest.mark.parametrize("hermitian", [False, True], ids=['complex', 'real'])
+def test_equivalent_to_matrix_element(hermitian):
+    dimension = 20
+    state = qutip.rand_ket(dimension, 0.3)
+    op = qutip.rand_herm(dimension, 0.2)
+    if not hermitian:
+        op = op + 1j*qutip.rand_herm(dimension, 0.1)
+    matrix = (state.dag() * op * state).data[0, 0]
+    assert abs(qutip.expect(op, state) - matrix) < 1e-14
+
+
+@pytest.mark.parametrize("solve", [
+    pytest.param(qutip.sesolve, id="sesolve"),
+    pytest.param(functools.partial(qutip.mesolve, c_ops=[0.001 * _sz]),
+                 id="mesolve"),
+])
+def test_compatibility_with_solver(solve):
+    e_ops = [getattr(qutip, 'sigma'+x)() for x in 'xyzmp']
+    h = qutip.sigmax()
+    state = qutip.basis(2, 0)
+    times = np.linspace(0, 10, 101)
+    direct = solve(h, state, times, e_ops=e_ops).expect
+    indirect = qutip.expect(e_ops, solve(h, state, times).states)
+    assert len(direct) == len(indirect)
+    for direct_, indirect_ in zip(direct, indirect):
+        assert len(direct_) == len(indirect_)
+        assert isinstance(direct_, np.ndarray)
+        assert isinstance(indirect_, np.ndarray)
+        assert direct_.dtype == indirect_.dtype
+        assert np.allclose(direct_, indirect_, atol=1e-12)

--- a/qutip/tests/test_expect.py
+++ b/qutip/tests/test_expect.py
@@ -176,4 +176,4 @@ def test_compatibility_with_solver(solve):
         assert isinstance(direct_, np.ndarray)
         assert isinstance(indirect_, np.ndarray)
         assert direct_.dtype == indirect_.dtype
-        assert np.allclose(direct_, indirect_, atol=1e-12)
+        np.testing.assert_allclose(direct_, indirect_, atol=1e-12)

--- a/qutip/tests/test_fileio.py
+++ b/qutip/tests/test_fileio.py
@@ -31,145 +31,46 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-import os
-from numpy import amax
-from numpy.testing import assert_, run_module_suite
-from numpy.random import rand
-import scipy
-from qutip import *
-from qutip import file_data_store, file_data_read
+import pytest
+import numpy as np
+import qutip
+
+_dimension = 10
 
 
-class TestFileIO:
-    """
-    A test class for the QuTiP functions for writing and reading data to files.
-    """
+class Test_file_data_store_file_data_read:
+    # Tests parametrised seprately to give nicer descriptions in verbose mode.
 
-    def testRWRealDefault(self):
-        "Read and write real valued default formatted data"
+    def case(self, filename, kwargs):
+        data = 1 - 2*np.random.rand(_dimension, _dimension)
+        if kwargs.get('numtype', 'complex') == 'complex':
+            data = data * (0.5*0.5j)
+        qutip.file_data_store(filename, data, **kwargs)
+        out = qutip.file_data_read(filename)
+        assert np.allclose(data, out, atol=1e-8)
 
-        # create some random data
-        N = 10
-        data = (1 - 2 * rand(N, N))
+    def test_defaults(self, tmpfile):
+        return self.case(tmpfile.name, {})
 
-        file_data_store("test.dat", data)
-        data2 = file_data_read("test.dat")
-        # make sure the deviation is small:
-        assert_(amax(abs((data - data2))) < 1e-8)
-        os.remove("test.dat")
+    @pytest.mark.parametrize("type_", ["real", "complex"])
+    @pytest.mark.parametrize("format_", ["decimal", "exp"])
+    def test_type_format(self, tmpfile, type_, format_):
+        kwargs = {'numtype': type_, 'numformat': format_}
+        return self.case(tmpfile.name, kwargs)
 
-    def testRWRealDecimal(self):
-        "Read and write real valued decimal formatted data"
-
-        # create some random data
-        N = 10
-        data = (1 - 2 * rand(N, N))
-
-        file_data_store("test.dat", data, "real", "decimal")
-        data2 = file_data_read("test.dat", ",")
-        # make sure the deviation is small:
-        assert_(amax(abs((data - data2))) < 1e-8)
-        os.remove("test.dat")
-
-    def testRWRealExp(self):
-        "Read and write real valued exp formatted data"
-
-        # create some random data
-        N = 10
-        data = (1 - 2 * rand(N, N))
-
-        file_data_store("test.dat", data, "real", "exp")
-        data2 = file_data_read("test.dat", ",")
-        # make sure the deviation is small:
-        assert_(amax(abs((data - data2))) < 1e-8)
-        os.remove("test.dat")
-
-    def testRWComplexDefault(self):
-        "Read and write complex valued default formatted data"
-
-        # create some random data
-        N = 10
-        data = (1 - 2 * rand(N, N)) + 1j * (1 - 2 * rand(N, N))
-
-        file_data_store("test.dat", data)
-        data2 = file_data_read("test.dat")
-        # make sure the deviation is small:
-        assert_(amax(abs((data - data2))) < 1e-8)
-        os.remove("test.dat")
-
-    def testRWComplexDecimal(self):
-        "Read and write complex valued decimal formatted data"
-
-        # create some random data
-        N = 10
-        data = (1 - 2 * rand(N, N)) + 1j * (1 - 2 * rand(N, N))
-
-        file_data_store("test.dat", data, "complex", "decimal")
-        data2 = file_data_read("test.dat", ",")
-        # make sure the deviation is small:
-        assert_(amax(abs((data - data2))) < 1e-8)
-        os.remove("test.dat")
-
-    def testRWComplexExp(self):
-        "Read and write complex valued exp formatted data"
-
-        # create some random data
-        N = 10
-        data = (1 - 2 * rand(N, N)) + 1j * (1 - 2 * rand(N, N))
-
-        file_data_store("test.dat", data, "complex", "exp")
-        data2 = file_data_read("test.dat", ",")
-        # make sure the deviation is small:
-        assert_(amax(abs((data - data2))) < 1e-8)
-        os.remove("test.dat")
-
-    def testRWSeparatorDetection(self):
-        "Read and write with automatic separator detection"
-
-        # create some random data
-        N = 10
-        data = (1 - 2 * rand(N, N)) + 1j * (1 - 2 * rand(N, N))
-
-        # comma separated values
-        file_data_store("test.dat", data, "complex", "exp", ",")
-        data2 = file_data_read("test.dat")
-        assert_(amax(abs((data - data2))) < 1e-8)
-
-        # semicolon separated values
-        file_data_store("test.dat", data, "complex", "exp", ";")
-        data2 = file_data_read("test.dat")
-        assert_(amax(abs((data - data2))) < 1e-8)
-
-        # tab separated values
-        file_data_store("test.dat", data, "complex", "exp", "\t")
-        data2 = file_data_read("test.dat")
-        assert_(amax(abs((data - data2))) < 1e-8)
-
-        # space separated values
-        file_data_store("test.dat", data, "complex", "exp", " ")
-        data2 = file_data_read("test.dat")
-        assert_(amax(abs((data - data2))) < 1e-8)
-
-        # mixed-whitespace separated values
-        file_data_store("test.dat", data, "complex", "exp", " \t ")
-        data2 = file_data_read("test.dat")
-        assert_(amax(abs((data - data2))) < 1e-8)
-        os.remove("test.dat")
-
-    def testqsaveqload(self):
-        "qsave/qload"
-        A = sigmax()
-        B = num(5)
-        C = coherent_dm(10,1j)
-        ops = [A, B, C]
-        qsave(ops, 'fileio_check')
-        ops2 = qload('fileio_check')
-        assert_(ops == ops2)
-        try:
-            os.remove('fileio_check.qu')
-        except:
-            pass
+    @pytest.mark.parametrize("separator", [",", ";", "\t", " ", " \t "],
+                             ids=lambda x: "'" + x + "'")
+    def test_separator_detection(self, tmpfile, separator):
+        kwargs = {'numtype': 'complex', 'numformat': 'exp', 'sep': separator}
+        return self.case(tmpfile.name, kwargs)
 
 
-if __name__ == "__main__":
-    run_module_suite()
+@pytest.mark.usefixtures("in_temporary_directory")
+def test_qsave_qload():
+    ops_in = [qutip.sigmax(),
+              qutip.num(_dimension),
+              qutip.coherent_dm(_dimension, 1j)]
+    filename = "qsave_qload_test"
+    qutip.qsave(ops_in, filename)
+    ops_out = qutip.qload(filename)
+    assert ops_in == ops_out

--- a/qutip/tests/test_fileio.py
+++ b/qutip/tests/test_fileio.py
@@ -47,7 +47,7 @@ class Test_file_data_store_file_data_read:
             data = data * (0.5*0.5j)
         qutip.file_data_store(filename, data, **kwargs)
         out = qutip.file_data_read(filename)
-        assert np.allclose(data, out, atol=1e-8)
+        np.testing.assert_allclose(data, out, atol=1e-8)
 
     def test_defaults(self, tmpfile):
         return self.case(tmpfile.name, {})

--- a/qutip/tests/test_fileio.py
+++ b/qutip/tests/test_fileio.py
@@ -67,6 +67,11 @@ class Test_file_data_store_file_data_read:
 
 @pytest.mark.usefixtures("in_temporary_directory")
 def test_qsave_qload():
+    # qsave _always_ appends a suffix to the file name at the time of writing,
+    # but in case this changes in the future, to ensure that we never leak a
+    # temporary file into the user's folders, we simply apply this test in a
+    # temporary directory rather than manually creating a temporary file and
+    # modifying the name.
     ops_in = [qutip.sigmax(),
               qutip.num(_dimension),
               qutip.coherent_dm(_dimension, 1j)]

--- a/qutip/tests/test_floquet.py
+++ b/qutip/tests/test_floquet.py
@@ -32,41 +32,24 @@
 ###############################################################################
 
 import numpy as np
-from numpy.testing import assert_, run_module_suite
-from qutip import fsesolve, sigmax, sigmaz, rand_ket, num, mesolve
+import qutip
 
 
-class TestFloquet:
-    """
-    A test class for the QuTiP functions for Floquet formalism.
-    """
+def test_unitary_evolution_two_level_system():
+    delta = 1.0 * 2 * np.pi
+    eps0 = 1.0 * 2 * np.pi
+    A = 0.5 * 2 * np.pi
+    omega = np.sqrt(delta**2 + eps0**2)
+    T = 2*np.pi / omega
+    tlist = np.linspace(0, 2*T, 101)
+    psi0 = qutip.rand_ket(2)
+    H0 = -0.5*eps0*qutip.sigmaz() - 0.5*delta*qutip.sigmax()
+    H1 = 0.5 * A * qutip.sigmax()
+    args = {'w': omega}
+    H = [H0, [H1, lambda t, args: np.sin(args['w'] * t)]]
+    e_ops = [qutip.num(2)]
 
-    def testFloquetUnitary(self):
-        """
-        Floquet: test unitary evolution of time-dependent two-level system
-        """
+    trial = qutip.fsesolve(H, psi0, tlist, e_ops, T, args).expect[0]
+    expected = qutip.mesolve(H, psi0, tlist, [], e_ops, args).expect[0]
 
-        delta = 1.0 * 2 * np.pi
-        eps0 = 1.0 * 2 * np.pi
-        A = 0.5 * 2 * np.pi
-        omega = np.sqrt(delta ** 2 + eps0 ** 2)
-        T = (2 * np.pi) / omega
-        tlist = np.linspace(0.0, 2 * T, 101)
-        psi0 = rand_ket(2)
-        H0 = - eps0 / 2.0 * sigmaz() - delta / 2.0 * sigmax()
-        H1 = A / 2.0 * sigmax()
-        args = {'w': omega}
-        H = [H0, [H1, lambda t, args: np.sin(args['w'] * t)]]
-        e_ops = [num(2)]
-
-        # solve schrodinger equation with floquet solver
-        sol = fsesolve(H, psi0, tlist, e_ops, T, args)
-
-        # compare with results from standard schrodinger equation
-        sol_ref = mesolve(H, psi0, tlist, [], e_ops, args)
-
-        assert_(max(abs(sol.expect[0] - sol_ref.expect[0])) < 1e-4)
-
-
-if __name__ == "__main__":
-    run_module_suite()
+    assert np.allclose(trial, expected, atol=1e-4)

--- a/qutip/tests/test_floquet.py
+++ b/qutip/tests/test_floquet.py
@@ -52,4 +52,4 @@ def test_unitary_evolution_two_level_system():
     trial = qutip.fsesolve(H, psi0, tlist, e_ops, T, args).expect[0]
     expected = qutip.mesolve(H, psi0, tlist, [], e_ops, args).expect[0]
 
-    assert np.allclose(trial, expected, atol=1e-4)
+    np.testing.assert_allclose(trial, expected, atol=1e-4)

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -166,8 +166,8 @@ class TestExplicitForm:
         pytest.param(2*np.pi, -qutip.qeye([2, 2]), id="2pi"),
     ])
     def test_molmer_sorensen(self, angle, expected):
-        assert np.allclose(gates.molmer_sorensen(angle).full(),
-                           expected.full(), atol=1e-15)
+        np.testing.assert_allclose(gates.molmer_sorensen(angle).full(),
+                                   expected.full(), atol=1e-15)
 
     @pytest.mark.parametrize(["gate", "n_angles"], [
         pytest.param(gates.rx, 1, id="Rx"),
@@ -177,7 +177,8 @@ class TestExplicitForm:
         pytest.param(gates.qrot, 2, id="Rabi rotation"),
     ])
     def test_zero_rotations_are_identity(self, gate, n_angles):
-        assert np.allclose(np.eye(2), gate(*([0]*n_angles)), atol=1e-15)
+        np.testing.assert_allclose(np.eye(2), gate(*([0]*n_angles)),
+                                   atol=1e-15)
 
 
 class TestCliffordGroup:
@@ -293,7 +294,7 @@ class Test_expand_operator:
         test = gates.expand_operator(base,
                                      N=len(permutation), targets=permutation)
         expected = base.permute(_apply_permutation(permutation))
-        assert np.allclose(test.full(), expected.full(), atol=1e-15)
+        np.testing.assert_allclose(test.full(), expected.full(), atol=1e-15)
 
     @pytest.mark.parametrize('n_targets', range(1, 5))
     def test_general_qubit_expansion(self, n_targets):
@@ -304,7 +305,8 @@ class Test_expand_operator:
             expected = _tensor_with_entanglement([qutip.qeye(2)] * n_qubits,
                                                  operation, targets)
             test = gates.expand_operator(operation, n_qubits, targets)
-            assert np.allclose(test.full(), expected.full(), atol=1e-15)
+            np.testing.assert_allclose(test.full(), expected.full(),
+                                       atol=1e-15)
 
     def test_cnot_explicit(self):
         test = gates.expand_operator(gates.cnot(), 3, [2, 0]).full()
@@ -316,7 +318,7 @@ class Test_expand_operator:
                              [0, 1, 0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0, 1, 0],
                              [0, 0, 0, 1, 0, 0, 0, 0]])
-        assert np.allclose(test, expected, atol=1e-15)
+        np.testing.assert_allclose(test, expected, atol=1e-15)
 
     def test_cyclic_permutation(self):
         operators = [qutip.sigmax(), qutip.sigmaz()]
@@ -345,4 +347,4 @@ class Test_expand_operator:
             test = gates.expand_operator(base_test, N=n_qubits,
                                          targets=targets, dims=dimensions)
             assert test.dims == expected.dims
-            assert np.allclose(test.full(), expected.full())
+            np.testing.assert_allclose(test.full(), expected.full())

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -31,364 +31,318 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+import pytest
+import functools
 import itertools
 import numpy as np
-from numpy.testing import (assert_, assert_allclose, assert_array_equal, 
-                           run_module_suite)
-from qutip.states import basis, ket2dm
-from qutip.operators import identity, qeye, sigmax, sigmay, sigmaz
-from qutip.qip.operations.gates import (rx, ry, rz, phasegate, qrot, cnot, swap, iswap,
-                       sqrtswap, molmer_sorensen,
-                       toffoli, fredkin, gate_expand_3toN, 
-                       qubit_clifford_group, expand_operator)
-from qutip.random_objects import rand_ket, rand_herm, rand_unitary, rand_dm
-from qutip.tensor import tensor
-from qutip.qobj import Qobj
+import qutip
+from qutip.qip.operations import gates
+
+_paulis = [qutip.qeye(2), qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()]
 
 
-class TestGates:
+def _permutation_id(permutation):
+    return str(len(permutation)) + "-" + "".join(map(str, permutation))
+
+
+def _infidelity(a, b):
+    """Infidelity between two kets."""
+    return 1 - abs(a.overlap(b))
+
+
+def _hashable_without_global_phase(qobj):
     """
-    A test class for the QuTiP functions for generating quantum gates
+    Convert an operator into a hashable type, fixing the gauge of any global
+    phase to within tolerance.  This allows us to check for set equality.
     """
+    flat = qobj.full().flat.copy()
+    for phase in flat:
+        if phase != 0:
+            # Fix the gauge for any global phase.
+            flat = flat * np.exp(-1j * np.angle(phase))
+            break
+    # Floating point numbers cannot truly be compared with a hash on their
+    # rounded values, (e.g. 4e-11 and 6e-11 will round to 0 and 1e-10
+    # respectively even though they ought to be within tolerance), but as a
+    # quick test that nothing is horrendously broken, this should be enough.
+    return tuple(np.round(flat, decimals=10))
 
-    def testSwapGate(self):
+
+def _make_random_three_qubit_gate():
+    """Create a random three-qubit gate."""
+    operation = qutip.rand_unitary(8, dims=[[2]*3]*2)
+
+    def gate(N=None, controls=None, target=None):
+        if N is None:
+            return operation
+        return gates.gate_expand_3toN(operation, N, controls, target)
+    return gate
+
+
+def _tensor_with_entanglement(all_qubits, entangled, entangled_locations):
+    """
+    Create a full tensor product when a subspace component is already in an
+    entangled state.  The locations in `all_qubits` which are the entangled
+    points in the output are ignored and can take any value.
+
+    For example,
+        _tensor_with_entanglement([|a>, |b>, |c>, |d>], (|00> + |11>), [0, 2])
+    should product a tensor product like (|0b0d> + |1b1d>), i.e. qubits 0 and 2
+    in the final output are entangled, but the others are still separable.
+
+    Parameters:
+        all_qubits: list of kets --
+            A list of separable parts to tensor together.  States that are in
+            the locations referred to by `entangled_locations` are completely
+            ignored.
+        entangled: tensor-product ket -- the full entangled subspace
+        entangled_locations: list of int --
+            The locations that the qubits in the entangled subspace should be
+            in in the final tensor-product space.
+    """
+    n_entangled = len(entangled.dims[0])
+    n_separable = len(all_qubits) - n_entangled
+    separable = all_qubits.copy()
+    # Remove in reverse order so subsequent deletion locations don't change.
+    for location in sorted(entangled_locations, reverse=True):
+        del separable[location]
+    # Can't separate out entangled states to pass to tensor in the right places
+    # immediately, so tensor in at one end and then permute into place.
+    out = qutip.tensor(*separable, entangled)
+    permutation = list(range(n_separable))
+    current_locations = range(n_separable, n_separable + n_entangled)
+    # Sort to prevert later insertions changing previous locations.
+    insertions = sorted(zip(entangled_locations, current_locations),
+                        key=lambda x: x[0])
+    for out_location, current_location in insertions:
+        permutation.insert(out_location, current_location)
+    return out.permute(permutation)
+
+
+def _apply_permutation(permutation):
+    """
+    Permute the given permutation into the order denoted by its elements, i.e.
+        out[0] = permutation[permutation[0]]
+        out[1] = permutation[permutation[1]]
+        ...
+
+    This function is its own inverse.
+    """
+    out = [None] * len(permutation)
+    for value, location in enumerate(permutation):
+        out[location] = value
+    return out
+
+
+class TestExplicitForm:
+    def test_swap(self):
+        states = [qutip.rand_ket(2) for _ in [None]*2]
+        start = qutip.tensor(states)
+        swapped = qutip.tensor(states[::-1])
+        swap = gates.swap()
+        assert _infidelity(swapped, swap*start) < 1e-12
+        assert _infidelity(start, swap*swap*start) < 1e-12
+
+    @pytest.mark.parametrize('permutation', itertools.permutations([0, 1, 2]),
+                             ids=_permutation_id)
+    def test_toffoli(self, permutation):
+        test = gates.toffoli(N=3,
+                             controls=permutation[:2],
+                             target=permutation[2])
+        base = (qutip.tensor(1 - qutip.basis([2, 2], [1, 1]).proj(),
+                             qutip.qeye(2))
+                + qutip.tensor(qutip.basis([2, 2], [1, 1]).proj(),
+                               qutip.sigmax()))
+        # Iterate the permutation once, equivalent to finding its inverse,
+        # because for us, `permutation[n]` is where qubit `n` should be placed,
+        # whereas `Qobj.permuate` interprets that qubit `n` should be at the
+        # location `i` where `permutation[i] == n`.
+        expected = base.permute(_apply_permutation(permutation))
+        assert test == expected
+
+    @pytest.mark.parametrize(['angle', 'expected'], [
+        pytest.param(np.pi, -1j*qutip.tensor(qutip.sigmax(), qutip.sigmax()),
+                     id="pi"),
+        pytest.param(2*np.pi, -qutip.qeye([2, 2]), id="2pi"),
+    ])
+    def test_molmer_sorensen(self, angle, expected):
+        assert np.allclose(gates.molmer_sorensen(angle).full(),
+                           expected.full(), atol=1e-15)
+
+    @pytest.mark.parametrize(["gate", "n_angles"], [
+        pytest.param(gates.rx, 1, id="Rx"),
+        pytest.param(gates.ry, 1, id="Ry"),
+        pytest.param(gates.rz, 1, id="Rz"),
+        pytest.param(gates.phasegate, 1, id="phase"),
+        pytest.param(gates.qrot, 2, id="Rabi rotation"),
+    ])
+    def test_zero_rotations_are_identity(self, gate, n_angles):
+        assert np.allclose(np.eye(2), gate(*([0]*n_angles)), atol=1e-15)
+
+
+class TestCliffordGroup:
+    """
+    Test a sufficient set of conditions to prove that we have a full Clifford
+    group for a single qubit.
+    """
+    clifford = list(gates.qubit_clifford_group())
+    pauli_set = {_hashable_without_global_phase(x) for x in _paulis}
+
+    def test_single_qubit_group_dimension_is_24(self):
+        assert len(self.clifford) == 24
+
+    def test_all_elements_different(self):
+        # Test for equality by hashing into a set---duplicated entries will
+        # cause the dimension of the set to be lower than that of the list.
+        group = {_hashable_without_global_phase(x) for x in self.clifford}
+        assert len(group) == len(self.clifford)
+
+    @pytest.mark.parametrize("gate", gates.qubit_clifford_group())
+    def test_gate_normalises_pauli_group(self, gate):
         """
-        gates: swap gate
+        Test the fundamental definition of the Clifford group, i.e. that it
+        normalises the Pauli group.
         """
-        a, b = np.random.rand(), np.random.rand()
-        psi1 = (a * basis(2, 0) + b * basis(2, 1)).unit()
-
-        c, d = np.random.rand(), np.random.rand()
-        psi2 = (c * basis(2, 0) + d * basis(2, 1)).unit()
-
-        psi_in = tensor(psi1, psi2)
-        psi_out = tensor(psi2, psi1)
-
-        psi_res = swap() * psi_in
-        assert_((psi_out - psi_res).norm() < 1e-12)
-
-        psi_res = swap() * swap() * psi_in
-        assert_((psi_in - psi_res).norm() < 1e-12)
-
-    def test_clifford_group_len(self):
-        assert_(len(list(qubit_clifford_group())) == 24)
-
-    def _prop_identity(self, U, tol=1e-6):
-        """
-        Returns True if and only if U is proportional to the
-        identity.
-        """
-        U0 = complex(U[0, 0])  # scipy 1.3 return 0 dims array.
-        if U0 != 0:
-            norm_U = U / U0
-            return (qeye(U.dims[0]) - norm_U).norm() <= tol
-        else:
-            return False
-
-    def case_is_clifford(self, U):
-        paulis = (identity(2), sigmax(), sigmay(), sigmaz())
-
-        for P in paulis:
-            U_P = U * P * U.dag()
-
-            out = (np.any(
-                np.array([self._prop_identity(U_P * Q) for Q in paulis])
-            ))
-        return out
-
-    def test_are_cliffords(self):
-        for U in qubit_clifford_group():
-            assert_(self.case_is_clifford(U))
-
-    def testExpandGate1toN(self):
-        """
-        gates: expand 1 to N
-        """
-        N = 7
-
-        for g in [rx, ry, rz, phasegate]:
-
-            theta = np.random.rand() * 2 * 3.1415
-            a, b = np.random.rand(), np.random.rand()
-            psi1 = (a * basis(2, 0) + b * basis(2, 1)).unit()
-            psi2 = g(theta) * psi1
-
-            psi_rand_list = [rand_ket(2) for k in range(N)]
-
-            for m in range(N):
-
-                psi_in = tensor([psi1 if k == m else psi_rand_list[k]
-                                 for k in range(N)])
-                psi_out = tensor([psi2 if k == m else psi_rand_list[k]
-                                  for k in range(N)])
-
-                G = g(theta, N, m)
-                psi_res = G * psi_in
-
-                assert_((psi_out - psi_res).norm() < 1e-12)
-
-    def testExpandGate2toNSwap(self):
-        """
-        gates: expand 2 to N (using swap)
-        """
-
-        a, b = np.random.rand(), np.random.rand()
-        k1 = (a * basis(2, 0) + b * basis(2, 1)).unit()
-
-        c, d = np.random.rand(), np.random.rand()
-        k2 = (c * basis(2, 0) + d * basis(2, 1)).unit()
-
-        N = 6
-        kets = [rand_ket(2) for k in range(N)]
-
-        for m in range(N):
-            for n in set(range(N)) - {m}:
-
-                psi_in = tensor([k1 if k == m else k2 if k == n else kets[k]
-                                 for k in range(N)])
-                psi_out = tensor([k2 if k == m else k1 if k == n else kets[k]
-                                  for k in range(N)])
-
-                targets = [m, n]
-                G = swap(N, targets)
-
-                psi_out = G * psi_in
-
-                assert_((psi_out - G * psi_in).norm() < 1e-12)
-
-    def testExpandGate2toN(self):
-        """
-        gates: expand 2 to N (using cnot, iswap, sqrtswap)
-        """
-
-        a, b = np.random.rand(), np.random.rand()
-        k1 = (a * basis(2, 0) + b * basis(2, 1)).unit()
-
-        c, d = np.random.rand(), np.random.rand()
-        k2 = (c * basis(2, 0) + d * basis(2, 1)).unit()
-
-        psi_ref_in = tensor(k1, k2)
-
-        N = 6
-        psi_rand_list = [rand_ket(2) for k in range(N)]
-
-        for g in [cnot, iswap, sqrtswap]:
-
-            psi_ref_out = g() * psi_ref_in
-            rho_ref_out = ket2dm(psi_ref_out)
-
-            for m in range(N):
-                for n in set(range(N)) - {m}:
-
-                    psi_list = [psi_rand_list[k] for k in range(N)]
-                    psi_list[m] = k1
-                    psi_list[n] = k2
-                    psi_in = tensor(psi_list)
-
-                    if g == cnot:
-                        G = g(N, m, n)
-                    else:
-                        G = g(N, [m, n])
-
-                    psi_out = G * psi_in
-
-                    o1 = psi_out.overlap(psi_in)
-                    o2 = psi_ref_out.overlap(psi_ref_in)
-                    assert_(abs(o1 - o2) < 1e-12)
-
-                    p = [0, 1] if m < n else [1, 0]
-                    rho_out = psi_out.ptrace([m, n]).permute(p)
-
-                    assert_((rho_ref_out - rho_out).norm() < 1e-12)
-
-    def testExpandGate3toN_permutation(self):
-        """
-        gates: expand 3 to 3 with permuTation (using toffoli)
-        """
-        for _p in itertools.permutations([0, 1, 2]):
-            controls, target = [_p[0], _p[1]], _p[2]
-
-            controls = [1, 2]
-            target = 0
-
-            p = [1, 2, 3]
-            p[controls[0]] = 0
-            p[controls[1]] = 1
-            p[target] = 2
-
-            U = toffoli(N=3, controls=controls, target=target)
-
-            ops = [basis(2, 0).dag(),  basis(2, 0).dag(), identity(2)]
-            P = tensor(ops[p[0]], ops[p[1]], ops[p[2]])
-            assert_(P * U * P.dag() == identity(2))
-
-            ops = [basis(2, 1).dag(),  basis(2, 0).dag(), identity(2)]
-            P = tensor(ops[p[0]], ops[p[1]], ops[p[2]])
-            assert_(P * U * P.dag() == identity(2))
-
-            ops = [basis(2, 0).dag(),  basis(2, 1).dag(), identity(2)]
-            P = tensor(ops[p[0]], ops[p[1]], ops[p[2]])
-            assert_(P * U * P.dag() == identity(2))
-
-            ops = [basis(2, 1).dag(),  basis(2, 1).dag(), identity(2)]
-            P = tensor(ops[p[0]], ops[p[1]], ops[p[2]])
-            assert_(P * U * P.dag() == sigmax())
-
-    def testExpandGate3toN(self):
-        """
-        gates: expand 3 to N (using toffoli, fredkin, and random 3 qubit gate)
-        """
-
-        a, b = np.random.rand(), np.random.rand()
-        psi1 = (a * basis(2, 0) + b * basis(2, 1)).unit()
-
-        c, d = np.random.rand(), np.random.rand()
-        psi2 = (c * basis(2, 0) + d * basis(2, 1)).unit()
-
-        e, f = np.random.rand(), np.random.rand()
-        psi3 = (e * basis(2, 0) + f * basis(2, 1)).unit()
-
-        N = 4
-        psi_rand_list = [rand_ket(2) for k in range(N)]
-
-        _rand_gate_U = tensor([rand_herm(2, density=1) for k in range(3)])
-
-        def _rand_3qubit_gate(N=None, controls=None, k=None):
-            if N is None:
-                return _rand_gate_U
-            else:
-                return gate_expand_3toN(_rand_gate_U, N, controls, k)
-
-        for g in [fredkin, toffoli, _rand_3qubit_gate]:
-
-            psi_ref_in = tensor(psi1, psi2, psi3)
-            psi_ref_out = g() * psi_ref_in
-
-            for m in range(N):
-                for n in set(range(N)) - {m}:
-                    for k in set(range(N)) - {m, n}:
-
-                        psi_list = [psi_rand_list[p] for p in range(N)]
-                        psi_list[m] = psi1
-                        psi_list[n] = psi2
-                        psi_list[k] = psi3
-                        psi_in = tensor(psi_list)
-
-                        if g == fredkin:
-                            targets = [n, k]
-                            G = g(N, control=m, targets=targets)
-                        else:
-                            controls = [m, n]
-                            G = g(N, controls, k)
-
-                        psi_out = G * psi_in
-
-                        o1 = psi_out.overlap(psi_in)
-                        o2 = psi_ref_out.overlap(psi_ref_in)
-                        assert_(abs(o1 - o2) < 1e-12)
-
-    def test_expand_operator(self):
-        """
-        gate : expand qubits operator to a N qubits system.
-        """
-        # oper size is N, no expansion
-        oper = tensor(sigmax(), sigmay())
-        assert_allclose(expand_operator(oper=oper, targets=[0, 1], N=2), oper)
-        assert_allclose(expand_operator(oper=oper, targets=[1, 0], N=2), 
-                            tensor(sigmay(), sigmax()))
-
-        # random single qubit gate test, integer as target
-        r = rand_unitary(2)
-        assert_allclose(expand_operator(r, 3, 0), tensor([r, identity(2), identity(2)]))
-        assert_allclose(expand_operator(r, 3, 1), tensor([identity(2), r, identity(2)]))
-        assert_allclose(expand_operator(r, 3, 2), tensor([identity(2), identity(2), r]))
-
-        # random 2qubits gate test, list as target
-        r2 = rand_unitary(4)
-        r2.dims = [[2, 2], [2, 2]]
-        assert_allclose(expand_operator(r2, 3, [2, 1]), tensor(
-            [identity(2), r2.permute([1, 0])]))
-        assert_allclose(expand_operator(r2, 3, [0, 1]), tensor(
-            [r2, identity(2)]))
-        assert_allclose(expand_operator(r2, 3, [0, 2]), tensor(
-            [r2, identity(2)]).permute([0, 2, 1]))
-
-        # cnot expantion, qubit 2 control qubit 0
-        assert_allclose(expand_operator(cnot(), 3, [2, 0]), Qobj([
-            [1., 0., 0., 0., 0., 0., 0., 0.],
-            [0., 0., 0., 0., 0., 1., 0., 0.],
-            [0., 0., 1., 0., 0., 0., 0., 0.],
-            [0., 0., 0., 0., 0., 0., 0., 1.],
-            [0., 0., 0., 0., 1., 0., 0., 0.],
-            [0., 1., 0., 0., 0., 0., 0., 0.],
-            [0., 0., 0., 0., 0., 0., 1., 0.],
-            [0., 0., 0., 1., 0., 0., 0., 0.]],
-            dims=[[2, 2, 2], [2, 2, 2]]))
-
-        # test expansion with cyclic permutation
-        result = expand_operator(
-            tensor([sigmaz(), sigmax()]), N=3, targets=[2, 0],
-            cyclic_permutation=True)
-        mat1 = tensor(sigmax(), qeye(2), sigmaz())
-        mat2 = tensor(sigmaz(), sigmax(), qeye(2))
-        mat3 = tensor(qeye(2), sigmaz(), sigmax())
-        assert_(mat1 in result)
-        assert_(mat2 in result)
-        assert_(mat3 in result)
-
-        # test for dimensions other than 2
-        mat3 = rand_dm(3, density=1.)
-        oper = tensor([sigmax(), mat3])
-        N = 4
-        dims = [2, 2, 3, 4]
-        result = expand_operator(oper, N, targets=[0, 2], dims=dims)
-        assert_array_equal(result.dims[0], dims)
-        dims = [3, 2, 4, 2]
-        result = expand_operator(oper, N, targets=[3, 0], dims=dims)
-        assert_array_equal(result.dims[0], dims)
-        dims = [3, 2, 4, 2]
-        result = expand_operator(oper, N, targets=[1, 0], dims=dims)
-        assert_array_equal(result.dims[0], dims)
-
-    def test_molmer_sorensen(self):
-        """
-        gate: test for the molmer_sorensen gate
-        """
-        assert_allclose(
-            molmer_sorensen(np.pi, targets=[0, 1]),
-            Qobj(-1j*np.array(
-                 [[0, 0, 0, 1],
-                  [0, 0, 1, 0],
-                  [0, 1, 0, 0],
-                  [1, 0, 0, 0]]), dims=[[2, 2], [2, 2]]),
-            atol=1e-15)
-        assert_allclose(
-            molmer_sorensen(2*np.pi, targets=[0, 1]),
-            Qobj(-np.array(
-                 [[1, 0, 0, 0],
-                  [0, 1, 0, 0],
-                  [0, 0, 1, 0],
-                  [0, 0, 0, 1]]), dims=[[2, 2], [2, 2]]),
-            atol=1e-15)
-        assert_allclose(
-            molmer_sorensen(np.pi/2, N=4, targets=[1, 2]),
-            tensor([identity(2), molmer_sorensen(np.pi/2), identity(2)])
-        )
-
-    def test_qrot(self):
-        """
-        gate: test for the qubit rotation gate
-        """
-        assert_allclose(qrot(0, 0), identity(2))
-        assert_allclose(
-            qrot(np.pi, np.pi/2),
-            Qobj([[0, -1], [1, 0]]),
-            atol=1e-15)
-        assert_allclose(
-            qrot(np.pi/4., np.pi/3., N=2, target=1),
-            tensor([identity(2), qrot(np.pi/4., np.pi/3.)])
-        )
-
-
-if __name__ == "__main__":
-    run_module_suite()
+        # Assert that each Clifford gate maps the set of Pauli gates back onto
+        # itself (though not necessarily in order).  This condition is no
+        # stronger than simply considering each (gate, Pauli) pair separately.
+        normalised = {_hashable_without_global_phase(gate * pauli * gate.dag())
+                      for pauli in _paulis}
+        assert normalised == self.pauli_set
+
+
+class TestGateExpansion:
+    """
+    Test that gates act correctly when supplied with controls and targets, i.e.
+    that they pick out the correct qubits to act on, the action is correct, and
+    all other qubits are untouched.
+    """
+    n_qubits = 5
+
+    @pytest.mark.parametrize(["gate", "n_angles"], [
+        pytest.param(gates.rx, 1, id="Rx"),
+        pytest.param(gates.ry, 1, id="Ry"),
+        pytest.param(gates.rz, 1, id="Rz"),
+        pytest.param(gates.phasegate, 1, id="phase"),
+        pytest.param(gates.qrot, 2, id="Rabi rotation"),
+    ])
+    def test_single_qubit_rotation(self, gate, n_angles):
+        base = qutip.rand_ket(2)
+        angles = np.random.rand(n_angles) * 2*np.pi
+        applied = gate(*angles) * base
+        random = [qutip.rand_ket(2) for _ in [None]*(self.n_qubits - 1)]
+        for target in range(self.n_qubits):
+            start = qutip.tensor(random[:target] + [base] + random[target:])
+            test = gate(*angles, self.n_qubits, target) * start
+            expected = qutip.tensor(random[:target] + [applied]
+                                    + random[target:])
+            assert _infidelity(test, expected) < 1e-12
+
+    @pytest.mark.parametrize(['gate', 'n_controls'], [
+        pytest.param(gates.cnot, 1, id="cnot"),
+        pytest.param(gates.swap, 0, id="swap"),
+        pytest.param(gates.iswap, 0, id="iswap"),
+        pytest.param(gates.sqrtswap, 0, id="sqrt(swap)"),
+        pytest.param(functools.partial(gates.molmer_sorensen, 0.5*np.pi), 0,
+                     id="Molmer-Sorensen")
+    ])
+    def test_two_qubit(self, gate, n_controls):
+        targets = [qutip.rand_ket(2) for _ in [None]*2]
+        others = [qutip.rand_ket(2) for _ in [None]*self.n_qubits]
+        reference = gate() * qutip.tensor(*targets)
+        for q1, q2 in itertools.permutations(range(self.n_qubits), 2):
+            qubits = others.copy()
+            qubits[q1], qubits[q2] = targets
+            args = [[q1, q2]] if n_controls == 0 else [q1, q2]
+            test = gate(self.n_qubits, *args) * qutip.tensor(*qubits)
+            expected = _tensor_with_entanglement(qubits, reference, [q1, q2])
+            assert _infidelity(test, expected) < 1e-12
+
+    @pytest.mark.parametrize(['gate', 'n_controls'], [
+        pytest.param(gates.fredkin, 1, id="Fredkin"),
+        pytest.param(gates.toffoli, 2, id="Toffoli"),
+        pytest.param(_make_random_three_qubit_gate(), 2, id="random"),
+    ])
+    def test_three_qubit(self, gate, n_controls):
+        targets = [qutip.rand_ket(2) for _ in [None]*3]
+        others = [qutip.rand_ket(2) for _ in [None]*self.n_qubits]
+        reference = gate() * qutip.tensor(targets)
+        for q1, q2, q3 in itertools.permutations(range(self.n_qubits), 3):
+            qubits = others.copy()
+            qubits[q1], qubits[q2], qubits[q3] = targets
+            args = [q1, [q2, q3]] if n_controls == 1 else [[q1, q2], q3]
+            test = gate(self.n_qubits, *args) * qutip.tensor(*qubits)
+            expected = _tensor_with_entanglement(qubits, reference,
+                                                 [q1, q2, q3])
+            assert _infidelity(test, expected) < 1e-12
+
+
+class Test_expand_operator:
+    # Conceptually, a lot of these tests are complete duplicates of
+    # `TestGateExpansion`, except that they explicitly target an underlying
+    # function in `qutip.qip.operations.gates` which (as of 2020-03-01) is not
+    # called in the majority of cases---it appears to be newer than the
+    # surrounding code, but the surrounding code wasn't updated.
+    @pytest.mark.parametrize(
+        'permutation',
+        itertools.chain(*[itertools.permutations(range(k))
+                          for k in [2, 3, 4]]),
+        ids=_permutation_id)
+    def test_permutation_without_expansion(self, permutation):
+        base = qutip.tensor([qutip.rand_unitary(2) for _ in permutation])
+        test = gates.expand_operator(base,
+                                     N=len(permutation), targets=permutation)
+        expected = base.permute(_apply_permutation(permutation))
+        assert np.allclose(test.full(), expected.full(), atol=1e-15)
+
+    @pytest.mark.parametrize('n_targets', range(1, 5))
+    def test_general_qubit_expansion(self, n_targets):
+        # Test all permutations with the given number of targets.
+        n_qubits = 5
+        operation = qutip.rand_unitary(2**n_targets, dims=[[2]*n_targets]*2)
+        for targets in itertools.permutations(range(n_qubits), n_targets):
+            expected = _tensor_with_entanglement([qutip.qeye(2)] * n_qubits,
+                                                 operation, targets)
+            test = gates.expand_operator(operation, n_qubits, targets)
+            assert np.allclose(test.full(), expected.full(), atol=1e-15)
+
+    def test_cnot_explicit(self):
+        test = gates.expand_operator(gates.cnot(), 3, [2, 0]).full()
+        expected = np.array([[1, 0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 1, 0, 0],
+                             [0, 0, 1, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0, 1],
+                             [0, 0, 0, 0, 1, 0, 0, 0],
+                             [0, 1, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 1, 0],
+                             [0, 0, 0, 1, 0, 0, 0, 0]])
+        assert np.allclose(test, expected, atol=1e-15)
+
+    def test_cyclic_permutation(self):
+        operators = [qutip.sigmax(), qutip.sigmaz()]
+        test = gates.expand_operator(qutip.tensor(*operators), N=3,
+                                     targets=[0, 1], cyclic_permutation=True)
+        base_expected = qutip.tensor(*operators, qutip.qeye(2))
+        expected = [base_expected.permute(x)
+                    for x in [[0, 1, 2], [1, 2, 0], [2, 0, 1]]]
+        assert len(expected) == len(test)
+        for element in expected:
+            assert element in test
+
+    @pytest.mark.parametrize('dimensions', [
+        pytest.param([3, 4, 5], id="standard"),
+        pytest.param([3, 3, 4, 4, 2], id="standard"),
+        pytest.param([1, 2, 3], id="1D space"),
+    ])
+    def test_non_qubit_systems(self, dimensions):
+        n_qubits = len(dimensions)
+        for targets in itertools.permutations(range(n_qubits), 2):
+            operators = [qutip.rand_unitary(dimension) if n in targets
+                         else qutip.qeye(dimension)
+                         for n, dimension in enumerate(dimensions)]
+            expected = qutip.tensor(*operators)
+            base_test = qutip.tensor(*[operators[x] for x in targets])
+            test = gates.expand_operator(base_test, N=n_qubits,
+                                         targets=targets, dims=dimensions)
+            assert test.dims == expected.dims
+            assert np.allclose(test.full(), expected.full())

--- a/qutip/tests/test_heom_solver.py
+++ b/qutip/tests/test_heom_solver.py
@@ -33,103 +33,65 @@
 ###############################################################################
 
 """
-Tests for main control.pulseoptim methods
+Test the Hierarchical Model Solver from qutip.nonmarkov.heom.
 """
 
-from __future__ import division
-
-import os
 import numpy as np
-from numpy import pi, real, cos, tanh
-from numpy.testing import (
-    assert_, assert_almost_equal, run_module_suite, assert_equal)
-from scipy.integrate import quad, IntegrationWarning
-from qutip import Qobj, sigmaz, basis, expect
+from scipy.integrate import quad
+import pytest
+import qutip
 from qutip.nonmarkov.heom import HSolverDL
-from qutip.solver import Options
-import warnings
-warnings.simplefilter('ignore', IntegrationWarning)
-    
-class TestHSolver:
-    """
-    A test class for the hierarchy model solver
-    """
-    
-    def test_pure_dephasing(self):
-        """
-        HSolverDL: Compare with pure-dephasing analytical
-        assert that the analytical result and HEOM produce the 
-        same time dephasing evoltion.
-        """
-        resid_tol = 1e-4
-        
-        def spectral_density(omega, lam_c, omega_c):
-            return 2.0*lam_c*omega*omega_c / (omega_c**2 + omega**2)
-    
-        def integrand(omega, lam_c, omega_c, Temp, t):
-            J = spectral_density(omega, lam_c, omega_c)
-            return (-4.0*J*(1.0 - cos(omega*t)) / 
-                        (tanh(omega/(2.0*Temp))*omega**2))
-                        
-                        
-        cut_freq = 0.05 
-        coup_strength = 0.025
-        temperature = 1.0/0.95
-        tlist = np.linspace(0, 10, 21)
-        
-        # Calculate the analytical results by numerical integration
-        lam_c = coup_strength/pi
-        PEG_DL = [0.5*np.exp(quad(integrand, 0, np.inf, 
-                              args=(lam_c, cut_freq, temperature, t))[0])
-                              for t in tlist]
-        
-      
-        H_sys = Qobj(np.zeros((2, 2)))
-        Q = sigmaz()
-        initial_state = 0.5*Qobj(np.ones((2, 2)))
-        P12p = basis(2,0)*basis(2,1).dag()
 
-        integ_options = Options(nsteps=15000, store_states=True)
-        
-        test_desc = "renorm, bnd_cut_approx, and stats"
-        hsolver = HSolverDL(H_sys, Q, coup_strength, temperature, 
-                            20, 2, cut_freq, 
-                         renorm=True, bnd_cut_approx=True, 
-                         options=integ_options, stats=True)
-        
-        result = hsolver.run(initial_state, tlist)
-        P12_result1 = expect(result.states, P12p)
-        resid = abs(real(P12_result1 - PEG_DL))
-        max_resid = max(resid)
-        assert_(max_resid < resid_tol, "Max residual {} outside tolerence {}, "
-                "for hsolve with {}".format(max_resid, resid_tol, test_desc))
-        
-        resid_tol = 1e-3
-        test_desc = "renorm"
-        hsolver.configure(H_sys, Q, coup_strength, temperature, 
-                            20, 2, cut_freq, 
-                         renorm=True, bnd_cut_approx=False, 
-                         options=integ_options, stats=False)
-        assert_(hsolver.stats == None, "Failed to unset stats")
-        result = hsolver.run(initial_state, tlist)
-        P12_result1 = expect(result.states, P12p)
-        resid = abs(real(P12_result1 - PEG_DL))
-        max_resid = max(resid)
-        assert_(max_resid < resid_tol, "Max residual {} outside tolerence {}, "
-                "for hsolve with {}".format(max_resid, resid_tol, test_desc))
-        
-        resid_tol = 1e-4
-        test_desc = "bnd_cut_approx"
-        hsolver.configure(H_sys, Q, coup_strength, temperature, 
-                            20, 2, cut_freq, 
-                         renorm=False, bnd_cut_approx=True, 
-                         options=integ_options, stats=False)
-        assert_(hsolver.stats == None, "Failed to unset stats")
-        result = hsolver.run(initial_state, tlist)
-        P12_result1 = expect(result.states, P12p)
-        resid = abs(real(P12_result1 - PEG_DL))
-        max_resid = max(resid)
-        assert_(max_resid < resid_tol, "Max residual {} outside tolerence {}, "
-                "for hsolve with {}".format(max_resid, resid_tol, test_desc))
-        
-        
+
+@pytest.mark.filterwarnings("ignore::scipy.integrate.IntegrationWarning")
+@pytest.mark.parametrize(['renorm', 'bnd_cut_approx', 'stats', 'tol'], [
+    pytest.param(True, True, True, 1e-4, id="renorm-bnd_cut_approx-stats"),
+    pytest.param(True, False, False, 1e-3, id="renorm"),
+    pytest.param(False, True, False, 1e-4, id="bnd_cut_approx"),
+])
+def test_pure_dephasing_model(renorm, bnd_cut_approx, stats, tol):
+    """
+    HSolverDL: Compare with pure-dephasing analytical assert that the
+    analytical result and HEOM produce the same time dephasing evoltion.
+    """
+    cut_frequency = 0.05
+    coupling_strength = 0.025
+    lam_c = coupling_strength / np.pi
+    temperature = 1 / 0.95
+    times = np.linspace(0, 10, 21)
+
+    def _integrand(omega, t):
+        J = 2*lam_c * omega * cut_frequency / (omega**2 + cut_frequency**2)
+        return (-4 * J * (1 - np.cos(omega*t))
+                / (np.tanh(0.5*omega / temperature) * omega**2))
+
+    # Calculate the analytical results by numerical integration
+    expected = [0.5*np.exp(quad(_integrand, 0, np.inf, args=(t,))[0])
+                for t in times]
+
+    H_sys = qutip.Qobj(np.zeros((2, 2)))
+    Q = qutip.sigmaz()
+    initial_state = 0.5*qutip.Qobj(np.ones((2, 2)))
+    projector = qutip.basis(2, 0) * qutip.basis(2, 1).dag()
+    options = qutip.Options(nsteps=15_000, store_states=True)
+    hsolver = HSolverDL(H_sys, Q, coupling_strength, temperature,
+                        20, 2, cut_frequency,
+                        renorm=renorm, bnd_cut_approx=bnd_cut_approx,
+                        options=options, stats=stats)
+    test = qutip.expect(hsolver.run(initial_state, times).states, projector)
+    if stats:
+        assert hsolver.stats is not None
+    else:
+        assert hsolver.stats is None
+    assert np.allclose(test, expected, atol=tol)
+
+
+def test_set_unset_stats():
+    # Arbitrary system, just checking that stats can be unset by `configure`
+    args = [qutip.qeye(2), qutip.sigmaz(),
+            0.1, 0.1, 10, 1, 0.1]
+    hsolver = HSolverDL(*args, stats=True)
+    hsolver.run(qutip.basis(2, 0).proj(), [0, 1])
+    assert hsolver.stats is not None
+    hsolver.configure(*args, stats=False)
+    assert hsolver.stats is None

--- a/qutip/tests/test_heom_solver.py
+++ b/qutip/tests/test_heom_solver.py
@@ -83,7 +83,7 @@ def test_pure_dephasing_model(renorm, bnd_cut_approx, stats, tol):
         assert hsolver.stats is not None
     else:
         assert hsolver.stats is None
-    assert np.allclose(test, expected, atol=tol)
+    np.testing.assert_allclose(test, expected, atol=tol)
 
 
 def test_set_unset_stats():

--- a/qutip/tests/test_interpolate.py
+++ b/qutip/tests/test_interpolate.py
@@ -62,7 +62,7 @@ def test_equivalence_to_scipy(noise):
     expected = scipy.interpolate.CubicSpline(x, y, bc_type="natural")
     # We use the bc_type="natural", i.e. zero second-derivatives at the
     # boundaries because that matches qutip.
-    assert np.allclose(test(x), expected(x), atol=1e-10), "Array argument"
+    np.testing.assert_allclose(test(x), expected(x), atol=1e-10)
     centres = 0.5 * (x[:-1] + x[1:])
     # Test some points not in the original.
     for point in centres:
@@ -149,4 +149,4 @@ def test_usage_in_solvers(solver, coefficients):
         H_test.append([operator, other])
     expected = solver(H_expected, state, times, e_ops=e_ops).expect[0]
     test = solver(H_test, state, times, e_ops=e_ops).expect[0]
-    assert np.allclose(test, expected, atol=1e-4)
+    np.testing.assert_allclose(test, expected, atol=1e-4)

--- a/qutip/tests/test_interpolate.py
+++ b/qutip/tests/test_interpolate.py
@@ -30,325 +30,123 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-import pytest
+import functools
 import numpy as np
-import scipy.interpolate as sint
-from numpy.testing import assert_, assert_equal, run_module_suite
-import unittest
-from qutip import *
-from qutip import _version2int
+import scipy.interpolate
+import pytest
+import qutip
 
-try:
-    import Cython
-except:
-    Cython_OK = False
-else:
-    Cython_OK = _version2int(Cython.__version__) >= _version2int('0.14')
+pytestmark = [pytest.mark.usefixtures("in_temporary_directory")]
 
 
-def testInterpolate1():
-    "Interpolate: Sine + noise (array)"
-    x = np.linspace(0,2*np.pi,200)
-    y = np.sin(x)+0.1*np.random.randn(x.shape[0])
-    S1 = Cubic_Spline(x[0],x[-1],y)
-    S2 = sint.interp1d(x,y,'cubic')
-    assert_(np.max(np.abs(S2(x)-S1(x))) < 1e-9)
+def pytest_generate_tests(metafunc):
+    """
+    Perform more complex parametrisation logic for tests in this module.  This
+    was originally needed because the `brmesolve` solver cannot mix splines and
+    functions in the Hamiltonian (it can only accept string-formatted
+    time-dependence), but we want to parametrize this for all the other tests.
+    """
+    if ("solver" in metafunc.fixturenames
+            and "coefficients" in metafunc.fixturenames):
+        _parametrize_solver_coefficients(metafunc)
 
 
-def testInterpolate2():
-    "Interpolate: Sine + noise (point)"
-    x = np.linspace(0,2*np.pi,200)
-    y = np.sin(x)+0.1*np.random.randn(x.shape[0])
-    S1 = Cubic_Spline(x[0],x[-1],y)
-    S2 = sint.interp1d(x,y,'cubic')
-    for k in range(x.shape[0]):
-        assert_(np.abs(S2(x[k])-S1(x[k])) < 1e-9)
+@pytest.mark.parametrize('noise', [
+    pytest.param(lambda n: 0.1*np.random.rand(n), id="real"),
+    pytest.param(lambda n: 0.1j*np.random.rand(n), id="complex"),
+])
+def test_equivalence_to_scipy(noise):
+    x = np.linspace(0, 2*np.pi, 200)
+    y = np.sin(x) + noise(x.shape[0])
+    test = qutip.Cubic_Spline(x[0], x[-1], y)
+    expected = scipy.interpolate.CubicSpline(x, y, bc_type="natural")
+    # We use the bc_type="natural", i.e. zero second-derivatives at the
+    # boundaries because that matches qutip.
+    assert np.allclose(test(x), expected(x), atol=1e-10), "Array argument"
+    centres = 0.5 * (x[:-1] + x[1:])
+    # Test some points not in the original.
+    for point in centres:
+        assert np.abs(test(point) - expected(point)) < 1e-10, "Scalar argument"
 
 
-def testInterpolate3():
-    "Interpolate: Complex sine + noise (array)"
-    x = np.linspace(0,2*np.pi,200)
-    y = np.sin(x)+0.1*np.random.randn(x.shape[0]) + \
-        0.1j*np.random.randn(x.shape[0])
-    S1 = Cubic_Spline(x[0],x[-1],y)
-    S2 = sint.interp1d(x,y,'cubic')
-    assert_(np.max(np.abs(S2(x)-S1(x))) < 1e-9)
+# We make a bunch of different test cases for the coefficients, all as a
+# three-tuple of
+#   (string, other, type)
+# where `string` is the string-format time-dependence (we use this as the
+# reference), `other` is what will become the time-dependence for this part of
+# the test, and `type` is a string in ["spline", "function", "string"] which
+# tells us how to interpret the type of `other`.  If `type` is "function" or
+# "string", then nothing is done to `other` and it is used as-is.  If `type` is
+# "spline", then `other` is given as a vectorised function which we turn into a
+# qutip.Cubic_Spline using appropriate `x` and `y` values.
+_case_real_spline = ('0.25*sin(t)', lambda t: 0.25*np.sin(t), 'spline')
+_case_real_string = ('0.25*cos(t)', '0.25*cos(t)', 'string')
+_case_real_function = ('0.25*sin(t)', lambda t, *_: 0.25*np.sin(t), 'function')
+_case_complex_spline = ('0.1j*sin(t)', lambda t: 0.1j*np.sin(t), 'spline')
+_case_complex_string = ('-0.1j*sin(t)', '-0.1j*sin(t)', 'string')
 
 
-def testInterpolate4():
-    "Interpolate: Complex sine + noise (point)"
-    x = np.linspace(0,2*np.pi,200)
-    y = np.sin(x)+0.1*np.random.randn(x.shape[0]) + \
-        0.1j*np.random.randn(x.shape[0])
-    S1 = Cubic_Spline(x[0],x[-1],y)
-    S2 = sint.interp1d(x,y,'cubic')
-    for k in range(x.shape[0]):
-        assert_(np.abs(S2(x[k])-S1(x[k])) < 1e-9)
+def _parametrize_solver_coefficients(metafunc):
+    """
+    Perform the parametrisation for test cases using a solver and some
+    time-dependent coefficients.  This is necessary because not all solvers can
+    accept all combinations of time-dependence specifications.
+    """
+    solvers = [
+        (qutip.sesolve, 'sesolve'),
+        (qutip.mesolve, 'mesolve'),
+        (functools.partial(qutip.mcsolve, ntraj=500), "mcsolve"),
+        (qutip.brmesolve, 'brmesolve')
+    ]
+    coefficients = [
+        ([_case_real_spline], "real-spline"),
+        ([_case_real_spline, _case_real_string], "real-spline,string"),
+        ([_case_real_spline, _case_real_function], "real-spline,function"),
+        ([_case_real_function], "real-function"),
+        ([_case_complex_spline, _case_complex_string],
+            "complex-spline,string"),
+    ]
+
+    def _valid_case(solver_id, coefficient_id):
+        invalids = [
+            "brmesolve" in solver_id and "function" in coefficient_id,
+        ]
+        return not any(invalids)
+
+    def _make_case(solver, solver_id, coefficient, coefficient_id):
+        marks = []
+        if "brmesolve" in solver_id:
+            marks.append(pytest.mark.requires_cython)
+        id_ = "-".join([solver_id, coefficient_id])
+        return pytest.param(solver, coefficient, id=id_, marks=marks)
+
+    cases = [_make_case(solver, solver_id, coefficient, coefficient_id)
+             for solver, solver_id in solvers
+             for coefficient, coefficient_id in coefficients
+             if _valid_case(solver_id, coefficient_id)]
+    metafunc.parametrize(["solver", "coefficients"], cases)
 
 
 @pytest.mark.slow
-def test_interpolate_evolve1():
+def test_usage_in_solvers(solver, coefficients):
     """
-    Interpolate: sesolve str-based (real)
+    Test that the Cubic_Spline can be used as a time-dependent argument to all
+    three principle solvers, both alone and in combination with other forms of
+    time-dependence.
     """
-    tlist = np.linspace(0,5,50)
-    y = 0.25*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    N = 10
-    psi0 = fock(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.25*sin(t)']]
-    H2 = [a.dag()*a,[a**2+a.dag()**2, S]]
-    out1 = sesolve(H, psi0, tlist, [a.dag()*a]).expect[0]
-    out2 = sesolve(H2, psi0, tlist, [a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-def test_interpolate_evolve2():
-    """
-    Interpolate: mesolve str-based (real)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.25*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    N = 10
-    psi0 = fock(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.25*sin(t)']]
-    H2 = [a.dag()*a,[a**2+a.dag()**2, S]]
-    out1 = mesolve(H, psi0, tlist, [], [a.dag()*a]).expect[0]
-    out2 = mesolve(H2, psi0, tlist, [], [a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-def test_interpolate_evolve3():
-    """
-    Interpolate: mcsolve str-based (real)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.25*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    N = 10
-    psi0 = fock(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.25*sin(t)']]
-    H2 = [a.dag()*a,[a**2+a.dag()**2, S]]
-    out1 = mcsolve(H, psi0, tlist, [], [a.dag()*a],ntraj=500).expect[0]
-    out2 = mcsolve(H2, psi0, tlist, [], [a.dag()*a],ntraj=500).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-def test_interpolate_evolve4():
-    """
-    Interpolate: sesolve str + interp (real)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.25*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    N = 10
-    psi0 = fock(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.25*sin(t)'], [a**2+a.dag()**2,'0.25*cos(t)']]
-    H2 = [a.dag()*a, [a**2+a.dag()**2, S], [a**2+a.dag()**2,'0.25*cos(t)']]
-    out1 = sesolve(H, psi0, tlist, [a.dag()*a]).expect[0]
-    out2 = sesolve(H2, psi0, tlist, [a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-def test_interpolate_evolve5():
-    """
-    Interpolate: sesolve func + interp (real)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.25*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    func = lambda t, *args: 0.25*np.cos(t)
-    N = 10
-    psi0 = fock(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.25*sin(t)'], [a**2+a.dag()**2,'0.25*cos(t)']]
-    H2 = [a.dag()*a, [a**2+a.dag()**2, S], [a**2+a.dag()**2,func]]
-    out1 = sesolve(H, psi0, tlist, [a.dag()*a]).expect[0]
-    out2 = sesolve(H2, psi0, tlist, [a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-def test_interpolate_evolve6():
-    """
-    Interpolate: mesolve str + interp (real)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.25*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    N = 10
-    psi0 = fock_dm(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.25*sin(t)'], [a**2+a.dag()**2,'0.25*cos(t)']]
-    H2 = [a.dag()*a, [a**2+a.dag()**2, S], [a**2+a.dag()**2,'0.25*cos(t)']]
-    out1 = mesolve(H, psi0, tlist, [], [a.dag()*a]).expect[0]
-    out2 = mesolve(H2, psi0, tlist, [], [a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-def test_interpolate_evolve7():
-    """
-    Interpolate: mesolve func + interp (real)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.25*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    func = lambda t, *args: 0.25*np.cos(t)
-    N = 10
-    psi0 = fock_dm(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.25*sin(t)'], [a**2+a.dag()**2,'0.25*cos(t)']]
-    H2 = [a.dag()*a, [a**2+a.dag()**2, S], [a**2+a.dag()**2,func]]
-    out1 = mesolve(H, psi0, tlist, [], [a.dag()*a]).expect[0]
-    out2 = mesolve(H2, psi0, tlist, [], [a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-def test_interpolate_evolve8():
-    """
-    Interpolate: mcsolve str + interp (real)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.25*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    N = 10
-    psi0 = fock(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.25*sin(t)'], [a**2+a.dag()**2,'0.25*cos(t)']]
-    H2 = [a.dag()*a, [a**2+a.dag()**2, S], [a**2+a.dag()**2,'0.25*cos(t)']]
-    out1 = mcsolve(H, psi0, tlist, [], [a.dag()*a]).expect[0]
-    out2 = mcsolve(H2, psi0, tlist, [], [a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-def test_interpolate_evolve9():
-    """
-    Interpolate: mcsolve func + interp (real)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.25*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    func = lambda t, *args: 0.25*np.cos(t)
-    N = 10
-    psi0 = fock(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.25*sin(t)'], [a**2+a.dag()**2,'0.25*cos(t)']]
-    H2 = [a.dag()*a, [a**2+a.dag()**2, S], [a**2+a.dag()**2,func]]
-    out1 = mcsolve(H, psi0, tlist, [], [a.dag()*a]).expect[0]
-    out2 = mcsolve(H2, psi0, tlist, [], [a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-def test_interpolate_evolve10():
-    """
-    Interpolate: mesolve str + interp (complex)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.1j*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    N = 10
-    psi0 = fock_dm(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.1j*sin(t)'], [a**2+a.dag()**2,'-0.1j*sin(t)']]
-    H2 = [a.dag()*a, [a**2+a.dag()**2, S], [a**2+a.dag()**2,'-0.1j*sin(t)']]
-    out1 = mesolve(H, psi0, tlist, [], [a.dag()*a]).expect[0]
-    out2 = mesolve(H2, psi0, tlist, [], [a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-def test_interpolate_evolve11():
-    """
-    Interpolate: mesolve func + interp (complex)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.1j*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    func = lambda t, *args: -0.1j*np.sin(t)
-    N = 10
-    psi0 = fock_dm(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.1j*sin(t)'], [a**2+a.dag()**2,'-0.1j*sin(t)']]
-    H2 = [a.dag()*a, [a**2+a.dag()**2, S], [a**2+a.dag()**2,func]]
-    out1 = mesolve(H, psi0, tlist, [], [a.dag()*a]).expect[0]
-    out2 = mesolve(H2, psi0, tlist, [], [a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
-def test_interpolate_brevolve1():
-    """
-    Interpolate: brmesolve str + interp (real)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.25*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    N = 10
-    psi0 = fock(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.25*sin(t)']]
-    H2 = [a.dag()*a,[a**2+a.dag()**2, S]]
-    out1 = mesolve(H, psi0, tlist, [], [a.dag()*a]).expect[0]
-    out2 = brmesolve(H2, psi0, tlist, a_ops=[], e_ops=[a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
-def test_interpolate_brevolve2():
-    """
-    Interpolate: brmesolve str + interp (complex)
-    """
-    tlist = np.linspace(0,5,50)
-    y = 0.1j*np.sin(tlist)
-    S = Cubic_Spline(tlist[0], tlist[-1], y)
-    N = 10
-    psi0 = fock_dm(N,1)
-    a = destroy(N)
-    H = [a.dag()*a,[a**2+a.dag()**2,'0.1j*sin(t)'], [a**2+a.dag()**2,'-0.1j*sin(t)']]
-    H2 = [a.dag()*a, [a**2+a.dag()**2, S], [a**2+a.dag()**2,'-0.1j*sin(t)']]
-    out1 = mesolve(H, psi0, tlist, [], [a.dag()*a]).expect[0]
-    out2 = brmesolve(H2, psi0, tlist, a_ops=[], e_ops=[a.dag()*a]).expect[0]
-    assert_(np.max(np.abs(out1-out2)) < 1e-4)
-
-
-@pytest.mark.slow
-@unittest.skipIf(not Cython_OK, 'Cython not found or version too low.')
-def test_interpolate_brevolve3():
-    """
-    Interpolate: brmesolve c_op as interp (str)
-    """
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    tlist = np.linspace(0, 10, 100)
-
-    f = lambda t: np.sqrt(kappa*np.exp(-t))
-
-    S = Cubic_Spline(tlist[0],tlist[-1],f(tlist))
-    c_ops = [[a, S]]
-    brdata = brmesolve(H, psi0, tlist, a_ops=[], e_ops=[a.dag() * a], c_ops=c_ops)
-    expt = brdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_(avg_diff < 1e-4)
-
-
-if __name__ == "__main__":
-    run_module_suite()
+    size = 10
+    a = qutip.destroy(size)
+    state = qutip.basis(size, 1)
+    times = np.linspace(0, 5, 50)
+    e_ops = [a.dag() * a]
+    H_expected = [a.dag()*a]
+    H_test = H_expected.copy()
+    operator = a**2 + a.dag()**2
+    for string, other, type_ in coefficients:
+        if type_ == 'spline':
+            other = qutip.Cubic_Spline(times[0], times[-1], other(times))
+        H_expected.append([operator, string])
+        H_test.append([operator, other])
+    expected = solver(H_expected, state, times, e_ops=e_ops).expect[0]
+    test = solver(H_test, state, times, e_ops=e_ops).expect[0]
+    assert np.allclose(test, expected, atol=1e-4)

--- a/qutip/tests/test_lattice.py
+++ b/qutip/tests/test_lattice.py
@@ -31,134 +31,117 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 import numpy as np
-from qutip.lattice import *
-from qutip import (Qobj, tensor, basis, qeye, isherm, sigmax)
-# from numpy.testing import (assert_equal, assert_, assert_almost_equal,
-#                            run_module_suite)
-from numpy.testing import (assert_, run_module_suite)
+import pytest
+import qutip
+
+_r2 = np.sqrt(2)
 
 
-class TestLattice:
+def _assert_angles_close(test, expected, atol):
+    """Assert that two arrays of angles are within tolerance of each other."""
+    assert np.allclose(test % (2*np.pi), expected % (2*np.pi), atol=atol)
+
+
+def _hamiltonian_expected(cells, periodic, sites_per_cell,
+                          freedom):
+    """Expected Hamiltonian for the simple 1D lattice model"""
+    # Within the cell, adjacent sites hop to each other, and it's always
+    # non-periodic.
+    cell = qutip.qdiags([-np.ones(sites_per_cell - 1)]*2, [1, -1])
+    # To hop to the cell one to the left, then you have to drop from the lowest
+    # in-cell location to the highest in the other.
+    hop_left = qutip.qdiags(np.ones(cells - 1), 1)
+    if periodic and cells > 2:
+        # If cells <= 2 then all cells border each other anyway.
+        hop_left += qutip.qdiags([1], -(cells - 1))
+    drop_site = -qutip.projection(sites_per_cell, sites_per_cell-1, 0)
+    if np.prod(freedom) != 1:
+        # Degenerate degrees of freedom per lattice site are unchanged.
+        identity = qutip.qeye(freedom)
+        cell = qutip.tensor(cell, identity)
+        drop_site = qutip.tensor(drop_site, identity)
+    out = (qutip.tensor(qutip.qeye(cells), cell)
+           + qutip.tensor(hop_left, drop_site)
+           + qutip.tensor(hop_left, drop_site).dag())
+    # Contract scalar spaces.
+    dims = [x for x in [cells, sites_per_cell] + freedom
+            if x != 1]
+    dims = dims or [1]
+    out.dims = [dims, dims]
+    return out
+
+
+def _k_expected(cells):
+    out = (2*np.pi/cells) * np.arange(-(cells//2), cells - (cells//2))
+    return out.reshape((-1, 1))
+
+
+def _ssh_lattice(intra, inter,
+                 cells=5, boundary="periodic", sites_per_cell=2,
+                 freedom=[1]):
+    part_hamiltonian = qutip.Qobj(np.array([[0, intra], [intra, 0]]))
+    free_identity = qutip.qeye(freedom)
+    hamiltonian = qutip.tensor(part_hamiltonian, free_identity)
+    hopping = qutip.tensor(qutip.Qobj(np.array([[0, 0], [inter, 0]])),
+                           free_identity)
+    return qutip.Lattice1d(num_cell=cells, boundary=boundary,
+                           cell_num_site=sites_per_cell,
+                           cell_site_dof=freedom,
+                           Hamiltonian_of_cell=hamiltonian,
+                           inter_hop=hopping)
+
+
+# Energies for the SSH model with 4 cells, 2 orbitals and 2 spins, with
+# intra=-0.5 and inter=-0.6.
+_ssh_energies = np.array([0.1, 0.55677644, 0.9539392,
+                          1.1, 0.9539392,  0.55677644])
+
+
+def _crow_lattice(coupling, phase_delay,
+                  cells=4, boundary="periodic", sites_per_cell=1,
+                  freedom=[2]):
+    r"""
+    Return a `qutip.Lattice1d` of a "Coupled Resonator Optical Waveguide"
+    (CROW) with the given coupling strength and phase delay.
+
+    See for example: https://www.doi.org/10.1103/PhysRevB.99.224201
+    where `coupling` is $J$ and `phase_delay` is $\eta$.
     """
-    Tests for `qutip.lattice` class.
-    """
-    def test_hamiltonian(self):
-        """
-        lattice: Test the method Lattice1d.Hamiltonian().
-        """
-        # num_cell = 1
-        # Four different instances
-        Periodic_Atom_Chain = Lattice1d(num_cell=1, boundary="periodic")
-        Aperiodic_Atom_Chain = Lattice1d(num_cell=1, boundary="aperiodic")
-        p_1223 = Lattice1d(num_cell=1, boundary="periodic",
-                           cell_num_site=2, cell_site_dof=[2, 3])
-        ap_1223 = Lattice1d(num_cell=1, boundary="aperiodic",
-                            cell_num_site=2, cell_site_dof=[2, 3])
+    cell_hamiltonian = coupling * np.sin(phase_delay) * qutip.sigmax()
+    phase_term = np.exp(1j * phase_delay)
+    hopping = [
+        0.5 * coupling * qutip.qdiags([phase_term, phase_term.conj()], 0),
+        0.5 * coupling * qutip.sigmax(),
+    ]
+    return qutip.Lattice1d(num_cell=cells, boundary=boundary,
+                           cell_num_site=sites_per_cell,
+                           cell_site_dof=freedom,
+                           Hamiltonian_of_cell=cell_hamiltonian,
+                           inter_hop=hopping)
 
-        # Their Hamiltonians
-        pHamt1 = Periodic_Atom_Chain.Hamiltonian()
-        apHamt1 = Aperiodic_Atom_Chain.Hamiltonian()
-        pHamt1223 = p_1223.Hamiltonian()
-        apHamt1223 = ap_1223.Hamiltonian()
 
-        # Benchmark answers
-        pHamt1_C = Qobj([[0.]], dims=[[1], [1]])
-        apHamt1_C = Qobj([[0.]], dims=[[1], [1]])
-        site1223 = np.diag(np.zeros(2-1)-1, 1) + np.diag(np.zeros(2-1)-1, -1)
-        Rpap1223 = tensor(Qobj(site1223), qeye([2, 3]))
-        pap1223 = Qobj(Rpap1223, dims=[[2, 2, 3], [2, 2, 3]])
-
-        # Checks for num_cell = 1
-        assert_(pHamt1 == pHamt1_C)
-        assert_(apHamt1 == apHamt1_C)
-        assert_(pHamt1223 == pap1223)    # for num_cell=1, periodic and
-        assert_(apHamt1223 == pap1223)   # aperiodic B.C. have same Hamiltonian
-
-        # num_cell = 2
-        # Four different instances
-        Periodic_Atom_Chain = Lattice1d(num_cell=2, boundary="periodic")
-        Aperiodic_Atom_Chain = Lattice1d(num_cell=2, boundary="aperiodic")
-
-        p_2222 = Lattice1d(num_cell=2, boundary="periodic",
-                           cell_num_site=2, cell_site_dof=[2, 2])
-        ap_2222 = Lattice1d(num_cell=2, boundary="aperiodic",
-                            cell_num_site=2, cell_site_dof=[2, 2])
-
-        # Their Hamiltonians
-        pHamt2222 = p_2222.Hamiltonian()
-        apHamt2222 = ap_2222.Hamiltonian()
-        pHamt2 = Periodic_Atom_Chain.Hamiltonian()
-        apHamt2 = Aperiodic_Atom_Chain.Hamiltonian()
-
-        # Benchmark answers
-        pHamt2_C = Qobj([[0., -1.],
-                         [-1.,  0.]], dims=[[2], [2]])
-        apHamt2_C = Qobj([[0., -1.],
-                          [-1., 0.]], dims=[[2], [2]])
-
-        pap_2222 = np.zeros((16, 16), dtype=complex)
-        pap_2222[0:4, 4:8] = -np.eye(4)
-        pap_2222[4:8, 0:4] = -np.eye(4)
-        pap_2222[4:8, 8:12] = -np.eye(4)
-        pap_2222[8:12, 4:8] = -np.eye(4)
-        pap_2222[8:12, 12:16] = -np.eye(4)
-        pap_2222[12:16, 8:12] = -np.eye(4)
-        pap_2222 = Qobj(pap_2222, dims=[[2, 2, 2, 2], [2, 2, 2, 2]])
-
-        # Checks for num_cell = 2
-        assert_(pHamt2 == pHamt2_C)
-        assert_(apHamt2 == apHamt2_C)
-        assert_(pHamt2222 == pap_2222)   # for num_cell=2, periodic and
-        assert_(apHamt2222 == pap_2222)  # aperiodic B.C. have same Hamiltonian
-
-        # num_cell = 3   # checking any num_cell >= 3 is pretty much equivalent
-        Periodic_Atom_Chain = Lattice1d(num_cell=3, boundary="periodic")
-        Aperiodic_Atom_Chain = Lattice1d(num_cell=3, boundary="aperiodic")
-        p_3122 = Lattice1d(num_cell=3, boundary="periodic",
-                           cell_num_site=1, cell_site_dof=[2, 2])
-        ap_3122 = Lattice1d(num_cell=3, boundary="aperiodic",
-                            cell_num_site=1, cell_site_dof=[2, 2])
-
-        # Their Hamiltonians
-        pHamt3 = Periodic_Atom_Chain.Hamiltonian()
-        apHamt3 = Aperiodic_Atom_Chain.Hamiltonian()
-        pHamt3122 = p_3122.Hamiltonian()
-        apHamt3122 = ap_3122.Hamiltonian()
-
-        # Benchmark answers
-        pHamt3_C = Qobj([[0., -1., -1.],
-                         [-1.,  0., -1.],
-                         [-1., -1.,  0.]], dims=[[3], [3]])
-        apHamt3_C = Qobj([[0., -1.,  0.],
-                          [-1.,  0., -1.],
-                          [0., -1.,  0.]], dims=[[3], [3]])
-
-        Hp_3122 = np.zeros((12, 12), dtype=complex)
-        Hp_3122[0:8, 4:12] = Hp_3122[0:8, 4:12] - np.eye(8)
-        Hp_3122[4:12, 0:8] = Hp_3122[4:12, 0:8] - np.eye(8)
-        Hp_3122[0:4, 8:12] = Hp_3122[0:4, 8:12] - np.eye(4)
-        Hp_3122[8:12, 0:4] = Hp_3122[8:12, 0:4] - np.eye(4)
-        Hp_3122 = Qobj(Hp_3122, dims=[[3, 2, 2], [3, 2, 2]])
-
-        Hap_3122 = np.zeros((12, 12), dtype=complex)
-        Hap_3122[0:8, 4:12] = Hap_3122[0:8, 4:12] - np.eye(8)
-        Hap_3122[4:12, 0:8] = Hap_3122[4:12, 0:8] - np.eye(8)
-        Hap_3122 = Qobj(Hap_3122, dims=[[3, 2, 2], [3, 2, 2]])
-
-        # Checks for num_cell = 3
-        assert_(pHamt3 == pHamt3_C)
-        assert_(apHamt3 == apHamt3_C)
-        assert_(pHamt3122 == Hp_3122)
-        assert_(apHamt3122 == Hap_3122)
+class TestLattice1d:
+    @pytest.mark.parametrize("cells", [1, 2, 3])
+    @pytest.mark.parametrize("periodic", [True, False],
+                             ids=["periodic", "aperiodic"])
+    @pytest.mark.parametrize("sites_per_cell", [1, 2])
+    @pytest.mark.parametrize("freedom", [[1], [2, 3]],
+                             ids=["simple chain", "onsite freedom"])
+    def test_hamiltonian(self, cells, periodic, sites_per_cell, freedom):
+        """Test that the lattice model produces the expected Hamiltonians."""
+        boundary = "periodic" if periodic else "aperiodic"
+        lattice = qutip.Lattice1d(num_cell=cells, boundary=boundary,
+                                  cell_site_dof=freedom,
+                                  cell_num_site=sites_per_cell)
+        expected = _hamiltonian_expected(cells, periodic, sites_per_cell,
+                                         freedom)
+        assert lattice.Hamiltonian() == expected
 
     def test_cell_structures(self):
-        """
-        lattice: Test the method Lattice1d.cell_structures().
-        """
         val_s = ['site0', 'site1']
         val_t = [' orb0', 'orb1']
-        (H_cell_form, inter_cell_T_form, H_cell,
-         inter_cell_T) = cell_structures(val_s, val_t)
+        H_cell_form, inter_cell_T_form, H_cell, inter_cell_T =\
+            qutip.cell_structures(val_s, val_t)
         c_H_form = [['<site0 orb0 H site0 orb0>',
                      '<site0 orb0 H site0orb1>',
                      '<site0 orb0 H site1 orb0>',
@@ -194,82 +177,60 @@ class TestLattice:
                           '<cell(i):site1orb1 H site1orb1:cell(i+1) >']]
         c_H = np.zeros((4, 4), dtype=complex)
         i_cell_T = np.zeros((4, 4), dtype=complex)
-        assert_(H_cell_form == c_H_form)
-        assert_(inter_cell_T_form == i_cell_T_form)
-        assert_((H_cell == c_H).all())
-        assert_((inter_cell_T == i_cell_T).all())
+        assert H_cell_form == c_H_form
+        assert inter_cell_T_form == i_cell_T_form
+        assert (H_cell == c_H).all()
+        assert (inter_cell_T == i_cell_T).all()
 
     def test_basis(self):
-        """
-        lattice: Test the method Lattice1d.basis().
-        """
-        lattice_3242 = Lattice1d(num_cell=3, boundary="periodic",
-                                 cell_num_site=2, cell_site_dof=[4, 2])
+        lattice_3242 = qutip.Lattice1d(num_cell=3, boundary="periodic",
+                                       cell_num_site=2, cell_site_dof=[4, 2])
         psi0 = lattice_3242.basis(1, 0, [2, 1])
         psi0dag_a = np.zeros((1, 48), dtype=complex)
         psi0dag_a[0, 21] = 1
-        psi0dag = Qobj(psi0dag_a, dims=[[1, 1, 1, 1], [3, 2, 4, 2]])
-        assert_(psi0 == psi0dag.dag())
+        psi0dag = qutip.Qobj(psi0dag_a, dims=[[1, 1, 1, 1], [3, 2, 4, 2]])
+        assert psi0 == psi0dag.dag()
 
     def test_distribute_operator(self):
-        """
-        lattice: Test the method Lattice1d.distribute_operator().
-        """
-        lattice_412 = Lattice1d(num_cell=4, boundary="periodic",
-                                cell_num_site=1, cell_site_dof=[2])
-        op = Qobj(np.array([[0, 1], [1, 0]]))
+        lattice_412 = qutip.Lattice1d(num_cell=4, boundary="periodic",
+                                      cell_num_site=1, cell_site_dof=[2])
+        op = qutip.Qobj(np.array([[0, 1], [1, 0]]))
         op_all = lattice_412.distribute_operator(op)
-        sv_op_all = tensor(qeye(4), sigmax())
-        assert_(op_all == sv_op_all)
+        sv_op_all = qutip.tensor(qutip.qeye(4), qutip.sigmax())
+        assert op_all == sv_op_all
 
     def test_operator_at_cells(self):
-        """
-        lattice: Test the method Lattice1d.operator_between_cells().
-        """
-        p_2222 = Lattice1d(num_cell=2, boundary="periodic",
-                           cell_num_site=2, cell_site_dof=[2, 2])
-        op_0 = basis(2, 0) * basis(2, 1).dag()
-        op_c = tensor(op_0, qeye([2, 2]))
+        p_2222 = qutip.Lattice1d(num_cell=2, boundary="periodic",
+                                 cell_num_site=2, cell_site_dof=[2, 2])
+        op_0 = qutip.projection(2, 0, 1)
+        op_c = qutip.tensor(op_0, qutip.qeye([2, 2]))
         OP = p_2222.operator_between_cells(op_c, 1, 0)
-        T = basis(2, 1) * basis(2, 0).dag()
-        QP = tensor(T, op_c)
-        assert_(OP == QP)
+        T = qutip.projection(2, 1, 0)
+        QP = qutip.tensor(T, op_c)
+        assert OP == QP
 
     def test_operator_between_cells(self):
-        """
-        lattice: Test the method Lattice1d.operator_at_cells().
-        """
-        lattice_412 = Lattice1d(num_cell=4, boundary="periodic",
-                                cell_num_site=1, cell_site_dof=[2])
-        op = Qobj(np.array([[0, 1], [1, 0]]))
+        lattice_412 = qutip.Lattice1d(num_cell=4, boundary="periodic",
+                                      cell_num_site=1, cell_site_dof=[2])
+        op = qutip.sigmax()
         op_sp = lattice_412.operator_at_cells(op, cells=[1, 2])
 
         aop_sp = np.zeros((8, 8), dtype=complex)
-        aop_sp[2:4, 2:4] = sigmax()
-        aop_sp[4:6, 4:6] = sigmax()
-        sv_op_sp = Qobj(aop_sp, dims=[[4, 2], [4, 2]])
-        assert_(op_sp == sv_op_sp)
+        aop_sp[2:4, 2:4] = aop_sp[4:6, 4:6] = op.full()
+        sv_op_sp = qutip.Qobj(aop_sp, dims=[[4, 2], [4, 2]])
+        assert op_sp == sv_op_sp
 
     def test_x(self):
-        """
-        lattice: Test the method Lattice1d.x().
-        """
-        lattice_3223 = Lattice1d(num_cell=3, boundary="periodic",
-                                 cell_num_site=2, cell_site_dof=[2, 3])
-        R = lattice_3223.x()
-        npR = R.full()
-        # count the number of off-diagonal elements n_off which should be 0
-        n_off = np.count_nonzero(npR - np.diag(np.diagonal(npR)))
-        assert_(n_off == 0)
-        assert_((np.diag(R) == np.kron(range(3), np.ones(12))).all())
+        lattice_3223 = qutip.Lattice1d(num_cell=3, boundary="periodic",
+                                       cell_num_site=2, cell_site_dof=[2, 3])
+        test = lattice_3223.x().full()
+        expected = np.diag([n for n in range(3) for _ in [None]*12])
+        assert np.allclose(test, expected, atol=1e-12)
 
     def test_k(self):
-        """
-        lattice: Test the method Lattice1d.k().
-        """
         L = 7
-        lattice_L123 = Lattice1d(num_cell=L, boundary="periodic",
-                                 cell_num_site=1, cell_site_dof=[2, 3])
+        lattice_L123 = qutip.Lattice1d(num_cell=L, boundary="periodic",
+                                       cell_num_site=1, cell_site_dof=[2, 3])
         kq = lattice_L123.k()
         kop = np.zeros((L, L), dtype=complex)
         for row in range(L):
@@ -278,382 +239,155 @@ class TestLattice:
                     kop[row, col] = (L-1)/2
                 else:
                     kop[row, col] = 1 / (np.exp(2j * np.pi * (row - col)/L)-1)
-
         kt = np.kron(kop * 2 * np.pi / L, np.eye(6))
         dim_H = [[2, 2, 3], [2, 2, 3]]
-        kt = Qobj(kt, dims=dim_H)
+        kt = qutip.Qobj(kt, dims=dim_H)
+        k_q = kq.eigenstates()[0]
+        k_t = kt.eigenstates()[0]
+        k_tC = k_t - (2*np.pi/L) * ((L-1) // 2)
+        assert np.allclose(k_tC, k_q, atol=1e-12)
 
-        [k_q, Vq] = kq.eigenstates()
-        [k_t, Vt] = kt.eigenstates()
-        k_tC = k_t - 2*np.pi/L*((L-1)//2)
-        # k_ts = [(i-(L-1)//2)*2*np.pi/L for i in range(L)]
-        # k_w = np.kron((np.array(k_ts)).T, np.ones((1,6)))
-        assert_((np.abs(k_tC - k_q) < 1E-13).all())
-
-    def test_get_dispersion(self):
-        """
-        lattice: Test the method Lattice1d.get_dispersion().
-        """
-        Periodic_Atom_Chain = Lattice1d(num_cell=8, boundary="periodic")
-        [knxA, val_kns] = Periodic_Atom_Chain.get_dispersion()
-        kB = np.array([[-3.14159265],
-                       [-2.35619449],
-                       [-1.57079633],
-                       [-0.78539816],
-                       [0.],
-                       [0.78539816],
-                       [1.57079633],
-                       [2.35619449]])
-        valB = np.array([[2., 1.41421356, 0., -1.41421356, -2.,
-                          -1.41421356, 0., 1.41421356]])
-        assert_(np.max(abs(knxA-kB)) < 1.0E-6)
-        assert_(np.max(abs(val_kns-valB)) < 1.0E-6)
-
-        # SSH model with num_cell = 4 and two orbitals, two spins
-        # cell_site_dof = [2,2]
-        t_intra = -0.5
-        t_inter = -0.6
-        H_cell = tensor(
-                Qobj(np.array([[0, t_intra], [t_intra, 0]])), qeye([2, 2]))
-        inter_cell_T = tensor(
-                Qobj(np.array([[0, 0], [t_inter, 0]])), qeye([2, 2]))
-
-        SSH_comp = Lattice1d(num_cell=6, boundary="periodic",
-                             cell_num_site=2, cell_site_dof=[2, 2],
-                             Hamiltonian_of_cell=H_cell, inter_hop=inter_cell_T)
-        [kScomp, vcomp] = SSH_comp.get_dispersion()
-        kS = np.array([[-3.14159265],
-                       [-2.0943951],
-                       [-1.04719755],
-                       [0.],
-                       [1.04719755],
-                       [2.0943951]])
-        Oband = np.array([-0.1, -0.55677644, -0.9539392, -1.1,
-                          -0.9539392, -0.55677644])
-        vS = np.array([Oband, Oband, Oband, Oband, -Oband, -Oband, -Oband,
-                       -Oband])
-        assert_(np.max(abs(kScomp-kS)) < 1.0E-6)
-        assert_(np.max(abs(vcomp-vS)) < 1.0E-6)
+    @pytest.mark.parametrize(["lattice", "k_expected", "energies_expected"], [
+        pytest.param(qutip.Lattice1d(num_cell=8),
+                     _k_expected(8),
+                     np.array([[2, np.sqrt(2), 0, -np.sqrt(2), -2,
+                                -np.sqrt(2), 0, np.sqrt(2)]]),
+                     id="atom chain"),
+        pytest.param(_ssh_lattice(-0.5, -0.6,
+                                  cells=6, sites_per_cell=2, freedom=[2, 2]),
+                     _k_expected(6),
+                     np.array([[-_ssh_energies]*4 + [_ssh_energies]*4]),
+                     id="ssh model")
+    ])
+    def test_get_dispersion(self, lattice, k_expected, energies_expected):
+        k_test, energies_test = lattice.get_dispersion()
+        _assert_angles_close(k_test, k_expected, atol=1e-8)
+        assert np.allclose(energies_test, energies_expected, atol=1e-8)
 
     def test_cell_periodic_parts(self):
-        """
-        lattice: Test the method Lattice1d.array_of_unk().
-        """
-        # Coupled Resonator Optical Waveguide(CROW) Example(PhysRevB.99.224201)
-        J = 2
-        eta = np.pi/4
-        H_cell = Qobj(np.array([[0, J*np.sin(eta)], [J*np.sin(eta), 0]]))
-        inter_cell_T0 = (J/2) * Qobj(np.array(
-                [[np.exp(eta * 1j), 0], [0, np.exp(-eta*1j)]]))
-        inter_cell_T1 = (J/2) * Qobj(np.array([[0, 1], [1, 0]]))
-
-        inter_cell_T = [inter_cell_T0, inter_cell_T1]
-
-        CROW_lattice = Lattice1d(num_cell=4, boundary="periodic",
-                                 cell_num_site=1, cell_site_dof=[2],
-                                 Hamiltonian_of_cell=H_cell,
-                                 inter_hop=inter_cell_T)
-        (kxA, val_kns) = CROW_lattice.get_dispersion()
-        (knxA, vec_kns) = CROW_lattice.cell_periodic_parts()
-        (knxA, qH_ks) = CROW_lattice.bulk_Hamiltonians()
-        for i in range(4):
-            for j in range(2):
-                if val_kns[j][i] == 0:
-                    E_V = Qobj(vec_kns[i, j, :])
-                    eE_V = qH_ks[i] * E_V
-                    assert_(np.max(abs(eE_V)) < 1.0E-12)
-                else:
-                    E_V = Qobj(vec_kns[i, j, :])
-                    eE_V = qH_ks[i] * E_V
-                    qE_V = np.divide(eE_V, E_V)
-                    oE = val_kns[j][i] * np.ones((2, 1))
-                    assert_(np.max(abs(oE-qE_V)) < 1.0E-12)
+        lattice = _crow_lattice(2, np.pi/4)
+        eigensystems = zip(lattice.get_dispersion()[1].T,
+                           lattice.cell_periodic_parts()[1])
+        hamiltonians = lattice.bulk_Hamiltonians()[1]
+        for hamiltonian, system in zip(hamiltonians, eigensystems):
+            for eigenvalue, eigenstate in zip(*system):
+                eigenstate = qutip.Qobj(eigenstate)
+                assert np.allclose((hamiltonian * eigenstate).full(),
+                                   (eigenvalue * eigenstate).full(),
+                                   atol=1e-12)
 
     def test_bulk_Hamiltonians(self):
-        """
-        lattice: Test the method Lattice1d.bulk_Hamiltonian_array().
-        """
-        # Coupled Resonator Optical Waveguide(CROW) Example(PhysRevB.99.224201)
-        J = 2
-        eta = np.pi/2
-        H_cell = Qobj(np.array([[0, J*np.sin(eta)], [J*np.sin(eta), 0]]))
-        inter_cell_T0 = (J/2)*Qobj(np.array([[np.exp(eta * 1j), 0],
-                                   [0, np.exp(-eta*1j)]]))
-        inter_cell_T1 = (J/2)*Qobj(np.array([[0, 1], [1, 0]]))
-        inter_cell_T = [inter_cell_T0, inter_cell_T1]
-
-        CROW_lattice = Lattice1d(num_cell=4, boundary="periodic",
-                                 cell_num_site=1, cell_site_dof=[2],
-                                 Hamiltonian_of_cell=H_cell,
-                                 inter_hop=inter_cell_T)
-        (knxA, qH_ks) = CROW_lattice.bulk_Hamiltonians()
-        Hk0 = np.array([[0.+0.j, 0.+0.j],
-                        [0.+0.j, 0.+0.j]])
-        Hk1 = np.array([[2.+0.j, 2.+0.j],
-                        [2.+0.j, -2.+0.j]])
-        Hk2 = np.array([[0.+0.j, 4.+0.j],
-                        [4.+0.j, 0.+0.j]])
-        Hk3 = np.array([[-2.+0.j, 2.+0.j],
-                        [2.+0.j, 2.+0.j]])
-        qHks = np.array([None for i in range(4)])
-        qHks[0] = Qobj(Hk0)
-        qHks[1] = Qobj(Hk1)
-        qHks[2] = Qobj(Hk2)
-        qHks[3] = Qobj(Hk3)
-        for i in range(4):
-            np.testing.assert_array_almost_equal(qH_ks[i], qHks[i], decimal=8)
+        test = _crow_lattice(2, np.pi/2).bulk_Hamiltonians()[1]
+        expected = [[[0, 0], [0, 0]],
+                    [[2, 2], [2, -2]],
+                    [[0, 4], [4, 0]],
+                    [[-2, 2], [2, 2]]]
+        for test_hamiltonian, expected_hamiltonian in zip(test, expected):
+            assert np.allclose(test_hamiltonian.full(), expected_hamiltonian,
+                               atol=1e-12)
 
     def test_bloch_wave_functions(self):
-        """
-        lattice: Test the method Lattice1d.bloch_wave_functions().
-        """
-        # Coupled Resonator Optical Waveguide(CROW) Example(PhysRevB.99.224201)
-        J = 2
-        eta = np.pi/2
-        H_cell = Qobj(np.array([[0, J*np.sin(eta)], [J*np.sin(eta), 0]]))
-        inter_cell_T0 = (J/2)*Qobj(np.array([[np.exp(eta * 1j), 0], [0,
-                                   np.exp(-eta*1j)]]))
-        inter_cell_T1 = (J/2)*Qobj(np.array([[0, 1], [1, 0]]))
+        lattice = _crow_lattice(2, np.pi/2)
+        hamiltonian = lattice.Hamiltonian()
+        expected = np.array([[0,    2,   1j,  1,   0,   0,  -1j,  1],
+                             [2,    0,   1,  -1j,  0,   0,   1,   1j],
+                             [-1j,  1,   0,   2,   1j,  1,   0,   0],
+                             [1,    1j,  2,   0,   1,  -1j,  0,   0],
+                             [0,    0,  -1j,  1,   0,   2,   1j,  1],
+                             [0,    0,   1,   1j,  2,   0,   1,  -1j],
+                             [1j,   1,   0,   0,  -1j,  1,   0,   2],
+                             [1,   -1j,  0,   0,   1,   1j,  2,   0]])
+        assert np.allclose(hamiltonian.full(), expected, atol=1e-8)
+        for eigenvalue, eigenstate in lattice.bloch_wave_functions():
+            assert np.allclose((hamiltonian * eigenstate).full(),
+                               (eigenvalue * eigenstate).full(),
+                               atol=1e-12)
 
-        inter_cell_T = [inter_cell_T0, inter_cell_T1]
 
-        CROW_lattice = Lattice1d(num_cell=4, boundary="periodic",
-                                 cell_num_site=1, cell_site_dof=[2],
-                                 Hamiltonian_of_cell=H_cell,
-                                 inter_hop=inter_cell_T)
-        CROW_Haml = CROW_lattice.Hamiltonian()
+class TestIntegration:
+    def test_fixed_crow(self):
+        lattice = _crow_lattice(2, np.pi/4, cells=4)
+        hamiltonian = lattice.Hamiltonian()
+        expected_hamiltonian = np.array([
+            [0, _r2, (1+1j)/_r2, 1, 0, 0, (1-1j)/_r2, 1],
+            [_r2, 0, 1, (1-1j)/_r2, 0, 0, 1, (1+1j)/_r2],
+            [(1-1j)/_r2, 1, 0, _r2, (1+1j)/_r2, 1, 0, 0],
+            [1, (1+1j)/_r2, _r2, 0, 1, (1-1j)/_r2, 0, 0],
+            [0, 0, (1-1j)/_r2, 1, 0, _r2, (1+1j)/_r2, 1],
+            [0, 0, 1, (1+1j)/_r2, _r2, 0, 1, (1-1j)/_r2],
+            [(1+1j)/_r2, 1, 0, 0, (1-1j)/_r2, 1, 0, _r2],
+            [1, (1-1j)/_r2, 0, 0, 1, (1+1j)/_r2, _r2, 0]])
+        assert np.allclose(hamiltonian, expected_hamiltonian, atol=1e-12)
 
-        H_CROW = Qobj(np.array([[0.+0.j, 2.+0.j, 0.+1.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 1.+0.j],
-                                [2.+0.j, 0.+0.j, 1.+0.j, 0.-1.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+1.j],
-                                [0.-1.j, 1.+0.j, 0.+0.j, 2.+0.j, 0.+1.j, 1.+0.j, 0.+0.j, 0.+0.j],
-                                [1.+0.j, 0.+1.j, 2.+0.j, 0.+0.j, 1.+0.j, 0.-1.j, 0.+0.j, 0.+0.j],
-                                [0.+0.j, 0.+0.j, 0.-1.j, 1.+0.j, 0.+0.j, 2.+0.j, 0.+1.j, 1.+0.j],
-                                [0.+0.j, 0.+0.j, 1.+0.j, 0.+1.j, 2.+0.j, 0.+0.j, 1.+0.j, 0.-1.j],
-                                [0.+1.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 1.+0.j, 0.+0.j, 2.+0.j],
-                                [1.+0.j, 0.-1.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+1.j, 2.+0.j, 0.+0.j]]),
-                      dims=[[4, 2], [4, 2]])
-        # Check for CROW with num_cell = 4
-        assert_(np.max(abs(CROW_Haml-H_CROW)) < 1.0E-6)  # 1.0E-8 worked too
-        eigen_states = CROW_lattice.bloch_wave_functions()
-        for i in range(8):
-            if eigen_states[i][0] == 0:
-                E_V = eigen_states[i][1]
-                eE_V = CROW_Haml * E_V
-                assert_(np.max(abs(eE_V)) < 1.0E-10)
-            else:
-                E_V = eigen_states[i][1]
-                eE_V = CROW_Haml * E_V
-                qE_V = np.divide(eE_V, E_V)
-                oE = eigen_states[i][0] * np.ones((8, 1))
-                assert_(np.max(abs(oE-qE_V)) < 1.0E-10)
+        test_k, test_energies = lattice.get_dispersion()
+        expected_k = _k_expected(4)
+        expected_energies = 2*np.array([[-1,    -1,    -1, -1],
+                                        [1-_r2,  1, 1+_r2,  1]])
+        _assert_angles_close(test_k, expected_k, atol=1e-12)
+        assert np.allclose(test_energies, expected_energies, atol=1e-12)
 
-    def test_CROW(self):
-        """
-        lattice: Test the methods of Lattice1d in a CROW model.
-        """
-        # Coupled Resonator Optical Waveguide(CROW) Example(PhysRevB.99.224201)
-        J = 2
-        eta = np.pi/4
-        H_cell = Qobj(np.array([[0, J * np.sin(eta)], [J * np.sin(eta), 0]]))
-        inter_cell_T0 = (J/2)*Qobj(np.array([[np.exp(eta * 1j), 0],
-                                   [0, np.exp(-eta*1j)]]))
-        inter_cell_T1 = (J/2)*Qobj(np.array([[0, 1], [1, 0]]))
+        for value, state in lattice.bloch_wave_functions():
+            assert np.allclose(hamiltonian*state, value*state, atol=1e-12)
 
-        inter_cell_T = [inter_cell_T0, inter_cell_T1]
+        test_bulk_system = zip(test_energies.T,
+                               lattice.cell_periodic_parts()[1])
+        test_bulk_h = lattice.bulk_Hamiltonians()[1]
+        expected_bulk_h = np.array([
+            [[-_r2, _r2-2], [_r2-2, -_r2]],
+            [[_r2,    _r2], [_r2,   -_r2]],
+            [[_r2,  2+_r2], [2+_r2,  _r2]],
+            [[-_r2,   _r2], [_r2,    _r2]]])
+        for test, expected in zip(test_bulk_h, expected_bulk_h):
+            assert np.allclose(test.full(), expected, atol=1e-8)
+        for hamiltonian, system in zip(test_bulk_h, test_bulk_system):
+            for eigenvalue, eigenstate in zip(*system):
+                eigenstate = qutip.Qobj(eigenstate)
+                assert np.allclose((hamiltonian * eigenstate).full(),
+                                   (eigenvalue * eigenstate).full(),
+                                   atol=1e-12)
 
-        CROW_lattice = Lattice1d(num_cell=4, boundary="periodic",
-                                 cell_num_site=1, cell_site_dof=[2],
-                                 Hamiltonian_of_cell=H_cell,
-                                 inter_hop=inter_cell_T)
-        CROW_Haml = CROW_lattice.Hamiltonian()
+    def test_random_crow(self):
+        cells = np.random.randint(2, 60)
+        phase = 2*np.pi * np.random.rand()
+        lattice = _crow_lattice(1, phase, cells=cells)
+        expected_k = _k_expected(cells)
+        _s, _c = np.sin(phase), np.cos(phase)
+        expected_energies = np.array([
+            [cosk*_c + np.sqrt(2*_s*(_s+cosk) + (cosk*_c)**2),
+             cosk*_c - np.sqrt(2*_s*(_s+cosk) + (cosk*_c)**2)]
+            for cosk in np.cos(expected_k).flat])
+        expected_energies = np.sort(expected_energies.T, axis=0)
+        test_k, test_energies = lattice.get_dispersion()
+        _assert_angles_close(test_k, expected_k, atol=1e-12)
+        assert np.allclose(test_energies, expected_energies, atol=1e-12)
 
-        # Benchmark answers
-        H_CROW = Qobj([[0.+0.j, 1.41421356+0.j, 0.70710678+0.70710678j, 1.+0.j,
-                        0.+0.j, 0.+0.j, 0.70710678-0.70710678j, 1.+0.j],
-        [1.41421356+0.j, 0.+0.j, 1.+0.j,  0.70710678-0.70710678j,
-         0.+0.j, 0.+0.j, 1.+0.j, 0.70710678+0.70710678j],
-        [0.70710678-0.70710678j, 1.+0.j, 0.+0.j, 1.41421356+0.j,
-         0.70710678+0.70710678j, 1.+0.j, 0.+0.j, 0.+0.j],
-        [1.+0.j, 0.70710678+0.70710678j, 1.41421356+0.j, 0.+0.j,
-         1.+0.j, 0.70710678-0.70710678j, 0.+0.j, 0.+0.j],
-        [0.+0.j, 0.+0.j, 0.70710678-0.70710678j, 1.+0.j,
-         0.+0.j, 1.41421356+0.j, 0.70710678+0.70710678j, 1.+0.j],
-        [0.+0.j, 0.+0.j, 1.+0.j, 0.70710678+0.70710678j,
-         1.41421356+0.j, 0.+0.j, 1.+0.j, 0.70710678-0.70710678j],
-        [0.70710678+0.70710678j, 1.+0.j, 0.+0.j, 0.+0.j,
-         0.70710678-0.70710678j, 1.+0.j, 0.+0.j, 1.41421356+0.j],
-        [1.+0.j, 0.70710678-0.70710678j, 0.+0.j, 0.+0.j,
-         1.+0.j, 0.70710678+0.70710678j, 1.41421356+0.j, 0.+0.j]],
-         dims=[[4, 2], [4, 2]])
+    def test_fixed_ssh(self):
+        intra, inter = -0.5, -0.6
+        cells = 5
+        lattice = _ssh_lattice(intra, inter,
+                               cells=cells, sites_per_cell=2, freedom=[1])
+        Hin = qutip.Qobj([[0, intra], [intra, 0]])
+        Ht = qutip.Qobj([[0, 0], [inter, 0]])
+        D = qutip.qeye(cells)
+        T = qutip.qdiags([np.ones(cells-1), [1]], [1, 1-cells])
+        hopping = qutip.tensor(T, Ht)
+        expected_hamiltonian = qutip.tensor(D, Hin) + hopping + hopping.dag()
+        assert lattice.Hamiltonian() == expected_hamiltonian
 
-        # Check for CROW with num_cell = 4
-        assert_(np.max(abs(CROW_Haml-H_CROW)) < 1.0E-6)  # 1.0E-8 worked too
+        test_k, test_energies = lattice.get_dispersion()
+        band = np.array([0.35297281, 0.89185772, 1.1, 0.89185772, 0.35297281])
+        _assert_angles_close(test_k, _k_expected(cells), atol=1e-12)
+        assert np.allclose(test_energies, np.array([-band, band]), atol=1e-8)
 
-        (kxA, val_kns) = CROW_lattice.get_dispersion()
-        kCR = np.array([[-3.14159265],
-                        [-1.57079633],
-                        [0.],
-                        [1.57079633]])
-        vCR = np.array([[-2.        , -2.        , -2.        , -2.],
-                        [-0.82842712, 2.         , 4.82842712 , 2.]])
-        assert_(np.max(abs(kxA-kCR)) < 1.0E-6)
-        assert_(np.max(abs(val_kns-vCR)) < 1.0E-6)
-
-        eigen_states = CROW_lattice.bloch_wave_functions()
-        for i in range(8):
-            E_V = eigen_states[i][1]
-            eE_V = CROW_Haml * E_V
-            qE_V = np.divide(eE_V, E_V)
-            oE = eigen_states[i][0] * np.ones((8, 1))
-            assert_(np.max(abs(oE-qE_V)) < 1.0E-10)
-        (knxA, qH_ks) = CROW_lattice.bulk_Hamiltonians()
-        (knxA, vec_kns) = CROW_lattice.cell_periodic_parts()
-
-        Hk0 = np.array([[-1.41421356+0.j, -0.58578644+0.j],
-                        [-0.58578644+0.j, -1.41421356+0.j]])
-        Hk1 = np.array([[1.41421356+0.j, 1.41421356+0.j],
-                        [1.41421356+0.j, -1.41421356+0.j]])
-        Hk2 = np.array([[1.41421356+0.j, 3.41421356+0.j],
-                        [3.41421356+0.j, 1.41421356+0.j]])
-        Hk3 = np.array([[-1.41421356+0.j, 1.41421356+0.j],
-                        [1.41421356+0.j, 1.41421356+0.j]])
-        qHks = np.array([None for i in range(4)])
-        qHks[0] = Qobj(Hk0)
-        qHks[1] = Qobj(Hk1)
-        qHks[2] = Qobj(Hk2)
-        qHks[3] = Qobj(Hk3)
-        for i in range(4):
-            np.testing.assert_array_almost_equal(qH_ks[i], qHks[i], decimal=8)
-        for i in range(4):
-            for j in range(2):
-                E_V = Qobj(vec_kns[i, j, :])
-                eE_V = qH_ks[i] * E_V
-                qE_V = np.divide(eE_V, E_V)
-                oE = val_kns[j][i]*np.ones((2, 1))
-                assert_(np.max(abs(oE-qE_V)) < 1.0E-12)
-
-        # A test on CROW lattice dispersion with a random number of cells and
-        # random values of eta
-        J = 1
-        num_cell = np.random.randint(2, 60)
-        eta = 2*np.pi*np.random.random()
-
-        H_cell = Qobj(np.array([[0, J * np.sin(eta)], [J * np.sin(eta), 0]]))
-        inter_cell_T0 = (J/2) * Qobj(np.array([[np.exp(eta * 1j), 0],
-                                              [0, np.exp(-eta*1j)]]))
-        inter_cell_T1 = (J/2) * Qobj(np.array([[0, 1], [1, 0]]))
-        inter_cell_T = [inter_cell_T0, inter_cell_T1]
-
-        CROW_Random = Lattice1d(num_cell=num_cell, boundary="periodic",
-                                cell_num_site=1, cell_site_dof=[2],
-                                Hamiltonian_of_cell=H_cell,
-                                inter_hop=inter_cell_T)
-        a = 1  # The unit cell length is always considered 1
-        kn_start = 0
-        kn_end = 2*np.pi/a
-        Ana_val_kns = np.zeros((2, num_cell), dtype=float)
-        knxA = np.zeros((num_cell, 1), dtype=float)
-
-        for ks in range(num_cell):
-            knx = kn_start + (ks*(kn_end-kn_start)/num_cell)
-            if knx >= np.pi:
-                knxA[ks, 0] = knx - 2 * np.pi
-            else:
-                knxA[ks, 0] = knx
-        knxA = np.roll(knxA, np.floor_divide(num_cell, 2))
-
-        for ks in range(num_cell):
-            knx = knxA[ks, 0]
-            # Ana_val_kns are the analytical bands
-            val0 = np.cos(knx) * np.cos(eta) + np.sqrt(2 * np.sin(eta) ** 2
-                          + (np.cos(knx) * np.cos(eta)) ** 2
-                          + 2 * np.sin(eta) * np.cos(knx))
-            val1 = np.cos(knx) * np.cos(eta) - np.sqrt(2 * np.sin(eta) ** 2
-                          + (np.cos(knx) * np.cos(eta)) ** 2
-                          + 2 * np.sin(eta) * np.cos(knx))
-            vals = [val0, val1]
-            Ana_val_kns[0, ks] = np.min(vals)
-            Ana_val_kns[1, ks] = np.max(vals)
-
-        (kxA, val_kns) = CROW_Random.get_dispersion()
-        assert_(np.max(abs(kxA-knxA)) < 1.0E-8)
-        assert_(np.max(abs(val_kns-Ana_val_kns)) < 1.0E-8)
-
-    def test_SSH(self):
-        """
-        lattice: Test the methods of Lattice1d in a SSH model.
-        """
-        # SSH model with num_cell = 4 and two orbitals, two spins
-        # cell_site_dof = [2,2]
-        t_intra = -0.5
-        t_inter = -0.6
-        H_cell = Qobj(np.array([[0, t_intra], [t_intra, 0]]))
-        inter_cell_T = Qobj(np.array([[0, 0], [t_inter, 0]]))
-
-        SSH_lattice = Lattice1d(num_cell=5, boundary="periodic",
-                             cell_num_site=2, cell_site_dof=[1],
-                             Hamiltonian_of_cell=H_cell,
-                             inter_hop=inter_cell_T)        
-        Ham_Sc = SSH_lattice.Hamiltonian()
-
-        Hin = Qobj([[0, -0.5], [-0.5, 0]])
-        Ht = Qobj([[0, 0], [-0.6, 0]])
-        D = qeye(5)
-        T = np.diag(np.zeros(4)+1, 1)
-        Tdag = np.diag(np.zeros(4)+1, -1)
-        Tdag[0][4] = 1
-        T[4][0] = 1
-        T = Qobj(T)
-        Tdag = Qobj(Tdag)
-        H_Sc = tensor(D, Hin) + tensor(T, Ht) + tensor(Tdag, Ht.dag())
-        # check for SSH model with num_cell = 5          
-        assert_(Ham_Sc == H_Sc)
-
-        (kxA,val_ks) = SSH_lattice.get_dispersion()
-        kSSH = np.array([[-2.51327412],
-                         [-1.25663706],
-                         [ 0.        ],
-                         [ 1.25663706],
-                         [ 2.51327412]])
-        vSSH = np.array([[-0.35297281, -0.89185772, -1.1, -0.89185772, -0.35297281],
-                         [ 0.35297281,  0.89185772,  1.1, 0.89185772, 0.35297281]])
-        assert_(np.max(abs(kxA-kSSH)) < 1.0E-6)
-        assert_(np.max(abs(val_ks-vSSH)) < 1.0E-6)
-
-        # A test on SSH lattice dispersion with a random number of cells and
-        # random values of t_inter and t_intra
-        num_cell = np.random.randint(2, 60)
-        t_intra = -np.random.random()
-        t_inter = -np.random.random()
-        H_cell = Qobj(np.array([[0, t_intra], [t_intra, 0]]))
-        inter_cell_T = Qobj(np.array([[0, 0], [t_inter, 0]]))
-        SSH_Random = Lattice1d(num_cell=num_cell, boundary="periodic",
-                             cell_num_site=2, cell_site_dof=[1],
-                             Hamiltonian_of_cell=H_cell,
-                             inter_hop=inter_cell_T)
-        a = 1  # The unit cell length is always considered 1
-        kn_start = 0
-        kn_end = 2*np.pi/a
-        Ana_val_kns = np.zeros((2, num_cell), dtype=float)
-        knxA = np.zeros((num_cell, 1), dtype=float)
-
-        for ks in range(num_cell):
-            knx = kn_start + (ks * (kn_end-kn_start)/num_cell)
-            if knx >= np.pi:
-                knxA[ks, 0] = knx - 2 * np.pi
-            else:
-                knxA[ks, 0] = knx
-        knxA = np.roll(knxA, np.floor_divide(num_cell, 2))
-
-        for ks in range(num_cell):
-            knx = knxA[ks, 0]
-            # Ana_val_kns are the analytical bands
-            Ana_val_kns[0, ks] = -np.sqrt(t_intra ** 2 + t_inter ** 2
-                       + 2 * t_intra * t_inter * np.cos(knx))
-            Ana_val_kns[1, ks] = np.sqrt(t_intra ** 2 + t_inter ** 2
-                       + 2 * t_intra * t_inter * np.cos(knx))
-        (kxA, val_kns) = SSH_Random.get_dispersion()
-        assert_(np.max(abs(val_kns-Ana_val_kns)) < 1.0E-13)
-
-if __name__ == "__main__":
-    run_module_suite()
+    def test_random_ssh(self):
+        cells = np.random.randint(2, 60)
+        intra, inter = -np.random.random(), -np.random.random()
+        lattice = _ssh_lattice(intra, inter,
+                               cells=cells, sites_per_cell=2, freedom=[1])
+        expected_k = _k_expected(cells)
+        band = np.sqrt(intra**2 + inter**2 + 2*intra*inter*np.cos(expected_k))
+        band = np.array(band.flat)
+        expected_energies = np.array([-band, band])
+        test_k, test_energies = lattice.get_dispersion()
+        _assert_angles_close(test_k, expected_k, atol=1e-12)
+        assert np.allclose(test_energies, expected_energies, atol=1e-12)

--- a/qutip/tests/test_lattice.py
+++ b/qutip/tests/test_lattice.py
@@ -39,7 +39,8 @@ _r2 = np.sqrt(2)
 
 def _assert_angles_close(test, expected, atol):
     """Assert that two arrays of angles are within tolerance of each other."""
-    assert np.allclose(test % (2*np.pi), expected % (2*np.pi), atol=atol)
+    np.testing.assert_allclose(test % (2*np.pi), expected % (2*np.pi),
+                               atol=atol)
 
 
 def _hamiltonian_expected(cells, periodic, sites_per_cell,
@@ -225,7 +226,7 @@ class TestLattice1d:
                                        cell_num_site=2, cell_site_dof=[2, 3])
         test = lattice_3223.x().full()
         expected = np.diag([n for n in range(3) for _ in [None]*12])
-        assert np.allclose(test, expected, atol=1e-12)
+        np.testing.assert_allclose(test, expected, atol=1e-12)
 
     def test_k(self):
         L = 7
@@ -245,7 +246,7 @@ class TestLattice1d:
         k_q = kq.eigenstates()[0]
         k_t = kt.eigenstates()[0]
         k_tC = k_t - (2*np.pi/L) * ((L-1) // 2)
-        assert np.allclose(k_tC, k_q, atol=1e-12)
+        np.testing.assert_allclose(k_tC, k_q, atol=1e-12)
 
     @pytest.mark.parametrize(["lattice", "k_expected", "energies_expected"], [
         pytest.param(qutip.Lattice1d(num_cell=8),
@@ -256,13 +257,13 @@ class TestLattice1d:
         pytest.param(_ssh_lattice(-0.5, -0.6,
                                   cells=6, sites_per_cell=2, freedom=[2, 2]),
                      _k_expected(6),
-                     np.array([[-_ssh_energies]*4 + [_ssh_energies]*4]),
+                     np.array([-_ssh_energies]*4 + [_ssh_energies]*4),
                      id="ssh model")
     ])
     def test_get_dispersion(self, lattice, k_expected, energies_expected):
         k_test, energies_test = lattice.get_dispersion()
         _assert_angles_close(k_test, k_expected, atol=1e-8)
-        assert np.allclose(energies_test, energies_expected, atol=1e-8)
+        np.testing.assert_allclose(energies_test, energies_expected, atol=1e-8)
 
     def test_cell_periodic_parts(self):
         lattice = _crow_lattice(2, np.pi/4)
@@ -272,9 +273,9 @@ class TestLattice1d:
         for hamiltonian, system in zip(hamiltonians, eigensystems):
             for eigenvalue, eigenstate in zip(*system):
                 eigenstate = qutip.Qobj(eigenstate)
-                assert np.allclose((hamiltonian * eigenstate).full(),
-                                   (eigenvalue * eigenstate).full(),
-                                   atol=1e-12)
+                np.testing.assert_allclose((hamiltonian * eigenstate).full(),
+                                           (eigenvalue * eigenstate).full(),
+                                           atol=1e-12)
 
     def test_bulk_Hamiltonians(self):
         test = _crow_lattice(2, np.pi/2).bulk_Hamiltonians()[1]
@@ -283,8 +284,9 @@ class TestLattice1d:
                     [[0, 4], [4, 0]],
                     [[-2, 2], [2, 2]]]
         for test_hamiltonian, expected_hamiltonian in zip(test, expected):
-            assert np.allclose(test_hamiltonian.full(), expected_hamiltonian,
-                               atol=1e-12)
+            np.testing.assert_allclose(test_hamiltonian.full(),
+                                       expected_hamiltonian,
+                                       atol=1e-12)
 
     def test_bloch_wave_functions(self):
         lattice = _crow_lattice(2, np.pi/2)
@@ -297,11 +299,11 @@ class TestLattice1d:
                              [0,    0,   1,   1j,  2,   0,   1,  -1j],
                              [1j,   1,   0,   0,  -1j,  1,   0,   2],
                              [1,   -1j,  0,   0,   1,   1j,  2,   0]])
-        assert np.allclose(hamiltonian.full(), expected, atol=1e-8)
+        np.testing.assert_allclose(hamiltonian.full(), expected, atol=1e-8)
         for eigenvalue, eigenstate in lattice.bloch_wave_functions():
-            assert np.allclose((hamiltonian * eigenstate).full(),
-                               (eigenvalue * eigenstate).full(),
-                               atol=1e-12)
+            np.testing.assert_allclose((hamiltonian * eigenstate).full(),
+                                       (eigenvalue * eigenstate).full(),
+                                       atol=1e-12)
 
 
 class TestIntegration:
@@ -317,17 +319,20 @@ class TestIntegration:
             [0, 0, 1, (1+1j)/_r2, _r2, 0, 1, (1-1j)/_r2],
             [(1+1j)/_r2, 1, 0, 0, (1-1j)/_r2, 1, 0, _r2],
             [1, (1-1j)/_r2, 0, 0, 1, (1+1j)/_r2, _r2, 0]])
-        assert np.allclose(hamiltonian, expected_hamiltonian, atol=1e-12)
+        np.testing.assert_allclose(hamiltonian, expected_hamiltonian,
+                                   atol=1e-12)
 
         test_k, test_energies = lattice.get_dispersion()
         expected_k = _k_expected(4)
         expected_energies = 2*np.array([[-1,    -1,    -1, -1],
                                         [1-_r2,  1, 1+_r2,  1]])
         _assert_angles_close(test_k, expected_k, atol=1e-12)
-        assert np.allclose(test_energies, expected_energies, atol=1e-12)
+        np.testing.assert_allclose(test_energies, expected_energies,
+                                   atol=1e-12)
 
         for value, state in lattice.bloch_wave_functions():
-            assert np.allclose(hamiltonian*state, value*state, atol=1e-12)
+            np.testing.assert_allclose(hamiltonian*state, value*state,
+                                       atol=1e-12)
 
         test_bulk_system = zip(test_energies.T,
                                lattice.cell_periodic_parts()[1])
@@ -338,13 +343,13 @@ class TestIntegration:
             [[_r2,  2+_r2], [2+_r2,  _r2]],
             [[-_r2,   _r2], [_r2,    _r2]]])
         for test, expected in zip(test_bulk_h, expected_bulk_h):
-            assert np.allclose(test.full(), expected, atol=1e-8)
+            np.testing.assert_allclose(test.full(), expected, atol=1e-8)
         for hamiltonian, system in zip(test_bulk_h, test_bulk_system):
             for eigenvalue, eigenstate in zip(*system):
                 eigenstate = qutip.Qobj(eigenstate)
-                assert np.allclose((hamiltonian * eigenstate).full(),
-                                   (eigenvalue * eigenstate).full(),
-                                   atol=1e-12)
+                np.testing.assert_allclose((hamiltonian * eigenstate).full(),
+                                           (eigenvalue * eigenstate).full(),
+                                           atol=1e-12)
 
     def test_random_crow(self):
         cells = np.random.randint(2, 60)
@@ -359,7 +364,8 @@ class TestIntegration:
         expected_energies = np.sort(expected_energies.T, axis=0)
         test_k, test_energies = lattice.get_dispersion()
         _assert_angles_close(test_k, expected_k, atol=1e-12)
-        assert np.allclose(test_energies, expected_energies, atol=1e-12)
+        np.testing.assert_allclose(test_energies, expected_energies,
+                                   atol=1e-12)
 
     def test_fixed_ssh(self):
         intra, inter = -0.5, -0.6
@@ -377,7 +383,8 @@ class TestIntegration:
         test_k, test_energies = lattice.get_dispersion()
         band = np.array([0.35297281, 0.89185772, 1.1, 0.89185772, 0.35297281])
         _assert_angles_close(test_k, _k_expected(cells), atol=1e-12)
-        assert np.allclose(test_energies, np.array([-band, band]), atol=1e-8)
+        np.testing.assert_allclose(test_energies, np.array([-band, band]),
+                                   atol=1e-8)
 
     def test_random_ssh(self):
         cells = np.random.randint(2, 60)
@@ -390,4 +397,5 @@ class TestIntegration:
         expected_energies = np.array([-band, band])
         test_k, test_energies = lattice.get_dispersion()
         _assert_angles_close(test_k, expected_k, atol=1e-12)
-        assert np.allclose(test_energies, expected_energies, atol=1e-12)
+        np.testing.assert_allclose(test_energies, expected_energies,
+                                   atol=1e-12)

--- a/qutip/tests/test_mcsolve.py
+++ b/qutip/tests/test_mcsolve.py
@@ -32,17 +32,16 @@
 ###############################################################################
 
 import pytest
-import functools
 import numpy as np
 import qutip
 
 
-def _return_constant(constant, *args, **kwargs):
-    return constant
+def _return_constant(t, args):
+    return args['constant']
 
 
-def _return_decay(constant, rate, t, *args, **kwargs):
-    return constant * np.exp(-rate * t)
+def _return_decay(t, args):
+    return args['constant'] * np.exp(-args['rate'] * t)
 
 
 @pytest.mark.usefixtures("in_temporary_directory")
@@ -70,9 +69,9 @@ class StatesAndExpectOutputCase:
         for test, expected_part in zip(result.expect, expected):
             np.testing.assert_allclose(test, expected_part, rtol=tol)
 
-    def test_states_and_expect(self, hamiltonian, c_ops, expected, tol):
+    def test_states_and_expect(self, hamiltonian, args, c_ops, expected, tol):
         options = qutip.Options(average_states=True, store_states=True)
-        result = qutip.mcsolve(hamiltonian, self.state, self.times,
+        result = qutip.mcsolve(hamiltonian, self.state, self.times, args=args,
                                c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj,
                                options=options)
         self._assert_expect(result, expected, tol)
@@ -88,23 +87,23 @@ class TestNoCollapse(StatesAndExpectOutputCase):
         tol = 1e-8
         expect = (qutip.expect(self.e_ops[0], self.state)
                   * np.ones_like(self.times))
-        # Use partial to allow pickling.
-        zero_function = functools.partial(_return_constant, 0)
         hamiltonian_types = [
-            (self.h, "Qobj", False),
-            ([self.h], "list", False),
-            ([self.h, [self.h, '0']], "string", True),
-            ([self.h, [self.h, zero_function]], "function", False),
+            (self.h, {}, "Qobj", False),
+            ([self.h], {}, "list", False),
+            ([self.h, [self.h, '0']], {}, "string", True),
+            ([self.h, [self.h, _return_constant]], {'constant': 0},
+             "function", False),
         ]
         cases = []
-        for hamiltonian, id, slow in hamiltonian_types:
+        for hamiltonian, args, id, slow in hamiltonian_types:
             if slow and 'only' in metafunc.function.__name__:
                 # Skip the single-output test if it's a slow case.
                 continue
             marks = [pytest.mark.slow] if slow else []
-            cases.append(pytest.param(hamiltonian, [], [expect], tol,
+            cases.append(pytest.param(hamiltonian, args, [], [expect], tol,
                                       id=id, marks=marks))
-        metafunc.parametrize(['hamiltonian', 'c_ops', 'expected', 'tol'],
+        metafunc.parametrize(['hamiltonian', 'args', 'c_ops', 'expected',
+                              'tol'],
                              cases)
 
     # Previously the "states_only" and "expect_only" tests were mixed in to
@@ -113,15 +112,15 @@ class TestNoCollapse(StatesAndExpectOutputCase):
     # runtimes shorter.  The known-good cases are still tested in the other
     # test cases, this is just testing the single-output behaviour.
 
-    def test_states_only(self, hamiltonian, c_ops, expected, tol):
+    def test_states_only(self, hamiltonian, args, c_ops, expected, tol):
         options = qutip.Options(average_states=True, store_states=True)
-        result = qutip.mcsolve(hamiltonian, self.state, self.times,
+        result = qutip.mcsolve(hamiltonian, self.state, self.times, args=args,
                                c_ops=c_ops, e_ops=[], ntraj=self.ntraj,
                                options=options)
         self._assert_states(result, expected, tol)
 
-    def test_expect_only(self, hamiltonian, c_ops, expected, tol):
-        result = qutip.mcsolve(hamiltonian, self.state, self.times,
+    def test_expect_only(self, hamiltonian, args, c_ops, expected, tol):
+        result = qutip.mcsolve(hamiltonian, self.state, self.times, args=args,
                                c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj)
         self._assert_expect(result, expected, tol)
 
@@ -137,19 +136,18 @@ class TestConstantCollapse(StatesAndExpectOutputCase):
         expect = (qutip.expect(self.e_ops[0], self.state)
                   * np.exp(-coupling * self.times))
         collapse_op = qutip.destroy(self.size)
-        # Use partial to allow pickling.
-        collapse_function = functools.partial(_return_constant,
-                                              np.sqrt(coupling))
         c_op_types = [
-            (np.sqrt(coupling)*collapse_op, "constant"),
-            ([collapse_op, 'sqrt({})'.format(coupling)], "string"),
-            ([collapse_op, collapse_function], "function"),
+            (np.sqrt(coupling)*collapse_op, {}, "constant"),
+            ([collapse_op, 'sqrt({})'.format(coupling)], {}, "string"),
+            ([collapse_op, _return_constant], {'constant': np.sqrt(coupling)},
+             "function"),
         ]
         cases = []
-        for c_op, id in c_op_types:
-            cases.append(pytest.param(self.h, [c_op], [expect], tol,
+        for c_op, args, id in c_op_types:
+            cases.append(pytest.param(self.h, args, [c_op], [expect], tol,
                                       id=id, marks=[pytest.mark.slow]))
-        metafunc.parametrize(['hamiltonian', 'c_ops', 'expected', 'tol'],
+        metafunc.parametrize(['hamiltonian', 'args', 'c_ops', 'expected',
+                              'tol'],
                              cases)
 
 
@@ -164,20 +162,18 @@ class TestTimeDependentCollapse(StatesAndExpectOutputCase):
         expect = (qutip.expect(self.e_ops[0], self.state)
                   * np.exp(-coupling * (1 - np.exp(-self.times))))
         collapse_op = qutip.destroy(self.size)
-        # Use partial to allow pickling.
-        collapse_function = functools.partial(_return_decay,
-                                              np.sqrt(coupling),
-                                              0.5)
+        collapse_args = {'constant': np.sqrt(coupling), 'rate': 0.5}
         collapse_string = 'sqrt({} * exp(-t))'.format(coupling)
         c_op_types = [
-            ([collapse_op, collapse_function], "function"),
-            ([collapse_op, collapse_string], "string"),
+            ([collapse_op, _return_decay], collapse_args, "function"),
+            ([collapse_op, collapse_string], {}, "string"),
         ]
         cases = []
-        for c_op, id in c_op_types:
-            cases.append(pytest.param(self.h, [c_op], [expect], tol,
+        for c_op, args, id in c_op_types:
+            cases.append(pytest.param(self.h, args, [c_op], [expect], tol,
                                       id=id, marks=[pytest.mark.slow]))
-        metafunc.parametrize(['hamiltonian', 'c_ops', 'expected', 'tol'],
+        metafunc.parametrize(['hamiltonian', 'args', 'c_ops', 'expected',
+                              'tol'],
                              cases)
 
 

--- a/qutip/tests/test_mcsolve.py
+++ b/qutip/tests/test_mcsolve.py
@@ -30,561 +30,274 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
+
 import pytest
+import functools
 import numpy as np
-from numpy.testing import assert_equal, run_module_suite, assert_
-import unittest
-from qutip import *
-from qutip import _version2int
-
-# find Cython if it exists
-try:
-    import Cython
-except:
-    Cython_found = 0
-else:
-    Cython_found = 1
-
-kappa = 0.2
+import qutip
 
 
-def sqrt_kappa(t, args):
-    return np.sqrt(kappa)
+def _return_constant(constant, *args, **kwargs):
+    return constant
 
 
-def sqrt_kappa2(t, args):
-    return np.sqrt(kappa * np.exp(-t))
+def _return_decay(constant, rate, t, *args, **kwargs):
+    return constant * np.exp(-rate * t)
 
 
-def const_H1_coeff(t, args):
-    return 0.0
+@pytest.mark.usefixtures("in_temporary_directory")
+class StatesAndExpectOutputCase:
+    """
+    Mixin class to test the states and expectation values from ``mcsolve``.
+    """
+    size = 10
+    h = qutip.num(size)
+    state = qutip.basis(size, size-1)
+    times = np.linspace(0, 1, 101)
+    e_ops = [qutip.num(size)]
+    ntraj = 750
 
-# average error for failure
-mc_error = 5e-2  # 5%
-ntraj = 750
+    def _assert_states(self, result, expected, tol):
+        assert hasattr(result, 'states')
+        assert len(result.states) == len(self.times)
+        for test_operator, expected_part in zip(self.e_ops, expected):
+            test = qutip.expect(test_operator, result.states)
+            np.testing.assert_allclose(test, expected_part, rtol=tol)
 
+    def _assert_expect(self, result, expected, tol):
+        assert hasattr(result, 'expect')
+        assert len(result.expect) == len(self.e_ops)
+        for test, expected_part in zip(result.expect, expected):
+            np.testing.assert_allclose(test, expected_part, rtol=tol)
 
-def test_MCNoCollExpt():
-    "Monte-carlo: Constant H with no collapse ops (expect)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
+    def test_states(self, hamiltonian, c_ops, expected, tol):
+        options = qutip.Options(average_states=True, store_states=True)
+        result = qutip.mcsolve(hamiltonian, self.state, self.times,
+                               c_ops=c_ops, e_ops=[], ntraj=self.ntraj,
+                               options=options)
+        self._assert_states(result, expected, tol)
 
+    def test_expect(self, hamiltonian, c_ops, expected, tol):
+        result = qutip.mcsolve(hamiltonian, self.state, self.times,
+                               c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj)
+        self._assert_expect(result, expected, tol)
 
-def test_MCNoCollStates():
-    "Monte-carlo: Constant H with no collapse ops (states)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [], ntraj=ntraj)
-    states = mcdata.states
-    expt = expect(a.dag() * a, states)
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
-
-
-def test_MCNoCollExpectStates():
-    "Monte-carlo: Constant H with no collapse ops (expect and states)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj,
-                     options=Options(store_states=True))
-    actual_answer = 9.0 * np.ones(len(tlist))
-    expt = mcdata.expect[0]
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
-    assert_(len(mcdata.states) == len(tlist))
-    assert_(isinstance(mcdata.states[0], Qobj))
-    expt = expect(a.dag() * a, mcdata.states)
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
+    def test_states_and_expect(self, hamiltonian, c_ops, expected, tol):
+        options = qutip.Options(average_states=True, store_states=True)
+        result = qutip.mcsolve(hamiltonian, self.state, self.times,
+                               c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj,
+                               options=options)
+        self._assert_expect(result, expected, tol)
+        self._assert_states(result, expected, tol)
 
 
-@pytest.mark.slow
-def test_MCNoCollStrExpt():
-    "Monte-carlo: Constant H (str format) with no collapse ops (expect)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = [a.dag() * a, [a.dag() * a, 'c']]
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], args={'c': 0.0},
-                     ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
+class TestNoCollapse(StatesAndExpectOutputCase):
+    """
+    Test that `mcsolve` correctly solves the system when there is a constant
+    Hamiltonian and no collapses.
+    """
+    def pytest_generate_tests(self, metafunc):
+        tol = 1e-8
+        expect = (qutip.expect(self.e_ops[0], self.state)
+                  * np.ones_like(self.times))
+        # Use partial to allow pickling.
+        zero_function = functools.partial(_return_constant, 0)
+        hamiltonian_types = [
+            (self.h, "Qobj", False),
+            ([self.h], "list", False),
+            ([self.h, [self.h, '0']], "string", True),
+            ([self.h, [self.h, zero_function]], "function", False),
+        ]
+        cases = []
+        for hamiltonian, id, slow in hamiltonian_types:
+            marks = [pytest.mark.slow] if slow else []
+            cases.append(pytest.param(hamiltonian, [], [expect], tol,
+                                      id=id, marks=marks))
+        metafunc.parametrize(['hamiltonian', 'c_ops', 'expected', 'tol'],
+                             cases)
 
 
-def test_MCNoCollFuncExpt():
-    "Monte-carlo: Constant H (func format) with no collapse ops (expect)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = [a.dag() * a, [a.dag() * a, const_H1_coeff]]
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
+class TestConstantCollapse(StatesAndExpectOutputCase):
+    """
+    Test that `mcsolve` correctly solves the system when there is a constant
+    collapse operator.
+    """
+    def pytest_generate_tests(self, metafunc):
+        tol = 0.05
+        coupling = 0.2
+        expect = (qutip.expect(self.e_ops[0], self.state)
+                  * np.exp(-coupling * self.times))
+        collapse_op = qutip.destroy(self.size)
+        # Use partial to allow pickling.
+        collapse_function = functools.partial(_return_constant,
+                                              np.sqrt(coupling))
+        c_op_types = [
+            (np.sqrt(coupling)*collapse_op, "constant"),
+            ([collapse_op, 'sqrt({})'.format(coupling)], "string"),
+            ([collapse_op, collapse_function], "function"),
+        ]
+        cases = []
+        for c_op, id in c_op_types:
+            cases.append(pytest.param(self.h, [c_op], [expect], tol,
+                                      id=id, marks=[pytest.mark.slow]))
+        metafunc.parametrize(['hamiltonian', 'c_ops', 'expected', 'tol'],
+                             cases)
 
 
-@pytest.mark.slow
-def test_MCNoCollStrStates():
-    "Monte-carlo: Constant H (str format) with no collapse ops (states)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = [a.dag() * a, [a.dag() * a, 'c']]
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [], args={'c': 0.0})
-    states = mcdata.states
-    expt = expect(a.dag() * a, states)
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
+class TestTimeDependentCollapse(StatesAndExpectOutputCase):
+    """
+    Test that `mcsolve` correctly solves the system when the collapse operators
+    are time-dependent.
+    """
+    def pytest_generate_tests(self, metafunc):
+        tol = 0.1
+        coupling = 0.2
+        expect = (qutip.expect(self.e_ops[0], self.state)
+                  * np.exp(-coupling * (1 - np.exp(-self.times))))
+        collapse_op = qutip.destroy(self.size)
+        # Use partial to allow pickling.
+        collapse_function = functools.partial(_return_decay,
+                                              np.sqrt(coupling),
+                                              0.5)
+        collapse_string = 'sqrt({} * exp(-t))'.format(coupling)
+        c_op_types = [
+            ([collapse_op, collapse_function], "function"),
+            ([collapse_op, collapse_string], "string"),
+        ]
+        cases = []
+        for c_op, id in c_op_types:
+            cases.append(pytest.param(self.h, [c_op], [expect], tol,
+                                      id=id, marks=[pytest.mark.slow]))
+        metafunc.parametrize(['hamiltonian', 'c_ops', 'expected', 'tol'],
+                             cases)
 
 
-def test_MCNoCollFuncStates():
-    "Monte-carlo: Constant H (func format) with no collapse ops (states)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = [a.dag() * a, [a.dag() * a, const_H1_coeff]]
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [], ntraj=ntraj)
-    states = mcdata.states
-    expt = expect(a.dag() * a, states)
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
-
-
-def test_MCCollapseTimesOperators():
-    "Monte-carlo: Check for stored collapse operators and times"
-    N = 10
-    kappa = 5.0
+def test_stored_collapse_operators_and_times():
+    """
+    Test that the output contains information on which collapses happened and
+    at what times, and make sure that this information makes sense.
+    """
+    size = 10
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    state = qutip.basis(size, size-1)
     times = np.linspace(0, 10, 100)
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)
-    c_ops = [np.sqrt(kappa) * a, np.sqrt(kappa) * a]
-    result = mcsolve(H, psi0, times, c_ops, [], ntraj=1)
-    assert_(len(result.col_times[0]) > 0)
-    assert_(len(result.col_which) == len(result.col_times))
-    assert_(all([col in [0, 1] for col in result.col_which[0]]))
+    c_ops = [a, a]
+    result = qutip.mcsolve(H, state, times, c_ops, ntraj=1)
+    assert len(result.col_times[0]) > 0
+    assert len(result.col_which) == len(result.col_times)
+    assert all(col in [0, 1] for col in result.col_which[0])
 
 
-@pytest.mark.slow
-def test_MCSimpleConst():
-    "Monte-carlo: Constant H with constant collapse"
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [np.sqrt(kappa) * a]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
+@pytest.mark.parametrize('options', [
+    pytest.param(qutip.Options(average_expect=True), id="average_expect=True"),
+    pytest.param(qutip.Options(average_states=False),
+                 id="average_states=False"),
+])
+def test_expectation_dtype(options):
+    # We're just testing the output value, so it's important whether certain
+    # things are complex or real, but not what the magnitudes of constants are.
+    focks = 5
+    a = qutip.tensor(qutip.destroy(focks), qutip.qeye(2))
+    sm = qutip.tensor(qutip.qeye(focks), qutip.sigmam())
+    H = 1j*a.dag()*sm + a
+    H = H + H.dag()
+    state = qutip.basis([focks, 2], [0, 1])
+    times = np.linspace(0, 10, 5)
+    c_ops = [a, sm]
+    e_ops = [a.dag()*a, sm.dag()*sm, a]
+    data = qutip.mcsolve(H, state, times, c_ops, e_ops, ntraj=5,
+                         options=options)
+    assert isinstance(data.expect[0][1], float)
+    assert isinstance(data.expect[1][1], float)
+    assert isinstance(data.expect[2][1], complex)
 
 
-@pytest.mark.slow
-def test_MCSimpleConstStates():
-    "Monte-carlo: Constant H with constant collapse (states)"
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [np.sqrt(kappa) * a]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [], ntraj=ntraj,
-                     options=Options(average_states=True))
-    assert_(len(mcdata.states) == len(tlist))
-    assert_(isinstance(mcdata.states[0], Qobj))
-    expt = expect(a.dag() * a, mcdata.states)
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
+class TestSeeds:
+    sizes = [6, 6, 6]
+    dampings = [0.1, 0.4, 0.1]
+    ntraj = 25  # Big enough to ensure there are differences without being slow
+    a = [qutip.destroy(size) for size in sizes]
+    H = 1j * (qutip.tensor(a[0], a[1].dag(), a[2].dag())
+              - qutip.tensor(a[0].dag(), a[1], a[2]))
+    state = qutip.tensor(qutip.coherent(sizes[0], np.sqrt(2)),
+                         qutip.basis(sizes[1:], [0, 0]))
+    times = np.linspace(0, 10, 2)
+    c_ops = [
+        np.sqrt(2*dampings[0]) * qutip.tensor(a[0], qutip.qeye(sizes[1:])),
+        (np.sqrt(2*dampings[1])
+         * qutip.tensor(qutip.qeye(sizes[0]), a[1], qutip.qeye(sizes[2]))),
+        np.sqrt(2*dampings[2]) * qutip.tensor(qutip.qeye(sizes[:2]), a[2]),
+    ]
+
+    def test_seeds_can_be_reused(self):
+        args = (self.H, self.state, self.times)
+        kwargs = {'c_ops': self.c_ops, 'ntraj': self.ntraj}
+        first = qutip.mcsolve(*args, **kwargs)
+        options = qutip.Options(seeds=first.seeds)
+        second = qutip.mcsolve(*args, options=options, **kwargs)
+        for first_t, second_t in zip(first.col_times, second.col_times):
+            np.testing.assert_equal(first_t, second_t)
+        for first_w, second_w in zip(first.col_which, second.col_which):
+            np.testing.assert_equal(first_w, second_w)
+
+    def test_seeds_are_not_reused_by_default(self):
+        args = (self.H, self.state, self.times)
+        kwargs = {'c_ops': self.c_ops, 'ntraj': self.ntraj}
+        first = qutip.mcsolve(*args, **kwargs)
+        second = qutip.mcsolve(*args, **kwargs)
+        assert not all(np.array_equal(first_t, second_t)
+                       for first_t, second_t in zip(first.col_times,
+                                                    second.col_times))
+        assert not all(np.array_equal(first_w, second_w)
+                       for first_w, second_w in zip(first.col_which,
+                                                    second.col_which))
 
 
-@pytest.mark.slow
-def test_MCSimpleConstExptStates():
-    "Monte-carlo: Constant H with constant collapse (states)"
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [np.sqrt(kappa) * a]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj,
-                     options=Options(average_states=True, store_states=True))
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    expt1 = mcdata.expect[0]
-    avg_diff = np.mean(abs(actual_answer - expt1) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
-    assert_(len(mcdata.states) == len(tlist))
-    assert_(isinstance(mcdata.states[0], Qobj))
-    expt2 = expect(a.dag() * a, mcdata.states)
-    avg_diff = np.mean(abs(actual_answer - expt2) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
+def test_list_ntraj():
+    """Test that `ntraj` can be a list."""
+    size = 5
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    state = qutip.basis(size, 1)
+    times = np.linspace(0, 0.8, 100)
+    # Arbitrary coupling and bath temperature.
+    coupling = 1 / 0.129
+    n_th = 0.063
+    c_ops = [np.sqrt(coupling * (n_th + 1)) * a,
+             np.sqrt(coupling * n_th) * a.dag()]
+    e_ops = [qutip.num(size)]
+    ntraj = [1, 5, 15, 100]
+    mc = qutip.mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj)
+    assert len(ntraj) == len(mc.expect)
 
 
-@pytest.mark.slow
-def test_MCSimpleSingleCollapse():
-    """Monte-carlo: Constant H with single collapse operator"""
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [np.sqrt(kappa) * a]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
-
-
-@pytest.mark.slow
-def test_MCSimpleSingleExpect():
-    """Monte-carlo: Constant H with single expect operator"""
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [np.sqrt(kappa) * a]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
-
-
-@pytest.mark.slow
-def test_MCSimpleConstFunc():
-    "Monte-carlo: Collapse terms constant (func format)"
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [[a, sqrt_kappa]]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
-
-
-@pytest.mark.slow
-def test_MCSimpleConstStr():
-    "Monte-carlo: Collapse terms constant (str format)"
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [[a, 'sqrt(k)']]
-    args = {'k': kappa}
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], args=args,
-                     ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
-
-
-def test_MCTDFunc():
-    "Monte-carlo: Time-dependent H (func format)"
-    error = 5e-2*4
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [[a, sqrt_kappa2]]
-    tlist = np.linspace(0, 5, 51)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a],
-                     ntraj=ntraj//2)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
-
-
-def test_MCTDStr():
-    "Monte-carlo: Time-dependent H (str format)"
-    error = 5e-2*4
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [[a, 'sqrt(k*exp(-t))']]
-    args = {'k': kappa}
-    tlist = np.linspace(0, 5, 51)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], args=args,
-                     ntraj=ntraj//2)
-    expt = mcdata.expect[0]
-    actual = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
-    diff = np.mean(abs(actual - expt) / actual)
-    assert_equal(diff < error, True)
-
-
-def test_mc_dtypes1():
-    "Monte-carlo: check for correct dtypes (average_states=True)"
-    # set system parameters
-    kappa = 2.0  # mirror coupling
-    gamma = 0.2  # spontaneous emission rate
-    g = 1  # atom/cavity coupling strength
-    wc = 0  # cavity frequency
-    w0 = 0  # atom frequency
-    wl = 0  # driving frequency
-    E = 0.5  # driving amplitude
-    N = 5  # number of cavity energy levels (0->3 Fock states)
-    tlist = np.linspace(0, 10, 5)  # times for expectation values
-    # construct Hamiltonian
-    ida = qeye(N)
-    idatom = qeye(2)
-    a = tensor(destroy(N), idatom)
-    sm = tensor(ida, sigmam())
-    H = (w0 - wl) * sm.dag() * sm + (wc - wl) * a.dag() * a + \
-        1j * g * (a.dag() * sm - sm.dag() * a) + E * (a.dag() + a)
-    # collapse operators
-    C1 = np.sqrt(2 * kappa) * a
-    C2 = np.sqrt(gamma) * sm
-    C1dC1 = C1.dag() * C1
-    C2dC2 = C2.dag() * C2
-    # intial state
-    psi0 = tensor(basis(N, 0), basis(2, 1))
-    opts = Options(average_expect=True)
-    data = mcsolve(
-        H, psi0, tlist, [C1, C2], [C1dC1, C2dC2, a], ntraj=5, options=opts)
-    assert_equal(isinstance(data.expect[0][1], float), True)
-    assert_equal(isinstance(data.expect[1][1], float), True)
-    assert_equal(isinstance(data.expect[2][1], complex), True)
-
-
-def test_mc_dtypes2():
-    "Monte-carlo: check for correct dtypes (average_states=False)"
-    # set system parameters
-    kappa = 2.0  # mirror coupling
-    gamma = 0.2  # spontaneous emission rate
-    g = 1  # atom/cavity coupling strength
-    wc = 0  # cavity frequency
-    w0 = 0  # atom frequency
-    wl = 0  # driving frequency
-    E = 0.5  # driving amplitude
-    N = 5  # number of cavity energy levels (0->3 Fock states)
-    tlist = np.linspace(0, 10, 5)  # times for expectation values
-    # construct Hamiltonian
-    ida = qeye(N)
-    idatom = qeye(2)
-    a = tensor(destroy(N), idatom)
-    sm = tensor(ida, sigmam())
-    H = (w0 - wl) * sm.dag() * sm + (wc - wl) * a.dag() * a + \
-        1j * g * (a.dag() * sm - sm.dag() * a) + E * (a.dag() + a)
-    # collapse operators
-    C1 = np.sqrt(2 * kappa) * a
-    C2 = np.sqrt(gamma) * sm
-    C1dC1 = C1.dag() * C1
-    C2dC2 = C2.dag() * C2
-    # intial state
-    psi0 = tensor(basis(N, 0), basis(2, 1))
-    opts = Options(average_expect=False)
-    data = mcsolve(
-        H, psi0, tlist, [C1, C2], [C1dC1, C2dC2, a], ntraj=5, options=opts)
-    assert_equal(isinstance(data.expect[0][0][1], float), True)
-    assert_equal(isinstance(data.expect[0][1][1], float), True)
-    assert_equal(isinstance(data.expect[0][2][1], complex), True)
-
-
-@pytest.mark.slow
-def test_mc_seed_reuse():
-    "Monte-carlo: check reusing seeds"
-    N0 = 6
-    N1 = 6
-    N2 = 6
-    # damping rates
-    gamma0 = 0.1
-    gamma1 = 0.4
-    gamma2 = 0.1
-    alpha = np.sqrt(2)  # initial coherent state param for mode 0
-    tlist = np.linspace(0, 10, 2)
-    ntraj = 500  # number of trajectories
-    # define operators
-    a0 = tensor(destroy(N0), qeye(N1), qeye(N2))
-    a1 = tensor(qeye(N0), destroy(N1), qeye(N2))
-    a2 = tensor(qeye(N0), qeye(N1), destroy(N2))
-    # number operators for each mode
-    num0 = a0.dag() * a0
-    num1 = a1.dag() * a1
-    num2 = a2.dag() * a2
-    # dissipative operators for zero-temp. baths
-    C0 = np.sqrt(2.0 * gamma0) * a0
-    C1 = np.sqrt(2.0 * gamma1) * a1
-    C2 = np.sqrt(2.0 * gamma2) * a2
-    # initial state: coherent mode 0 & vacuum for modes #1 & #2
-    psi0 = tensor(coherent(N0, alpha), basis(N1, 0), basis(N2, 0))
-    # trilinear Hamiltonian
-    H = 1j * (a0 * a1.dag() * a2.dag() - a0.dag() * a1 * a2)
-    # run Monte-Carlo
-    data1 = mcsolve(H, psi0, tlist, [C0, C1, C2], [num0, num1, num2],
-                    ntraj=ntraj)
-    data2 = mcsolve(H, psi0, tlist, [C0, C1, C2], [num0, num1, num2],
-                    ntraj=ntraj, options=Options(seeds=data1.seeds))
-    for k in range(ntraj):
-        assert_equal(np.allclose(data1.col_times[k],data2.col_times[k]), True)
-        assert_equal(np.allclose(data1.col_which[k],data2.col_which[k]), True)
-
-
-@pytest.mark.slow
-def test_mc_seed_noreuse():
-    "Monte-carlo: check not reusing seeds"
-    N0 = 6
-    N1 = 6
-    N2 = 6
-    # damping rates
-    gamma0 = 0.1
-    gamma1 = 0.4
-    gamma2 = 0.1
-    alpha = np.sqrt(2)  # initial coherent state param for mode 0
-    tlist = np.linspace(0, 10, 2)
-    ntraj = 500  # number of trajectories
-    # define operators
-    a0 = tensor(destroy(N0), qeye(N1), qeye(N2))
-    a1 = tensor(qeye(N0), destroy(N1), qeye(N2))
-    a2 = tensor(qeye(N0), qeye(N1), destroy(N2))
-    # number operators for each mode
-    num0 = a0.dag() * a0
-    num1 = a1.dag() * a1
-    num2 = a2.dag() * a2
-    # dissipative operators for zero-temp. baths
-    C0 = np.sqrt(2.0 * gamma0) * a0
-    C1 = np.sqrt(2.0 * gamma1) * a1
-    C2 = np.sqrt(2.0 * gamma2) * a2
-    # initial state: coherent mode 0 & vacuum for modes #1 & #2
-    psi0 = tensor(coherent(N0, alpha), basis(N1, 0), basis(N2, 0))
-    # trilinear Hamiltonian
-    H = 1j * (a0 * a1.dag() * a2.dag() - a0.dag() * a1 * a2)
-    # run Monte-Carlo
-    data1 = mcsolve(H, psi0, tlist, [C0, C1, C2], [num0, num1, num2],
-                    ntraj=ntraj)
-    data2 = mcsolve(H, psi0, tlist, [C0, C1, C2], [num0, num1, num2],
-                    ntraj=ntraj)
-    diff_flag = False
-    for k in range(ntraj):
-        if len(data1.col_times[k]) != len(data2.col_times[k]):
-            diff_flag = 1
-            break
-        else:
-            if not np.allclose(data1.col_which[k],data2.col_which[k]):
-                diff_flag = 1
-                break
-    assert_equal(diff_flag, 1)
-
-
-@pytest.mark.slow
-def test_mc_ntraj_list():
-    "Monte-carlo: list of trajectories"
-    N = 5
-    a = destroy(N)
-    H = a.dag()*a       # Simple oscillator Hamiltonian
-    psi0 = basis(N, 1)  # Initial Fock state with one photon
-    kappa = 1.0/0.129   # Coupling rate to heat bath
-    nth = 0.063         # Temperature with <n>=0.063
-    # Build collapse operators for the thermal bath
-    c_ops = []
-    c_ops.append(np.sqrt(kappa * (1 + nth)) * a)
-    c_ops.append(np.sqrt(kappa * nth) * a.dag())
-    ntraj = [1, 5, 15, 100]  # number of MC trajectories
-    tlist = np.linspace(0, 0.8, 100)
-    mc = mcsolve(H, psi0, tlist, c_ops, [a.dag()*a], ntraj)
-    assert_equal(len(mc.expect), 4)
-
-
-def f_dargs(t, args):
-    # allows only one collapse
+# Defined in module-scope so it's pickleable.
+def _dynamic(t, args):
     return 0 if args["collapse"] else 1
 
 
-def test_mc_dyn_args():
-    "Monte-carlo: dynamics arguments"
-    N = 5
-    a = destroy(N)
-    H = a.dag()*a       # Simple oscillator Hamiltonian
-    psi0 = basis(N, 2)  # Initial Fock state with one photon
-    c_ops = []
-    c_ops.append([a, f_dargs])
-    c_ops.append([a.dag(), f_dargs])
-    ntraj = [10]  # number of MC trajectories
-    tlist = np.linspace(0, 1, 11)
-    mc = mcsolve(H, psi0, tlist, c_ops, [a.dag()*a],
-                 ntraj, args={"collapse":[]})
-    assert_(all(len(col)<=1 for col in mc.col_which))
+def test_dynamic_arguments():
+    """Test dynamically updated arguments are usable."""
+    size = 5
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    times = np.linspace(0, 1, 11)
+    state = qutip.basis(size, 2)
+
+    c_ops = [[a, _dynamic], [a.dag(), _dynamic]]
+    mc = qutip.mcsolve(H, state, times, c_ops, ntraj=25, args={"collapse": []})
+    assert all(len(collapses) <= 1 for collapses in mc.col_which)
 
 
-def test_mc_functd_sum():
-    "Monte-carlo: Test for #490"
-    psi0 = (basis(2,0) + basis(2,1)).unit()
-    H0 = sigmax()
-    H1 = sigmay()
-    H2 = sigmaz()
-    def H1_coeff(t,args):
-        return t-1
-
-    def H2_coeff(t,args):
-        return -t
-
-    h_t = [H0,[H1, H1_coeff],
-           [H2, H2_coeff]]
-    ntraj = 1
-
-    tlist = np.linspace(0, 3, 10)
-    medata = mesolve(h_t, psi0, tlist, [], [], args = {})
-    mcdata = mcsolve(h_t, psi0, tlist, [], [], ntraj = ntraj, args = {})
-    assert_(max([(medata.states[k]-mcdata.states[k]).norm()
-                 for k in range(10)]) < 1e-5)
-
-
-if __name__ == "__main__":
-    run_module_suite()
+def test_regression_490():
+    """Test for regression of gh-490."""
+    h = [qutip.sigmax(),
+         [qutip.sigmay(), lambda t, args: t-1],
+         [qutip.sigmaz(), lambda t, args: -t]]
+    state = (qutip.basis(2, 0) + qutip.basis(2, 1)).unit()
+    times = np.linspace(0, 3, 10)
+    result_me = qutip.mesolve(h, state, times)
+    result_mc = qutip.mcsolve(h, state, times, ntraj=1)
+    for state_me, state_mc in zip(result_me.states, result_mc.states):
+        np.testing.assert_allclose(state_me.full(), state_mc.full(), atol=1e-8)


### PR DESCRIPTION
Continuing the work of #1164 - this is part two of many more to come, depending on how long I can keep doing this!  Of particular note is the first commit in this PR, which registers `pytest.mark.slow` with `pytest` to stop it warning about an unknown mark in use.

There are several additional comments and explanations in the expanded commit messages, where I've tried to explain a little bit about bugs I found and reasons for swapping over to certain libraries (e.g. for temporary file handling).

I'm in part opening a new PR now so that I can see if the CodeClimate tests are passing.  I shouldn't have many pep8 issues because I have a tool to check, but I don't have CodeClimate working locally for things like the complexity (if it even checks them for tests...).

I've been really rather aggressively using the parametrisation that `pytest` offers for fixtures, which is cutting out an awful lot of code duplication, and hopefully making it a bit clearer when things are exactly the same.

One common theme I'm finding when I'm running these tests is that there's an awful lot of warnings caused by `pyximport`, a part of `Cython`, which is using the Python 2 era `imp` instead of the newer `importlib`.  I'm not sure there's anything we can or should do about this, though.