### PR TITLE
Fix dtype for randint

### DIFF
--- a/qutip/mcsolve.py
+++ b/qutip/mcsolve.py
@@ -282,7 +282,9 @@ class _MC():
             pass
 
         if len(seeds) < ntraj:
-            self.seeds = seeds + list(randint(0, 2**31-1, size=ntraj-len(seeds)))
+            self.seeds = seeds + list(randint(0, 2**32,
+                                              size=ntraj-len(seeds),
+                                              dtype=np.uint32))
         else:
             self.seeds = seeds[:ntraj]
 

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -400,7 +400,7 @@ class StochasticSolverOptions:
             if isinstance(noise, int):
                 # noise contain a seed
                 np.random.seed(noise)
-                noise = np.random.randint(0, 2**32, ntraj)
+                noise = np.random.randint(0, 2**32, ntraj, dtype=np.uint32)
             noise = np.array(noise)
             if len(noise.shape) == 1:
                 if noise.shape[0] < ntraj:
@@ -429,7 +429,7 @@ class StochasticSolverOptions:
                 self.noise = noise
 
         else:
-            self.noise = np.random.randint(0, 2**32, ntraj).astype("u4")
+            self.noise = np.random.randint(0, 2**32, ntraj, dtype=np.uint32)
             self.noise_type = 0
 
         # Map


### PR DESCRIPTION
Fix a bug seen on qutip google group:
`np.random.randint(0,2**32)` used to generate seeds for trajectories fails on system where the default int is 32bits. Set the used data type to unsigned int32 which correspond to accepted seed data type.