### PR TITLE
Fix function `QubitCircuit.add_circuit`

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -383,9 +383,8 @@ class QubitCircuit:
                               gate.arg_label)
             elif gate.name in ["BERKELEY", "SWAPalpha", "SWAP", "ISWAP",
                                "SQRTSWAP", "SQRTISWAP"]:
-                self.add_gate(gate.name, None,
-                              [gate.controls[0] + start,
-                               gate.controls[1] + start], None, None)
+                self.add_gate(gate.name, [gate.targets[0] + start,
+                              gate.targets[1] + start], None, None)
             elif gate.name in ["TOFFOLI"]:
                 self.add_gate(gate.name, gate.targets[0] + start,
                               [gate.controls[0] + start,

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -60,6 +60,16 @@ except ImportError:
 
 __all__ = ['Gate', 'QubitCircuit']
 
+__single_qubit_gates = ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE",
+                        "X", "Y", "Z", "S", "T"]
+__para_gates = ["RX", "RY", "RZ", "CPHASE", "SWAPalpha", "PHASEGATE",
+                "GLOBALPHASE", "CRX", "CRY", "CRZ"]
+__ctrl_gates = ["CNOT", "CSIGN", "CRX", "CRY", "CRZ", "CY", "CZ",
+                "CS", "CT"]
+__swap_like = ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
+               "SWAPalpha"]
+__toffoli_like = ["TOFFOLI"]
+__fredkin_like = ["FREDKIN"]
 
 class Gate:
     """
@@ -106,33 +116,42 @@ class Gate:
                 if not all_integer:
                     raise ValueError("Index of a qubit must be an integer")
 
-        if name in ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
-                    "SWAPalpha"]:
+        if name in __swap_like:
             if (self.targets is None) or (len(self.targets) != 2):
                 raise ValueError("Gate %s requires two targets" % name)
             if self.controls is not None:
                 raise ValueError("Gate %s cannot have a control" % name)
 
-        elif name in ["CNOT", "CSIGN", "CRX", "CRY", "CRZ", "CY", "CZ",
-                      "CS", "CT"]:
+        if name in __ctrl_gates:
             if self.targets is None or len(self.targets) != 1:
                 raise ValueError("Gate %s requires one target" % name)
             if self.controls is None or len(self.controls) != 1:
                 raise ValueError("Gate %s requires one control" % name)
 
-        elif name in ["SNOT", "RX", "RY", "RZ", "PHASEGATE", "X", "Y",
-                      "Z", "S", "T"]:
-            if self.controls is not None:
-                raise ValueError("Gate %s does not take controls" % name)
+        if name in __fredkin_like:
+            if self.targets is None or len(self.targets) != 2:
+                raise ValueError("Gate %s requires one target" % name)
+            if self.controls is None or len(self.controls) != 1:
+                raise ValueError("Gate %s requires two control" % name)
 
-        elif name in ["RX", "RY", "RZ", "CPHASE", "SWAPalpha", "PHASEGATE",
-                      "GLOBALPHASE", "CRX", "CRY", "CRZ"]:
-            if arg_value is None:
-                raise ValueError("Gate %s requires an argument value" % name)
-
-        elif name in ["X", "Y", "Z", "S", "T"]:
+        if name in __toffoli_like:
             if self.targets is None or len(self.targets) != 1:
                 raise ValueError("Gate %s requires one target" % name)
+            if self.controls is None or len(self.controls) != 2:
+                raise ValueError("Gate %s requires two control" % name)
+
+        if name in __para_gates:
+            if arg_value is None:
+                raise ValueError("Gate %s requires an argument value" % name)
+        else:
+            if arg_value is not None:
+                raise ValueError("Gate %s does not take argument value" % name)
+
+        if name in __single_qubit_gates:
+            if self.targets is None or len(self.targets) != 1:
+                raise ValueError("Gate %s requires one target" % name)
+            if self.controls is not None:
+                raise ValueError("Gate %s cannot have a control" % name)
 
         self.arg_value = arg_value
         self.arg_label = arg_label

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -60,16 +60,17 @@ except ImportError:
 
 __all__ = ['Gate', 'QubitCircuit']
 
-__single_qubit_gates = ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE",
+_single_qubit_gates = ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE",
                         "X", "Y", "Z", "S", "T"]
-__para_gates = ["RX", "RY", "RZ", "CPHASE", "SWAPalpha", "PHASEGATE",
+_para_gates = ["RX", "RY", "RZ", "CPHASE", "SWAPalpha", "PHASEGATE",
                 "GLOBALPHASE", "CRX", "CRY", "CRZ"]
-__ctrl_gates = ["CNOT", "CSIGN", "CRX", "CRY", "CRZ", "CY", "CZ",
+_ctrl_gates = ["CNOT", "CSIGN", "CRX", "CRY", "CRZ", "CY", "CZ",
                 "CS", "CT"]
-__swap_like = ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
+_swap_like = ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
                "SWAPalpha"]
-__toffoli_like = ["TOFFOLI"]
-__fredkin_like = ["FREDKIN"]
+_toffoli_like = ["TOFFOLI"]
+_fredkin_like = ["FREDKIN"]
+
 
 class Gate:
     """
