### PR TITLE
Add pytest helper functions and fixtures

### DIFF
--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -50,9 +50,24 @@ def _add_repeats_if_marked(metafunc):
                              ids=["rep({})".format(x+1) for x in range(count)])
 
 
+def _skip_cython_tests_if_unavailable(item):
+    """
+    Skip the current test item if Cython is unavailable for import, or isn't a
+    high enough version.
+    """
+    if item.get_closest_marker("requires_cython"):
+        # importorskip rather than mark.skipif because this way we get pytest's
+        # version-handling semantics.
+        pytest.importorskip('Cython', minversion='0.14')
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_generate_tests(metafunc):
     _add_repeats_if_marked(metafunc)
+
+
+def pytest_runtest_setup(item):
+    _skip_cython_tests_if_unavailable(item)
 
 
 @pytest.fixture

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -32,8 +32,10 @@
 ###############################################################################
 
 import pytest
+import functools
 import os
 import tempfile
+import numpy as np
 
 
 def _add_repeats_if_marked(metafunc):
@@ -68,6 +70,106 @@ def pytest_generate_tests(metafunc):
 
 def pytest_runtest_setup(item):
     _skip_cython_tests_if_unavailable(item)
+
+
+def _patched_build_err_msg(arrays, err_msg, header='Items are not equal:',
+                           verbose=True, names=('ACTUAL', 'DESIRED'),
+                           precision=8):
+    """
+    Taken almost verbatim from `np.testing._private.utils`, except this version
+    doesn't truncate output if it's longer than three lines.
+
+    LICENCE
+    -------
+    Copyright (c) 2005-2020, NumPy Developers.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    - Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    - Neither the name of the NumPy Developers nor the names of any
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+    """
+    msg = ['\n' + header]
+    if err_msg:
+        if err_msg.find('\n') == -1 and len(err_msg) < 79-len(header):
+            msg = [msg[0] + ' ' + err_msg]
+        else:
+            msg.append(err_msg)
+    if verbose:
+        for i, a in enumerate(arrays):
+            if isinstance(a, np.ndarray):
+                # precision argument is only needed if the objects are ndarrays
+                r_func = functools.partial(np.core.array_repr,
+                                           precision=precision)
+            else:
+                r_func = repr
+
+            try:
+                # [diff] Remove truncation threshold from array output.
+                with np.printoptions(threshold=np.inf):
+                    r = r_func(a)
+            except Exception as exc:
+                r = '[repr failed for <{}>: {}]'.format(type(a).__name__, exc)
+            # [diff] The original truncates the output to 3 lines here.
+            msg.append(' %s: %s' % (names[i], r))
+    return '\n'.join(msg)
+
+
+# Find the private module used by numpy to store its testing utility functions
+# so that we can monkeypatch the error messages to be more verbose.  QuTiP
+# supports numpy from 1.12 upwards, so we have to search.
+_numpy_private_utils_paths = [
+    ['_private', 'utils'],    # 1.15.0 <= x
+    ['nose_tools', 'utils'],  # 1.14.0 <= x < 1.15.0
+    ['utils'],                # 1.14.0 > x
+]
+for possible_path in _numpy_private_utils_paths:
+    try:
+        module = np.testing
+        for submodule in possible_path:
+            module = getattr(module, submodule)
+        _numpy_private_utils = module
+        break
+    except NameError:
+        pass
+else:
+    # If we can't locate it for some reason, then we don't attempt to patch.
+    _numpy_private_utils = None
+
+if _numpy_private_utils is not None:
+    @pytest.fixture(autouse=True)
+    def do_not_truncate_numpy_output(monkeypatch):
+        """
+        Monkeypatch the internal numpy function used for printing arrays so
+        that we get full output that isn't cut off after three lines.
+        """
+        with monkeypatch.context() as patch:
+            patch.setattr(np.testing._private.utils, "build_err_msg",
+                          _patched_build_err_msg)
+            # Yield inside context manager just to minimize the amount of time
+            # we've monkeypatched such a core library (and a private function!)
+            yield
 
 
 @pytest.fixture

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -32,6 +32,8 @@
 ###############################################################################
 
 import pytest
+import os
+import tempfile
 
 
 def _add_repeats_if_marked(metafunc):
@@ -51,3 +53,28 @@ def _add_repeats_if_marked(metafunc):
 @pytest.hookimpl(trylast=True)
 def pytest_generate_tests(metafunc):
     _add_repeats_if_marked(metafunc)
