### PR TITLE
Remove duplicate line in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ REQUIRES = ['numpy (>=1.12)', 'scipy (>=1.0)', 'cython (>=0.21)']
 EXTRAS_REQUIRE = {'graphics':['matplotlib(>=1.2.1)']}
 INSTALL_REQUIRES = ['numpy>=1.12', 'scipy>=1.0', 'cython>=0.21']
 PACKAGES = ['qutip', 'qutip/ui', 'qutip/cy', 'qutip/cy/src',
-            'qutip/qip', 'qutip/qip/device',
             'qutip/qip', 'qutip/qip/device', 'qutip/qip/operations',
             'qutip/qip/compiler',
             'qutip/qip/algorithms', 'qutip/control', 'qutip/nonmarkov',


### PR DESCRIPTION
Removes a duplicate line in `setup.py`, possibly introduced in the merging of #1074.

**Changelog**
too minor to mention