### PR TITLE
Fix error in definition of m_ops for heterodyne detection in smesolve()

### DIFF
--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -601,7 +601,7 @@ def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
         sso.sops = []
         for c in sso.sc_ops:
             if sso.m_ops is None:
-                m_ops += [c + c.dag(), 1j * (c - c.dag())]
+                m_ops += [c + c.dag(), -1j * (c - c.dag())]
             sso.sops += [(spre(c) + spost(c.dag())) / np.sqrt(2),
                          (spre(c) - spost(c.dag())) * -1j / np.sqrt(2)]
         sso.m_ops = m_ops
@@ -787,7 +787,7 @@ def _positive_map(sso, e_ops_dict):
         sops = []
         for c in sso.sc_ops:
             if sso.m_ops is None:
-                m_ops += [c + c.dag(), 1j * (c - c.dag())]
+                m_ops += [c + c.dag(), -1j * (c - c.dag())]
             sops += [c / np.sqrt(2), -1j / np.sqrt(2) * c]
         sso.m_ops = m_ops
         if not isinstance(sso.dW_factors, list):

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -787,7 +787,7 @@ def _positive_map(sso, e_ops_dict):
         sops = []
         for c in sso.sc_ops:
             if sso.m_ops is None:
-                m_ops += [c + c.dag(), -1j * c - c.dag()]
+                m_ops += [c + c.dag(), 1j * (c - c.dag())]
             sops += [c / np.sqrt(2), -1j / np.sqrt(2) * c]
         sso.m_ops = m_ops
         if not isinstance(sso.dW_factors, list):

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -601,7 +601,7 @@ def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
         sso.sops = []
         for c in sso.sc_ops:
             if sso.m_ops is None:
-                m_ops += [c + c.dag(), -1j * c - c.dag()]
+                m_ops += [c + c.dag(), 1j * (c - c.dag())]
             sso.sops += [(spre(c) + spost(c.dag())) / np.sqrt(2),
                          (spre(c) - spost(c.dag())) * -1j / np.sqrt(2)]
         sso.m_ops = m_ops


### PR DESCRIPTION
**Description**
There was an error in line 613 of qutip/stochastic.py as the measurement operators for heterodyne detection in the implemented stochastic master equation should be `c + c.dag()` and `1j (c - c.dag())` as explicitely presented in equation (5.64) and the following 2 paragraphs in https://arxiv.org/abs/1710.09523. The same measurement operators can also be drawn from equation (4.108) of Milburn & Wiseman _Quantum Measurement and Control_.

**Changelog**
Fixed error in m_ops definition for heterodyne detection in smesolve.
