### PR TITLE
Fix add_1q_gates + test

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -317,7 +317,9 @@ class QubitCircuit(object):
         else:
             if end is None:
                 end = self.N - 1
-            for i in range(start, end):
+            if (end >= self.N):
+                raise ValueError("%d is not a valid qubit number" % end)
+            for i in range(start, end+1):
                 self.gates.append(Gate(name, targets=i, controls=None,
                                        arg_value=arg_value,
                                        arg_label=arg_label))

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -317,8 +317,6 @@ class QubitCircuit(object):
         else:
             if end is None:
                 end = self.N - 1
-            if (end >= self.N):
-                raise ValueError("%d is not a valid qubit number" % end)
             for i in range(start, end+1):
                 self.gates.append(Gate(name, targets=i, controls=None,
                                        arg_value=arg_value,

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -159,9 +159,9 @@ class TestQubitCircuit:
 
     def test_add_gate(self):
         """
-        Addition of a gate object directly to a `QubitCircuit` 
+        Addition of a gate object directly to a `QubitCircuit`
         """
-        qc = QubitCircuit(3)
+        qc = QubitCircuit(6)
         qc.add_gate("CNOT", targets=[1], controls=[0])
         test_gate = Gate("RZ", targets=[1], arg_value = 1.570796,
                          arg_label="P")
@@ -169,6 +169,7 @@ class TestQubitCircuit:
         qc.add_gate("TOFFOLI", controls=[0, 1], targets=[2])
         qc.add_gate("SNOT", targets=[3])
         qc.add_gate(test_gate, index = [3])
+        qc.add_1q_gate("RY", start = 4, end = 6, arg_value = 1.570796)
 
         # Test explicit gate addition
         assert_(qc.gates[0].name == "CNOT")
@@ -184,6 +185,11 @@ class TestQubitCircuit:
         assert_(qc.gates[3].name == test_gate.name)
         assert_(qc.gates[3].targets == test_gate.targets)
         assert_(qc.gates[3].controls == test_gate.controls)
+
+        # Test adding 1 qubit gate on [start, end] qubits
+        for i in range(4, 7):
+            assert_(qc.gates[i].name == "RY")
+            assert_(qc.gates[i].targets == [i])
 
     def test_add_state(self):
         """
@@ -207,14 +213,14 @@ class TestQubitCircuit:
         qc1.add_state("A", targets=[1,4,9], state_type="output")
         qc1.add_state("beta", targets=[0], state_type="output")
         assert_(qc1.input_states[0] == None)
-        
+
         assert_(qc1.input_states[2] == "0")
         assert_(qc1.input_states[3] == "0")
         assert_(qc1.input_states[6] == "0")
         assert_(qc1.input_states[1] == "+")
         assert_(qc1.input_states[4] == "+")
 
-        assert_(qc1.output_states[2] == None)        
+        assert_(qc1.output_states[2] == None)
         assert_(qc1.output_states[1] == "A")
         assert_(qc1.output_states[4] == "A")
         assert_(qc1.output_states[9] == "A")
@@ -247,12 +253,14 @@ class TestQubitCircuit:
         assert_(qc.input_states[2] == None)
         assert_(qc.output_states[1] == "+")
 
+    def test_add_
+
     def test_user_gate(self):
         """
         User defined gate for QubitCircuit
         """
         def customer_gate1(arg_values):
-            mat = np.zeros((4, 4), dtype=np.complex)
+             mat = np.zeros((4, 4), dtype=np.complex)
             mat[0, 0] = mat[1, 1] = 1.
             mat[2:4, 2:4] = rx(arg_values)
             return Qobj(mat, dims=[[2, 2], [2, 2]])
@@ -286,7 +294,7 @@ class TestQubitCircuit:
             control_value = arg_value
             dim = mat3.dims[0][0]
             return (tensor(fock_dm(2, control_value), mat3) +
-                    tensor(fock_dm(2, 1 - control_value), identity(dim)))        
+                    tensor(fock_dm(2, 1 - control_value), identity(dim)))
 
         qc = QubitCircuit(2, dims=[3, 2])
         qc.user_gates = {"CTRLMAT3": controlled_mat3}

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -254,14 +254,13 @@ class TestQubitCircuit:
         assert_(qc.input_states[2] == None)
         assert_(qc.output_states[1] == "+")
 
-    def test_add_
 
     def test_user_gate(self):
         """
         User defined gate for QubitCircuit
         """
         def customer_gate1(arg_values):
-             mat = np.zeros((4, 4), dtype=np.complex)
+            mat = np.zeros((4, 4), dtype=np.complex)
             mat[0, 0] = mat[1, 1] = 1.
             mat[2:4, 2:4] = rx(arg_values)
             return Qobj(mat, dims=[[2, 2], [2, 2]])

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -169,7 +169,7 @@ class TestQubitCircuit:
         qc.add_gate("TOFFOLI", controls=[0, 1], targets=[2])
         qc.add_gate("SNOT", targets=[3])
         qc.add_gate(test_gate, index = [3])
-        qc.add_1q_gate("RY", start = 4, end = 6, arg_value = 1.570796)
+        qc.add_1q_gate("RY", start = 4, end = 5, arg_value = 1.570796)
 
         # Test explicit gate addition
         assert_(qc.gates[0].name == "CNOT")
@@ -187,9 +187,10 @@ class TestQubitCircuit:
         assert_(qc.gates[3].controls == test_gate.controls)
 
         # Test adding 1 qubit gate on [start, end] qubits
-        for i in range(4, 7):
-            assert_(qc.gates[i].name == "RY")
-            assert_(qc.gates[i].targets == [i])
+        assert_(qc.gates[5].name == "RY")
+        assert_(qc.gates[5].targets == [4])
+        assert_(qc.gates[6].name == "RY")
+        assert_(qc.gates[6].targets == [5])
 
     def test_add_state(self):
         """


### PR DESCRIPTION
In response to issue #1210 , added a quick fix for the add_1q_gates so that it now includes the "end" qubit (specified by the end argument). I also added a test in test_add_gates in test_qubitcircuit.py to cover this issue. The function now applies the 1 qubit gate to every qubit in [start, end] (0-indexed), start and end inclusive. This should resolve #1210