### PR TITLE
Convert tests to pytest (solvers and internals)

### DIFF
--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -50,9 +50,24 @@ def _add_repeats_if_marked(metafunc):
                              ids=["rep({})".format(x+1) for x in range(count)])
 
 
+def _skip_cython_tests_if_unavailable(item):
+    """
+    Skip the current test item if Cython is unavailable for import, or isn't a
+    high enough version.
+    """
+    if item.get_closest_marker("requires_cython"):
+        # importorskip rather than mark.skipif because this way we get pytest's
+        # version-handling semantics.
+        pytest.importorskip('Cython', minversion='0.14')
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_generate_tests(metafunc):
     _add_repeats_if_marked(metafunc)
+
+
+def pytest_runtest_setup(item):
+    _skip_cython_tests_if_unavailable(item)
 
 
 @pytest.fixture

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -32,8 +32,10 @@
 ###############################################################################
 
 import pytest
+import functools
 import os
 import tempfile
+import numpy as np
 
 
 def _add_repeats_if_marked(metafunc):
@@ -68,6 +70,106 @@ def pytest_generate_tests(metafunc):
 
 def pytest_runtest_setup(item):
     _skip_cython_tests_if_unavailable(item)
+
+
+def _patched_build_err_msg(arrays, err_msg, header='Items are not equal:',
+                           verbose=True, names=('ACTUAL', 'DESIRED'),
+                           precision=8):
+    """
+    Taken almost verbatim from `np.testing._private.utils`, except this version
+    doesn't truncate output if it's longer than three lines.
+
+    LICENCE
+    -------
+    Copyright (c) 2005-2020, NumPy Developers.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    - Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    - Neither the name of the NumPy Developers nor the names of any
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+    """
+    msg = ['\n' + header]
+    if err_msg:
+        if err_msg.find('\n') == -1 and len(err_msg) < 79-len(header):
+            msg = [msg[0] + ' ' + err_msg]
+        else:
+            msg.append(err_msg)
+    if verbose:
+        for i, a in enumerate(arrays):
+            if isinstance(a, np.ndarray):
+                # precision argument is only needed if the objects are ndarrays
+                r_func = functools.partial(np.core.array_repr,
+                                           precision=precision)
+            else:
+                r_func = repr
+
+            try:
+                # [diff] Remove truncation threshold from array output.
+                with np.printoptions(threshold=np.inf):
+                    r = r_func(a)
+            except Exception as exc:
+                r = '[repr failed for <{}>: {}]'.format(type(a).__name__, exc)
+            # [diff] The original truncates the output to 3 lines here.
+            msg.append(' %s: %s' % (names[i], r))
+    return '\n'.join(msg)
+
+
+# Find the private module used by numpy to store its testing utility functions
+# so that we can monkeypatch the error messages to be more verbose.  QuTiP
+# supports numpy from 1.12 upwards, so we have to search.
+_numpy_private_utils_paths = [
+    ['_private', 'utils'],    # 1.15.0 <= x
+    ['nose_tools', 'utils'],  # 1.14.0 <= x < 1.15.0
+    ['utils'],                # 1.14.0 > x
+]
+for possible_path in _numpy_private_utils_paths:
+    try:
+        module = np.testing
+        for submodule in possible_path:
+            module = getattr(module, submodule)
+        _numpy_private_utils = module
+        break
+    except NameError:
+        pass
+else:
+    # If we can't locate it for some reason, then we don't attempt to patch.
+    _numpy_private_utils = None
+
+if _numpy_private_utils is not None:
+    @pytest.fixture(autouse=True)
+    def do_not_truncate_numpy_output(monkeypatch):
+        """
+        Monkeypatch the internal numpy function used for printing arrays so
+        that we get full output that isn't cut off after three lines.
+        """
+        with monkeypatch.context() as patch:
+            patch.setattr(np.testing._private.utils, "build_err_msg",
+                          _patched_build_err_msg)
+            # Yield inside context manager just to minimize the amount of time
+            # we've monkeypatched such a core library (and a private function!)
+            yield
 
 
 @pytest.fixture

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -32,6 +32,8 @@
 ###############################################################################
 
 import pytest
+import os
+import tempfile
 
 
 def _add_repeats_if_marked(metafunc):
@@ -51,3 +53,28 @@ def _add_repeats_if_marked(metafunc):
 @pytest.hookimpl(trylast=True)
 def pytest_generate_tests(metafunc):
     _add_repeats_if_marked(metafunc)
+
+
+@pytest.fixture
+def in_temporary_directory():
+    """
+    Creates a temporary directory for the lifetime of the fixture and changes
+    into it.  All relative paths used will be in the temporary directory, and
+    everything will automatically be cleaned up at the end of the fixture's
+    life.
+    """
+    previous_dir = os.getcwd()
+    with tempfile.TemporaryDirectory() as temporary_dir:
+        os.chdir(temporary_dir)
+        yield
+        # pytest should catch exceptions occuring in functions using the
+        # fixture, so this should always be called.  We want it here rather
+        # than outside to prevent the case of the directory failing to be
+        # removed because it is 'busy'.
+        os.chdir(previous_dir)
+
+
+@pytest.fixture
+def tmpfile():
+    with tempfile.NamedTemporaryFile() as file:
+        yield file

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -1,0 +1,53 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+import pytest
+
+
+def _add_repeats_if_marked(metafunc):
+    """
+    If the metafunc is marked with the 'repeat' mark, then add the requisite
+    number of repeats via parametrisation.
+    """
+    marker = metafunc.definition.get_closest_marker('repeat')
+    if marker:
+        count = marker.args[0]
+        metafunc.fixturenames.append('_repeat_count')
+        metafunc.parametrize('_repeat_count',
+                             range(count),
+                             ids=["rep({})".format(x+1) for x in range(count)])
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_generate_tests(metafunc):
+    _add_repeats_if_marked(metafunc)

--- a/qutip/tests/pytest.ini
+++ b/qutip/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: Mark a test as taking a long time to run, and so can be skipped with `pytest -m "not slow"`.

--- a/qutip/tests/pytest.ini
+++ b/qutip/tests/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     slow: Mark a test as taking a long time to run, and so can be skipped with `pytest -m "not slow"`.
     repeat(n): Repeat the given test 'n' times.
+    requires_cython: Mark that the given test requires Cython to be installed.  Such tests will be skipped if Cython is not available.

--- a/qutip/tests/pytest.ini
+++ b/qutip/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: Mark a test as taking a long time to run, and so can be skipped with `pytest -m "not slow"`.
+    repeat(n): Repeat the given test 'n' times.

--- a/qutip/tests/test_brmesolve.py
+++ b/qutip/tests/test_brmesolve.py
@@ -47,11 +47,16 @@ _x_a_op = [qutip.sigmax(), lambda w: _simple_qubit_gamma * (w >= 0)]
 
 
 @pytest.mark.parametrize("me_c_ops, brme_c_ops, brme_a_ops", [
-        ([_m_c_op],          [],        [_x_a_op]),
-        ([_m_c_op],          [_m_c_op], []),
-        ([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op]),
-    ])
+    pytest.param([_m_c_op], [], [_x_a_op], id="me collapse-br coupling"),
+    pytest.param([_m_c_op], [_m_c_op], [], id="me collapse-br collapse"),
+    pytest.param([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op],
+                 id="me collapse-br collapse-br coupling"),
+])
 def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
+    """
+    Test that the BR solver handles collapse and coupling operators correctly
+    relative to the standard ME solver.
+    """
     delta = 0.0 * 2*np.pi
     epsilon = 0.5 * 2*np.pi
     e_ops = pauli_spin_operators()

--- a/qutip/tests/test_brmesolve.py
+++ b/qutip/tests/test_brmesolve.py
@@ -62,7 +62,7 @@ def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
     brme = qutip.brmesolve(H, psi0, times,
                            brme_a_ops, e_ops, brme_c_ops).expect
     for me_expectation, brme_expectation in zip(me, brme):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
 
 def _harmonic_oscillator_spectrum_frequency(n_th, w0, kappa):
@@ -105,12 +105,12 @@ def test_harmonic_oscillator(n_th):
     me = qutip.mesolve(H, psi0, times, c_ops, e_ops)
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
     num = qutip.num(N)
     me_num = qutip.expect(num, me.states)
     brme_num = qutip.expect(num, brme.states)
-    assert np.allclose(me_num, brme_num, atol=1e-2)
+    np.testing.assert_allclose(me_num, brme_num, atol=1e-2)
 
 
 def test_jaynes_cummings_zero_temperature():
@@ -136,7 +136,7 @@ def test_jaynes_cummings_zero_temperature():
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
         # Accept 5% error.
-        assert np.allclose(me_expectation, brme_expectation, atol=5e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=5e-2)
 
 
 def test_pull_572_error():
@@ -175,7 +175,7 @@ def test_pull_572_error():
     # Solution of the master equation
     times = np.linspace(0, 10./gamma3, 1000)
     sol = qutip.bloch_redfield_solve(R, ekets, ini, times, [proj_up1])
-    assert np.allclose(sol[0], np.ones_like(times))
+    np.testing.assert_allclose(sol[0], np.ones_like(times))
 
 
 def test_solver_accepts_list_hamiltonian():
@@ -193,4 +193,4 @@ def test_solver_accepts_list_hamiltonian():
     me = qutip.mesolve(H, psi0, times, c_ops=c_ops, e_ops=e_ops).expect
     brme = qutip.brmesolve(H, psi0, times, [], e_ops, c_ops).expect
     for me_expectation, brme_expectation in zip(me, brme):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-8)

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -67,7 +67,7 @@ def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
     brme = qutip.brmesolve([[H, '1']], psi0, times,
                            brme_a_ops, e_ops, brme_c_ops).expect
     for me_expectation, brme_expectation in zip(me, brme):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
 
 def _harmonic_oscillator_spectrum_frequency(n_th, w0, kappa):
@@ -109,12 +109,12 @@ def test_harmonic_oscillator(n_th):
     me = qutip.mesolve(H, psi0, times, c_ops, e_ops)
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
-        assert np.allclose(me_expectation, brme_expectation, atol=1e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
     num = qutip.num(N)
     me_num = qutip.expect(num, me.states)
     brme_num = qutip.expect(num, brme.states)
-    assert np.allclose(me_num, brme_num, atol=1e-2)
+    np.testing.assert_allclose(me_num, brme_num, atol=1e-2)
 
 
 @pytest.mark.slow
@@ -138,7 +138,7 @@ def test_jaynes_cummings_zero_temperature():
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
         # Accept 5% error.
-        assert np.allclose(me_expectation, brme_expectation, atol=5e-2)
+        np.testing.assert_allclose(me_expectation, brme_expectation, atol=5e-2)
 
 
 def _mixed_string(kappa, _):
@@ -200,7 +200,7 @@ def test_nonhermitian_e_ops():
     times = np.linspace(0, 10, 10)
     me = qutip.mesolve(H, psi0, times, c_ops=[], e_ops=[a]).expect[0]
     brme = qutip.brmesolve(H_brme, psi0, times, a_ops=[], e_ops=[a]).expect[0]
-    assert np.allclose(me, brme, atol=1e-4)
+    np.testing.assert_allclose(me, brme, atol=1e-4)
 
 
 @pytest.mark.slow
@@ -280,7 +280,7 @@ def test_split_operators_maintain_answer(collapse_operators):
     brme = qutip.brmesolve(H, psi0, times, a_ops, e_ops, brme_c_ops)
 
     for me_expect, brme_expect in zip(me.expect, brme.expect):
-        assert np.allclose(me_expect, brme_expect, atol=1e-2)
+        np.testing.assert_allclose(me_expect, brme_expect, atol=1e-2)
 
 
 @pytest.mark.slow

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -42,9 +42,10 @@ else:
     cython_version = qutip._version2int(Cython.__version__)
     Cython_OK = cython_version >= qutip._version2int('0.14')
 
-pytestmark = pytest.mark.skipif(not Cython_OK,
-                                reason="Cython not found, or version too low.",
-                                allow_module_level=True)
+pytestmark = [pytest.mark.skipif(not Cython_OK,
+                                 reason="Cython not found or version too low.",
+                                 allow_module_level=True),
+              pytest.mark.usefixtures("in_temporary_directory")]
 
 
 def pauli_spin_operators():

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -39,6 +39,9 @@ pytestmark = [
     pytest.mark.usefixtures("in_temporary_directory"),
 ]
 
+# A lot of this module is direct duplication of test_brmesolve.py, but using
+# string time dependence rather than functional.
+
 
 def pauli_spin_operators():
     return [qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()]
@@ -52,11 +55,16 @@ _x_a_op = [qutip.sigmax(), '{0} * (w >= 0)'.format(_simple_qubit_gamma)]
 
 @pytest.mark.slow
 @pytest.mark.parametrize("me_c_ops, brme_c_ops, brme_a_ops", [
-        ([_m_c_op],          [],        [_x_a_op]),
-        ([_m_c_op],          [_m_c_op], []),
-        ([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op]),
-    ])
+    pytest.param([_m_c_op], [], [_x_a_op], id="me collapse-br coupling"),
+    pytest.param([_m_c_op], [_m_c_op], [], id="me collapse-br collapse"),
+    pytest.param([_m_c_op, _z_c_op], [_z_c_op], [_x_a_op],
+                 id="me collapse-br collapse-br coupling"),
+])
 def test_simple_qubit_system(me_c_ops, brme_c_ops, brme_a_ops):
