### PR TITLE
Deprecate qutip.graph functions

### DIFF
--- a/qutip/graph.py
+++ b/qutip/graph.py
@@ -45,6 +45,13 @@ from qutip.cy.graph_utils import (
     _breadth_first_search, _node_degrees,
     _reverse_cuthill_mckee, _maximum_bipartite_matching,
     _weighted_bipartite_matching)
+import warnings
+
+
+def _deprecate():
+    warnings.warn(("qutip graph functions are deprecated."
+                   " Consider using scipy.sparse.csgraph instead."),
+                  DeprecationWarning)
 
 
 def graph_degree(A):
@@ -62,6 +69,7 @@ def graph_degree(A):
     degree : array
         Array of integers giving the degree for each node (row).
     """
+    _deprecate()
     if not (sp.isspmatrix_csc(A) or sp.isspmatrix_csr(A)):
         raise TypeError('Input must be CSC or CSR sparse matrix.')
     return np.asarray(_node_degrees(A.indices, A.indptr, A.shape[0]))
@@ -90,6 +98,7 @@ def breadth_first_search(A, start):
         Level of the nodes in the order that they are traversed.
 
     """
+    _deprecate()
     if not (sp.isspmatrix_csc(A) or sp.isspmatrix_csr(A)):
         raise TypeError('Input must be CSC or CSR sparse matrix.')
     num_rows = A.shape[0]
@@ -117,6 +126,7 @@ def column_permutation(A):
     perm : array
         Array of permuted row and column indices.
     """
+    _deprecate()
     if not sp.isspmatrix_csc(A):
         A = sp.csc_matrix(A)
     count = np.diff(A.indptr)
@@ -160,6 +170,7 @@ def reverse_cuthill_mckee(A, sym=False):
     Matrices", ACM '69 Proceedings of the 1969 24th national conference,
     (1969).
     """
+    _deprecate()
     if not (sp.isspmatrix_csc(A) or sp.isspmatrix_csr(A)):
         raise TypeError('Input must be CSC or CSR sparse matrix.')
     nrows = A.shape[0]
@@ -201,6 +212,7 @@ def maximum_bipartite_matching(A, perm_type='row'):
     Analysis of Maximum Transversal Algorithms", ACM Trans. Math. Softw.
     38, no. 2, (2011).
     """
+    _deprecate()
     nrows = A.shape[0]
     if A.shape[0] != A.shape[1]:
         raise ValueError(
@@ -258,6 +270,7 @@ def weighted_bipartite_matching(A, perm_type='row'):
     large entries to the diagonal of sparse matrices", SIAM J.  Matrix Anal.
     and Applics. 20, no. 4, 889 (1997).
     """
+    _deprecate()
     nrows = A.shape[0]
     if A.shape[0] != A.shape[1]:
         raise ValueError('weighted_bfs_matching requires a square matrix.')

--- a/qutip/graph.py
+++ b/qutip/graph.py
@@ -35,9 +35,9 @@ This module contains a collection of graph theory routines used mainly
 to reorder matrices for iterative steady state solvers.
 """
 
-__all__ = ['graph_degree', 'column_permutation', 'breadth_first_search', 
-            'reverse_cuthill_mckee', 'maximum_bipartite_matching', 
-            'weighted_bipartite_matching']
+__all__ = ['graph_degree', 'column_permutation', 'breadth_first_search',
+           'reverse_cuthill_mckee', 'maximum_bipartite_matching',
+           'weighted_bipartite_matching']
 
 import numpy as np
 import scipy.sparse as sp
@@ -49,8 +49,8 @@ from qutip.cy.graph_utils import (
 
 def graph_degree(A):
     """
-    Returns the degree for the nodes (rows) of a symmetric
-    graph in sparse CSR or CSC format, or a qobj.
+    Returns the degree for the nodes (rows) of a symmetric graph in sparse CSR
+    or CSC format, or a qobj.
 
     Parameters
     ----------
@@ -61,7 +61,6 @@ def graph_degree(A):
     -------
     degree : array
         Array of integers giving the degree for each node (row).
-
     """
     if not (sp.isspmatrix_csc(A) or sp.isspmatrix_csr(A)):
         raise TypeError('Input must be CSC or CSR sparse matrix.')
@@ -73,8 +72,8 @@ def breadth_first_search(A, start):
     Breadth-First-Search (BFS) of a graph in CSR or CSC matrix format starting
     from a given node (row).  Takes Qobjs and CSR or CSC matrices as inputs.
 
-    This function requires a matrix with symmetric structure.
-    Use A+trans(A) if original matrix is not symmetric or not sure.
+    This function requires a matrix with symmetric structure.  Use A+trans(A)
+    if original matrix is not symmetric or not sure.
 
     Parameters
     ----------
@@ -93,7 +92,6 @@ def breadth_first_search(A, start):
     """
     if not (sp.isspmatrix_csc(A) or sp.isspmatrix_csr(A)):
         raise TypeError('Input must be CSC or CSR sparse matrix.')
