### PR TITLE
Prefix variable names with _ to clear Travis CI warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 
-stage_generic_linux: &stage_generic_linux
+_stage_generic_linux: &stage_generic_linux
   os: linux
   language: python
   # change dir
@@ -24,19 +24,19 @@ stage_generic_linux: &stage_generic_linux
     - conda install mkl blas=*=mkl numpy scipy pytest pytest-cov cython coveralls
     - python setup.py install
 
-stage_linux_36: &stage_linux_36
+_stage_linux_36: &stage_linux_36
   <<: *stage_generic_linux
   name: "Python 3.6"
   dist: trusty
   python: 3.6
 
-stage_linux_37: &stage_linux_37
+_stage_linux_37: &stage_linux_37
   <<: *stage_generic_linux
   name: "Python 3.7"
   dist: xenial
   python: 3.7
 
-stage_linux_38: &stage_linux_38
+_stage_linux_38: &stage_linux_38
   <<: *stage_generic_linux
   name: "Python 3.8"
   dist: xenial
@@ -53,7 +53,7 @@ stage_linux_38: &stage_linux_38
     - conda install numpy scipy pytest pytest-cov cython coveralls
     - python setup.py install
 
-stage_linux_37_no_cython: &stage_linux_37_no_cython
+_stage_linux_37_no_cython: &stage_linux_37_no_cython
   <<: *stage_generic_linux
   name: "Python 3.7 no cython"
   dist: xenial
@@ -73,7 +73,7 @@ stage_linux_37_no_cython: &stage_linux_37_no_cython
     - python setup.py install
     - conda uninstall cython
 
-stage_linux_37_openblas: &stage_linux_37_openblas
+_stage_linux_37_openblas: &stage_linux_37_openblas
   <<: *stage_generic_linux
   name: "Python 3.7 OpenBLAS"
   dist: xenial
@@ -90,7 +90,7 @@ stage_linux_37_openblas: &stage_linux_37_openblas
     - conda install nomkl blas=*=openblas numpy scipy pytest pytest-cov cython
     - python setup.py install
 
-stage_linux_37_omp: &stage_linux_37_omp
+_stage_linux_37_omp: &stage_linux_37_omp
   <<: *stage_generic_linux
   name: "Python 3.7 OpenMP"
   dist: xenial
@@ -109,7 +109,7 @@ stage_linux_37_omp: &stage_linux_37_omp
   after_success:
     - coveralls
 
-stage_osx: &stage_osx
+_stage_osx: &stage_osx
   os: osx
   name: "Python 3.7, OSX 10.13, XCode 10"
   osx_image: xcode10


### PR DESCRIPTION
Prefixes variable names with ```_``` to clear the Travis CI warnings, as mentioned in #1133.

Before the changes, the ```travis lint``` output was:

```
Warnings for .travis.yml:
[x] [warn] on root: deprecated key: stage_generic_linux (anchor on a non-private key)
[x] [warn] on root: deprecated key: stage_linux_36 (anchor on a non-private key)
[x] [warn] on root: deprecated key: stage_linux_37 (anchor on a non-private key)
[x] [warn] on root: deprecated key: stage_linux_38 (anchor on a non-private key)
[x] [warn] on root: deprecated key: stage_linux_37_no_cython (anchor on a non-private key)
[x] [warn] on root: deprecated key: stage_linux_37_openblas (anchor on a non-private key)
[x] [warn] on root: deprecated key: stage_linux_37_omp (anchor on a non-private key)
[x] [warn] on root: deprecated key: stage_osx (anchor on a non-private key)
```

After the changes, it is:

```
Hooray, .travis.yml looks valid :)
```