+    """
+    Test that the BR solver handles collapse and coupling operators correctly
+    relative to the standard ME solver.
+    """
     delta = 0.0 * 2*np.pi
     epsilon = 0.5 * 2*np.pi
     e_ops = pauli_spin_operators()

--- a/qutip/tests/test_brmesolve_td.py
+++ b/qutip/tests/test_brmesolve_td.py
@@ -34,18 +34,10 @@ import pytest
 import numpy as np
 import qutip
 
-try:
-    import Cython
-except ImportError:
-    Cython_OK = False
-else:
-    cython_version = qutip._version2int(Cython.__version__)
-    Cython_OK = cython_version >= qutip._version2int('0.14')
-
-pytestmark = [pytest.mark.skipif(not Cython_OK,
-                                 reason="Cython not found or version too low.",
-                                 allow_module_level=True),
-              pytest.mark.usefixtures("in_temporary_directory")]
+pytestmark = [
+    pytest.mark.requires_cython,
+    pytest.mark.usefixtures("in_temporary_directory"),
+]
 
 
 def pauli_spin_operators():

--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -52,8 +52,8 @@ def test_zheevr():
         our_evals = np.zeros(dimension, dtype=np.float64)
         our_evecs = _test_zheevr(H.full('F'), our_evals)
         scipy_evals, scipy_evecs = scipy.linalg.eigh(H.full())