+
+
+@pytest.fixture
+def in_temporary_directory():
+    """
+    Creates a temporary directory for the lifetime of the fixture and changes
+    into it.  All relative paths used will be in the temporary directory, and
+    everything will automatically be cleaned up at the end of the fixture's
+    life.
+    """
+    previous_dir = os.getcwd()
+    with tempfile.TemporaryDirectory() as temporary_dir:
+        os.chdir(temporary_dir)
+        yield
+        # pytest should catch exceptions occuring in functions using the
+        # fixture, so this should always be called.  We want it here rather
+        # than outside to prevent the case of the directory failing to be
+        # removed because it is 'busy'.
+        os.chdir(previous_dir)
+
+
+@pytest.fixture
+def tmpfile():
+    with tempfile.NamedTemporaryFile() as file:
+        yield file

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -1,0 +1,53 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+import pytest
+
+
+def _add_repeats_if_marked(metafunc):
+    """
+    If the metafunc is marked with the 'repeat' mark, then add the requisite
+    number of repeats via parametrisation.
+    """
+    marker = metafunc.definition.get_closest_marker('repeat')
+    if marker:
+        count = marker.args[0]
+        metafunc.fixturenames.append('_repeat_count')
+        metafunc.parametrize('_repeat_count',
+                             range(count),
+                             ids=["rep({})".format(x+1) for x in range(count)])
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_generate_tests(metafunc):
+    _add_repeats_if_marked(metafunc)

--- a/qutip/tests/pytest.ini
+++ b/qutip/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: Mark a test as taking a long time to run, and so can be skipped with `pytest -m "not slow"`.

--- a/qutip/tests/pytest.ini
+++ b/qutip/tests/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     slow: Mark a test as taking a long time to run, and so can be skipped with `pytest -m "not slow"`.
     repeat(n): Repeat the given test 'n' times.
+    requires_cython: Mark that the given test requires Cython to be installed.  Such tests will be skipped if Cython is not available.

--- a/qutip/tests/pytest.ini
+++ b/qutip/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: Mark a test as taking a long time to run, and so can be skipped with `pytest -m "not slow"`.
+    repeat(n): Repeat the given test 'n' times.

--- a/qutip/tests/test_brmesolve.py
+++ b/qutip/tests/test_brmesolve.py
@@ -47,11 +47,16 @@ _x_a_op = [qutip.sigmax(), lambda w: _simple_qubit_gamma * (w >= 0)]
 
 
 @pytest.mark.parametrize("me_c_ops, brme_c_ops, brme_a_ops", [
-        ([_m_c_op],          [],        [_x_a_op]),
-        ([_m_c_op],          [_m_c_op], []),
-        ([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op]),
-    ])
+    pytest.param([_m_c_op], [], [_x_a_op], id="me collapse-br coupling"),
+    pytest.param([_m_c_op], [_m_c_op], [], id="me collapse-br collapse"),
+    pytest.param([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op],
+                 id="me collapse-br collapse-br coupling"),
+])
 def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
+    """
+    Test that the BR solver handles collapse and coupling operators correctly
+    relative to the standard ME solver.
+    """
     delta = 0.0 * 2*np.pi
     epsilon = 0.5 * 2*np.pi
     e_ops = pauli_spin_operators()

--- a/qutip/tests/test_brmesolve.py
+++ b/qutip/tests/test_brmesolve.py
@@ -62,7 +62,7 @@ def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
     brme = qutip.brmesolve(H, psi0, times,
                            brme_a_ops, e_ops, brme_c_ops).expect
     for me_expectation, brme_expectation in zip(me, brme):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
 
 def _harmonic_oscillator_spectrum_frequency(n_th, w0, kappa):
@@ -105,12 +105,12 @@ def test_harmonic_oscillator(n_th):
     me = qutip.mesolve(H, psi0, times, c_ops, e_ops)
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
     num = qutip.num(N)
     me_num = qutip.expect(num, me.states)
     brme_num = qutip.expect(num, brme.states)
-    assert np.allclose(me_num, brme_num, atol=1e-2)
+    np.testing.assert_allclose(me_num, brme_num, atol=1e-2)
 
 
 def test_jaynes_cummings_zero_temperature():
@@ -136,7 +136,7 @@ def test_jaynes_cummings_zero_temperature():
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
         # Accept 5% error.
-        assert np.allclose(me_expectation, brme_expectation, atol=5e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=5e-2)
 
 
 def test_pull_572_error():
