### PR TITLE
Test skip for 4.5.1 release

### DIFF
--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -34,6 +34,7 @@
 import numpy as np
 import scipy.linalg
 import pytest
+import platform
 import qutip
 from qutip.cy.brtools_checks import (
     _test_zheevr, _test_diag_liou_mult, _test_dense_to_eigbasis,
@@ -42,6 +43,7 @@ from qutip.cy.brtools_checks import (
 )
 
 
+@pytest.mark.skipif("platform.system() == 'Darwin'")
 def test_zheevr():
     """
     zheevr: store eigenvalues in the passed array, and return the eigenvectors

--- a/qutip/tests/test_cavityqed.py
+++ b/qutip/tests/test_cavityqed.py
@@ -44,7 +44,8 @@ from qutip.operators import sigmaz, sigmax
 from qutip.solver import Options
 from qutip.states import basis
 from qutip.tensor import tensor
-
+import platform
+import pytest
 
 class Testcqed:
     """
@@ -132,6 +133,7 @@ class Testcqed:
             fidelity(result, rho1), 1., rtol=1e-2,
             err_msg="Analytical run_state fails in DispersiveCavityQED")
 
+    @pytest.mark.skipif("platform.system() == 'Darwin'")
     def test_numerical_evo(self):
         """
         Test of run_state with qutip solver

--- a/qutip/tests/test_metrics.py
+++ b/qutip/tests/test_metrics.py
@@ -65,6 +65,7 @@ import qutip.settings
 
 import platform
 import unittest
+import pytest
 
 try:
     import cvxpy
@@ -295,6 +296,7 @@ def test_hellinger_inequality():
         assert_(hellinger >= bures)
 
 
+@pytest.mark.skipif("platform.system() == 'Darwin'")
 def test_hellinger_monotonicity():
     """
     Metrics: Hellinger dist.: check monotonicity


### PR DESCRIPTION
The segfault on mac is not fixed yet. @nathanshammah found 3 tests that fails because of it.
Since we don't have a solution comming soon, we are simply skipping these tests for 4.5.1.

This is the error in #1197.

In common with these 3 test is the computation of eigenvalues, 2 of them do it directly with scipy, the last one compare the cython version to the scipy one.