@@ -116,42 +117,38 @@ class Gate:
                 if not all_integer:
                     raise ValueError("Index of a qubit must be an integer")
 
-        if name in __swap_like:
+        if name in _single_qubit_gates:
+            if self.targets is None or len(self.targets) != 1:
+                raise ValueError("Gate %s requires one target" % name)
+            if self.controls is not None:
+                raise ValueError("Gate %s cannot have a control" % name)
+        elif name in _swap_like:
             if (self.targets is None) or (len(self.targets) != 2):
                 raise ValueError("Gate %s requires two targets" % name)
             if self.controls is not None:
                 raise ValueError("Gate %s cannot have a control" % name)
-
-        if name in __ctrl_gates:
+        elif name in _ctrl_gates:
             if self.targets is None or len(self.targets) != 1:
                 raise ValueError("Gate %s requires one target" % name)
             if self.controls is None or len(self.controls) != 1:
                 raise ValueError("Gate %s requires one control" % name)
-
-        if name in __fredkin_like:
+        elif name in _fredkin_like:
             if self.targets is None or len(self.targets) != 2:
                 raise ValueError("Gate %s requires one target" % name)
             if self.controls is None or len(self.controls) != 1:
                 raise ValueError("Gate %s requires two control" % name)
-
-        if name in __toffoli_like:
+        elif name in _toffoli_like:
             if self.targets is None or len(self.targets) != 1:
                 raise ValueError("Gate %s requires one target" % name)
             if self.controls is None or len(self.controls) != 2:
                 raise ValueError("Gate %s requires two control" % name)
 
-        if name in __para_gates:
+        if name in _para_gates:
             if arg_value is None:
                 raise ValueError("Gate %s requires an argument value" % name)
         else:
             if arg_value is not None:
                 raise ValueError("Gate %s does not take argument value" % name)
-
-        if name in __single_qubit_gates:
-            if self.targets is None or len(self.targets) != 1:
-                raise ValueError("Gate %s requires one target" % name)
-            if self.controls is not None:
-                raise ValueError("Gate %s cannot have a control" % name)
 
         self.arg_value = arg_value
         self.arg_label = arg_label

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -61,13 +61,13 @@ except ImportError:
 __all__ = ['Gate', 'QubitCircuit']
 
 _single_qubit_gates = ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE",
-                        "X", "Y", "Z", "S", "T"]
+                       "X", "Y", "Z", "S", "T"]
 _para_gates = ["RX", "RY", "RZ", "CPHASE", "SWAPalpha", "PHASEGATE",
-                "GLOBALPHASE", "CRX", "CRY", "CRZ"]
+               "GLOBALPHASE", "CRX", "CRY", "CRZ"]
 _ctrl_gates = ["CNOT", "CSIGN", "CRX", "CRY", "CRZ", "CY", "CZ",
-                "CS", "CT"]
+               "CS", "CT"]
 _swap_like = ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
-               "SWAPalpha"]
+              "SWAPalpha"]
 _toffoli_like = ["TOFFOLI"]
 _fredkin_like = ["FREDKIN"]
 
@@ -147,7 +147,7 @@ class Gate:
             if arg_value is None:
                 raise ValueError("Gate %s requires an argument value" % name)
         else:
-            if arg_value is not None:
+            if (name in _GATE_NAME_TO_LABEL) and (arg_value is not None):
                 raise ValueError("Gate %s does not take argument value" % name)
 
         self.arg_value = arg_value
