### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: BUG
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Please provide a minimal working example. For instance:
+
+```python
+from qutip import identity
+# do something
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**You Environment**
+Please use `qutip.about()` to get the information about your environment and paste it here.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ENH
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
I created two issue templates for bugs and features using the GitHub template in Settings->Options->Featuress. I adjusted the bug issue template for our use. The Feature request template stays almost the same as the default one.

The bug report issue will automatically get a label `BUG`, while the feature request issue will get a label `ENH`.

Anyone like to have a look and see if there is anything that should be added or modified?