-
     num_rows = A.shape[0]
     start = int(start)
     order, levels = _breadth_first_search(A.indices, A.indptr, num_rows, start)
@@ -104,11 +102,11 @@ def breadth_first_search(A, start):
 
 def column_permutation(A):
     """
-    Finds the non-symmetric column permutation of A such that the columns 
+    Finds the non-symmetric column permutation of A such that the columns
     are given in ascending order according to the number of nonzero entries.
-    This is sometimes useful for decreasing the fill-in of sparse LU 
+    This is sometimes useful for decreasing the fill-in of sparse LU
     factorization.
-    
+
     Parameters
     ----------
     A : csc_matrix
@@ -118,7 +116,6 @@ def column_permutation(A):
     -------
     perm : array
         Array of permuted row and column indices.
-    
     """
     if not sp.isspmatrix_csc(A):
         A = sp.csc_matrix(A)
@@ -129,10 +126,10 @@ def column_permutation(A):
 
 def reverse_cuthill_mckee(A, sym=False):
     """
-    Returns the permutation array that orders a sparse CSR or CSC matrix
-    in Reverse-Cuthill McKee ordering. Since the input matrix must be
-    symmetric, this routine works on the matrix A+Trans(A) if the sym flag is
-    set to False (Default).
+    Returns the permutation array that orders a sparse CSR or CSC matrix in
+    Reverse-Cuthill McKee ordering. Since the input matrix must be symmetric,
+    this routine works on the matrix A+Trans(A) if the sym flag is set to False
+    (Default).
 
     It is assumed by default (*sym=False*) that the input matrix is not
     symmetric. This is because it is faster to do A+Trans(A) than it is to
@@ -162,16 +159,12 @@ def reverse_cuthill_mckee(A, sym=False):
     E. Cuthill and J. McKee, "Reducing the Bandwidth of Sparse Symmetric
     Matrices", ACM '69 Proceedings of the 1969 24th national conference,
     (1969).
-    
     """
     if not (sp.isspmatrix_csc(A) or sp.isspmatrix_csr(A)):
         raise TypeError('Input must be CSC or CSR sparse matrix.')
-
     nrows = A.shape[0]
-
     if not sym:
         A = A + A.transpose()
-
     return _reverse_cuthill_mckee(A.indices, A.indptr, nrows)
 
 
@@ -182,8 +175,7 @@ def maximum_bipartite_matching(A, perm_type='row'):
     a permutation is always possible provided that the matrix is nonsingular.
     This function looks at the structure of the matrix only.
 
-    The input matrix will be converted to CSC matrix format if
-    necessary.
+    The input matrix will be converted to CSC matrix format if necessary.
 
     Parameters
     ----------
@@ -208,13 +200,11 @@ def maximum_bipartite_matching(A, perm_type='row'):
     I. S. Duff, K. Kaya, and B. Ucar, "Design, Implementation, and
     Analysis of Maximum Transversal Algorithms", ACM Trans. Math. Softw.
     38, no. 2, (2011).
-    
     """
     nrows = A.shape[0]
     if A.shape[0] != A.shape[1]:
         raise ValueError(
             'Maximum bipartite matching requires a square matrix.')
-
     if sp.isspmatrix_csr(A) or sp.isspmatrix_coo(A):
         A = A.tocsc()
     elif not sp.isspmatrix_csc(A):
@@ -222,24 +212,21 @@ def maximum_bipartite_matching(A, perm_type='row'):
 
     if perm_type == 'column':
         A = A.transpose().tocsc()
-
     perm = _maximum_bipartite_matching(A.indices, A.indptr, nrows)
-
     if np.any(perm == -1):
         raise Exception('Possibly singular input matrix.')
-
     return perm
 
 
 def weighted_bipartite_matching(A, perm_type='row'):
     """
-    Returns an array of row permutations that attempts to maximize
-    the product of the ABS values of the diagonal elements in
-    a nonsingular square CSC sparse matrix. Such a permutation is
-    always possible provided that the matrix is nonsingular.
+    Returns an array of row permutations that attempts to maximize the product
+    of the ABS values of the diagonal elements in a nonsingular square CSC
+    sparse matrix. Such a permutation is always possible provided that the
+    matrix is nonsingular.
 
-    This function looks at both the structure and ABS values of the
-    underlying matrix.
+    This function looks at both the structure and ABS values of the underlying
+    matrix.
 
     Parameters
     ----------