@@ -564,14 +564,14 @@ class QubitCircuit:
         temp_resolved.append(Gate("RY", gate.targets[0], None,
                                   arg_value=half_pi,
                                   arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets, None,
+        temp_resolved.append(Gate("RX", gate.targets[1], None,
                                   arg_value=np.pi, arg_label=r"\pi"))
         temp_resolved.append(Gate("CNOT", gate.targets[0],
                                   gate.targets[1]))
         temp_resolved.append(Gate("RY", gate.targets[0], None,
                                   arg_value=half_pi,
                                   arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets, None,
+        temp_resolved.append(Gate("RX", gate.targets[1], None,
                                   arg_value=np.pi, arg_label=r"\pi"))
         temp_resolved.append(Gate("GLOBALPHASE", None, None,
                                   arg_value=np.pi, arg_label=r"\pi"))

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -564,14 +564,14 @@ class QubitCircuit:
         temp_resolved.append(Gate("RY", gate.targets[0], None,
                                   arg_value=half_pi,
                                   arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets[1], None,
+        temp_resolved.append(Gate("RX", gate.targets[0], None,
                                   arg_value=np.pi, arg_label=r"\pi"))
         temp_resolved.append(Gate("CNOT", gate.targets[0],
                                   gate.targets[1]))
         temp_resolved.append(Gate("RY", gate.targets[0], None,
                                   arg_value=half_pi,
                                   arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets[1], None,
+        temp_resolved.append(Gate("RX", gate.targets[0], None,
                                   arg_value=np.pi, arg_label=r"\pi"))
         temp_resolved.append(Gate("GLOBALPHASE", None, None,
                                   arg_value=np.pi, arg_label=r"\pi"))

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -263,7 +263,7 @@ class TestQubitCircuit:
         assert_(len(qc1.gates) == len(qc.gates))
 
         # Test each gate
-        for i in range(qc1.gates):
+        for i in range(len(qc1.gates)):
             assert_(qc1.gates[i].name == qc.gates[i].name)
             assert_(qc1.gates[i].targets == qc.gates[i].targets)
             assert_(qc1.gates[i].controls == qc.gates[i].controls)

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -37,8 +37,8 @@ from qutip.qip.operations.gates import (
     gate_sequence_product, rx)
 from qutip.operators import identity
 from qutip.qip.circuit import (
-    QubitCircuit, Gate, __ctrl_gates, __single_qubit_gates, __swap_like, __toffoli_like,
-    __fredkin_like, __para_gates)
+    QubitCircuit, Gate, _ctrl_gates, _single_qubit_gates, _swap_like, _toffoli_like,
+    _fredkin_like, _para_gates)
 from qutip.tensor import tensor
 from qutip.qobj import Qobj, ptrace
 from qutip.random_objects import rand_dm
@@ -193,9 +193,9 @@ class TestQubitCircuit:
         assert_(qc.gates[6].targets == [5])
         assert_(qc.gates[5].arg_value == 1.570796)
 
-        # Test Exceptions
-        for gate in __single_qubit_gates:
-            if gate not in __para_gates:
+        # Test Exceptions  # Global phase is not included
+        for gate in _single_qubit_gates:
+            if gate not in _para_gates:
                 # No target
                 assert_raises(ValueError, qc.add_gate, gate,None,None)
                 # Multiple targets
@@ -209,8 +209,8 @@ class TestQubitCircuit:
                 assert_raises(ValueError, qc.add_gate, gate,[0,1,2],None,1)
                 # With control
                 assert_raises(ValueError, qc.add_gate, gate,[0],[1],1)
-        for gate in __ctrl_gates:
-            if gate not in __para_gates:
+        for gate in _ctrl_gates:
+            if gate not in _para_gates:
                 # No target
                 assert_raises(ValueError, qc.add_gate, gate,None,[1])
                 # No control
@@ -220,8 +220,8 @@ class TestQubitCircuit:
                 assert_raises(ValueError, qc.add_gate, gate,None,[1],1)
                 # No control
                 assert_raises(ValueError, qc.add_gate, gate,[0],None,1)
-        for gate in __swap_like:
-            if gate not in __para_gates:
+        for gate in _swap_like:
+            if gate not in _para_gates:
                 # Single target
                 assert_raises(ValueError, qc.add_gate, gate,[0],None)
                 # With control
@@ -231,12 +231,12 @@ class TestQubitCircuit:
                 assert_raises(ValueError, qc.add_gate, gate,[0],None,1)
                 # With control
                 assert_raises(ValueError, qc.add_gate, gate,[0,1],[3],1)
-        for gate in __fredkin_like:
+        for gate in _fredkin_like:
             # Single target
             assert_raises(ValueError, qc.add_gate, gate,[0],[2])
             # No control
             assert_raises(ValueError, qc.add_gate, gate,[0,1],None)
-        for gate in __toffoli_like:
+        for gate in _toffoli_like:
             # No target
             assert_raises(ValueError, qc.add_gate, gate,None,[1,2])
             # Single control

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -278,7 +278,7 @@ class TestQubitCircuit:
         assert_(len(qc2.gates) == len(qc.gates))
 
         # Test if the positions are correct
-        for i in range(qc2.gates):
+        for i in range(len(qc2.gates)):
             if qc.gates[i].targets is not None:
                 assert_(qc2.gates[i].targets[0] == qc.gates[i].targets[0]+2)
             if qc.gates[i].controls is not None:


### PR DESCRIPTION
The SWAP gates couldn't be added to circuits with `add_circuit`. The function handles the `controls` of the gates while SWAP gates only take the argument `targets`