### PR TITLE
fix typo in QobjEvo._shift

### DIFF
--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -1345,7 +1345,7 @@ class QobjEvo:
                 new_op[1] = _StrWrapper(new_op[2])
             elif op.type == "array":
                 new_op[2] = _Shift(op.get_coeff)
-                new_op[1] = new_op[1]
+                new_op[1] = new_op[2]
                 new_op[3] = "func"
                 self.type = "mixed_callable"
             elif op.type == "spline":


### PR DESCRIPTION
Fix a typo in _shift that I though I fixed some time ago.