@@ -258,8 +245,8 @@ def weighted_bipartite_matching(A, perm_type='row'):
     -----
     This function uses a weighted maximum cardinality bipartite matching
     algorithm based on breadth-first search (BFS).  The columns are weighted
-    according to the element of max ABS value in the associated rows and
-    are traversed in descending order by weight.  When performing the BFS
+    according to the element of max ABS value in the associated rows and are
+    traversed in descending order by weight.  When performing the BFS
     traversal, the row associated to a given column is the one with maximum
     weight. Unlike other techniques[1]_, this algorithm does not guarantee the
     product of the diagonal is maximized.  However, this limitation is offset
@@ -267,16 +254,13 @@ def weighted_bipartite_matching(A, perm_type='row'):
 
     References
     ----------
-    I. S. Duff and J. Koster, "The design and use of algorithms for
-    permuting large entries to the diagonal of sparse matrices", SIAM J.
-    Matrix Anal. and Applics. 20, no. 4, 889 (1997).
-
+    I. S. Duff and J. Koster, "The design and use of algorithms for permuting
+    large entries to the diagonal of sparse matrices", SIAM J.  Matrix Anal.
+    and Applics. 20, no. 4, 889 (1997).
     """
-   
     nrows = A.shape[0]
     if A.shape[0] != A.shape[1]:
         raise ValueError('weighted_bfs_matching requires a square matrix.')
-
     if sp.isspmatrix_csr(A) or sp.isspmatrix_coo(A):
         A = A.tocsc()
     elif not sp.isspmatrix_csc(A):
@@ -284,12 +268,9 @@ def weighted_bipartite_matching(A, perm_type='row'):
 
     if perm_type == 'column':
         A = A.transpose().tocsc()
-
     perm = _weighted_bipartite_matching(
-                    np.asarray(np.abs(A.data), dtype=float), 
+                    np.asarray(np.abs(A.data), dtype=float),
                     A.indices, A.indptr, nrows)
-
     if np.any(perm == -1):
         raise Exception('Possibly singular input matrix.')
-
     return perm

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -58,7 +58,7 @@ from qutip.superoperator import liouvillian, vec2mat
 from qutip.sparse import (sp_permute, sp_bandwidth, sp_reshape,
                           sp_profile)
 from qutip.cy.spmath import zcsr_kron
-from qutip.graph import reverse_cuthill_mckee, weighted_bipartite_matching
+from qutip.graph import weighted_bipartite_matching
 from qutip import (mat2vec, tensor, identity, operator_to_vector)
 import qutip.settings as settings
 from qutip.utilities import _version2int
@@ -353,7 +353,7 @@ def _steadystate_LU_liouvillian(L, ss_args, has_mkl=0):
         if settings.debug:
             logger.debug('Calculating Reverse Cuthill-Mckee ordering...')
         _rcm_start = time.time()
-        perm2 = reverse_cuthill_mckee(L)
+        perm2 = sp.csgraph.reverse_cuthill_mckee(L)
         _rcm_end = time.time()
         rev_perm = np.argsort(perm2)
         L = sp_permute(L, perm2, perm2, form)
@@ -508,7 +508,7 @@ def _steadystate_eigen(L, ss_args):
         if settings.debug:
             old_band = sp_bandwidth(L)[0]
             logger.debug('Original bandwidth: %i' % old_band)
-        perm = reverse_cuthill_mckee(L)
+        perm = sp.csgraph.reverse_cuthill_mckee(L)
         rev_perm = np.argsort(perm)
         L = sp_permute(L, perm, perm, 'csc')
         if settings.debug:
@@ -780,7 +780,7 @@ def _steadystate_power_liouvillian(L, ss_args, has_mkl=0):
             logger.debug('Calculating Reverse Cuthill-Mckee ordering...')
         ss_args['info']['perm'].append('rcm')
         _rcm_start = time.time()
-        perm2 = reverse_cuthill_mckee(L)
+        perm2 = sp.csgraph.reverse_cuthill_mckee(L)
         _rcm_end = time.time()
         ss_args['info']['rcm_time'] = _rcm_end-_rcm_start
         rev_perm = np.argsort(perm2)
@@ -1147,7 +1147,7 @@ def _pseudo_inverse_sparse(L, rhoss, w=None, **pseudo_args):
             L = 1.0j*(1e-15)*spre(tr_op) + L
 
     if pseudo_args['use_rcm']:
-        perm = reverse_cuthill_mckee(L.data)
+        perm = sp.csgraph.reverse_cuthill_mckee(L.data)
         A = sp_permute(L.data, perm, perm)
         Q = sp_permute(Q, perm, perm)
     else:

--- a/qutip/tests/test_graph.py
+++ b/qutip/tests/test_graph.py
@@ -35,6 +35,7 @@ import numpy as np
 from numpy.testing import run_module_suite, assert_equal
 import scipy.sparse as sp
 from scipy.sparse.csgraph import breadth_first_order as BFO
+import pytest
 
 pwd = os.path.dirname(__file__)
 
@@ -47,7 +48,8 @@ from qutip.sparse import sp_permute, sp_bandwidth
 def test_graph_degree():
     "Graph: Graph Degree"
     A = rand_dm(25, 0.1)
-    deg = graph_degree(A.data)
+    with pytest.deprecated_call():
+        deg = graph_degree(A.data)
     A = A.full()
     np_deg = []
     for k in range(25):
@@ -68,7 +70,8 @@ def test_graph_bfs():
     A.data = np.real(A.data)
     seed = np.random.randint(24)
     arr1 = BFO(A, seed)[0]
-    arr2 = breadth_first_search(A, seed)[0]
+    with pytest.deprecated_call():
+        arr2 = breadth_first_search(A, seed)[0]
     assert_equal((arr1 - arr2).all(), 0)
 
 
@@ -83,7 +86,8 @@ def test_graph_rcm_simple():
                   [0, 0, 0, 1, 0, 0, 1, 0],
                   [0, 1, 0, 0, 0, 1, 0, 1]], dtype=np.int32)
     A = sp.csr_matrix(A)
-    perm = reverse_cuthill_mckee(A)
+    with pytest.deprecated_call():
+        perm = reverse_cuthill_mckee(A)
     ans = np.array([6, 3, 7, 5, 1, 2, 4, 0])
     assert_equal((perm - ans).all(), 0)
 
@@ -100,7 +104,8 @@ def test_graph_rcm_boost():
     M[6, 7] = 1
     M = M+M.T
     M = sp.csr_matrix(M, dtype=complex)
-    perm = reverse_cuthill_mckee(M, 1)
+    with pytest.deprecated_call():
+        perm = reverse_cuthill_mckee(M, 1)
     ans_perm = np.array([9, 7, 6, 4, 1, 5, 0, 2, 3, 8])
     assert_equal((perm - ans_perm).all(), 0)
     P = sp_permute(M, perm, perm)
@@ -122,7 +127,8 @@ def test_graph_rcm_qutip():
         )*sm+(wc-wl)*a.dag()*a+1j*g*(a.dag()*sm-sm.dag()*a)+E*(a.dag()+a)
     c_ops = [np.sqrt(2*kappa)*a, np.sqrt(gamma)*sm]
     L = liouvillian(H, c_ops)
-    perm = reverse_cuthill_mckee(L.data)
+    with pytest.deprecated_call():
+        perm = reverse_cuthill_mckee(L.data)
     ans = np.array([12, 14, 4, 6, 10, 8, 2, 15, 0, 13, 7, 5, 9, 11, 1, 3])
     assert_equal(perm, ans)
 
@@ -133,7 +139,8 @@ def test_graph_maximum_bipartite_matching():
     perm = np.random.permutation(25)
     perm2 = np.random.permutation(25)
     B = sp_permute(A, perm, perm2)
-    perm = maximum_bipartite_matching(B)
+    with pytest.deprecated_call():
+        perm = maximum_bipartite_matching(B)
     C = sp_permute(B, perm, [])
     assert_equal(any(C.diagonal() == 0), False)
 
@@ -149,7 +156,8 @@ def test_graph_weighted_matching():
     perm = np.random.permutation(25)
     perm2 = np.random.permutation(25)
     B = sp_permute(A, perm, perm2)
-    perm = weighted_bipartite_matching(B)
+    with pytest.deprecated_call():
+        perm = weighted_bipartite_matching(B)
     C = sp_permute(B, perm, [])
     assert_equal(np.sum(A.diagonal()), np.sum(C.diagonal()))
 
@@ -157,10 +165,12 @@ def test_graph_weighted_matching():
 def test_column_permutation():
     "Graph: Column Permutation"
     A = sp.rand(5, 5, 0.25, format='csc')
-    perm = column_permutation(A)
+    with pytest.deprecated_call():
+        perm = column_permutation(A)
     B = sp_permute(A, [], perm)
     counts = np.diff(B.indptr)
     assert_equal(np.all(np.argsort(counts) == np.arange(5)), True)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Implements the changes mentioned in #1203.

The `qutip.graph` functions are pure mathematical functions which are beyond the purview of the package.  Most of them have already been merged into `scipy.sparse.csgraph`, so we now move to using those and mark the functions as deprecated.

Only two functions are actually used, and they're not even currently tested.  `weighted_bipartite_matching` is not present in `scipy`, but is still marked as deprecated because we can move it into being an internal-only function, or simply remove the code that depends on it since those paths are not tested.

This will allow the removal of a good amount of Cython code, and simplify maintenance.