### PR TITLE
phase fixing in eigenstates (#1118)

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1650,8 +1650,8 @@ class Qobj(object):
 
         raise TypeError("Can only calculate overlap for state vector Qobjs")
 
-    def eigenstates(self, sparse=False, sort='low',
-                    eigvals=0, tol=0, maxiter=100000):
+    def eigenstates(self, sparse=False, sort='low', eigvals=0,
+                    tol=0, maxiter=100000, phase_fix=None):
         """Eigenstates and eigenenergies.
 
         Eigenstates and eigenenergies are defined for operators and
@@ -1675,6 +1675,10 @@ class Qobj(object):
         maxiter : int
             Maximum number of iterations performed by sparse solver (if used).
 
+        phase_fix : int, None
+            If not None, set the phase of each kets so that ket[phase_fix,0]
+            is real positive.
+
         Returns
         -------
         eigvals : array
@@ -1697,7 +1701,13 @@ class Qobj(object):
         ekets = np.array([Qobj(vec, dims=new_dims) for vec in evecs],
                          dtype=object)
         norms = np.array([ket.norm() for ket in ekets])
-        return evals, ekets / norms
+        if phase_fix is None:
+            phase = np.array([1] * len(ekets))
+        else:
+            phase = np.array([np.abs(ket[phase_fix,0]) / ket[phase_fix,0]
+                              if ket[phase_fix,0] else 1
+                              for ket in ekets ])
+        return evals, ekets / norms * phase
 
     def eigenenergies(self, sparse=False, sort='low',
                       eigvals=0, tol=0, maxiter=100000):

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1706,7 +1706,7 @@ class Qobj(object):
         else:
             phase = np.array([np.abs(ket[phase_fix,0]) / ket[phase_fix,0]
                               if ket[phase_fix,0] else 1
-                              for ket in ekets ])
+                              for ket in ekets])
         return evals, ekets / norms * phase
 
     def eigenenergies(self, sparse=False, sort='low',


### PR DESCRIPTION
Add options to fix the phase `Qobj.eigenstates` by choosing 1 element to be real positive.

The sign fix from #1118 would be obtained with:
```
N = 50
psi2 = fock(N,0)
x = create(N) + destroy(N)
eigs = x.eigenstates(phase_fix=0)[1]
```
also, in a more general form:

```
N = 50
n = 20
psi2 = fock(N,n)
x = create(N) + destroy(N)
eigs = x.eigenstates(phase_fix=n)[1]
```
Default usage not changed.