@@ -175,7 +175,7 @@ def test_pull_572_error():
     # Solution of the master equation
     times = np.linspace(0, 10./gamma3, 1000)
     sol = qutip.bloch_redfield_solve(R, ekets, ini, times, [proj_up1])
-    assert np.allclose(sol[0], np.ones_like(times))
+    np.testing.assert_allclose(sol[0], np.ones_like(times))
 
 
 def test_solver_accepts_list_hamiltonian():
@@ -193,4 +193,4 @@ def test_solver_accepts_list_hamiltonian():
     me = qutip.mesolve(H, psi0, times, c_ops=c_ops, e_ops=e_ops).expect
     brme = qutip.brmesolve(H, psi0, times, [], e_ops, c_ops).expect
     for me_expectation, brme_expectation in zip(me, brme):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-8)

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -67,7 +67,7 @@ def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
     brme = qutip.brmesolve([[H, '1']], psi0, times,
                            brme_a_ops, e_ops, brme_c_ops).expect
     for me_expectation, brme_expectation in zip(me, brme):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
 
 def _harmonic_oscillator_spectrum_frequency(n_th, w0, kappa):
@@ -109,12 +109,12 @@ def test_harmonic_oscillator(n_th):
     me = qutip.mesolve(H, psi0, times, c_ops, e_ops)
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
     num = qutip.num(N)
     me_num = qutip.expect(num, me.states)
     brme_num = qutip.expect(num, brme.states)
-    assert np.allclose(me_num, brme_num, atol=1e-2)
+    np.testing.assert_allclose(me_num, brme_num, atol=1e-2)
 
 
 @pytest.mark.slow
@@ -138,7 +138,7 @@ def test_jaynes_cummings_zero_temperature():
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
         # Accept 5% error.
-        assert np.allclose(me_expectation, brme_expectation, atol=5e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=5e-2)
 
 
 def _mixed_string(kappa, _):
@@ -200,7 +200,7 @@ def test_nonhermitian_e_ops():
     times = np.linspace(0, 10, 10)
     me = qutip.mesolve(H, psi0, times, c_ops=[], e_ops=[a]).expect[0]
     brme = qutip.brmesolve(H_brme, psi0, times, a_ops=[], e_ops=[a]).expect[0]
-    assert np.allclose(me, brme, atol=1e-4)
+    np.testing.assert_allclose(me, brme, atol=1e-4)
 
 
 @pytest.mark.slow
@@ -280,7 +280,7 @@ def test_split_operators_maintain_answer(collapse_operators):
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops, brme_c_ops)
 
     for me_expect, brme_expect in zip(me.expect, brme.expect):
-        assert np.allclose(me_expect, brme_expect, atol=1e-2)
+        np.testing.assert_allclose(me_expect, brme_expect, atol=1e-2)
 
 
 @pytest.mark.slow

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -42,9 +42,10 @@ else:
     cython_version = qutip._version2int(Cython.__version__)
     Cython_OK = cython_version >= qutip._version2int('0.14')
 
-pytestmark = pytest.mark.skipif(not Cython_OK,
-                                reason="Cython not found, or version too low.",
-                                allow_module_level=True)
+pytestmark = [pytest.mark.skipif(not Cython_OK,
+                                 reason="Cython not found or version too low.",
+                                 allow_module_level=True),
+              pytest.mark.usefixtures("in_temporary_directory")]
 
 
 def pauli_spin_operators():

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -39,6 +39,9 @@ pytestmark = [
     pytest.mark.usefixtures("in_temporary_directory"),
 ]
 
+# A lot of this module is direct duplication of test_brmesolve.py, but using
+# string time dependence rather than functional.
+
 
 def pauli_spin_operators():
     return [qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()]
@@ -52,11 +55,16 @@ _x_a_op = [qutip.sigmax(), '{0} * (w >= 0)'.format(_simple_qubit_gamma)]
 
 @pytest.mark.slow
 @pytest.mark.parametrize("me_c_ops, brme_c_ops, brme_a_ops", [
-        ([_m_c_op],          [],        [_x_a_op]),
-        ([_m_c_op],          [_m_c_op], []),
-        ([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op]),
-    ])
+    pytest.param([_m_c_op], [], [_x_a_op], id="me collapse-br coupling"),
+    pytest.param([_m_c_op], [_m_c_op], [], id="me collapse-br collapse"),
+    pytest.param([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op],
+                 id="me collapse-br collapse-br coupling"),
+])
 def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