-        assert np.allclose(scipy_evals, our_evals)
-        assert np.allclose(scipy_evecs, our_evecs)
+        np.testing.assert_allclose(scipy_evals, our_evals, atol=1e-12)
+        np.testing.assert_allclose(scipy_evecs, our_evecs, atol=1e-12)
 
 
 @pytest.mark.parametrize("operator", [
@@ -72,7 +72,7 @@ def test_dense_operator_to_eigbasis(operator):
         basis_zheevr = _test_zheevr(H.full('F'), _eigenvalues)
         calculated = _test_dense_to_eigbasis(operator.full('F'), basis_zheevr,
                                              dimension, qutip.settings.atol)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_vec_to_eigbasis():
@@ -85,7 +85,7 @@ def test_vec_to_eigbasis():
         target = qutip.mat2vec(R.transform(basis).full()).ravel()
         flat_vector = qutip.mat2vec(R.full()).ravel()
         calculated = _test_vec_to_eigbasis(H.full('F'), flat_vector)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_eigvec_to_fockbasis():
@@ -101,7 +101,7 @@ def test_eigvec_to_fockbasis():
         flat_eigenvectors = qutip.mat2vec(R.transform(basis).full()).ravel()
         calculated = _test_eigvec_to_fockbasis(flat_eigenvectors, evecs_zheevr,
                                                dimension)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_vector_roundtrip():
@@ -110,7 +110,8 @@ def test_vector_roundtrip():
     for _ in range(50):
         H = qutip.rand_herm(dimension, 0.5).full('F')
         vector = qutip.mat2vec(qutip.rand_dm(dimension, 0.5).full()).ravel()
-        assert np.allclose(vector, _test_vector_roundtrip(H, vector))
+        np.testing.assert_allclose(vector, _test_vector_roundtrip(H, vector),
+                                   atol=1e-12)
 
 
 def test_diag_liou_mult():
@@ -123,7 +124,7 @@ def test_diag_liou_mult():
         calculated = np.zeros_like(coefficients)
         target = L.data.dot(coefficients)
         _test_diag_liou_mult(evals, coefficients, calculated, dimension)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_cop_super_mult():
@@ -140,7 +141,7 @@ def test_cop_super_mult():
         _eigenvalues = np.empty((dimension,), dtype=np.float64)
         _cop_super_mult(a.full('F'), _test_zheevr(H.full('F'), _eigenvalues),
                         vec, 1, calculated, dimension, qutip.settings.atol)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 @pytest.mark.parametrize("secular",
@@ -165,4 +166,4 @@ def test_br_term_mult(secular):
         calculated = np.zeros_like(target)
         _test_br_term_mult(time, operator.full('F'), evecs, evals, vec,
                            calculated, secular, 0.1, atol)
-        assert np.allclose(target, calculated)
+        np.testing.assert_allclose(target, calculated, atol=atol)

--- a/qutip/tests/test_cy_structs.py
+++ b/qutip/tests/test_cy_structs.py
@@ -30,76 +30,68 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
+
+import pytest
 import numpy as np
-import scipy.sparse as sp
-from qutip import rand_dm
+import scipy.sparse
+import qutip
 from qutip.fastsparse import fast_csr_matrix
 from qutip.cy.checks import (_test_sorting, _test_coo2csr_inplace_struct,
-                            _test_csr2coo_struct, _test_coo2csr_struct)
+                             _test_csr2coo_struct, _test_coo2csr_struct)
 from qutip.random_objects import rand_jacobi_rotation
-from numpy.testing import assert_equal, assert_, run_module_suite
+
 
 def _unsorted_csr(N, density=0.5):
-    N = np.arange(N)
-    M = sp.diags(N,0, dtype=complex, format='csr')
-    N = N.shape[0]
-    nvals = N**2*density
+    M = scipy.sparse.diags(np.arange(N), 0, dtype=complex, format='csr')
+    nvals = N**2 * density
     while M.nnz < 0.95*nvals:
         M = rand_jacobi_rotation(M)
     M = M.tocsr()
-    return fast_csr_matrix((M.data,M.indices,M.indptr),
-                            shape = M.shape)
+    return fast_csr_matrix((M.data, M.indices, M.indptr), shape=M.shape)
 
 
+def sparse_arrays_equal(a, b):
+    return not (a != b).data.any()
 
+
+@pytest.mark.repeat(20)
 def test_coo2csr_struct():
     "Cython structs : COO to CSR"
-    for k in range(20):
-        A = rand_dm(5,0.5).data
-        B = A.tocoo()
-        C = _test_coo2csr_struct(B)
-        assert_(not (A!=C).data.any())
+    A = qutip.rand_dm(5, 0.5).data
+    assert sparse_arrays_equal(A, _test_coo2csr_struct(A.tocoo()))
 
 
-
+@pytest.mark.repeat(20)
 def test_indices_sort():
     "Cython structs : sort CSR indices inplace"
-    for k in range(20):
-        A = _unsorted_csr(10,0.25)
-        B = A.copy()
-        B.sort_indices()
-        _test_sorting(A)
-        assert_(np.all(A.data == B.data))
-        assert_(np.all(A.indices == B.indices))
+    A = _unsorted_csr(10, 0.25)
+    B = A.copy()
+    B.sort_indices()
+    _test_sorting(A)
+    assert np.all(A.data == B.data)
+    assert np.all(A.indices == B.indices)
 
 
+@pytest.mark.repeat(20)
 def test_coo2csr_inplace_nosort():
     "Cython structs : COO to CSR inplace (no sort)"
-    for k in range(20):
-        A = rand_dm(5,0.5).data
-        B = A.tocoo()
-        C = _test_coo2csr_inplace_struct(B, sorted = 0)
-        assert_(not (A!=C).data.any())
+    A = qutip.rand_dm(5, 0.5).data
+    B = _test_coo2csr_inplace_struct(A.tocoo(), sorted=0)
+    assert sparse_arrays_equal(A, B)
 
 
+@pytest.mark.repeat(20)
 def test_coo2csr_inplace_sort():
     "Cython structs : COO to CSR inplace (sorted)"
-    for k in range(20):
-        A = rand_dm(5,0.5).data
-        B = A.tocoo()
-        C = _test_coo2csr_inplace_struct(B, sorted = 1)
-        assert_(not (A!=C).data.any())
+    A = qutip.rand_dm(5, 0.5).data
+    B = _test_coo2csr_inplace_struct(A.tocoo(), sorted=1)
+    assert sparse_arrays_equal(A, B)
 
 
+@pytest.mark.repeat(20)
 def test_csr2coo():
     "Cython structs : CSR to COO"
-    for k in range(20):
-        A = rand_dm(5,0.5).data
-        B = A.tocoo()
-        C = _test_csr2coo_struct(A)
-        assert_(not (B!=C).data.any())
-
-
-
-if __name__ == "__main__":
-    run_module_suite()
+    A = qutip.rand_dm(5, 0.5).data
+    B = A.tocoo()
+    C = _test_csr2coo_struct(A)
+    assert sparse_arrays_equal(B, C)

--- a/qutip/tests/test_eigenstates.py
+++ b/qutip/tests/test_eigenstates.py
@@ -31,61 +31,85 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-from qutip import sigmax, sigmay, sigmaz, tensor, destroy, qeye
-from numpy import amax
-from numpy.testing import assert_equal, run_module_suite
-from numpy.random import rand
+import pytest
+import numpy as np
+import qutip
 
 
-def test_diagHamiltonian1():
+def _canonicalise_eigenvector(vec):
     """
-    Diagonalization of random two-level system
+    Normalise an eigenvector so that the first non-zero value is equal to one,
+    and the array is flattened.  Just normalising based on vector magnitude
+    isn't enough to fully fix the gauge because the vectors could still be
+    multiplied by a unit complex number.
     """
-
-    H = rand() * sigmax() + rand() * sigmay() +\
-        rand() * sigmaz()
-
-    evals, ekets = H.eigenstates()
-
-    for n in range(len(evals)):
-        # assert that max(H * ket - e * ket) is small
-        assert_equal(amax(
-            abs((H * ekets[n] - evals[n] * ekets[n]).full())) < 1e-10, True)
+    vec = vec.flatten()
+    nonzero = vec != 0
+    if not np.any(nonzero):
+        return vec
+    return vec / vec[np.argmax(nonzero)]
 
 
-def test_diagHamiltonian2():
-    """
-    Diagonalization of composite systems
-    """
+# Random diagonal Hamiltonian.
+_diagonal_dimension = 10
+_diagonal_eigenvalues = np.sort(np.random.rand(_diagonal_dimension))
+_diagonal_eigenstates = np.array([[0]*n + [1] + [0]*(_diagonal_dimension-n-1)
+                                  for n in range(_diagonal_dimension)])
+_diagonal_hamiltonian = qutip.qdiags(_diagonal_eigenvalues, 0)
 
-    H1 = rand() * sigmax() + rand() * sigmay() +\
-        rand() * sigmaz()
-    H2 = rand() * sigmax() + rand() * sigmay() +\
-        rand() * sigmaz()
-
-    H = tensor(H1, H2)
-
-    evals, ekets = H.eigenstates()
-
-    for n in range(len(evals)):
-        # assert that max(H * ket - e * ket) is small
-        assert_equal(amax(
-            abs((H * ekets[n] - evals[n] * ekets[n]).full())) < 1e-10, True)
-
-    N1 = 10
-    N2 = 2
-
-    a1 = tensor(destroy(N1), qeye(N2))
-    a2 = tensor(qeye(N1), destroy(N2))
-    H = rand() * a1.dag() * a1 + rand() * a2.dag() * a2 + \
-        rand() * (a1 + a1.dag()) * (a2 + a2.dag())
-    evals, ekets = H.eigenstates()
-
-    for n in range(len(evals)):
-        # assert that max(H * ket - e * ket) is small
-        assert_equal(amax(
-            abs((H * ekets[n] - evals[n] * ekets[n]).full())) < 1e-10, True)
+# Arbitrary known non-diagonal complex Hamiltonian.
+_nondiagonal_hamiltonian = qutip.Qobj(np.array([
+    [0.16252356,             0.27696416+0.0405202j,  0.19577420+0.07815636j],
+    [0.27696416-0.0405202j,  0.45859633,             0.36222915+0.17372725j],
+    [0.19577420-0.07815636j, 0.36222915-0.17372725j, 0.44149665]]))
+_nondiagonal_eigenvalues = np.array([
+    -0.022062710138316392, 0.08888141616526818, 0.995797833973048])
+_nondiagonal_eigenstates = np.array([
+    [-0.737511505546763, 0.5270680510449308-0.29398599661318j,
+     0.009793118179759598+0.3029065489313791j],
+    [0.5552814080417957, 0.23570050756381764 - 0.3577691669342573j,
+     -0.3741560255426259+0.6067259021655438j],
+    [-0.3843687514214284, -0.670810624386174+0.04723455831286158j,
+     -0.5593181579625106+0.2953063897306936j]])
 
 
-if __name__ == "__main__":
-    run_module_suite()
+@pytest.mark.parametrize(["hamiltonian", "eigenvalues", "eigenstates"], [
+    pytest.param(qutip.sigmaz(), [-1, 1], [[0, 1], [1, 0]], id="diagonal-2"),
+    pytest.param(_diagonal_hamiltonian, _diagonal_eigenvalues,
+                 _diagonal_eigenstates,
+                 id="diagonal-"+str(_diagonal_dimension)),
+    pytest.param(qutip.sigmax(), [-1, 1], [[-1, 1], [1, 1]], id="sigmax"),
+    pytest.param(_nondiagonal_hamiltonian, _nondiagonal_eigenvalues,
+                 _nondiagonal_eigenstates, id="non-diagonal"),
+])
+def test_known_eigensystem(hamiltonian, eigenvalues, eigenstates):
+    test_values, test_states = hamiltonian.eigenstates()
+    eigenvalues = np.array(eigenvalues)
+    eigenstates = np.array(eigenstates)
+    test_order = np.argsort(test_values)
+    test_vectors = [_canonicalise_eigenvector(test_states[i].full())
+                    for i in test_order]
+    expected_order = np.argsort(eigenvalues)
+    expected_vectors = [_canonicalise_eigenvector(eigenstates[i])
+                        for i in expected_order]
+    np.testing.assert_allclose(test_values[test_order],
+                               eigenvalues[expected_order],
+                               atol=1e-10)
+    for test, expected in zip(test_vectors, expected_vectors):
+        np.testing.assert_allclose(test, expected, atol=1e-10)
+
+
+# Specify parametrisation over a random Hamiltonian by specifying the
+# dimensions, rather than duplicating that logic.
+@pytest.fixture(params=[pytest.param([5], id="simple"),
+                        pytest.param([5, 3, 4], id="tensor")])
+def random_hamiltonian(request):
+    dimensions = request.param
+    return qutip.tensor(*[qutip.rand_herm(dim) for dim in dimensions])
+
+
+def test_satisfy_eigenvalue_equation(random_hamiltonian):
+    for eigenvalue, eigenstate in zip(*random_hamiltonian.eigenstates()):
+        np.testing.assert_allclose((random_hamiltonian * eigenstate).full(),
+                                   (eigenvalue * eigenstate).full(),
+                                   atol=1e-10)

--- a/qutip/tests/test_lattice.py
+++ b/qutip/tests/test_lattice.py
@@ -31,134 +31,118 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 import numpy as np
-from qutip.lattice import *
-from qutip import (Qobj, tensor, basis, qeye, isherm, sigmax)
-# from numpy.testing import (assert_equal, assert_, assert_almost_equal,
-#                            run_module_suite)
-from numpy.testing import (assert_, run_module_suite)
+import pytest
+import qutip
+
+_r2 = np.sqrt(2)
 
 
-class TestLattice:
+def _assert_angles_close(test, expected, atol):
+    """Assert that two arrays of angles are within tolerance of each other."""
+    np.testing.assert_allclose(test % (2*np.pi), expected % (2*np.pi),
+                               atol=atol)
+
+
+def _hamiltonian_expected(cells, periodic, sites_per_cell,
+                          freedom):
+    """Expected Hamiltonian for the simple 1D lattice model"""
+    # Within the cell, adjacent sites hop to each other, and it's always
+    # non-periodic.
+    cell = qutip.qdiags([-np.ones(sites_per_cell - 1)]*2, [1, -1])
+    # To hop to the cell one to the left, then you have to drop from the lowest
+    # in-cell location to the highest in the other.
+    hop_left = qutip.qdiags(np.ones(cells - 1), 1)
+    if periodic and cells > 2:
+        # If cells <= 2 then all cells border each other anyway.
+        hop_left += qutip.qdiags([1], -(cells - 1))
+    drop_site = -qutip.projection(sites_per_cell, sites_per_cell-1, 0)
+    if np.prod(freedom) != 1:
+        # Degenerate degrees of freedom per lattice site are unchanged.
+        identity = qutip.qeye(freedom)
+        cell = qutip.tensor(cell, identity)
+        drop_site = qutip.tensor(drop_site, identity)
+    out = (qutip.tensor(qutip.qeye(cells), cell)
+           + qutip.tensor(hop_left, drop_site)
+           + qutip.tensor(hop_left, drop_site).dag())
+    # Contract scalar spaces.
+    dims = [x for x in [cells, sites_per_cell] + freedom
+            if x != 1]
+    dims = dims or [1]
+    out.dims = [dims, dims]
+    return out
+
+
+def _k_expected(cells):
+    out = (2*np.pi/cells) * np.arange(-(cells//2), cells - (cells//2))
+    return out.reshape((-1, 1))
+
+
+def _ssh_lattice(intra, inter,
+                 cells=5, boundary="periodic", sites_per_cell=2,
+                 freedom=[1]):
+    part_hamiltonian = qutip.Qobj(np.array([[0, intra], [intra, 0]]))
+    free_identity = qutip.qeye(freedom)
+    hamiltonian = qutip.tensor(part_hamiltonian, free_identity)
+    hopping = qutip.tensor(qutip.Qobj(np.array([[0, 0], [inter, 0]])),
+                           free_identity)
+    return qutip.Lattice1d(num_cell=cells, boundary=boundary,
+                           cell_num_site=sites_per_cell,
+                           cell_site_dof=freedom,
+                           Hamiltonian_of_cell=hamiltonian,
+                           inter_hop=hopping)
+
+
+# Energies for the SSH model with 4 cells, 2 orbitals and 2 spins, with
+# intra=-0.5 and inter=-0.6.
+_ssh_energies = np.array([0.1, 0.55677644, 0.9539392,
+                          1.1, 0.9539392,  0.55677644])
+
+
+def _crow_lattice(coupling, phase_delay,
+                  cells=4, boundary="periodic", sites_per_cell=1,
+                  freedom=[2]):
+    r"""
+    Return a `qutip.Lattice1d` of a "Coupled Resonator Optical Waveguide"
+    (CROW) with the given coupling strength and phase delay.
+
+    See for example: https://www.doi.org/10.1103/PhysRevB.99.224201
+    where `coupling` is $J$ and `phase_delay` is $\eta$.
     """
-    Tests for `qutip.lattice` class.
-    """
-    def test_hamiltonian(self):
-        """
-        lattice: Test the method Lattice1d.Hamiltonian().
-        """
-        # num_cell = 1
-        # Four different instances
-        Periodic_Atom_Chain = Lattice1d(num_cell=1, boundary="periodic")
-        Aperiodic_Atom_Chain = Lattice1d(num_cell=1, boundary="aperiodic")
-        p_1223 = Lattice1d(num_cell=1, boundary="periodic",
-                           cell_num_site=2, cell_site_dof=[2, 3])
-        ap_1223 = Lattice1d(num_cell=1, boundary="aperiodic",
-                            cell_num_site=2, cell_site_dof=[2, 3])
+    cell_hamiltonian = coupling * np.sin(phase_delay) * qutip.sigmax()
+    phase_term = np.exp(1j * phase_delay)
+    hopping = [
+        0.5 * coupling * qutip.qdiags([phase_term, phase_term.conj()], 0),
+        0.5 * coupling * qutip.sigmax(),
+    ]
+    return qutip.Lattice1d(num_cell=cells, boundary=boundary,
+                           cell_num_site=sites_per_cell,
+                           cell_site_dof=freedom,
+                           Hamiltonian_of_cell=cell_hamiltonian,
+                           inter_hop=hopping)
 
-        # Their Hamiltonians
-        pHamt1 = Periodic_Atom_Chain.Hamiltonian()
-        apHamt1 = Aperiodic_Atom_Chain.Hamiltonian()
-        pHamt1223 = p_1223.Hamiltonian()
-        apHamt1223 = ap_1223.Hamiltonian()
 
-        # Benchmark answers
-        pHamt1_C = Qobj([[0.]], dims=[[1], [1]])
-        apHamt1_C = Qobj([[0.]], dims=[[1], [1]])
-        site1223 = np.diag(np.zeros(2-1)-1, 1) + np.diag(np.zeros(2-1)-1, -1)
-        Rpap1223 = tensor(Qobj(site1223), qeye([2, 3]))
-        pap1223 = Qobj(Rpap1223, dims=[[2, 2, 3], [2, 2, 3]])
-
-        # Checks for num_cell = 1
-        assert_(pHamt1 == pHamt1_C)
-        assert_(apHamt1 == apHamt1_C)
-        assert_(pHamt1223 == pap1223)    # for num_cell=1, periodic and
-        assert_(apHamt1223 == pap1223)   # aperiodic B.C. have same Hamiltonian
-
-        # num_cell = 2
-        # Four different instances
-        Periodic_Atom_Chain = Lattice1d(num_cell=2, boundary="periodic")
-        Aperiodic_Atom_Chain = Lattice1d(num_cell=2, boundary="aperiodic")
-
-        p_2222 = Lattice1d(num_cell=2, boundary="periodic",
-                           cell_num_site=2, cell_site_dof=[2, 2])
-        ap_2222 = Lattice1d(num_cell=2, boundary="aperiodic",
-                            cell_num_site=2, cell_site_dof=[2, 2])
-
-        # Their Hamiltonians
-        pHamt2222 = p_2222.Hamiltonian()
-        apHamt2222 = ap_2222.Hamiltonian()
-        pHamt2 = Periodic_Atom_Chain.Hamiltonian()
-        apHamt2 = Aperiodic_Atom_Chain.Hamiltonian()
-
-        # Benchmark answers
-        pHamt2_C = Qobj([[0., -1.],
-                         [-1.,  0.]], dims=[[2], [2]])
-        apHamt2_C = Qobj([[0., -1.],
-                          [-1., 0.]], dims=[[2], [2]])
-
-        pap_2222 = np.zeros((16, 16), dtype=complex)
-        pap_2222[0:4, 4:8] = -np.eye(4)
-        pap_2222[4:8, 0:4] = -np.eye(4)
-        pap_2222[4:8, 8:12] = -np.eye(4)
-        pap_2222[8:12, 4:8] = -np.eye(4)
-        pap_2222[8:12, 12:16] = -np.eye(4)
-        pap_2222[12:16, 8:12] = -np.eye(4)
-        pap_2222 = Qobj(pap_2222, dims=[[2, 2, 2, 2], [2, 2, 2, 2]])
-
-        # Checks for num_cell = 2
-        assert_(pHamt2 == pHamt2_C)
-        assert_(apHamt2 == apHamt2_C)
-        assert_(pHamt2222 == pap_2222)   # for num_cell=2, periodic and
-        assert_(apHamt2222 == pap_2222)  # aperiodic B.C. have same Hamiltonian
-
-        # num_cell = 3   # checking any num_cell >= 3 is pretty much equivalent
-        Periodic_Atom_Chain = Lattice1d(num_cell=3, boundary="periodic")
-        Aperiodic_Atom_Chain = Lattice1d(num_cell=3, boundary="aperiodic")
-        p_3122 = Lattice1d(num_cell=3, boundary="periodic",
-                           cell_num_site=1, cell_site_dof=[2, 2])
-        ap_3122 = Lattice1d(num_cell=3, boundary="aperiodic",
-                            cell_num_site=1, cell_site_dof=[2, 2])
-
-        # Their Hamiltonians
-        pHamt3 = Periodic_Atom_Chain.Hamiltonian()
-        apHamt3 = Aperiodic_Atom_Chain.Hamiltonian()
-        pHamt3122 = p_3122.Hamiltonian()
-        apHamt3122 = ap_3122.Hamiltonian()
-
-        # Benchmark answers
-        pHamt3_C = Qobj([[0., -1., -1.],
-                         [-1.,  0., -1.],
-                         [-1., -1.,  0.]], dims=[[3], [3]])
-        apHamt3_C = Qobj([[0., -1.,  0.],
-                          [-1.,  0., -1.],
-                          [0., -1.,  0.]], dims=[[3], [3]])
-
-        Hp_3122 = np.zeros((12, 12), dtype=complex)
-        Hp_3122[0:8, 4:12] = Hp_3122[0:8, 4:12] - np.eye(8)
-        Hp_3122[4:12, 0:8] = Hp_3122[4:12, 0:8] - np.eye(8)
-        Hp_3122[0:4, 8:12] = Hp_3122[0:4, 8:12] - np.eye(4)
-        Hp_3122[8:12, 0:4] = Hp_3122[8:12, 0:4] - np.eye(4)
-        Hp_3122 = Qobj(Hp_3122, dims=[[3, 2, 2], [3, 2, 2]])
-
-        Hap_3122 = np.zeros((12, 12), dtype=complex)
-        Hap_3122[0:8, 4:12] = Hap_3122[0:8, 4:12] - np.eye(8)
-        Hap_3122[4:12, 0:8] = Hap_3122[4:12, 0:8] - np.eye(8)
-        Hap_3122 = Qobj(Hap_3122, dims=[[3, 2, 2], [3, 2, 2]])
-
-        # Checks for num_cell = 3
-        assert_(pHamt3 == pHamt3_C)
-        assert_(apHamt3 == apHamt3_C)
-        assert_(pHamt3122 == Hp_3122)
-        assert_(apHamt3122 == Hap_3122)
+class TestLattice1d:
+    @pytest.mark.parametrize("cells", [1, 2, 3])
+    @pytest.mark.parametrize("periodic", [True, False],
+                             ids=["periodic", "aperiodic"])
+    @pytest.mark.parametrize("sites_per_cell", [1, 2])
+    @pytest.mark.parametrize("freedom", [[1], [2, 3]],
+                             ids=["simple chain", "onsite freedom"])
+    def test_hamiltonian(self, cells, periodic, sites_per_cell, freedom):
+        """Test that the lattice model produces the expected Hamiltonians."""
+        boundary = "periodic" if periodic else "aperiodic"
+        lattice = qutip.Lattice1d(num_cell=cells, boundary=boundary,
+                                  cell_site_dof=freedom,
+                                  cell_num_site=sites_per_cell)
+        expected = _hamiltonian_expected(cells, periodic, sites_per_cell,
+                                         freedom)
+        assert lattice.Hamiltonian() == expected
 
     def test_cell_structures(self):
-        """
-        lattice: Test the method Lattice1d.cell_structures().
-        """
         val_s = ['site0', 'site1']
         val_t = [' orb0', 'orb1']
-        (H_cell_form, inter_cell_T_form, H_cell,
-         inter_cell_T) = cell_structures(val_s, val_t)
+        H_cell_form, inter_cell_T_form, H_cell, inter_cell_T =\
+            qutip.cell_structures(val_s, val_t)
         c_H_form = [['<site0 orb0 H site0 orb0>',
                      '<site0 orb0 H site0orb1>',
                      '<site0 orb0 H site1 orb0>',
@@ -194,82 +178,60 @@ class TestLattice:
                           '<cell(i):site1orb1 H site1orb1:cell(i+1) >']]
         c_H = np.zeros((4, 4), dtype=complex)
         i_cell_T = np.zeros((4, 4), dtype=complex)
-        assert_(H_cell_form == c_H_form)
-        assert_(inter_cell_T_form == i_cell_T_form)
-        assert_((H_cell == c_H).all())
-        assert_((inter_cell_T == i_cell_T).all())
+        assert H_cell_form == c_H_form
+        assert inter_cell_T_form == i_cell_T_form
+        assert (H_cell == c_H).all()
+        assert (inter_cell_T == i_cell_T).all()
 
     def test_basis(self):
-        """
-        lattice: Test the method Lattice1d.basis().
-        """
-        lattice_3242 = Lattice1d(num_cell=3, boundary="periodic",
-                                 cell_num_site=2, cell_site_dof=[4, 2])
+        lattice_3242 = qutip.Lattice1d(num_cell=3, boundary="periodic",
+                                       cell_num_site=2, cell_site_dof=[4, 2])
         psi0 = lattice_3242.basis(1, 0, [2, 1])
         psi0dag_a = np.zeros((1, 48), dtype=complex)
         psi0dag_a[0, 21] = 1
-        psi0dag = Qobj(psi0dag_a, dims=[[1, 1, 1, 1], [3, 2, 4, 2]])
-        assert_(psi0 == psi0dag.dag())
+        psi0dag = qutip.Qobj(psi0dag_a, dims=[[1, 1, 1, 1], [3, 2, 4, 2]])
+        assert psi0 == psi0dag.dag()
 
     def test_distribute_operator(self):
-        """
-        lattice: Test the method Lattice1d.distribute_operator().
-        """
-        lattice_412 = Lattice1d(num_cell=4, boundary="periodic",
-                                cell_num_site=1, cell_site_dof=[2])
-        op = Qobj(np.array([[0, 1], [1, 0]]))
+        lattice_412 = qutip.Lattice1d(num_cell=4, boundary="periodic",
+                                      cell_num_site=1, cell_site_dof=[2])
+        op = qutip.Qobj(np.array([[0, 1], [1, 0]]))
         op_all = lattice_412.distribute_operator(op)
-        sv_op_all = tensor(qeye(4), sigmax())
-        assert_(op_all == sv_op_all)
+        sv_op_all = qutip.tensor(qutip.qeye(4), qutip.sigmax())
+        assert op_all == sv_op_all
 
     def test_operator_at_cells(self):
-        """
-        lattice: Test the method Lattice1d.operator_between_cells().
-        """
-        p_2222 = Lattice1d(num_cell=2, boundary="periodic",
-                           cell_num_site=2, cell_site_dof=[2, 2])
-        op_0 = basis(2, 0) * basis(2, 1).dag()
-        op_c = tensor(op_0, qeye([2, 2]))
+        p_2222 = qutip.Lattice1d(num_cell=2, boundary="periodic",
+                                 cell_num_site=2, cell_site_dof=[2, 2])
+        op_0 = qutip.projection(2, 0, 1)
+        op_c = qutip.tensor(op_0, qutip.qeye([2, 2]))
         OP = p_2222.operator_between_cells(op_c, 1, 0)
-        T = basis(2, 1) * basis(2, 0).dag()
-        QP = tensor(T, op_c)
-        assert_(OP == QP)
+        T = qutip.projection(2, 1, 0)
+        QP = qutip.tensor(T, op_c)
+        assert OP == QP
 
     def test_operator_between_cells(self):
-        """
-        lattice: Test the method Lattice1d.operator_at_cells().
-        """
-        lattice_412 = Lattice1d(num_cell=4, boundary="periodic",
-                                cell_num_site=1, cell_site_dof=[2])
-        op = Qobj(np.array([[0, 1], [1, 0]]))
+        lattice_412 = qutip.Lattice1d(num_cell=4, boundary="periodic",
+                                      cell_num_site=1, cell_site_dof=[2])
+        op = qutip.sigmax()
         op_sp = lattice_412.operator_at_cells(op, cells=[1, 2])
 
         aop_sp = np.zeros((8, 8), dtype=complex)
-        aop_sp[2:4, 2:4] = sigmax()
-        aop_sp[4:6, 4:6] = sigmax()
-        sv_op_sp = Qobj(aop_sp, dims=[[4, 2], [4, 2]])
-        assert_(op_sp == sv_op_sp)
+        aop_sp[2:4, 2:4] = aop_sp[4:6, 4:6] = op.full()
+        sv_op_sp = qutip.Qobj(aop_sp, dims=[[4, 2], [4, 2]])
+        assert op_sp == sv_op_sp
 
     def test_x(self):
-        """
-        lattice: Test the method Lattice1d.x().
-        """
-        lattice_3223 = Lattice1d(num_cell=3, boundary="periodic",
-                                 cell_num_site=2, cell_site_dof=[2, 3])
-        R = lattice_3223.x()
-        npR = R.full()
-        # count the number of off-diagonal elements n_off which should be 0
-        n_off = np.count_nonzero(npR - np.diag(np.diagonal(npR)))
-        assert_(n_off == 0)
-        assert_((np.diag(R) == np.kron(range(3), np.ones(12))).all())
+        lattice_3223 = qutip.Lattice1d(num_cell=3, boundary="periodic",
+                                       cell_num_site=2, cell_site_dof=[2, 3])
+        test = lattice_3223.x().full()
+        expected = np.diag([n for n in range(3) for _ in [None]*12])
+        np.testing.assert_allclose(test, expected, atol=1e-12)
 
     def test_k(self):
-        """
-        lattice: Test the method Lattice1d.k().
-        """
         L = 7
-        lattice_L123 = Lattice1d(num_cell=L, boundary="periodic",
-                                 cell_num_site=1, cell_site_dof=[2, 3])
+        lattice_L123 = qutip.Lattice1d(num_cell=L, boundary="periodic",
+                                       cell_num_site=1, cell_site_dof=[2, 3])
         kq = lattice_L123.k()
         kop = np.zeros((L, L), dtype=complex)
         for row in range(L):
@@ -278,382 +240,162 @@ class TestLattice:
                     kop[row, col] = (L-1)/2
                 else:
                     kop[row, col] = 1 / (np.exp(2j * np.pi * (row - col)/L)-1)
-
         kt = np.kron(kop * 2 * np.pi / L, np.eye(6))
         dim_H = [[2, 2, 3], [2, 2, 3]]
-        kt = Qobj(kt, dims=dim_H)
+        kt = qutip.Qobj(kt, dims=dim_H)
+        k_q = kq.eigenstates()[0]
+        k_t = kt.eigenstates()[0]
+        k_tC = k_t - (2*np.pi/L) * ((L-1) // 2)
+        np.testing.assert_allclose(k_tC, k_q, atol=1e-12)
 
-        [k_q, Vq] = kq.eigenstates()
-        [k_t, Vt] = kt.eigenstates()
-        k_tC = k_t - 2*np.pi/L*((L-1)//2)
-        # k_ts = [(i-(L-1)//2)*2*np.pi/L for i in range(L)]
-        # k_w = np.kron((np.array(k_ts)).T, np.ones((1,6)))
-        assert_((np.abs(k_tC - k_q) < 1E-13).all())
-
-    def test_get_dispersion(self):
-        """
-        lattice: Test the method Lattice1d.get_dispersion().
-        """
-        Periodic_Atom_Chain = Lattice1d(num_cell=8, boundary="periodic")
-        [knxA, val_kns] = Periodic_Atom_Chain.get_dispersion()
-        kB = np.array([[-3.14159265],
-                       [-2.35619449],
-                       [-1.57079633],
-                       [-0.78539816],
-                       [0.],
-                       [0.78539816],
-                       [1.57079633],
-                       [2.35619449]])
-        valB = np.array([[2., 1.41421356, 0., -1.41421356, -2.,
-                          -1.41421356, 0., 1.41421356]])
-        assert_(np.max(abs(knxA-kB)) < 1.0E-6)
-        assert_(np.max(abs(val_kns-valB)) < 1.0E-6)
-
-        # SSH model with num_cell = 4 and two orbitals, two spins
-        # cell_site_dof = [2,2]
-        t_intra = -0.5
-        t_inter = -0.6
-        H_cell = tensor(
-                Qobj(np.array([[0, t_intra], [t_intra, 0]])), qeye([2, 2]))
-        inter_cell_T = tensor(
-                Qobj(np.array([[0, 0], [t_inter, 0]])), qeye([2, 2]))
-
-        SSH_comp = Lattice1d(num_cell=6, boundary="periodic",
-                             cell_num_site=2, cell_site_dof=[2, 2],
-                             Hamiltonian_of_cell=H_cell, inter_hop=inter_cell_T)
-        [kScomp, vcomp] = SSH_comp.get_dispersion()
-        kS = np.array([[-3.14159265],
-                       [-2.0943951],
-                       [-1.04719755],
-                       [0.],
-                       [1.04719755],
-                       [2.0943951]])
-        Oband = np.array([-0.1, -0.55677644, -0.9539392, -1.1,
-                          -0.9539392, -0.55677644])
-        vS = np.array([Oband, Oband, Oband, Oband, -Oband, -Oband, -Oband,
-                       -Oband])
-        assert_(np.max(abs(kScomp-kS)) < 1.0E-6)
-        assert_(np.max(abs(vcomp-vS)) < 1.0E-6)
+    @pytest.mark.parametrize(["lattice", "k_expected", "energies_expected"], [
+        pytest.param(qutip.Lattice1d(num_cell=8),
+                     _k_expected(8),
+                     np.array([[2, np.sqrt(2), 0, -np.sqrt(2), -2,
+                                -np.sqrt(2), 0, np.sqrt(2)]]),
+                     id="atom chain"),
+        pytest.param(_ssh_lattice(-0.5, -0.6,
+                                  cells=6, sites_per_cell=2, freedom=[2, 2]),
+                     _k_expected(6),
+                     np.array([-_ssh_energies]*4 + [_ssh_energies]*4),
+                     id="ssh model")
+    ])
+    def test_get_dispersion(self, lattice, k_expected, energies_expected):
+        k_test, energies_test = lattice.get_dispersion()
+        _assert_angles_close(k_test, k_expected, atol=1e-8)
+        np.testing.assert_allclose(energies_test, energies_expected, atol=1e-8)
 
     def test_cell_periodic_parts(self):
-        """
-        lattice: Test the method Lattice1d.array_of_unk().
-        """
-        # Coupled Resonator Optical Waveguide(CROW) Example(PhysRevB.99.224201)
-        J = 2
-        eta = np.pi/4
-        H_cell = Qobj(np.array([[0, J*np.sin(eta)], [J*np.sin(eta), 0]]))
-        inter_cell_T0 = (J/2) * Qobj(np.array(
-                [[np.exp(eta * 1j), 0], [0, np.exp(-eta*1j)]]))
-        inter_cell_T1 = (J/2) * Qobj(np.array([[0, 1], [1, 0]]))
-
-        inter_cell_T = [inter_cell_T0, inter_cell_T1]
-
-        CROW_lattice = Lattice1d(num_cell=4, boundary="periodic",
-                                 cell_num_site=1, cell_site_dof=[2],
-                                 Hamiltonian_of_cell=H_cell,
-                                 inter_hop=inter_cell_T)
-        (kxA, val_kns) = CROW_lattice.get_dispersion()
-        (knxA, vec_kns) = CROW_lattice.cell_periodic_parts()
-        (knxA, qH_ks) = CROW_lattice.bulk_Hamiltonians()
-        for i in range(4):
-            for j in range(2):
-                if val_kns[j][i] == 0:
-                    E_V = Qobj(vec_kns[i, j, :])
-                    eE_V = qH_ks[i] * E_V
-                    assert_(np.max(abs(eE_V)) < 1.0E-12)
-                else:
-                    E_V = Qobj(vec_kns[i, j, :])
-                    eE_V = qH_ks[i] * E_V
-                    qE_V = np.divide(eE_V, E_V)
-                    oE = val_kns[j][i] * np.ones((2, 1))
-                    assert_(np.max(abs(oE-qE_V)) < 1.0E-12)
+        lattice = _crow_lattice(2, np.pi/4)
+        eigensystems = zip(lattice.get_dispersion()[1].T,
+                           lattice.cell_periodic_parts()[1])
+        hamiltonians = lattice.bulk_Hamiltonians()[1]
+        for hamiltonian, system in zip(hamiltonians, eigensystems):
+            for eigenvalue, eigenstate in zip(*system):
+                eigenstate = qutip.Qobj(eigenstate)
+                np.testing.assert_allclose((hamiltonian * eigenstate).full(),
+                                           (eigenvalue * eigenstate).full(),
+                                           atol=1e-12)
 
     def test_bulk_Hamiltonians(self):
-        """
-        lattice: Test the method Lattice1d.bulk_Hamiltonian_array().
-        """
-        # Coupled Resonator Optical Waveguide(CROW) Example(PhysRevB.99.224201)
-        J = 2
-        eta = np.pi/2
-        H_cell = Qobj(np.array([[0, J*np.sin(eta)], [J*np.sin(eta), 0]]))
-        inter_cell_T0 = (J/2)*Qobj(np.array([[np.exp(eta * 1j), 0],
-                                   [0, np.exp(-eta*1j)]]))
-        inter_cell_T1 = (J/2)*Qobj(np.array([[0, 1], [1, 0]]))
-        inter_cell_T = [inter_cell_T0, inter_cell_T1]
-
-        CROW_lattice = Lattice1d(num_cell=4, boundary="periodic",
-                                 cell_num_site=1, cell_site_dof=[2],
-                                 Hamiltonian_of_cell=H_cell,
-                                 inter_hop=inter_cell_T)
-        (knxA, qH_ks) = CROW_lattice.bulk_Hamiltonians()
-        Hk0 = np.array([[0.+0.j, 0.+0.j],
-                        [0.+0.j, 0.+0.j]])
-        Hk1 = np.array([[2.+0.j, 2.+0.j],
-                        [2.+0.j, -2.+0.j]])
-        Hk2 = np.array([[0.+0.j, 4.+0.j],
-                        [4.+0.j, 0.+0.j]])
-        Hk3 = np.array([[-2.+0.j, 2.+0.j],
-                        [2.+0.j, 2.+0.j]])
-        qHks = np.array([None for i in range(4)])
-        qHks[0] = Qobj(Hk0)
-        qHks[1] = Qobj(Hk1)
-        qHks[2] = Qobj(Hk2)
-        qHks[3] = Qobj(Hk3)
-        for i in range(4):
-            np.testing.assert_array_almost_equal(qH_ks[i], qHks[i], decimal=8)
+        test = _crow_lattice(2, np.pi/2).bulk_Hamiltonians()[1]
+        expected = [[[0, 0], [0, 0]],
+                    [[2, 2], [2, -2]],
+                    [[0, 4], [4, 0]],
+                    [[-2, 2], [2, 2]]]
+        for test_hamiltonian, expected_hamiltonian in zip(test, expected):
+            np.testing.assert_allclose(test_hamiltonian.full(),
+                                       expected_hamiltonian,
+                                       atol=1e-12)
 
     def test_bloch_wave_functions(self):
-        """
-        lattice: Test the method Lattice1d.bloch_wave_functions().
-        """
-        # Coupled Resonator Optical Waveguide(CROW) Example(PhysRevB.99.224201)
-        J = 2
-        eta = np.pi/2
-        H_cell = Qobj(np.array([[0, J*np.sin(eta)], [J*np.sin(eta), 0]]))
-        inter_cell_T0 = (J/2)*Qobj(np.array([[np.exp(eta * 1j), 0], [0,
-                                   np.exp(-eta*1j)]]))
-        inter_cell_T1 = (J/2)*Qobj(np.array([[0, 1], [1, 0]]))
+        lattice = _crow_lattice(2, np.pi/2)
+        hamiltonian = lattice.Hamiltonian()
+        expected = np.array([[0,    2,   1j,  1,   0,   0,  -1j,  1],
+                             [2,    0,   1,  -1j,  0,   0,   1,   1j],
+                             [-1j,  1,   0,   2,   1j,  1,   0,   0],
+                             [1,    1j,  2,   0,   1,  -1j,  0,   0],
+                             [0,    0,  -1j,  1,   0,   2,   1j,  1],
+                             [0,    0,   1,   1j,  2,   0,   1,  -1j],
+                             [1j,   1,   0,   0,  -1j,  1,   0,   2],
+                             [1,   -1j,  0,   0,   1,   1j,  2,   0]])
+        np.testing.assert_allclose(hamiltonian.full(), expected, atol=1e-8)
+        for eigenvalue, eigenstate in lattice.bloch_wave_functions():
+            np.testing.assert_allclose((hamiltonian * eigenstate).full(),
+                                       (eigenvalue * eigenstate).full(),
+                                       atol=1e-12)
 
-        inter_cell_T = [inter_cell_T0, inter_cell_T1]
 
-        CROW_lattice = Lattice1d(num_cell=4, boundary="periodic",
-                                 cell_num_site=1, cell_site_dof=[2],
-                                 Hamiltonian_of_cell=H_cell,
-                                 inter_hop=inter_cell_T)
-        CROW_Haml = CROW_lattice.Hamiltonian()
+class TestIntegration:
+    def test_fixed_crow(self):
+        lattice = _crow_lattice(2, np.pi/4, cells=4)
+        hamiltonian = lattice.Hamiltonian()
+        expected_hamiltonian = np.array([
+            [0, _r2, (1+1j)/_r2, 1, 0, 0, (1-1j)/_r2, 1],
+            [_r2, 0, 1, (1-1j)/_r2, 0, 0, 1, (1+1j)/_r2],
+            [(1-1j)/_r2, 1, 0, _r2, (1+1j)/_r2, 1, 0, 0],
+            [1, (1+1j)/_r2, _r2, 0, 1, (1-1j)/_r2, 0, 0],
+            [0, 0, (1-1j)/_r2, 1, 0, _r2, (1+1j)/_r2, 1],
+            [0, 0, 1, (1+1j)/_r2, _r2, 0, 1, (1-1j)/_r2],
+            [(1+1j)/_r2, 1, 0, 0, (1-1j)/_r2, 1, 0, _r2],
+            [1, (1-1j)/_r2, 0, 0, 1, (1+1j)/_r2, _r2, 0]])
+        np.testing.assert_allclose(hamiltonian, expected_hamiltonian,
+                                   atol=1e-12)
 
-        H_CROW = Qobj(np.array([[0.+0.j, 2.+0.j, 0.+1.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 1.+0.j],
-                                [2.+0.j, 0.+0.j, 1.+0.j, 0.-1.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+1.j],
-                                [0.-1.j, 1.+0.j, 0.+0.j, 2.+0.j, 0.+1.j, 1.+0.j, 0.+0.j, 0.+0.j],
-                                [1.+0.j, 0.+1.j, 2.+0.j, 0.+0.j, 1.+0.j, 0.-1.j, 0.+0.j, 0.+0.j],
-                                [0.+0.j, 0.+0.j, 0.-1.j, 1.+0.j, 0.+0.j, 2.+0.j, 0.+1.j, 1.+0.j],
-                                [0.+0.j, 0.+0.j, 1.+0.j, 0.+1.j, 2.+0.j, 0.+0.j, 1.+0.j, 0.-1.j],
-                                [0.+1.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 1.+0.j, 0.+0.j, 2.+0.j],
-                                [1.+0.j, 0.-1.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+1.j, 2.+0.j, 0.+0.j]]),
-                      dims=[[4, 2], [4, 2]])
-        # Check for CROW with num_cell = 4
-        assert_(np.max(abs(CROW_Haml-H_CROW)) < 1.0E-6)  # 1.0E-8 worked too
-        eigen_states = CROW_lattice.bloch_wave_functions()
-        for i in range(8):
-            if eigen_states[i][0] == 0:
-                E_V = eigen_states[i][1]
-                eE_V = CROW_Haml * E_V
-                assert_(np.max(abs(eE_V)) < 1.0E-10)
-            else:
-                E_V = eigen_states[i][1]
-                eE_V = CROW_Haml * E_V
-                qE_V = np.divide(eE_V, E_V)
-                oE = eigen_states[i][0] * np.ones((8, 1))
-                assert_(np.max(abs(oE-qE_V)) < 1.0E-10)
+        test_k, test_energies = lattice.get_dispersion()
+        expected_k = _k_expected(4)
+        expected_energies = 2*np.array([[-1,    -1,    -1, -1],
+                                        [1-_r2,  1, 1+_r2,  1]])
+        _assert_angles_close(test_k, expected_k, atol=1e-12)
+        np.testing.assert_allclose(test_energies, expected_energies,
+                                   atol=1e-12)
 
-    def test_CROW(self):
-        """
-        lattice: Test the methods of Lattice1d in a CROW model.
-        """
-        # Coupled Resonator Optical Waveguide(CROW) Example(PhysRevB.99.224201)
-        J = 2
-        eta = np.pi/4
-        H_cell = Qobj(np.array([[0, J * np.sin(eta)], [J * np.sin(eta), 0]]))
-        inter_cell_T0 = (J/2)*Qobj(np.array([[np.exp(eta * 1j), 0],
-                                   [0, np.exp(-eta*1j)]]))
-        inter_cell_T1 = (J/2)*Qobj(np.array([[0, 1], [1, 0]]))
+        for value, state in lattice.bloch_wave_functions():
+            np.testing.assert_allclose(hamiltonian*state, value*state,
+                                       atol=1e-12)
 
-        inter_cell_T = [inter_cell_T0, inter_cell_T1]
+        test_bulk_system = zip(test_energies.T,
+                               lattice.cell_periodic_parts()[1])
+        test_bulk_h = lattice.bulk_Hamiltonians()[1]
+        expected_bulk_h = np.array([
+            [[-_r2, _r2-2], [_r2-2, -_r2]],
+            [[_r2,    _r2], [_r2,   -_r2]],
+            [[_r2,  2+_r2], [2+_r2,  _r2]],
+            [[-_r2,   _r2], [_r2,    _r2]]])
+        for test, expected in zip(test_bulk_h, expected_bulk_h):
+            np.testing.assert_allclose(test.full(), expected, atol=1e-8)
+        for hamiltonian, system in zip(test_bulk_h, test_bulk_system):
+            for eigenvalue, eigenstate in zip(*system):
+                eigenstate = qutip.Qobj(eigenstate)
+                np.testing.assert_allclose((hamiltonian * eigenstate).full(),
+                                           (eigenvalue * eigenstate).full(),
+                                           atol=1e-12)
 
-        CROW_lattice = Lattice1d(num_cell=4, boundary="periodic",
-                                 cell_num_site=1, cell_site_dof=[2],
-                                 Hamiltonian_of_cell=H_cell,
-                                 inter_hop=inter_cell_T)
-        CROW_Haml = CROW_lattice.Hamiltonian()
+    def test_random_crow(self):
+        cells = np.random.randint(2, 60)
+        phase = 2*np.pi * np.random.rand()
+        lattice = _crow_lattice(1, phase, cells=cells)
+        expected_k = _k_expected(cells)
+        _s, _c = np.sin(phase), np.cos(phase)
+        expected_energies = np.array([
+            [cosk*_c + np.sqrt(2*_s*(_s+cosk) + (cosk*_c)**2),
+             cosk*_c - np.sqrt(2*_s*(_s+cosk) + (cosk*_c)**2)]
+            for cosk in np.cos(expected_k).flat])
+        expected_energies = np.sort(expected_energies.T, axis=0)
+        test_k, test_energies = lattice.get_dispersion()
+        _assert_angles_close(test_k, expected_k, atol=1e-12)
+        np.testing.assert_allclose(test_energies, expected_energies,
+                                   atol=1e-12)
 
-        # Benchmark answers
-        H_CROW = Qobj([[0.+0.j, 1.41421356+0.j, 0.70710678+0.70710678j, 1.+0.j,
-                        0.+0.j, 0.+0.j, 0.70710678-0.70710678j, 1.+0.j],
-        [1.41421356+0.j, 0.+0.j, 1.+0.j,  0.70710678-0.70710678j,
-         0.+0.j, 0.+0.j, 1.+0.j, 0.70710678+0.70710678j],
-        [0.70710678-0.70710678j, 1.+0.j, 0.+0.j, 1.41421356+0.j,
-         0.70710678+0.70710678j, 1.+0.j, 0.+0.j, 0.+0.j],
-        [1.+0.j, 0.70710678+0.70710678j, 1.41421356+0.j, 0.+0.j,
-         1.+0.j, 0.70710678-0.70710678j, 0.+0.j, 0.+0.j],
-        [0.+0.j, 0.+0.j, 0.70710678-0.70710678j, 1.+0.j,
-         0.+0.j, 1.41421356+0.j, 0.70710678+0.70710678j, 1.+0.j],
-        [0.+0.j, 0.+0.j, 1.+0.j, 0.70710678+0.70710678j,
-         1.41421356+0.j, 0.+0.j, 1.+0.j, 0.70710678-0.70710678j],
-        [0.70710678+0.70710678j, 1.+0.j, 0.+0.j, 0.+0.j,
-         0.70710678-0.70710678j, 1.+0.j, 0.+0.j, 1.41421356+0.j],
-        [1.+0.j, 0.70710678-0.70710678j, 0.+0.j, 0.+0.j,
-         1.+0.j, 0.70710678+0.70710678j, 1.41421356+0.j, 0.+0.j]],
-         dims=[[4, 2], [4, 2]])
+    def test_fixed_ssh(self):
+        intra, inter = -0.5, -0.6
+        cells = 5
+        lattice = _ssh_lattice(intra, inter,
+                               cells=cells, sites_per_cell=2, freedom=[1])
+        Hin = qutip.Qobj([[0, intra], [intra, 0]])
+        Ht = qutip.Qobj([[0, 0], [inter, 0]])
+        D = qutip.qeye(cells)
+        T = qutip.qdiags([np.ones(cells-1), [1]], [1, 1-cells])
+        hopping = qutip.tensor(T, Ht)
+        expected_hamiltonian = qutip.tensor(D, Hin) + hopping + hopping.dag()
+        assert lattice.Hamiltonian() == expected_hamiltonian
 
-        # Check for CROW with num_cell = 4
-        assert_(np.max(abs(CROW_Haml-H_CROW)) < 1.0E-6)  # 1.0E-8 worked too
+        test_k, test_energies = lattice.get_dispersion()
+        band = np.array([0.35297281, 0.89185772, 1.1, 0.89185772, 0.35297281])
+        _assert_angles_close(test_k, _k_expected(cells), atol=1e-12)
+        np.testing.assert_allclose(test_energies, np.array([-band, band]),
+                                   atol=1e-8)
 
-        (kxA, val_kns) = CROW_lattice.get_dispersion()
-        kCR = np.array([[-3.14159265],
-                        [-1.57079633],
-                        [0.],
-                        [1.57079633]])
-        vCR = np.array([[-2.        , -2.        , -2.        , -2.],
-                        [-0.82842712, 2.         , 4.82842712 , 2.]])
-        assert_(np.max(abs(kxA-kCR)) < 1.0E-6)
-        assert_(np.max(abs(val_kns-vCR)) < 1.0E-6)
-
-        eigen_states = CROW_lattice.bloch_wave_functions()
-        for i in range(8):
-            E_V = eigen_states[i][1]
-            eE_V = CROW_Haml * E_V
-            qE_V = np.divide(eE_V, E_V)
-            oE = eigen_states[i][0] * np.ones((8, 1))
-            assert_(np.max(abs(oE-qE_V)) < 1.0E-10)
-        (knxA, qH_ks) = CROW_lattice.bulk_Hamiltonians()
-        (knxA, vec_kns) = CROW_lattice.cell_periodic_parts()
-
-        Hk0 = np.array([[-1.41421356+0.j, -0.58578644+0.j],
-                        [-0.58578644+0.j, -1.41421356+0.j]])
-        Hk1 = np.array([[1.41421356+0.j, 1.41421356+0.j],
-                        [1.41421356+0.j, -1.41421356+0.j]])
-        Hk2 = np.array([[1.41421356+0.j, 3.41421356+0.j],
-                        [3.41421356+0.j, 1.41421356+0.j]])
-        Hk3 = np.array([[-1.41421356+0.j, 1.41421356+0.j],
-                        [1.41421356+0.j, 1.41421356+0.j]])
-        qHks = np.array([None for i in range(4)])
-        qHks[0] = Qobj(Hk0)
-        qHks[1] = Qobj(Hk1)
-        qHks[2] = Qobj(Hk2)
-        qHks[3] = Qobj(Hk3)
-        for i in range(4):
-            np.testing.assert_array_almost_equal(qH_ks[i], qHks[i], decimal=8)
-        for i in range(4):
-            for j in range(2):
-                E_V = Qobj(vec_kns[i, j, :])
-                eE_V = qH_ks[i] * E_V
-                qE_V = np.divide(eE_V, E_V)
-                oE = val_kns[j][i]*np.ones((2, 1))
-                assert_(np.max(abs(oE-qE_V)) < 1.0E-12)
-
-        # A test on CROW lattice dispersion with a random number of cells and
-        # random values of eta
-        J = 1
-        num_cell = np.random.randint(2, 60)
-        eta = 2*np.pi*np.random.random()
-
-        H_cell = Qobj(np.array([[0, J * np.sin(eta)], [J * np.sin(eta), 0]]))
-        inter_cell_T0 = (J/2) * Qobj(np.array([[np.exp(eta * 1j), 0],
-                                              [0, np.exp(-eta*1j)]]))
-        inter_cell_T1 = (J/2) * Qobj(np.array([[0, 1], [1, 0]]))
-        inter_cell_T = [inter_cell_T0, inter_cell_T1]
-
-        CROW_Random = Lattice1d(num_cell=num_cell, boundary="periodic",
-                                cell_num_site=1, cell_site_dof=[2],
-                                Hamiltonian_of_cell=H_cell,
-                                inter_hop=inter_cell_T)
-        a = 1  # The unit cell length is always considered 1
-        kn_start = 0
-        kn_end = 2*np.pi/a
-        Ana_val_kns = np.zeros((2, num_cell), dtype=float)
-        knxA = np.zeros((num_cell, 1), dtype=float)
-
-        for ks in range(num_cell):
-            knx = kn_start + (ks*(kn_end-kn_start)/num_cell)
-            if knx >= np.pi:
-                knxA[ks, 0] = knx - 2 * np.pi
-            else:
-                knxA[ks, 0] = knx
-        knxA = np.roll(knxA, np.floor_divide(num_cell, 2))
-
-        for ks in range(num_cell):
-            knx = knxA[ks, 0]
-            # Ana_val_kns are the analytical bands
-            val0 = np.cos(knx) * np.cos(eta) + np.sqrt(2 * np.sin(eta) ** 2
-                          + (np.cos(knx) * np.cos(eta)) ** 2
-                          + 2 * np.sin(eta) * np.cos(knx))
-            val1 = np.cos(knx) * np.cos(eta) - np.sqrt(2 * np.sin(eta) ** 2
-                          + (np.cos(knx) * np.cos(eta)) ** 2
-                          + 2 * np.sin(eta) * np.cos(knx))
-            vals = [val0, val1]
-            Ana_val_kns[0, ks] = np.min(vals)
-            Ana_val_kns[1, ks] = np.max(vals)
-
-        (kxA, val_kns) = CROW_Random.get_dispersion()
-        assert_(np.max(abs(kxA-knxA)) < 1.0E-8)
-        assert_(np.max(abs(val_kns-Ana_val_kns)) < 1.0E-8)
-
-    def test_SSH(self):
-        """
-        lattice: Test the methods of Lattice1d in a SSH model.
-        """
-        # SSH model with num_cell = 4 and two orbitals, two spins
-        # cell_site_dof = [2,2]
-        t_intra = -0.5
-        t_inter = -0.6
-        H_cell = Qobj(np.array([[0, t_intra], [t_intra, 0]]))
-        inter_cell_T = Qobj(np.array([[0, 0], [t_inter, 0]]))
-
-        SSH_lattice = Lattice1d(num_cell=5, boundary="periodic",
-                             cell_num_site=2, cell_site_dof=[1],
-                             Hamiltonian_of_cell=H_cell,
-                             inter_hop=inter_cell_T)        
-        Ham_Sc = SSH_lattice.Hamiltonian()
-
-        Hin = Qobj([[0, -0.5], [-0.5, 0]])
-        Ht = Qobj([[0, 0], [-0.6, 0]])
-        D = qeye(5)
-        T = np.diag(np.zeros(4)+1, 1)
-        Tdag = np.diag(np.zeros(4)+1, -1)
-        Tdag[0][4] = 1
-        T[4][0] = 1
-        T = Qobj(T)
-        Tdag = Qobj(Tdag)
-        H_Sc = tensor(D, Hin) + tensor(T, Ht) + tensor(Tdag, Ht.dag())
-        # check for SSH model with num_cell = 5          
-        assert_(Ham_Sc == H_Sc)
-
-        (kxA,val_ks) = SSH_lattice.get_dispersion()
-        kSSH = np.array([[-2.51327412],
-                         [-1.25663706],
-                         [ 0.        ],
-                         [ 1.25663706],
-                         [ 2.51327412]])
-        vSSH = np.array([[-0.35297281, -0.89185772, -1.1, -0.89185772, -0.35297281],
-                         [ 0.35297281,  0.89185772,  1.1, 0.89185772, 0.35297281]])
-        assert_(np.max(abs(kxA-kSSH)) < 1.0E-6)
-        assert_(np.max(abs(val_ks-vSSH)) < 1.0E-6)
-
-        # A test on SSH lattice dispersion with a random number of cells and
-        # random values of t_inter and t_intra
-        num_cell = np.random.randint(2, 60)
-        t_intra = -np.random.random()
-        t_inter = -np.random.random()
-        H_cell = Qobj(np.array([[0, t_intra], [t_intra, 0]]))
-        inter_cell_T = Qobj(np.array([[0, 0], [t_inter, 0]]))
-        SSH_Random = Lattice1d(num_cell=num_cell, boundary="periodic",
-                             cell_num_site=2, cell_site_dof=[1],
-                             Hamiltonian_of_cell=H_cell,
-                             inter_hop=inter_cell_T)
-        a = 1  # The unit cell length is always considered 1
-        kn_start = 0
-        kn_end = 2*np.pi/a
-        Ana_val_kns = np.zeros((2, num_cell), dtype=float)
-        knxA = np.zeros((num_cell, 1), dtype=float)
-
-        for ks in range(num_cell):
-            knx = kn_start + (ks * (kn_end-kn_start)/num_cell)
-            if knx >= np.pi:
-                knxA[ks, 0] = knx - 2 * np.pi
-            else:
-                knxA[ks, 0] = knx
-        knxA = np.roll(knxA, np.floor_divide(num_cell, 2))
-
-        for ks in range(num_cell):
-            knx = knxA[ks, 0]
-            # Ana_val_kns are the analytical bands
-            Ana_val_kns[0, ks] = -np.sqrt(t_intra ** 2 + t_inter ** 2
-                       + 2 * t_intra * t_inter * np.cos(knx))
-            Ana_val_kns[1, ks] = np.sqrt(t_intra ** 2 + t_inter ** 2
-                       + 2 * t_intra * t_inter * np.cos(knx))
-        (kxA, val_kns) = SSH_Random.get_dispersion()
-        assert_(np.max(abs(val_kns-Ana_val_kns)) < 1.0E-13)
-
-if __name__ == "__main__":
-    run_module_suite()
+    def test_random_ssh(self):
+        cells = np.random.randint(2, 60)
+        intra, inter = -np.random.random(), -np.random.random()
+        lattice = _ssh_lattice(intra, inter,
+                               cells=cells, sites_per_cell=2, freedom=[1])
+        expected_k = _k_expected(cells)
+        band = np.sqrt(intra**2 + inter**2 + 2*intra*inter*np.cos(expected_k))
+        band = np.array(band.flat)
+        expected_energies = np.array([-band, band])
+        test_k, test_energies = lattice.get_dispersion()
+        _assert_angles_close(test_k, expected_k, atol=1e-12)
+        np.testing.assert_allclose(test_energies, expected_energies,
+                                   atol=1e-12)

--- a/qutip/tests/test_mcsolve.py
+++ b/qutip/tests/test_mcsolve.py
@@ -30,561 +30,274 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
+
 import pytest
+import functools
 import numpy as np
-from numpy.testing import assert_equal, run_module_suite, assert_
-import unittest
-from qutip import *
-from qutip import _version2int
-
-# find Cython if it exists
-try:
-    import Cython
-except:
-    Cython_found = 0
-else:
-    Cython_found = 1
-
-kappa = 0.2
+import qutip
 
 
-def sqrt_kappa(t, args):
-    return np.sqrt(kappa)
+def _return_constant(constant, *args, **kwargs):
+    return constant
 
 
-def sqrt_kappa2(t, args):
-    return np.sqrt(kappa * np.exp(-t))
+def _return_decay(constant, rate, t, *args, **kwargs):
+    return constant * np.exp(-rate * t)
 
 
-def const_H1_coeff(t, args):
-    return 0.0
+@pytest.mark.usefixtures("in_temporary_directory")
+class StatesAndExpectOutputCase:
+    """
+    Mixin class to test the states and expectation values from ``mcsolve``.
+    """
+    size = 10
+    h = qutip.num(size)
+    state = qutip.basis(size, size-1)
+    times = np.linspace(0, 1, 101)
+    e_ops = [qutip.num(size)]
+    ntraj = 750
 
-# average error for failure
-mc_error = 5e-2  # 5%
-ntraj = 750
+    def _assert_states(self, result, expected, tol):
+        assert hasattr(result, 'states')
+        assert len(result.states) == len(self.times)
+        for test_operator, expected_part in zip(self.e_ops, expected):
+            test = qutip.expect(test_operator, result.states)
+            np.testing.assert_allclose(test, expected_part, rtol=tol)
 
+    def _assert_expect(self, result, expected, tol):
+        assert hasattr(result, 'expect')
+        assert len(result.expect) == len(self.e_ops)
+        for test, expected_part in zip(result.expect, expected):
+            np.testing.assert_allclose(test, expected_part, rtol=tol)
 
-def test_MCNoCollExpt():
-    "Monte-carlo: Constant H with no collapse ops (expect)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
+    def test_states(self, hamiltonian, c_ops, expected, tol):
+        options = qutip.Options(average_states=True, store_states=True)
+        result = qutip.mcsolve(hamiltonian, self.state, self.times,
+                               c_ops=c_ops, e_ops=[], ntraj=self.ntraj,
+                               options=options)
+        self._assert_states(result, expected, tol)
 
+    def test_expect(self, hamiltonian, c_ops, expected, tol):
+        result = qutip.mcsolve(hamiltonian, self.state, self.times,
+                               c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj)
+        self._assert_expect(result, expected, tol)
 
-def test_MCNoCollStates():
-    "Monte-carlo: Constant H with no collapse ops (states)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [], ntraj=ntraj)
-    states = mcdata.states
-    expt = expect(a.dag() * a, states)
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
-
-
-def test_MCNoCollExpectStates():
-    "Monte-carlo: Constant H with no collapse ops (expect and states)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj,
-                     options=Options(store_states=True))
-    actual_answer = 9.0 * np.ones(len(tlist))
-    expt = mcdata.expect[0]
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
-    assert_(len(mcdata.states) == len(tlist))
-    assert_(isinstance(mcdata.states[0], Qobj))
-    expt = expect(a.dag() * a, mcdata.states)
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
+    def test_states_and_expect(self, hamiltonian, c_ops, expected, tol):
+        options = qutip.Options(average_states=True, store_states=True)
+        result = qutip.mcsolve(hamiltonian, self.state, self.times,
+                               c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj,
+                               options=options)
+        self._assert_expect(result, expected, tol)
+        self._assert_states(result, expected, tol)
 
 
-@pytest.mark.slow
-def test_MCNoCollStrExpt():
-    "Monte-carlo: Constant H (str format) with no collapse ops (expect)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = [a.dag() * a, [a.dag() * a, 'c']]
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], args={'c': 0.0},
-                     ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
+class TestNoCollapse(StatesAndExpectOutputCase):
+    """
+    Test that `mcsolve` correctly solves the system when there is a constant
+    Hamiltonian and no collapses.
+    """
+    def pytest_generate_tests(self, metafunc):
+        tol = 1e-8
+        expect = (qutip.expect(self.e_ops[0], self.state)
+                  * np.ones_like(self.times))
+        # Use partial to allow pickling.
+        zero_function = functools.partial(_return_constant, 0)
+        hamiltonian_types = [
+            (self.h, "Qobj", False),
+            ([self.h], "list", False),
+            ([self.h, [self.h, '0']], "string", True),
+            ([self.h, [self.h, zero_function]], "function", False),
+        ]
+        cases = []
+        for hamiltonian, id, slow in hamiltonian_types:
+            marks = [pytest.mark.slow] if slow else []
+            cases.append(pytest.param(hamiltonian, [], [expect], tol,
+                                      id=id, marks=marks))
+        metafunc.parametrize(['hamiltonian', 'c_ops', 'expected', 'tol'],
+                             cases)
 
 
-def test_MCNoCollFuncExpt():
-    "Monte-carlo: Constant H (func format) with no collapse ops (expect)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = [a.dag() * a, [a.dag() * a, const_H1_coeff]]
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
+class TestConstantCollapse(StatesAndExpectOutputCase):
+    """
+    Test that `mcsolve` correctly solves the system when there is a constant
+    collapse operator.
+    """
+    def pytest_generate_tests(self, metafunc):
+        tol = 0.05
+        coupling = 0.2
+        expect = (qutip.expect(self.e_ops[0], self.state)
+                  * np.exp(-coupling * self.times))
+        collapse_op = qutip.destroy(self.size)
+        # Use partial to allow pickling.
+        collapse_function = functools.partial(_return_constant,
+                                              np.sqrt(coupling))
+        c_op_types = [
+            (np.sqrt(coupling)*collapse_op, "constant"),
+            ([collapse_op, 'sqrt({})'.format(coupling)], "string"),
+            ([collapse_op, collapse_function], "function"),
+        ]
+        cases = []
+        for c_op, id in c_op_types:
+            cases.append(pytest.param(self.h, [c_op], [expect], tol,
+                                      id=id, marks=[pytest.mark.slow]))
+        metafunc.parametrize(['hamiltonian', 'c_ops', 'expected', 'tol'],
+                             cases)
 
 
-@pytest.mark.slow
-def test_MCNoCollStrStates():
-    "Monte-carlo: Constant H (str format) with no collapse ops (states)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = [a.dag() * a, [a.dag() * a, 'c']]
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [], args={'c': 0.0})
-    states = mcdata.states
-    expt = expect(a.dag() * a, states)
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
+class TestTimeDependentCollapse(StatesAndExpectOutputCase):
+    """
+    Test that `mcsolve` correctly solves the system when the collapse operators
+    are time-dependent.
+    """
+    def pytest_generate_tests(self, metafunc):
+        tol = 0.1
+        coupling = 0.2
+        expect = (qutip.expect(self.e_ops[0], self.state)
+                  * np.exp(-coupling * (1 - np.exp(-self.times))))
+        collapse_op = qutip.destroy(self.size)
+        # Use partial to allow pickling.
+        collapse_function = functools.partial(_return_decay,
+                                              np.sqrt(coupling),
+                                              0.5)
+        collapse_string = 'sqrt({} * exp(-t))'.format(coupling)
+        c_op_types = [
+            ([collapse_op, collapse_function], "function"),
+            ([collapse_op, collapse_string], "string"),
+        ]
+        cases = []
+        for c_op, id in c_op_types:
+            cases.append(pytest.param(self.h, [c_op], [expect], tol,
+                                      id=id, marks=[pytest.mark.slow]))
+        metafunc.parametrize(['hamiltonian', 'c_ops', 'expected', 'tol'],
+                             cases)
 
 
-def test_MCNoCollFuncStates():
-    "Monte-carlo: Constant H (func format) with no collapse ops (states)"
-    error = 1e-8
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = [a.dag() * a, [a.dag() * a, const_H1_coeff]]
-    psi0 = basis(N, 9)  # initial state
-    c_op_list = []
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [], ntraj=ntraj)
-    states = mcdata.states
-    expt = expect(a.dag() * a, states)
-    actual_answer = 9.0 * np.ones(len(tlist))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
-
-
-def test_MCCollapseTimesOperators():
-    "Monte-carlo: Check for stored collapse operators and times"
-    N = 10
-    kappa = 5.0
+def test_stored_collapse_operators_and_times():
+    """
+    Test that the output contains information on which collapses happened and
+    at what times, and make sure that this information makes sense.
+    """
+    size = 10
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    state = qutip.basis(size, size-1)
     times = np.linspace(0, 10, 100)
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)
-    c_ops = [np.sqrt(kappa) * a, np.sqrt(kappa) * a]
-    result = mcsolve(H, psi0, times, c_ops, [], ntraj=1)
-    assert_(len(result.col_times[0]) > 0)
-    assert_(len(result.col_which) == len(result.col_times))
-    assert_(all([col in [0, 1] for col in result.col_which[0]]))
+    c_ops = [a, a]
+    result = qutip.mcsolve(H, state, times, c_ops, ntraj=1)
+    assert len(result.col_times[0]) > 0
+    assert len(result.col_which) == len(result.col_times)
+    assert all(col in [0, 1] for col in result.col_which[0])
 
 
-@pytest.mark.slow
-def test_MCSimpleConst():
-    "Monte-carlo: Constant H with constant collapse"
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [np.sqrt(kappa) * a]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
+@pytest.mark.parametrize('options', [
+    pytest.param(qutip.Options(average_expect=True), id="average_expect=True"),
+    pytest.param(qutip.Options(average_states=False),
+                 id="average_states=False"),
+])
+def test_expectation_dtype(options):
+    # We're just testing the output value, so it's important whether certain
+    # things are complex or real, but not what the magnitudes of constants are.
+    focks = 5
+    a = qutip.tensor(qutip.destroy(focks), qutip.qeye(2))
+    sm = qutip.tensor(qutip.qeye(focks), qutip.sigmam())
+    H = 1j*a.dag()*sm + a
+    H = H + H.dag()
+    state = qutip.basis([focks, 2], [0, 1])
+    times = np.linspace(0, 10, 5)
+    c_ops = [a, sm]
+    e_ops = [a.dag()*a, sm.dag()*sm, a]
+    data = qutip.mcsolve(H, state, times, c_ops, e_ops, ntraj=5,
+                         options=options)
+    assert isinstance(data.expect[0][1], float)
+    assert isinstance(data.expect[1][1], float)
+    assert isinstance(data.expect[2][1], complex)
 
 
-@pytest.mark.slow
-def test_MCSimpleConstStates():
-    "Monte-carlo: Constant H with constant collapse (states)"
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [np.sqrt(kappa) * a]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [], ntraj=ntraj,
-                     options=Options(average_states=True))
-    assert_(len(mcdata.states) == len(tlist))
-    assert_(isinstance(mcdata.states[0], Qobj))
-    expt = expect(a.dag() * a, mcdata.states)
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
+class TestSeeds:
+    sizes = [6, 6, 6]
+    dampings = [0.1, 0.4, 0.1]
+    ntraj = 25  # Big enough to ensure there are differences without being slow
+    a = [qutip.destroy(size) for size in sizes]
+    H = 1j * (qutip.tensor(a[0], a[1].dag(), a[2].dag())
+              - qutip.tensor(a[0].dag(), a[1], a[2]))
+    state = qutip.tensor(qutip.coherent(sizes[0], np.sqrt(2)),
+                         qutip.basis(sizes[1:], [0, 0]))
+    times = np.linspace(0, 10, 2)
+    c_ops = [
+        np.sqrt(2*dampings[0]) * qutip.tensor(a[0], qutip.qeye(sizes[1:])),
+        (np.sqrt(2*dampings[1])
+         * qutip.tensor(qutip.qeye(sizes[0]), a[1], qutip.qeye(sizes[2]))),
+        np.sqrt(2*dampings[2]) * qutip.tensor(qutip.qeye(sizes[:2]), a[2]),
+    ]
+
+    def test_seeds_can_be_reused(self):
+        args = (self.H, self.state, self.times)
+        kwargs = {'c_ops': self.c_ops, 'ntraj': self.ntraj}
+        first = qutip.mcsolve(*args, **kwargs)
+        options = qutip.Options(seeds=first.seeds)
+        second = qutip.mcsolve(*args, options=options, **kwargs)
+        for first_t, second_t in zip(first.col_times, second.col_times):
+            np.testing.assert_equal(first_t, second_t)
+        for first_w, second_w in zip(first.col_which, second.col_which):
+            np.testing.assert_equal(first_w, second_w)
+
+    def test_seeds_are_not_reused_by_default(self):
+        args = (self.H, self.state, self.times)
+        kwargs = {'c_ops': self.c_ops, 'ntraj': self.ntraj}
+        first = qutip.mcsolve(*args, **kwargs)
+        second = qutip.mcsolve(*args, **kwargs)
+        assert not all(np.array_equal(first_t, second_t)
+                       for first_t, second_t in zip(first.col_times,
+                                                    second.col_times))
+        assert not all(np.array_equal(first_w, second_w)
+                       for first_w, second_w in zip(first.col_which,
+                                                    second.col_which))
 
 
-@pytest.mark.slow
-def test_MCSimpleConstExptStates():
-    "Monte-carlo: Constant H with constant collapse (states)"
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [np.sqrt(kappa) * a]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj,
-                     options=Options(average_states=True, store_states=True))
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    expt1 = mcdata.expect[0]
-    avg_diff = np.mean(abs(actual_answer - expt1) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
-    assert_(len(mcdata.states) == len(tlist))
-    assert_(isinstance(mcdata.states[0], Qobj))
-    expt2 = expect(a.dag() * a, mcdata.states)
-    avg_diff = np.mean(abs(actual_answer - expt2) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
+def test_list_ntraj():
+    """Test that `ntraj` can be a list."""
+    size = 5
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    state = qutip.basis(size, 1)
+    times = np.linspace(0, 0.8, 100)
+    # Arbitrary coupling and bath temperature.
+    coupling = 1 / 0.129
+    n_th = 0.063
+    c_ops = [np.sqrt(coupling * (n_th + 1)) * a,
+             np.sqrt(coupling * n_th) * a.dag()]
+    e_ops = [qutip.num(size)]
+    ntraj = [1, 5, 15, 100]
+    mc = qutip.mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj)
+    assert len(ntraj) == len(mc.expect)
 
 
-@pytest.mark.slow
-def test_MCSimpleSingleCollapse():
-    """Monte-carlo: Constant H with single collapse operator"""
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [np.sqrt(kappa) * a]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
-
-
-@pytest.mark.slow
-def test_MCSimpleSingleExpect():
-    """Monte-carlo: Constant H with single expect operator"""
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [np.sqrt(kappa) * a]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
-
-
-@pytest.mark.slow
-def test_MCSimpleConstFunc():
-    "Monte-carlo: Collapse terms constant (func format)"
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [[a, sqrt_kappa]]
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
-
-
-@pytest.mark.slow
-def test_MCSimpleConstStr():
-    "Monte-carlo: Collapse terms constant (str format)"
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [[a, 'sqrt(k)']]
-    args = {'k': kappa}
-    tlist = np.linspace(0, 10, 100)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], args=args,
-                     ntraj=ntraj)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * tlist)
-    avg_diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(avg_diff < mc_error, True)
-
-
-def test_MCTDFunc():
-    "Monte-carlo: Time-dependent H (func format)"
-    error = 5e-2*4
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [[a, sqrt_kappa2]]
-    tlist = np.linspace(0, 5, 51)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a],
-                     ntraj=ntraj//2)
-    expt = mcdata.expect[0]
-    actual_answer = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
-    diff = np.mean(abs(actual_answer - expt) / actual_answer)
-    assert_equal(diff < error, True)
-
-
-def test_MCTDStr():
-    "Monte-carlo: Time-dependent H (str format)"
-    error = 5e-2*4
-    N = 10  # number of basis states to consider
-    a = destroy(N)
-    H = a.dag() * a
-    psi0 = basis(N, 9)  # initial state
-    kappa = 0.2  # coupling to oscillator
-    c_op_list = [[a, 'sqrt(k*exp(-t))']]
-    args = {'k': kappa}
-    tlist = np.linspace(0, 5, 51)
-    mcdata = mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], args=args,
-                     ntraj=ntraj//2)
-    expt = mcdata.expect[0]
-    actual = 9.0 * np.exp(-kappa * (1.0 - np.exp(-tlist)))
-    diff = np.mean(abs(actual - expt) / actual)
-    assert_equal(diff < error, True)
-
-
-def test_mc_dtypes1():
-    "Monte-carlo: check for correct dtypes (average_states=True)"
-    # set system parameters
-    kappa = 2.0  # mirror coupling
-    gamma = 0.2  # spontaneous emission rate
-    g = 1  # atom/cavity coupling strength
-    wc = 0  # cavity frequency
-    w0 = 0  # atom frequency
-    wl = 0  # driving frequency
-    E = 0.5  # driving amplitude
-    N = 5  # number of cavity energy levels (0->3 Fock states)
-    tlist = np.linspace(0, 10, 5)  # times for expectation values
-    # construct Hamiltonian
-    ida = qeye(N)
-    idatom = qeye(2)
-    a = tensor(destroy(N), idatom)
-    sm = tensor(ida, sigmam())
-    H = (w0 - wl) * sm.dag() * sm + (wc - wl) * a.dag() * a + \
-        1j * g * (a.dag() * sm - sm.dag() * a) + E * (a.dag() + a)
-    # collapse operators
-    C1 = np.sqrt(2 * kappa) * a
-    C2 = np.sqrt(gamma) * sm
-    C1dC1 = C1.dag() * C1
-    C2dC2 = C2.dag() * C2
-    # intial state
-    psi0 = tensor(basis(N, 0), basis(2, 1))
-    opts = Options(average_expect=True)
-    data = mcsolve(
-        H, psi0, tlist, [C1, C2], [C1dC1, C2dC2, a], ntraj=5, options=opts)
-    assert_equal(isinstance(data.expect[0][1], float), True)
-    assert_equal(isinstance(data.expect[1][1], float), True)
-    assert_equal(isinstance(data.expect[2][1], complex), True)
-
-
-def test_mc_dtypes2():
-    "Monte-carlo: check for correct dtypes (average_states=False)"
-    # set system parameters
-    kappa = 2.0  # mirror coupling
-    gamma = 0.2  # spontaneous emission rate
-    g = 1  # atom/cavity coupling strength
-    wc = 0  # cavity frequency
-    w0 = 0  # atom frequency
-    wl = 0  # driving frequency
-    E = 0.5  # driving amplitude
-    N = 5  # number of cavity energy levels (0->3 Fock states)
-    tlist = np.linspace(0, 10, 5)  # times for expectation values
-    # construct Hamiltonian
-    ida = qeye(N)
-    idatom = qeye(2)
-    a = tensor(destroy(N), idatom)
-    sm = tensor(ida, sigmam())
-    H = (w0 - wl) * sm.dag() * sm + (wc - wl) * a.dag() * a + \
-        1j * g * (a.dag() * sm - sm.dag() * a) + E * (a.dag() + a)
-    # collapse operators
-    C1 = np.sqrt(2 * kappa) * a
-    C2 = np.sqrt(gamma) * sm
-    C1dC1 = C1.dag() * C1
-    C2dC2 = C2.dag() * C2
-    # intial state
-    psi0 = tensor(basis(N, 0), basis(2, 1))
-    opts = Options(average_expect=False)
-    data = mcsolve(
-        H, psi0, tlist, [C1, C2], [C1dC1, C2dC2, a], ntraj=5, options=opts)
-    assert_equal(isinstance(data.expect[0][0][1], float), True)
-    assert_equal(isinstance(data.expect[0][1][1], float), True)
-    assert_equal(isinstance(data.expect[0][2][1], complex), True)
-
-
-@pytest.mark.slow
-def test_mc_seed_reuse():
-    "Monte-carlo: check reusing seeds"
-    N0 = 6
-    N1 = 6
-    N2 = 6
-    # damping rates
-    gamma0 = 0.1
-    gamma1 = 0.4
-    gamma2 = 0.1
-    alpha = np.sqrt(2)  # initial coherent state param for mode 0
-    tlist = np.linspace(0, 10, 2)
-    ntraj = 500  # number of trajectories
-    # define operators
-    a0 = tensor(destroy(N0), qeye(N1), qeye(N2))
-    a1 = tensor(qeye(N0), destroy(N1), qeye(N2))
-    a2 = tensor(qeye(N0), qeye(N1), destroy(N2))
-    # number operators for each mode
-    num0 = a0.dag() * a0
-    num1 = a1.dag() * a1
-    num2 = a2.dag() * a2
-    # dissipative operators for zero-temp. baths
-    C0 = np.sqrt(2.0 * gamma0) * a0
-    C1 = np.sqrt(2.0 * gamma1) * a1
-    C2 = np.sqrt(2.0 * gamma2) * a2
-    # initial state: coherent mode 0 & vacuum for modes #1 & #2
-    psi0 = tensor(coherent(N0, alpha), basis(N1, 0), basis(N2, 0))
-    # trilinear Hamiltonian
-    H = 1j * (a0 * a1.dag() * a2.dag() - a0.dag() * a1 * a2)
-    # run Monte-Carlo
-    data1 = mcsolve(H, psi0, tlist, [C0, C1, C2], [num0, num1, num2],
-                    ntraj=ntraj)
-    data2 = mcsolve(H, psi0, tlist, [C0, C1, C2], [num0, num1, num2],
-                    ntraj=ntraj, options=Options(seeds=data1.seeds))
-    for k in range(ntraj):
-        assert_equal(np.allclose(data1.col_times[k],data2.col_times[k]), True)
-        assert_equal(np.allclose(data1.col_which[k],data2.col_which[k]), True)
-
-
-@pytest.mark.slow
-def test_mc_seed_noreuse():
-    "Monte-carlo: check not reusing seeds"
-    N0 = 6
-    N1 = 6
-    N2 = 6
-    # damping rates
-    gamma0 = 0.1
-    gamma1 = 0.4
-    gamma2 = 0.1
-    alpha = np.sqrt(2)  # initial coherent state param for mode 0
-    tlist = np.linspace(0, 10, 2)
-    ntraj = 500  # number of trajectories
-    # define operators
-    a0 = tensor(destroy(N0), qeye(N1), qeye(N2))
-    a1 = tensor(qeye(N0), destroy(N1), qeye(N2))
-    a2 = tensor(qeye(N0), qeye(N1), destroy(N2))
-    # number operators for each mode
-    num0 = a0.dag() * a0
-    num1 = a1.dag() * a1
-    num2 = a2.dag() * a2
-    # dissipative operators for zero-temp. baths
-    C0 = np.sqrt(2.0 * gamma0) * a0
-    C1 = np.sqrt(2.0 * gamma1) * a1
-    C2 = np.sqrt(2.0 * gamma2) * a2
-    # initial state: coherent mode 0 & vacuum for modes #1 & #2
-    psi0 = tensor(coherent(N0, alpha), basis(N1, 0), basis(N2, 0))
-    # trilinear Hamiltonian
-    H = 1j * (a0 * a1.dag() * a2.dag() - a0.dag() * a1 * a2)
-    # run Monte-Carlo
-    data1 = mcsolve(H, psi0, tlist, [C0, C1, C2], [num0, num1, num2],
-                    ntraj=ntraj)
-    data2 = mcsolve(H, psi0, tlist, [C0, C1, C2], [num0, num1, num2],
-                    ntraj=ntraj)
-    diff_flag = False
-    for k in range(ntraj):
-        if len(data1.col_times[k]) != len(data2.col_times[k]):
-            diff_flag = 1
-            break
-        else:
-            if not np.allclose(data1.col_which[k],data2.col_which[k]):
-                diff_flag = 1
-                break
-    assert_equal(diff_flag, 1)
-
-
-@pytest.mark.slow
-def test_mc_ntraj_list():
-    "Monte-carlo: list of trajectories"
-    N = 5
-    a = destroy(N)
-    H = a.dag()*a       # Simple oscillator Hamiltonian
-    psi0 = basis(N, 1)  # Initial Fock state with one photon
-    kappa = 1.0/0.129   # Coupling rate to heat bath
-    nth = 0.063         # Temperature with <n>=0.063
-    # Build collapse operators for the thermal bath
-    c_ops = []
-    c_ops.append(np.sqrt(kappa * (1 + nth)) * a)
-    c_ops.append(np.sqrt(kappa * nth) * a.dag())
-    ntraj = [1, 5, 15, 100]  # number of MC trajectories
-    tlist = np.linspace(0, 0.8, 100)
-    mc = mcsolve(H, psi0, tlist, c_ops, [a.dag()*a], ntraj)
-    assert_equal(len(mc.expect), 4)
-
-
-def f_dargs(t, args):
-    # allows only one collapse
+# Defined in module-scope so it's pickleable.
+def _dynamic(t, args):
     return 0 if args["collapse"] else 1
 
 
-def test_mc_dyn_args():
-    "Monte-carlo: dynamics arguments"
-    N = 5
-    a = destroy(N)
-    H = a.dag()*a       # Simple oscillator Hamiltonian
-    psi0 = basis(N, 2)  # Initial Fock state with one photon
-    c_ops = []
-    c_ops.append([a, f_dargs])
-    c_ops.append([a.dag(), f_dargs])
-    ntraj = [10]  # number of MC trajectories
-    tlist = np.linspace(0, 1, 11)
-    mc = mcsolve(H, psi0, tlist, c_ops, [a.dag()*a],
-                 ntraj, args={"collapse":[]})
-    assert_(all(len(col)<=1 for col in mc.col_which))
+def test_dynamic_arguments():
+    """Test dynamically updated arguments are usable."""
+    size = 5
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    times = np.linspace(0, 1, 11)
+    state = qutip.basis(size, 2)
 
-def H1_coeff(t,args):
-    return t-1
-
-def H2_coeff(t,args):
-    return -t
-
-def test_mc_functd_sum():
-    "Monte-carlo: Test for #490"
-    psi0 = (basis(2,0) + basis(2,1)).unit()
-    H0 = sigmax()
-    H1 = sigmay()
-    H2 = sigmaz()
-
-    h_t = [H0,[H1, H1_coeff],
-           [H2, H2_coeff]]
-    ntraj = 1
-
-    tlist = np.linspace(0, 3, 10)
-    medata = mesolve(h_t, psi0, tlist, [], [], args = {})
-    mcdata = mcsolve(h_t, psi0, tlist, [], [], ntraj = ntraj, args = {})
-    assert_(max([(medata.states[k]-mcdata.states[k]).norm()
-                 for k in range(10)]) < 1e-5)
+    c_ops = [[a, _dynamic], [a.dag(), _dynamic]]
+    mc = qutip.mcsolve(H, state, times, c_ops, ntraj=25, args={"collapse": []})
+    assert all(len(collapses) <= 1 for collapses in mc.col_which)
 
 
-if __name__ == "__main__":
-    run_module_suite()
+def test_regression_490():
+    """Test for regression of gh-490."""
+    h = [qutip.sigmax(),
+         [qutip.sigmay(), lambda t, args: t-1],
+         [qutip.sigmaz(), lambda t, args: -t]]
+    state = (qutip.basis(2, 0) + qutip.basis(2, 1)).unit()
+    times = np.linspace(0, 3, 10)
+    result_me = qutip.mesolve(h, state, times)
+    result_mc = qutip.mcsolve(h, state, times, ntraj=1)
+    for state_me, state_mc in zip(result_me.states, result_mc.states):
+        np.testing.assert_allclose(state_me.full(), state_mc.full(), atol=1e-8)


### PR DESCRIPTION
These are the files that Eric (@Ericgig) was checking in #1181, but the commits are tidied up and rebased onto `master`.  I'll copy over the review comments in that PR that haven't been actioned yet.  The potential merge conflict with `test_mcsolve.py` is fixed.

This is based on #1249, and that one needs to be merged first.

**Changelog**
Major test refactor into a pytest style.
