### PR TITLE
Add more single-qubit gates to QubitCircuit

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -110,6 +110,10 @@ class Gate(object):
                             "GLOBALPHASE", "CRX", "CRY", "CRZ"]:
             if arg_value is None:
                 raise ValueError("Gate %s requires an argument value" % name)
+        
+        elif name in ["X", "Y", "Z", "S", "T"]:
+            if self.targets is None or len(self.targets) != 1:
+                raise ValueError("Gate %s requires one target" % name)
 
         self.arg_value = arg_value
         self.arg_label = arg_label
@@ -128,6 +132,11 @@ class Gate(object):
 
 
 _gate_name_to_label = {
+    'X': r'X',
+    'Y': r'Y',
+    'Z': r'Z',
+    'S': r'S',
+    'T': r'T',
     'RX': r'R_x',
     'RY': r'R_y',
     'RZ': r'R_z',

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -110,7 +110,7 @@ class Gate(object):
                             "GLOBALPHASE", "CRX", "CRY", "CRZ"]:
             if arg_value is None:
                 raise ValueError("Gate %s requires an argument value" % name)
-        
+
         elif name in ["X", "Y", "Z", "S", "T"]:
             if self.targets is None or len(self.targets) != 1:
                 raise ValueError("Gate %s requires one target" % name)

