### PR TITLE
Update steadystate.py

### DIFF
--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -266,7 +266,7 @@ def steadystate(A, c_op_list=[], method='direct', solver=None, **kwargs):
 
     # Set weight parameter to avg abs val in L if not set explicitly
     if 'weight' not in kwargs.keys():
-        ss_args['weight'] = np.mean(np.abs(A.data.data.max()))
+        ss_args['weight'] = np.mean(np.abs(A.data).max(0))
         ss_args['info']['weight'] = ss_args['weight']
 
     if ss_args['method'] == 'direct':
@@ -477,7 +477,7 @@ def _steadystate_direct_dense(L, ss_args):
     b[0] = ss_args['weight']
 
     L = L.data.todense()
-    L[0, :] = np.diag(ss_args['weight']*np.ones(n)).reshape((1, n ** 2))
+    L[0, :] += np.diag(ss_args['weight']*np.ones(n)).reshape((1, n ** 2))
     _dense_start = time.time()
     v = np.linalg.solve(L, b)
     _dense_end = time.time()


### PR DESCRIPTION


**Description**
Minor bug fix in steadystate 


**Changelog**
Fix the calculation of the weight to be the actual mean over the rows of the max of the abs of the liouvillian (now it is just the maximum of the abs of all the elements).

Fix the direct dense solver to add weight*T to the first row of the Liouvillian instead of replacing the first row.