+    """
+    Test that the BR solver handles collapse and coupling operators correctly
+    relative to the standard ME solver.
+    """
     delta = 0.0 * 2*np.pi
     epsilon = 0.5 * 2*np.pi
     e_ops = pauli_spin_operators()

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -34,18 +34,10 @@ import pytest
 import numpy as np
 import qutip
 
-try:
-    import Cython
-except ImportError:
-    Cython_OK = False
-else:
-    cython_version = qutip._version2int(Cython.__version__)
-    Cython_OK = cython_version >= qutip._version2int('0.14')
-
-pytestmark = [pytest.mark.skipif(not Cython_OK,
-                                 reason="Cython not found or version too low.",
-                                 allow_module_level=True),
-              pytest.mark.usefixtures("in_temporary_directory")]
+pytestmark = [
+    pytest.mark.requires_cython,
+    pytest.mark.usefixtures("in_temporary_directory"),
+]
 
 
 def pauli_spin_operators():

--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -52,8 +52,8 @@ def test_zheevr():
         our_evals = np.zeros(dimension, dtype=np.float64)
         our_evecs = _test_zheevr(H.full('F'), our_evals)
         scipy_evals, scipy_evecs = scipy.linalg.eigh(H.full())
-        assert np.allclose(scipy_evals, our_evals)
-        assert np.allclose(scipy_evecs, our_evecs)
+        np.testing.assert_allclose(scipy_evals, our_evals, atol=1e-12)
+        np.testing.assert_allclose(scipy_evecs, our_evecs, atol=1e-12)
 
 
 @pytest.mark.parametrize("operator", [
@@ -72,7 +72,7 @@ def test_dense_operator_to_eigbasis(operator):
         basis_zheevr = _test_zheevr(H.full('F'), _eigenvalues)
         calculated = _test_dense_to_eigbasis(operator.full('F'), basis_zheevr,
                                              dimension, qutip.settings.atol)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_vec_to_eigbasis():
@@ -85,7 +85,7 @@ def test_vec_to_eigbasis():
         target = qutip.mat2vec(R.transform(basis).full()).ravel()
         flat_vector = qutip.mat2vec(R.full()).ravel()
         calculated = _test_vec_to_eigbasis(H.full('F'), flat_vector)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_eigvec_to_fockbasis():
@@ -101,7 +101,7 @@ def test_eigvec_to_fockbasis():
         flat_eigenvectors = qutip.mat2vec(R.transform(basis).full()).ravel()
         calculated = _test_eigvec_to_fockbasis(flat_eigenvectors, evecs_zheevr,
                                                dimension)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_vector_roundtrip():
@@ -110,7 +110,8 @@ def test_vector_roundtrip():
     for _ in range(50):
         H = qutip.rand_herm(dimension, 0.5).full('F')
         vector = qutip.mat2vec(qutip.rand_dm(dimension, 0.5).full()).ravel()
-        assert np.allclose(vector, _test_vector_roundtrip(H, vector))
+        np.testing.assert_allclose(vector, _test_vector_roundtrip(H, vector),
+                                   atol=1e-12)
 
 
 def test_diag_liou_mult():
@@ -123,7 +124,7 @@ def test_diag_liou_mult():
         calculated = np.zeros_like(coefficients)
         target = L.data.dot(coefficients)
         _test_diag_liou_mult(evals, coefficients, calculated, dimension)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_cop_super_mult():
@@ -140,7 +141,7 @@ def test_cop_super_mult():
         _eigenvalues = np.empty((dimension,), dtype=np.float64)
         _cop_super_mult(a.full('F'), _test_zheevr(H.full('F'), _eigenvalues),
                         vec, 1, calculated, dimension, qutip.settings.atol)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 @pytest.mark.parametrize("secular",
@@ -165,4 +166,4 @@ def test_br_term_mult(secular):
         calculated = np.zeros_like(target)
         _test_br_term_mult(time, operator.full('F'), evecs, evals, vec,
                            calculated, secular, 0.1, atol)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=atol)


### PR DESCRIPTION
This is the base PR for the split-up of #1181.  This one puts in all the helper functions and updates to previously converted files that are present in that PR, and needs to be merged first before any of the others can be merged.  The commits are tidied up and rebased onto `master`.

This is the base PR for #1250, #1251 and #1252.

**Changelog**
Add pytest helper functions for large-scale test refactoring