### PR TITLE
4.5.1v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 
-stage_generic_linux: &stage_generic_linux
+_stage_generic_linux: &stage_generic_linux
   os: linux
   language: python
   # change dir
@@ -24,19 +24,19 @@ stage_generic_linux: &stage_generic_linux
     - conda install mkl blas=*=mkl numpy scipy pytest pytest-cov cython coveralls
     - python setup.py install
 
-stage_linux_36: &stage_linux_36
+_stage_linux_36: &stage_linux_36
   <<: *stage_generic_linux
   name: "Python 3.6"
   dist: trusty
   python: 3.6
 
-stage_linux_37: &stage_linux_37
+_stage_linux_37: &stage_linux_37
   <<: *stage_generic_linux
   name: "Python 3.7"
   dist: xenial
   python: 3.7
 
-stage_linux_38: &stage_linux_38
+_stage_linux_38: &stage_linux_38
   <<: *stage_generic_linux
   name: "Python 3.8"
   dist: xenial
@@ -53,7 +53,7 @@ stage_linux_38: &stage_linux_38
     - conda install numpy scipy pytest pytest-cov cython coveralls
     - python setup.py install
 
-stage_linux_37_no_cython: &stage_linux_37_no_cython
+_stage_linux_37_no_cython: &stage_linux_37_no_cython
   <<: *stage_generic_linux
   name: "Python 3.7 no cython"
   dist: xenial
@@ -73,7 +73,7 @@ stage_linux_37_no_cython: &stage_linux_37_no_cython
     - python setup.py install
     - conda uninstall cython
 
-stage_linux_37_openblas: &stage_linux_37_openblas
+_stage_linux_37_openblas: &stage_linux_37_openblas
   <<: *stage_generic_linux
   name: "Python 3.7 OpenBLAS"
   dist: xenial
@@ -90,7 +90,7 @@ stage_linux_37_openblas: &stage_linux_37_openblas
     - conda install nomkl blas=*=openblas numpy scipy pytest pytest-cov cython
     - python setup.py install
 
-stage_linux_37_omp: &stage_linux_37_omp
+_stage_linux_37_omp: &stage_linux_37_omp
   <<: *stage_generic_linux
   name: "Python 3.7 OpenMP"
   dist: xenial
@@ -109,7 +109,7 @@ stage_linux_37_omp: &stage_linux_37_omp
   after_success:
     - coveralls
 
-stage_osx: &stage_osx
+_stage_osx: &stage_osx
   os: osx
   name: "Python 3.7, OSX 10.13, XCode 10"
   osx_image: xcode10

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,4 +151,6 @@ jobs:
     - stage: test
       <<: *stage_linux_37_openblas
     - stage: test
+      <<: *stage_linux_38
+    - stage: test
       <<: *stage_osx

--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 QuTiP: Quantum Toolbox in Python
 ================================
 