--- a/qutip/qip/operations/__init__.py
+++ b/qutip/qip/operations/__init__.py
@@ -31,6 +31,7 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 from qutip.qip.operations.gates import (
+    x_gate, y_gate, z_gate, s_gate, t_gate,
     rx, ry, rz, sqrtnot, snot, phasegate, qrot,
     cphase, cnot,
     csign, berkeley, swapalpha, swap, iswap, sqrtswap,

--- a/qutip/qip/operations/gates.py
+++ b/qutip/qip/operations/gates.py
@@ -165,7 +165,7 @@ def t_gate(N=None, target=0):
     else:
         return Qobj([[1, 0],
                     [0, np.exp(1j*np.pi/4)]])
-      
+
 
 def rx(phi, N=None, target=0):
     """Single-qubit rotation for operator sigmax with angle phi.

--- a/qutip/qip/operations/gates.py
+++ b/qutip/qip/operations/gates.py
@@ -157,7 +157,7 @@ def t_gate(N=None, target=0):
     Returns
     -------
     result : qobj
-        Quantum object for operator describing a phase shift of pi/4.S
+        Quantum object for operator describing a phase shift of pi/4.
 
     """
     if N is not None:

--- a/qutip/qip/operations/gates.py
+++ b/qutip/qip/operations/gates.py
@@ -44,7 +44,7 @@ from qutip.tensor import tensor
 from qutip.states import fock_dm
 
 
-__all__ = ['x_gate', 'y_gate', 'z_gate', 's_gate', 't_gate', 
+__all__ = ['x_gate', 'y_gate', 'z_gate', 's_gate', 't_gate',
            'rx', 'ry', 'rz', 'sqrtnot', 'snot', 'phasegate', 'qrot',
            'cphase', 'cnot',
            'csign', 'berkeley', 'swapalpha', 'swap', 'iswap', 'sqrtswap',
@@ -65,7 +65,7 @@ def x_gate(N=None, target=0):
     Returns
     -------
     result : qobj
-        Quantum object for operator describing 
+        Quantum object for operator describing
         a single-qubit rotation through pi radians around the x-axis.
 
     Examples
@@ -90,9 +90,9 @@ def y_gate(N=None, target=0):
     Returns
     -------
     result : qobj
-        Quantum object for operator describing 
+        Quantum object for operator describing
         a single-qubit rotation through pi radians around the y-axis.
-    
+
     Examples
     --------
     >>> sigmay()
@@ -115,9 +115,9 @@ def z_gate(N=None, target=0):
     Returns
     -------
     result : qobj
-        Quantum object for operator describing 
+        Quantum object for operator describing
         a single-qubit rotation through pi radians around the z-axis.
-    
+
     Examples
     --------
      >>> sigmaz()
@@ -131,7 +131,7 @@ def z_gate(N=None, target=0):
     if N is not None:
         return gate_expand_1toN(z_gate(), N, target)
     else:
-        return sigmaz()   
+        return sigmaz()
 
 
 def s_gate(N=None, target=0):
@@ -140,14 +140,15 @@ def s_gate(N=None, target=0):
     Returns
     -------
     result : qobj
-        Quantum object for operator describing a 90 degree rotation around the z-axis.
+        Quantum object for operator describing
+        a 90 degree rotation around the z-axis.
 
     """
     if N is not None:
         return gate_expand_1toN(s_gate(), N, target)
     else:
         return Qobj([[1, 0],
-                     [0, -1j]])
+                    [0, -1j]])
 
 
 def t_gate(N=None, target=0):
@@ -163,7 +164,7 @@ def t_gate(N=None, target=0):
         return gate_expand_1toN(t_gate(), N, target)
     else:
         return Qobj([[1, 0],
-                     [0, np.exp(1j*np.pi/4)]])
+                    [0, np.exp(1j*np.pi/4)]])
                      
 
 def rx(phi, N=None, target=0):

--- a/qutip/qip/operations/gates.py
+++ b/qutip/qip/operations/gates.py
@@ -165,7 +165,7 @@ def t_gate(N=None, target=0):
     else:
         return Qobj([[1, 0],
                     [0, np.exp(1j*np.pi/4)]])
-                     
+      
 
 def rx(phi, N=None, target=0):
     """Single-qubit rotation for operator sigmax with angle phi.

--- a/qutip/qip/operations/gates.py
+++ b/qutip/qip/operations/gates.py
@@ -64,18 +64,9 @@ def x_gate(N=None, target=0):
 
     Returns
     -------
-    result : qobj
+    result : :class:`qutip.Qobj`
         Quantum object for operator describing
         a single-qubit rotation through pi radians around the x-axis.
-
-    Examples
-    --------
-    >>> sigmax()
-    Quantum object: dims = [[2], [2]], \
-    shape = [2, 2], type = oper, isHerm = False
-    Qobj data =
-    [[ 0.  1.]
-     [ 1.  0.]]
 
     """
     if N is not None:
@@ -89,18 +80,9 @@ def y_gate(N=None, target=0):
 
     Returns
     -------
-    result : qobj
+    result : :class:`qutip.Qobj`
         Quantum object for operator describing
         a single-qubit rotation through pi radians around the y-axis.
-
-    Examples
-    --------
-    >>> sigmay()
-    Quantum object: dims = [[2], [2]], \
-    shape = [2, 2], type = oper, isHerm = True
-    Qobj data =
-    [[ 0.+0.j  0.-1.j]
-     [ 0.+1.j  0.+0.j]]
 
     """
     if N is not None:
@@ -114,18 +96,9 @@ def z_gate(N=None, target=0):
 
     Returns
     -------
-    result : qobj
+    result : :class:`qutip.Qobj`
         Quantum object for operator describing
         a single-qubit rotation through pi radians around the z-axis.
-
-    Examples
-    --------
-     >>> sigmaz()
-    Quantum object: dims = [[2], [2]], \
-    shape = [2, 2], type = oper, isHerm = True
-    Qobj data =
-    [[ 1.  0.]
-     [ 0. -1.]]
 
     """
     if N is not None:
@@ -139,7 +112,7 @@ def s_gate(N=None, target=0):
 
     Returns
     -------
-    result : qobj
+    result : :class:`qutip.Qobj`
         Quantum object for operator describing
         a 90 degree rotation around the z-axis.
 
@@ -148,7 +121,7 @@ def s_gate(N=None, target=0):
         return gate_expand_1toN(s_gate(), N, target)
     else:
         return Qobj([[1, 0],
-                    [0, -1j]])
+                    [0, 1j]])
 
 
 def t_gate(N=None, target=0):
@@ -156,7 +129,7 @@ def t_gate(N=None, target=0):
 
     Returns
     -------
-    result : qobj
+    result : :class:`qutip.Qobj`
         Quantum object for operator describing a phase shift of pi/4.
 
     """

--- a/qutip/qip/operations/gates.py
+++ b/qutip/qip/operations/gates.py
@@ -44,7 +44,7 @@ from qutip.tensor import tensor
 from qutip.states import fock_dm
 
 
-__all__ = ['x_gate','y_gate','z_gate','s_gate','t_gate',
+__all__ = ['x_gate', 'y_gate', 'z_gate', 's_gate', 't_gate', 
            'rx', 'ry', 'rz', 'sqrtnot', 'snot', 'phasegate', 'qrot',
            'cphase', 'cnot',
            'csign', 'berkeley', 'swapalpha', 'swap', 'iswap', 'sqrtswap',
@@ -58,13 +58,15 @@ __all__ = ['x_gate','y_gate','z_gate','s_gate','t_gate',
 # Single Qubit Gates
 #
 
+
 def x_gate(N=None, target=0):
     """Pauli-X gate or sigmax operator.
 
     Returns
     -------
     result : qobj
-        Quantum object for operator describing a single-qubit rotation through pi radians around the x-axis.
+        Quantum object for operator describing 
+        a single-qubit rotation through pi radians around the x-axis.
 
     Examples
     --------
@@ -88,7 +90,8 @@ def y_gate(N=None, target=0):
     Returns
     -------
     result : qobj
-        Quantum object for operator describing a single-qubit rotation through pi radians around the y-axis.
+        Quantum object for operator describing 
+        a single-qubit rotation through pi radians around the y-axis.
     
     Examples
     --------
@@ -112,7 +115,8 @@ def z_gate(N=None, target=0):
     Returns
     -------
     result : qobj
-        Quantum object for operator describing a single-qubit rotation through pi radians around the z-axis.
+        Quantum object for operator describing 
+        a single-qubit rotation through pi radians around the z-axis.
     
     Examples
     --------

--- a/qutip/qip/operations/gates.py
+++ b/qutip/qip/operations/gates.py
@@ -157,7 +157,7 @@ def t_gate(N=None, target=0):
     Returns
     -------
     result : qobj
-        Quantum object for operator describing a phase shift of pi/4.
+        Quantum object for operator describing a phase shift of pi/4.S
 
     """
     if N is not None:

--- a/qutip/qip/operations/gates.py
+++ b/qutip/qip/operations/gates.py
@@ -39,12 +39,13 @@ from operator import mul
 import numpy as np
 import scipy.sparse as sp
 from qutip.qobj import Qobj
-from qutip.operators import identity, qeye, sigmax
+from qutip.operators import identity, qeye, sigmax, sigmay, sigmaz
 from qutip.tensor import tensor
 from qutip.states import fock_dm
 
 
-__all__ = ['rx', 'ry', 'rz', 'sqrtnot', 'snot', 'phasegate', 'qrot',
+__all__ = ['x_gate','y_gate','z_gate','s_gate','t_gate',
+           'rx', 'ry', 'rz', 'sqrtnot', 'snot', 'phasegate', 'qrot',
            'cphase', 'cnot',
            'csign', 'berkeley', 'swapalpha', 'swap', 'iswap', 'sqrtswap',
            'sqrtiswap', 'fredkin', 'molmer_sorensen',
@@ -57,6 +58,109 @@ __all__ = ['rx', 'ry', 'rz', 'sqrtnot', 'snot', 'phasegate', 'qrot',
 # Single Qubit Gates
 #
 
+def x_gate(N=None, target=0):
+    """Pauli-X gate or sigmax operator.
+
+    Returns
+    -------
+    result : qobj
+        Quantum object for operator describing a single-qubit rotation through pi radians around the x-axis.
+
+    Examples
+    --------
+    >>> sigmax()
+    Quantum object: dims = [[2], [2]], \
+    shape = [2, 2], type = oper, isHerm = False
+    Qobj data =
+    [[ 0.  1.]
+     [ 1.  0.]]
+
+    """
+    if N is not None:
+        return gate_expand_1toN(x_gate(), N, target)
+    else:
+        return sigmax()
+
+
+def y_gate(N=None, target=0):
+    """Pauli-Y gate or sigmay operator.
+
+    Returns
+    -------
+    result : qobj
+        Quantum object for operator describing a single-qubit rotation through pi radians around the y-axis.
+    
+    Examples
+    --------
+    >>> sigmay()
+    Quantum object: dims = [[2], [2]], \
+    shape = [2, 2], type = oper, isHerm = True
+    Qobj data =
+    [[ 0.+0.j  0.-1.j]
+     [ 0.+1.j  0.+0.j]]
+
+    """
+    if N is not None:
+        return gate_expand_1toN(y_gate(), N, target)
+    else:
+        return sigmay()
+
+
+def z_gate(N=None, target=0):
+    """Pauli-Z gate or sigmaz operator.
+
+    Returns
+    -------
+    result : qobj
+        Quantum object for operator describing a single-qubit rotation through pi radians around the z-axis.
+    
+    Examples
+    --------
+     >>> sigmaz()
+    Quantum object: dims = [[2], [2]], \
+    shape = [2, 2], type = oper, isHerm = True
+    Qobj data =
+    [[ 1.  0.]
+     [ 0. -1.]]
+
+    """
+    if N is not None:
+        return gate_expand_1toN(z_gate(), N, target)
+    else:
+        return sigmaz()   
+
+
+def s_gate(N=None, target=0):
+    """Single-qubit rotation also called Phase gate or the Z90 gate.
+
+    Returns
+    -------
+    result : qobj
+        Quantum object for operator describing a 90 degree rotation around the z-axis.
+
+    """
+    if N is not None:
+        return gate_expand_1toN(s_gate(), N, target)
+    else:
+        return Qobj([[1, 0],
+                     [0, -1j]])
+
+
+def t_gate(N=None, target=0):
+    """Single-qubit rotation related to the S gate by the relationship S=T*T.
+
+    Returns
+    -------
+    result : qobj
+        Quantum object for operator describing a phase shift of pi/4.
+
+    """
+    if N is not None:
+        return gate_expand_1toN(t_gate(), N, target)
+    else:
+        return Qobj([[1, 0],
+                     [0, np.exp(1j*np.pi/4)]])
+                     
 
 def rx(phi, N=None, target=0):
     """Single-qubit rotation for operator sigmax with angle phi.


### PR DESCRIPTION
1. Gate T and S were defined at qutip.qip.operation. Since Pauli-X, Pauli-Y and Pauli-Z exist in qutip.operators, they were imported as functions into qutip.qip.operation. All functions were tested. 
2. Each of the new gates was added to the circuit.py file. 
3. Not apply. 