### PR TITLE
Remove incorrect use of 'is' in comparisons

### DIFF
--- a/qutip/lattice.py
+++ b/qutip/lattice.py
@@ -1070,7 +1070,7 @@ class Lattice1d():
             else:
                 Phi_m_k[ks] = 2*np.pi + np.angle(mx_k[ks]+1j*my_k[ks])
 
-        if winding_number is 'defined':
+        if winding_number == 'defined':
             ddk_Phi_m_k = np.roll(Phi_m_k, -1) - Phi_m_k
             intg_over_k = -np.sum(ddk_Phi_m_k[0:knpoints//2])+np.sum(
                     ddk_Phi_m_k[knpoints//2:knpoints])

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -808,7 +808,7 @@ class QobjEvo:
                               if dargs[0] not in new_args]
         self.args.update(new_args)
         self._args_checks()
-        if self.compiled and self.compiled.split()[2] is not "cte":
+        if self.compiled and self.compiled.split()[2] != "cte":
             if isinstance(self.coeff_get, StrCoeff):
                 self.coeff_get.set_args(self.args)
                 self.coeff_get._set_dyn_args(self.dynamics_args)
@@ -826,7 +826,7 @@ class QobjEvo:
                 if self.compiled:
                     self.dynamics_args[i][2].compile()
         self._dynamics_args_update(0., state)
-        if self.compiled and self.compiled.split()[2] is not "cte":
+        if self.compiled and self.compiled.split()[2] != "cte":
             if isinstance(self.coeff_get, StrCoeff):
                 self.coeff_get.set_args(self.args)
                 self.coeff_get._set_dyn_args(self.dynamics_args)
@@ -1092,7 +1092,7 @@ class QobjEvo:
                 for j, op2 in enumerate(self.ops[i+1:]):
                     if op1.type != op2.type:
                         pass
-                    elif op1.type is "array":
+                    elif op1.type == "array":
                         if np.allclose(op1.coeff, op2.coeff):
                             this_set.append(j+i+1)
                     else:
@@ -1117,7 +1117,7 @@ class QobjEvo:
                 new_op[2] = new_op[1]
                 new_ops.append(EvoElement.make(new_op))
 
-            elif self.ops[_set[0]].type is "string":
+            elif self.ops[_set[0]].type == "string":
                 new_op = [self.ops[_set[0]].qobj, None, None, "string"]
                 new_str = "(" + self.ops[_set[0]].coeff + ")"
                 for i in _set[1:]:
@@ -1126,7 +1126,7 @@ class QobjEvo:
                 new_op[2] = new_str
                 new_ops.append(EvoElement.make(new_op))
 
-            elif self.ops[_set[0]].type is "array":
+            elif self.ops[_set[0]].type == "array":
                 new_op = [self.ops[_set[0]].qobj, None, None, "array"]
                 new_array = (self.ops[_set[0]].coeff).copy()
                 for i in _set[1:]:
@@ -1620,7 +1620,7 @@ class QobjEvo:
 
     def __getstate__(self):
         _dict_ = {key: self.__dict__[key]
-                  for key in self.__dict__ if key is not "compiled_qobjevo"}
+                  for key in self.__dict__ if key != "compiled_qobjevo"}
         if self.compiled:
             return (_dict_, self.compiled_qobjevo.__getstate__())
         else:

--- a/qutip/scattering.py
+++ b/qutip/scattering.py
@@ -276,9 +276,9 @@ def temporal_scattered_state(H, psi0, n_emissions, c_ops, tlist,
 
     if construct_effective_hamiltonian:
         # Construct an effective Hamiltonian from system hamiltonian and c_ops
-        if type(H) is Qobj:
+        if isinstance(H, Qobj):
             Heff = H - 1j / 2 * sum([op.dag() * op for op in c_ops])
-        elif type(H) is list:
+        elif isinstance(H, list):
             Heff = H + [-1j / 2 * sum([op.dag() * op for op in c_ops])]
         else:
             raise TypeError("Hamiltonian must be Qobj or list-callback format")

--- a/qutip/utilities.py
+++ b/qutip/utilities.py
@@ -68,7 +68,7 @@ def n_thermal(w, w_th):
 
     """
 
-    if type(w) is np.ndarray:
+    if isinstance(w, np.ndarray):
         return 1.0 / (np.exp(w / w_th) - 1.0)
 
     else:

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -445,7 +445,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     dx = dy = 0.8 * np.ones(n)
     dz = np.real(M.flatten())
 
-    if limits and type(limits) is list and len(limits) == 2:
+    if isinstance(limits, list) and len(limits) == 2:
         z_min = limits[0]
         z_max = limits[1]
     else:
@@ -845,7 +845,7 @@ def plot_wigner(rho, fig=None, ax=None, figsize=(6, 6),
     xvec = np.linspace(-alpha_max, alpha_max, 200)
     W0 = wigner(rho, xvec, xvec, method=method)
 
-    W, yvec = W0 if type(W0) is tuple else (W0, xvec)
+    W, yvec = W0 if isinstance(W0, tuple) else (W0, xvec)
 
     wlim = abs(W).max()
 


### PR DESCRIPTION
Corrects some fragile usage of `is` to compare strings and types.  This may have worked so far, but it's fragile and liable to break (e.g. strings with the same contents will always `==` each other, but they won't always satisfy `string1 is string2`).