### PR TITLE
Milstein's heterodyne index fix

### DIFF
--- a/qutip/cy/stochastic.pyx
+++ b/qutip/cy/stochastic.pyx
@@ -1749,7 +1749,7 @@ cdef class SMESolver(StochasticSolver):
             for j in range(i, self.num_ops):
                 c_op._mul_vec(t, &b[j,0], &Lb[i,j,0])
                 trAb[i,j] = self.expect(Lb[i,j,:])
-                _axpy(-trAp[j], b[i,:], Lb[i,j,:])
+                _axpy(-trAp[i], b[j,:], Lb[i,j,:])
                 _axpy(-trAb[i,j], rho, Lb[i,j,:])
 
         # L0b La LLb


### PR DESCRIPTION
<!--
**Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.

- [ ] Please read [Contributing to QuTiP Development](https://github.com/qutip/qutip-doc/blob/master/CONTRIBUTING.md)
- [ ] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
- [ ] Please add tests to cover your changes if applicable.
- [ ] If the behavior of the code has changed or new feature has been added, please also update the [documentation](https://github.com/qutip/qutip-doc) and the [notebook](https://github.com/qutip/qutip-notebooks). Feel free to ask if you are not sure.

Delete this checklist after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.
-->

**Description**
Index error in stochastic `smesolve` made `milstein` solver with `heterodyne` method converge only O(0.5) instead of the O(1) expected. This fix it.


**Changelog**
Fixed typo in stochastic code affecting `heterodyne` detection efficiency.
