### PR TITLE
Make LaTeX image conversion more resilient

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -37,7 +37,7 @@ import inspect
 
 import numpy as np
 
-from qutip.qip.circuit_latex import _latex_compile
+from qutip.qip import circuit_latex as _latex
 from qutip.qip.operations.gates import *
 from qutip.qip.qubits import qubit_states
 
@@ -1112,21 +1112,23 @@ class QubitCircuit(object):
 
         return code
 
-    def _repr_png_(self):
-        return _latex_compile(self.latex_code(), format="png")
+    if 'png' in _latex.CONVERTERS:
+        def _repr_png_(self):
+            return _latex.make_image(self.latex_code(), file_type="png")
 
-    def _repr_svg_(self):
-        return _latex_compile(self.latex_code(), format="svg")
+        @property
+        def png(self):
+            from IPython.display import Image
+            return Image(self._repr_png_(), embed=True)
 
-    @property
-    def png(self):
-        from IPython.display import Image
-        return Image(self._repr_png_(), embed=True)
+    if 'svg' in _latex.CONVERTERS:
+        def _repr_svg_(self):
+            return _latex.make_image(self.latex_code(), file_type="svg")
 
-    @property
-    def svg(self):
-        from IPython.display import SVG
-        return SVG(self._repr_svg_())
+        @property
+        def svg(self):
+            from IPython.display import SVG
+            return SVG(self._repr_svg_())
 
     def qasm(self):
 

--- a/qutip/qip/circuit_latex.py
+++ b/qutip/qip/circuit_latex.py
@@ -217,8 +217,8 @@ if _pdflatex is not None:
         # leftover files if something goes wrong (or we get a
         # KeyboardInterrupt) during conversion.
         previous_dir = os.getcwd()
-        try:
-            with tempfile.TemporaryDirectory() as temporary_dir:
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            try:
                 os.chdir(temporary_dir)
                 with open(filename + ".tex", "w") as file:
                     file.write(_latex_template % (_qcircuit_latex_min, code))
@@ -237,8 +237,10 @@ if _pdflatex is not None:
                     raise ValueError("".join(["Unknown output format: '",
                                               file_type, "'."]))
                 out = CONVERTERS[file_type](filename)
-        finally:
-            os.chdir(previous_dir)
+            finally:
+                # Leave the temporary directory before it is removed (necessary
+                # on Windows, but it doesn't hurt on POSIX).
+                os.chdir(previous_dir)
         return out
 else:
     def image_from_latex(*args, **kwargs):


### PR DESCRIPTION
Notionally fixes #1179, #1185.  Converts the `os.system` calls to `subprocess.run` because they're now the recommended way of doing things.

I check for existence of the dependencies at import time, and emit a warning (`ImportWarning`) if they don't exist.  This is ignored by the typical warning filters, so it won't actually show up for most users.

If a dependency doesn't exist, then we don't define the relevant methods on the `QubitCircuit` class to avoid IPython introspecting the class object and thinking that it can make a PNG/SVG.

This may not be the best way of doing things, but in this delocalised setting I think it's easier to talk/discuss around a problem with an example in front of us.

In particular, I think raising `NotImplementedError` on failing to find `pdflatex` might not be the right call: if it doesn't exist, then the PNG and SVG methods of `QubitCircuit` are currently still created, and then IPython would try to call them and produce an error that isn't the fault of the user.  Also, maybe there's a nicer way to make sure that the user sees the "not found" warnings the first time that they do something which involves a conversion?  At the moment, the class just doesn't get the methods defined.