-[A. Pitchford](https://github.com/ajgpitch), [C. Granade](https://github.com/cgranade), [A. Grimsmo](https://github.com/arnelg), [N. Shammah](https://github.com/nathanshammah), [S. Ahmed](https://github.com/quantshah), [N. Lambert](https://github.com/nwlambert), [E. Giguère](https://github.com/ericgig), [P. D. Nation](https://github.com/nonhermitian), and [J. R. Johansson](https://github.com/jrjohansson)
+[A. Pitchford](https://github.com/ajgpitch),
+[C. Granade](https://github.com/cgranade),
+[A. Grimsmo](https://github.com/arnelg),
+[N. Shammah](https://github.com/nathanshammah),
+[S. Ahmed](https://github.com/quantshah),
+[N. Lambert](https://github.com/nwlambert),
+[E. Giguère](https://github.com/ericgig),
+[B. Li](https://github.com/boxili),
+[P. D. Nation](https://github.com/nonhermitian),
+and [J. R. Johansson](https://github.com/jrjohansson)
 
 
 QuTiP is open-source software for simulating the dynamics of closed and open
@@ -19,6 +28,15 @@ Build status and test coverage
 [![build-status](https://secure.travis-ci.org/qutip/qutip.svg?branch=master)](http://travis-ci.org/qutip/qutip)
 [![Coverage Status](https://img.shields.io/coveralls/qutip/qutip.svg)](https://coveralls.io/r/qutip/qutip)
 [![Maintainability](https://api.codeclimate.com/v1/badges/df502674f1dfa1f1b67a/maintainability)](https://codeclimate.com/github/qutip/qutip/maintainability)
+
+Support
+--------
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
+[![Unitary Fund](https://img.shields.io/badge/Supported%20By-UNITARY%20FUND-brightgreen.svg?style=for-the-badge)](http://unitary.fund)
+
+QuTiP development is supported by [Nori's lab](http://dml.riken.jp/)
+at RIKEN, by the University of Sherbrooke, and by Aberystwyth University,
+[among other supporting organizations](http://qutip.org/#supporting-organizations).
 
 Download
 --------

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -59,7 +59,7 @@ def about():
     print("Previous lead developers: Chris Granade & A. Grimsmo.")
     print("Current admin team: Alexander Pitchford, Paul D. Nation, "
             "Nathan Shammah, Shahnawaz Ahmed, "
-            "Neill Lambert, and Eric Giguère.")
+            "Neill Lambert, Eric Giguère, and Boxi Li")
     print("Project Manager: Franco Nori.")
     print("Currently developed through wide collaboration. "
           "See https://github.com/qutip for details.")

--- a/qutip/cy/cqobjevo.pxd
+++ b/qutip/cy/cqobjevo.pxd
@@ -50,18 +50,18 @@ cdef class CQobjEvo:
     cdef complex[::1] coeff
     cdef complex* coeff_ptr
 
-    cdef void _factor(self, double t)
-    cdef void _factor_dyn(self, double t, complex* state, int[::1] state)
-    cdef void _mul_vec(self, double t, complex* vec, complex* out)
-    cdef void _mul_matf(self, double t, complex* mat, complex* out,
-                    int nrow, int ncols)
-    cdef void _mul_matc(self, double t, complex* mat, complex* out,
-                    int nrow, int ncols)
+    cdef int _factor(self, double t) except -1
+    cdef int _factor_dyn(self, double t, complex* state, int[::1] state) except -1
+    cdef int _mul_vec(self, double t, complex* vec, complex* out) except -1
+    cdef int _mul_matf(self, double t, complex* mat, complex* out,
+                    int nrow, int ncols) except -1
+    cdef int _mul_matc(self, double t, complex* mat, complex* out,
+                    int nrow, int ncols) except -1
 
     cpdef complex expect(self, double t, complex[::1] vec)
-    cdef complex _expect(self, double t, complex* vec)
-    cdef complex _expect_super(self, double t, complex* rho)
-    cdef complex _overlapse(self, double t, complex* oper)
+    cdef complex _expect(self, double t, complex* vec) except *
+    cdef complex _expect_super(self, double t, complex* rho) except *
+    cdef complex _overlapse(self, double t, complex* oper) except *
 
 
 cdef class CQobjCte(CQobjEvo):
@@ -93,7 +93,7 @@ cdef class CQobjEvoTdDense(CQobjEvo):
     cdef complex[:, ::1] data_t
     cdef complex* data_ptr
 
-    cdef void _factor(self, double t)
+    cdef int _factor(self, double t) except -1
     cdef void _call_core(self, complex[:,::1] out, complex* coeff)
 
 
@@ -109,5 +109,5 @@ cdef class CQobjEvoTdMatched(CQobjEvo):
     cdef complex[::1] data_t
     cdef complex* data_ptr
 
-    cdef void _factor(self, double t)
+    cdef int _factor(self, double t) except -1
     cdef void _call_core(self, complex[::1] out, complex* coeff)

--- a/qutip/cy/mcsolve.pyx
+++ b/qutip/cy/mcsolve.pyx
@@ -37,6 +37,7 @@
 import numpy as np
 cimport numpy as np
 cimport cython
+from cpython.exc cimport PyErr_CheckSignals
 import scipy.sparse as sp
 from scipy.linalg.cython_blas cimport dznrm2 as raw_dznrm2
 from qutip.qobj import Qobj
@@ -144,6 +145,7 @@ cdef class CyMcOde:
         # RUN ODE UNTIL EACH TIME IN TLIST
         norm2_prev = dznrm2(ODE._y) ** 2
         for k in range(1, num_times):
+            PyErr_CheckSignals()
             # ODE WHILE LOOP FOR INTEGRATE UP TO TIME TLIST[k]
             t_prev = ODE.t
             y_prev = ODE.y
@@ -386,6 +388,7 @@ cdef class CyMcOdeDiag(CyMcOde):
         self.t = tlist[0]
         norm2_prev = dznrm2(self.psi) ** 2
         for k in range(1, num_times):
+            PyErr_CheckSignals()
             norm2_prev = self.advance(tlist[k], norm2_prev, rand_vals, use_quick)
             while self.t < tlist[k]:
                 norm2_prev = self.advance(tlist[k], norm2_prev, rand_vals, 0)

--- a/qutip/cy/openmp/cqobjevo_omp.pyx
+++ b/qutip/cy/openmp/cqobjevo_omp.pyx
@@ -90,14 +90,15 @@ cdef class CQobjCteOmp(CQobjCte):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef void _mul_vec(self, double t, complex* vec, complex* out):
+    cdef int _mul_vec(self, double t, complex* vec, complex* out) except -1:
         spmvpy_openmp(self.cte.data, self.cte.indices, self.cte.indptr, vec, 1.,
                out, self.shape0, self.nthr)
+        return 0
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef complex _expect(self, double t, complex* vec):
+    cdef complex _expect(self, double t, complex* vec) except *:
         cdef complex[::1] y = np.zeros(self.shape0, dtype=complex)
         spmvpy_openmp(self.cte.data, self.cte.indices, self.cte.indptr, vec, 1.,
                &y[0], self.shape0, self.nthr)
@@ -110,18 +111,20 @@ cdef class CQobjCteOmp(CQobjCte):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef void _mul_matf(self, double t, complex* mat, complex* out,
-                        int nrow, int ncol):
+    cdef int _mul_matf(self, double t, complex* mat, complex* out,
+                        int nrow, int ncol) except -1:
         _spmmfpy_omp(self.cte.data, self.cte.indices, self.cte.indptr, mat, 1.,
                out, self.shape0, nrow, ncol, self.nthr)
+        return 0
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef void _mul_matc(self, double t, complex* mat, complex* out,
-                        int nrow, int ncol):
+    cdef int _mul_matc(self, double t, complex* mat, complex* out,
+                        int nrow, int ncol) except -1:
         _spmmcpy_par(self.cte.data, self.cte.indices, self.cte.indptr, mat, 1.,
                out, self.shape0, nrow, ncol, self.nthr)
+        return 0
 
 
 cdef class CQobjEvoTdOmp(CQobjEvoTd):
@@ -133,7 +136,7 @@ cdef class CQobjEvoTdOmp(CQobjEvoTd):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef void _mul_vec(self, double t, complex* vec, complex* out):
+    cdef int _mul_vec(self, double t, complex* vec, complex* out) except -1:
         cdef int[2] shape
         shape[0] = self.shape1
         shape[1] = 1
@@ -144,12 +147,13 @@ cdef class CQobjEvoTdOmp(CQobjEvoTd):
         for i in range(self.num_ops):
             spmvpy_openmp(self.ops[i].data, self.ops[i].indices, self.ops[i].indptr,
                    vec, self.coeff_ptr[i], out, self.shape0, self.nthr)
+        return 0
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef void _mul_matf(self, double t, complex* mat, complex* out,
-                        int nrow, int ncol):
+    cdef int _mul_matf(self, double t, complex* mat, complex* out,
+                        int nrow, int ncol) except -1:
         cdef int[2] shape
         shape[0] = nrow
         shape[1] = ncol
@@ -160,12 +164,13 @@ cdef class CQobjEvoTdOmp(CQobjEvoTd):
         for i in range(self.num_ops):
              _spmmfpy_omp(self.ops[i].data, self.ops[i].indices, self.ops[i].indptr,
                  mat, self.coeff_ptr[i], out, self.shape0, nrow, ncol, self.nthr)
+        return 0
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef void _mul_matc(self, double t, complex* mat, complex* out,
-                        int nrow, int ncol):
+    cdef int _mul_matc(self, double t, complex* mat, complex* out,
+                        int nrow, int ncol) except -1:
         cdef int[2] shape
         shape[0] = nrow
         shape[1] = ncol
@@ -176,6 +181,7 @@ cdef class CQobjEvoTdOmp(CQobjEvoTd):
         for i in range(self.num_ops):
              _spmmcpy_par(self.ops[i].data, self.ops[i].indices, self.ops[i].indptr,
                  mat, self.coeff_ptr[i], out, self.shape0, nrow, ncol, self.nthr)
+        return 0
 
 
 cdef class CQobjEvoTdMatchedOmp(CQobjEvoTdMatched):
@@ -187,7 +193,7 @@ cdef class CQobjEvoTdMatchedOmp(CQobjEvoTdMatched):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef void _mul_vec(self, double t, complex* vec, complex* out):
+    cdef int _mul_vec(self, double t, complex* vec, complex* out) except -1:
         cdef int[2] shape
         shape[0] = self.shape1
         shape[1] = 1
@@ -195,12 +201,13 @@ cdef class CQobjEvoTdMatchedOmp(CQobjEvoTdMatched):
         self._call_core(self.data_t, self.coeff_ptr)
         spmvpy_openmp(self.data_ptr, &self.indices[0], &self.indptr[0], vec,
                1., out, self.shape0, self.nthr)
+        return 0
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef void _mul_matf(self, double t, complex* mat, complex* out,
-                        int nrow, int ncol):
+    cdef int _mul_matf(self, double t, complex* mat, complex* out,
+                        int nrow, int ncol) except -1:
         cdef int[2] shape
         shape[0] = nrow
         shape[1] = ncol
@@ -208,12 +215,13 @@ cdef class CQobjEvoTdMatchedOmp(CQobjEvoTdMatched):
         self._call_core(self.data_t, self.coeff_ptr)
         _spmmfpy_omp(self.data_ptr, &self.indices[0], &self.indptr[0], mat, 1.,
                out, self.shape0, nrow, ncol, self.nthr)
+        return 0
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef void _mul_matc(self, double t, complex* mat, complex* out,
-                        int nrow, int ncol):
+    cdef int _mul_matc(self, double t, complex* mat, complex* out,
+                        int nrow, int ncol) except -1:
         cdef int[2] shape
         shape[0] = nrow
         shape[1] = ncol
@@ -221,3 +229,4 @@ cdef class CQobjEvoTdMatchedOmp(CQobjEvoTdMatched):
         self._call_core(self.data_t, self.coeff_ptr)
         _spmmcpy_par(self.data_ptr, &self.indices[0], &self.indptr[0], mat, 1.,
                out, self.shape0, nrow, ncol, self.nthr)
+        return 0

--- a/qutip/cy/stochastic.pyx
+++ b/qutip/cy/stochastic.pyx
@@ -34,6 +34,7 @@
 import numpy as np
 cimport numpy as np
 cimport cython
+from cpython.exc cimport PyErr_CheckSignals
 from libc.math cimport fabs
 from qutip.cy.cqobjevo cimport CQobjEvo
 from qutip.cy.brtools cimport ZHEEVR
@@ -526,6 +527,7 @@ cdef class StochasticSolver:
         measurements = np.zeros((len(times), len(sso.cm_ops)), dtype=complex)
         states_list = []
         for t_idx, t in enumerate(times):
+            PyErr_CheckSignals()
             if sso.ce_ops:
                 for e_idx, e in enumerate(sso.ce_ops):
                     s = e.compiled_qobjevo.expect(t, rho_t)

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -1345,7 +1345,7 @@ class QobjEvo:
                 new_op[1] = _StrWrapper(new_op[2])
             elif op.type == "array":
                 new_op[2] = _Shift(op.get_coeff)
-                new_op[1] = new_op[1]
+                new_op[1] = new_op[2]
                 new_op[3] = "func"
                 self.type = "mixed_callable"
             elif op.type == "spline":

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -54,14 +54,15 @@ def _import_str(code, basefilename, obj_name, cythonfile=False):
     Import 'obj_name' defined in 'code'.
     Using a temporary file starting by 'basefilename'.
     """
-    filename = basefilename + str(hash(code))[1:6]
+    filename = (basefilename + str(hash(code))[1:4] +
+                str(os.getpid()) + time.strftime("%M%S"))
     tries = 0
     import_list = []
     ext = ".pyx" if cythonfile else ".py"
     if os.getcwd() not in sys.path:
         sys.path.insert(0, os.getcwd())
     while not import_list and tries < 3:
-        try_file = filename + time.strftime("%d%H%M%S") + str(tries)
+        try_file = filename + str(tries)
         file_ = open(try_file+ext, "w")
         file_.writelines(code)
         file_.close()

--- a/qutip/qobjevo_codegen.py
+++ b/qutip/qobjevo_codegen.py
@@ -78,9 +78,10 @@ def _import_str(code, basefilename, obj_name, cythonfile=False):
             time.sleep(0.05)
             tries += 1
             _try_remove(try_file+ext)
+            err = e
     if not import_list:
         raise Exception("Could not convert string to importable function, "
-                        "tmpfile:" + try_file + ext) from e
+                        "tmpfile:" + try_file + ext) from err
     coeff_obj = import_list[0]
     return coeff_obj, try_file + ext
 

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -58,7 +58,7 @@ from qutip.superoperator import liouvillian, vec2mat
 from qutip.sparse import (sp_permute, sp_bandwidth, sp_reshape,
                           sp_profile)
 from qutip.cy.spmath import zcsr_kron
-from qutip.graph import reverse_cuthill_mckee, weighted_bipartite_matching
+from qutip.graph import weighted_bipartite_matching
 from qutip import (mat2vec, tensor, identity, operator_to_vector)
 import qutip.settings as settings
 from qutip.utilities import _version2int
@@ -353,7 +353,7 @@ def _steadystate_LU_liouvillian(L, ss_args, has_mkl=0):
         if settings.debug:
             logger.debug('Calculating Reverse Cuthill-Mckee ordering...')
         _rcm_start = time.time()
-        perm2 = reverse_cuthill_mckee(L)
+        perm2 = sp.csgraph.reverse_cuthill_mckee(L)
         _rcm_end = time.time()
         rev_perm = np.argsort(perm2)
         L = sp_permute(L, perm2, perm2, form)
@@ -508,7 +508,7 @@ def _steadystate_eigen(L, ss_args):
         if settings.debug:
             old_band = sp_bandwidth(L)[0]
             logger.debug('Original bandwidth: %i' % old_band)
-        perm = reverse_cuthill_mckee(L)
+        perm = sp.csgraph.reverse_cuthill_mckee(L)
         rev_perm = np.argsort(perm)
         L = sp_permute(L, perm, perm, 'csc')
         if settings.debug:
@@ -780,7 +780,7 @@ def _steadystate_power_liouvillian(L, ss_args, has_mkl=0):
             logger.debug('Calculating Reverse Cuthill-Mckee ordering...')
         ss_args['info']['perm'].append('rcm')
         _rcm_start = time.time()
-        perm2 = reverse_cuthill_mckee(L)
+        perm2 = sp.csgraph.reverse_cuthill_mckee(L)
         _rcm_end = time.time()
         ss_args['info']['rcm_time'] = _rcm_end-_rcm_start
         rev_perm = np.argsort(perm2)
@@ -1147,7 +1147,7 @@ def _pseudo_inverse_sparse(L, rhoss, w=None, **pseudo_args):
             L = 1.0j*(1e-15)*spre(tr_op) + L
 
     if pseudo_args['use_rcm']:
-        perm = reverse_cuthill_mckee(L.data)
+        perm = sp.csgraph.reverse_cuthill_mckee(L.data)
         A = sp_permute(L.data, perm, perm)
         Q = sp_permute(Q, perm, perm)
     else:

--- a/qutip/tests/test_graph.py
+++ b/qutip/tests/test_graph.py
@@ -35,6 +35,7 @@ import numpy as np
 from numpy.testing import run_module_suite, assert_equal
 import scipy.sparse as sp
 from scipy.sparse.csgraph import breadth_first_order as BFO
+import pytest
 
 pwd = os.path.dirname(__file__)
 
@@ -47,7 +48,8 @@ from qutip.sparse import sp_permute, sp_bandwidth
 def test_graph_degree():
     "Graph: Graph Degree"
     A = rand_dm(25, 0.1)
-    deg = graph_degree(A.data)
+    with pytest.deprecated_call():
+        deg = graph_degree(A.data)
     A = A.full()
     np_deg = []
     for k in range(25):
@@ -68,7 +70,8 @@ def test_graph_bfs():
     A.data = np.real(A.data)
     seed = np.random.randint(24)
     arr1 = BFO(A, seed)[0]
-    arr2 = breadth_first_search(A, seed)[0]
+    with pytest.deprecated_call():
+        arr2 = breadth_first_search(A, seed)[0]
     assert_equal((arr1 - arr2).all(), 0)
 
 
@@ -83,7 +86,8 @@ def test_graph_rcm_simple():
                   [0, 0, 0, 1, 0, 0, 1, 0],
                   [0, 1, 0, 0, 0, 1, 0, 1]], dtype=np.int32)
     A = sp.csr_matrix(A)
-    perm = reverse_cuthill_mckee(A)
+    with pytest.deprecated_call():
+        perm = reverse_cuthill_mckee(A)
     ans = np.array([6, 3, 7, 5, 1, 2, 4, 0])
     assert_equal((perm - ans).all(), 0)
 
@@ -100,7 +104,8 @@ def test_graph_rcm_boost():
     M[6, 7] = 1
     M = M+M.T
     M = sp.csr_matrix(M, dtype=complex)
-    perm = reverse_cuthill_mckee(M, 1)
+    with pytest.deprecated_call():
+        perm = reverse_cuthill_mckee(M, 1)
     ans_perm = np.array([9, 7, 6, 4, 1, 5, 0, 2, 3, 8])
     assert_equal((perm - ans_perm).all(), 0)
     P = sp_permute(M, perm, perm)
@@ -122,7 +127,8 @@ def test_graph_rcm_qutip():
         )*sm+(wc-wl)*a.dag()*a+1j*g*(a.dag()*sm-sm.dag()*a)+E*(a.dag()+a)
     c_ops = [np.sqrt(2*kappa)*a, np.sqrt(gamma)*sm]
     L = liouvillian(H, c_ops)
-    perm = reverse_cuthill_mckee(L.data)
+    with pytest.deprecated_call():
+        perm = reverse_cuthill_mckee(L.data)
     ans = np.array([12, 14, 4, 6, 10, 8, 2, 15, 0, 13, 7, 5, 9, 11, 1, 3])
     assert_equal(perm, ans)
 
@@ -133,7 +139,8 @@ def test_graph_maximum_bipartite_matching():
     perm = np.random.permutation(25)
     perm2 = np.random.permutation(25)
     B = sp_permute(A, perm, perm2)
-    perm = maximum_bipartite_matching(B)
+    with pytest.deprecated_call():
+        perm = maximum_bipartite_matching(B)
     C = sp_permute(B, perm, [])
     assert_equal(any(C.diagonal() == 0), False)
 
@@ -149,7 +156,8 @@ def test_graph_weighted_matching():
     perm = np.random.permutation(25)
     perm2 = np.random.permutation(25)
     B = sp_permute(A, perm, perm2)
-    perm = weighted_bipartite_matching(B)
+    with pytest.deprecated_call():
+        perm = weighted_bipartite_matching(B)
     C = sp_permute(B, perm, [])
     assert_equal(np.sum(A.diagonal()), np.sum(C.diagonal()))
 
@@ -157,10 +165,12 @@ def test_graph_weighted_matching():
 def test_column_permutation():
     "Graph: Column Permutation"
     A = sp.rand(5, 5, 0.25, format='csc')
-    perm = column_permutation(A)
+    with pytest.deprecated_call():
+        perm = column_permutation(A)
     B = sp_permute(A, [], perm)
     counts = np.diff(B.indptr)
     assert_equal(np.all(np.argsort(counts) == np.arange(5)), True)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_utilities.py
+++ b/qutip/tests/test_utilities.py
@@ -81,10 +81,22 @@ def test_unit_clebsch():
         j3p = np.random.randint(abs(j1-j2), j1+j2+1)
         m3 = np.random.randint(-j3, j3+1)
         m3p = np.random.randint(-j3p, j3p+1)
+        if np.random.rand() < 0.25:
+            j1 += 0.5
+            j3 += 0.5
+            j3p += 0.5
+            m3 += np.random.choice([-0.5, 0.5])
+            m3p += np.random.choice([-0.5, 0.5])
+        if np.random.rand() < 0.25:
+            j2 += 0.5
+            j3 += 0.5
+            j3p += 0.5
+            m3 += np.random.choice([-0.5, 0.5])
+            m3p += np.random.choice([-0.5, 0.5])
         sum_match = -1
         sum_differ = -int(j3 == j3p and m3 == m3p)
-        for m1 in range(-j1,j1+1):
-            for m2 in range(-j2,j2+1):
+        for m1 in np.arange(-j1,j1+1):
+            for m2 in np.arange(-j2,j2+1):
                 c1 = clebsch(j1, j2, j3, m1, m2, m3)
                 c2 = clebsch(j1, j2, j3p, m1, m2, m3p)
                 sum_match += c1**2
@@ -101,10 +113,18 @@ def test_unit_clebsch():
         m1p = np.random.randint(-j1,j1+1)
         m2 = np.random.randint(-j2,j2+1)
         m2p = np.random.randint(-j2,j2+1)
+        if np.random.rand() < 0.25:
+            j1 += 0.5
+            m1 += np.random.choice([-0.5, 0.5])
+            m1p += np.random.choice([-0.5, 0.5])
+        if np.random.rand() < 0.25:
+            j2 += 0.5
+            m2 += np.random.choice([-0.5, 0.5])
+            m2p += np.random.choice([-0.5, 0.5])
         sum_match = -1
         sum_differ = -int(m1 == m1p and m2 == m2p)
-        for j3 in range(abs(j1-j2),j1+j2+1):
-            for m3 in range(-j3,j3+1):
+        for j3 in np.arange(abs(j1-j2),j1+j2+1):
+            for m3 in np.arange(-j3,j3+1):
                 c1 = clebsch(j1, j2, j3, m1, m2, m3)
                 c2 = clebsch(j1, j2, j3, m1p, m2p, m3)
                 sum_match += c1**2

--- a/qutip/utilities.py
+++ b/qutip/utilities.py
@@ -112,11 +112,11 @@ def linspace_with(start, stop, num=50, elems=[]):
 
 
 def _factorial_prod(N, arr):
-    arr[:N] += 1
+    arr[:int(N)] += 1
 
 
 def _factorial_div(N, arr):
-    arr[:N] -= 1
+    arr[:int(N)] -= 1
 
 
 def _to_long(arr):
@@ -161,7 +161,7 @@ def clebsch(j1, j2, j3, m1, m2, m3):
     vmin = int(np.max([-j1 + j2 + m3, -j1 + m1, 0]))
     vmax = int(np.min([j2 + j3 + m1, j3 - j1 + j2, j3 + m3]))
 
-    c_factor = np.zeros((j1 + j2 + j3 + 1), np.int32)
+    c_factor = np.zeros((int(j1 + j2 + j3 + 1)), np.int32)
     _factorial_prod(j3 + j1 - j2, c_factor)
     _factorial_prod(j3 - j1 + j2, c_factor)
     _factorial_prod(j1 + j2 - j3, c_factor)
@@ -174,7 +174,7 @@ def clebsch(j1, j2, j3, m1, m2, m3):
     _factorial_div(j2 + m2, c_factor)
     C = np.sqrt((2.0 * j3 + 1.0)*_to_long(c_factor))
 
-    s_factors = np.zeros(((vmax + 1 - vmin), (j1 + j2 + j3)), np.int32)
+    s_factors = np.zeros(((vmax + 1 - vmin), (int(j1 + j2 + j3))), np.int32)
     sign = (-1) ** (vmin + j2 + m2)
     for i,v in enumerate(range(vmin, vmax + 1)):
         factor = s_factors[i,:]

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ from Cython.Distutils import build_ext
 # all information about QuTiP goes here
 MAJOR = 4
 MINOR = 5
-MICRO = 0
+MICRO = 1
 ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 REQUIRES = ['numpy (>=1.12)', 'scipy (>=1.0)', 'cython (>=0.21)']

--- a/setup.py
+++ b/setup.py
@@ -83,12 +83,12 @@ INCLUDE_DIRS = [np.get_include()] if np is not None else []
 NAME = "qutip"
 AUTHOR = ("Alexander Pitchford, Paul D. Nation, Robert J. Johansson, "
           "Chris Granade, Arne Grimsmo, Nathan Shammah, Shahnawaz Ahmed, "
-          "Neill Lambert, Eric Giguere")
+          "Neill Lambert, Eric Giguere, Boxi Li")
 AUTHOR_EMAIL = ("alex.pitchford@gmail.com, nonhermitian@gmail.com, "
                 "jrjohansson@gmail.com, cgranade@cgranade.com, "
                 "arne.grimsmo@gmail.com, nathan.shammah@gmail.com, "
                 "shahnawaz.ahmed95@gmail.com, nwlambert@gmail.com, "
-                "eric.giguere@usherbrooke.ca")
+                "eric.giguere@usherbrooke.ca, etamin1201@gmail.com")
 LICENSE = "BSD"
 DESCRIPTION = DOCLINES[0]
 LONG_DESCRIPTION = "\n".join(DOCLINES[2:])


### PR DESCRIPTION
Update to the original 4.5.1 which is already a month old.

New inclusions: 

Better error message for failed string coefficient compilation.
Run the python 3.8 test in travis. (by Simon Cross )
Fix clebsch function for half-integer (by Thomas Walker)
Deprecate graph function (by Jake Lishman)
Fix travis warning (by Ivan Carvalho)
Fix spin husimi/wigner functions (by maij)

I would like the mac stuff to be fixed and moving the mac test to 3.8, but that will take some time.

