### PR TITLE
Options default

### DIFF
--- a/qutip/configrc.py
+++ b/qutip/configrc.py
@@ -52,8 +52,8 @@ configparser.ConfigParser.getcomplex = getcomplex
 getter = {
     bool : "getboolean",
     int : "getint",
-    float : "getint",
-    complex : "getint",
+    float : "getfloat",
+    complex : "getcomplex",
     str : "get",
 }
 

--- a/qutip/configrc.py
+++ b/qutip/configrc.py
@@ -54,7 +54,7 @@ sections = [('qutip', qset)]
 
 def full_path(rc_file):
     rc_file = os.path.expanduser(rc_file)
-    if op.path.isabs(rc_file):
+    if os.path.isabs(rc_file):
         return rc_file
     qutip_conf_dir = os.path.join(os.path.expanduser("~"), '.qutip')
     return os.path.join(qutip_conf_dir, rc_file)
@@ -67,7 +67,7 @@ def has_qutip_rc():
     """
     qutip_conf_dir = os.path.join(os.path.expanduser("~"), '.qutip')
     if os.path.exists(qutip_conf_dir):
-        qutip_rc_file = os.path.join(qutip_conf_dir,rc_file)
+        qutip_rc_file = os.path.join(qutip_conf_dir, "qutiprc")
         qrc_exists = os.path.isfile(qutip_rc_file)
         if qrc_exists:
             return True, qutip_rc_file
@@ -83,10 +83,11 @@ def generate_qutiprc(rc_file="qutiprc"):
     """
     # Check for write access to home dir
     qutip_rc_file = full_path(rc_file)
-    qutip_conf_dir = os.path.dirname(rc_file)
+    qutip_conf_dir = os.path.dirname(qutip_rc_file)
     os.makedirs(qutip_conf_dir, exist_ok=True)
 
-    if os.path.isfile(rc_file):
+    if os.path.isfile(qutip_rc_file):
+        config = configparser.ConfigParser()
         config.read(qutip_rc_file)
         modified = False
         for section, settings_object in sections:
@@ -127,7 +128,7 @@ def has_rc_key(key, section=None, rc_file="qutiprc"):
     Verify if key exist in section of rc_file
     """
     rc_file = full_path(rc_file)
-    if not os.path.isfile(rc_file)
+    if not os.path.isfile(rc_file):
         return False
     config = configparser.ConfigParser()
     config.read(rc_file)
@@ -270,7 +271,7 @@ def write_rc_qset(rc_file):
     write_rc_object(rc_file, "qutip", qset)
 
 
-def load_rc_qset(rc_file, section, object):
+def load_rc_qset(rc_file):
     """
     Read qutip.settings to a qutiprc file.
 
@@ -326,7 +327,7 @@ def load_rc_config(rc_file):
                                   + op)
                     # raise Exception('Invalid config variable in qutiprc.')
         else:
-            warnings.warn("Section " section + " not found ")
+            warnings.warn("Section " + section + " not found ")
             # raise configparser.NoSectionError('qutip')
 
     if config.has_section('compiler'):

--- a/qutip/configrc.py
+++ b/qutip/configrc.py
@@ -33,7 +33,6 @@
 import os
 import qutip
 import qutip.settings as qset
-import qutip.solver as def_options
 import warnings
 try:
     import ConfigParser as configparser #py27

--- a/qutip/configrc.py
+++ b/qutip/configrc.py
@@ -198,7 +198,7 @@ def read_rc_key(key, datatype, section='qutip', rc_file="qutiprc"):
         raise ValueError("key not found")
     reader = get_reader(datatype(0), config)
     opts = config.options(section)
-    if not key in opts:
+    if key not in opts:
         raise ValueError("key not found")
     return reader(section, key)
 

--- a/qutip/configrc.py
+++ b/qutip/configrc.py
@@ -34,10 +34,7 @@ import os
 import qutip
 import qutip.settings as qset
 import warnings
-try:
-    import ConfigParser as configparser #py27
-except:
-    import configparser #py3x
+import configparser
 from functools import partial
 
 

--- a/qutip/configrc.py
+++ b/qutip/configrc.py
@@ -33,11 +33,32 @@
 import os
 import qutip
 import qutip.settings as qset
+import qutip.solver as def_options
 import warnings
 try:
     import ConfigParser as configparser #py27
 except:
     import configparser #py3x
+from functools import partial
+
+
+def getcomplex(self, section, option):
+    return complex(self.get(section, option))
+
+
+configparser.ConfigParser.getcomplex = getcomplex
+
+
+sections = [('qutip', qset)]
+
+
+def full_path(rc_file):
+    rc_file = os.path.expanduser(rc_file)
+    if op.path.isabs(rc_file):
+        return rc_file
+    qutip_conf_dir = os.path.join(os.path.expanduser("~"), '.qutip')
+    return os.path.join(qutip_conf_dir, rc_file)
+
 
 def has_qutip_rc():
     """
@@ -46,8 +67,8 @@ def has_qutip_rc():
     """
     qutip_conf_dir = os.path.join(os.path.expanduser("~"), '.qutip')
     if os.path.exists(qutip_conf_dir):
-        qutip_rc_file = os.path.join(qutip_conf_dir,'qutiprc')
-        qrc_exists = os.path.isfile(qutip_rc_file) 
+        qutip_rc_file = os.path.join(qutip_conf_dir,rc_file)
+        qrc_exists = os.path.isfile(qutip_rc_file)
         if qrc_exists:
             return True, qutip_rc_file
         else:
@@ -56,34 +77,233 @@ def has_qutip_rc():
         return False, ''
 
 
-def generate_qutiprc():
+def generate_qutiprc(rc_file="qutiprc"):
     """
     Generate a blank qutiprc file.
     """
     # Check for write access to home dir
-    if not os.access(os.path.expanduser("~"), os.W_OK):
-        return False
-    qutip_conf_dir = os.path.join(os.path.expanduser("~"), '.qutip')
-    if not os.path.exists(qutip_conf_dir):
-        try:
-            os.mkdir(qutip_conf_dir)
-        except:
-            warnings.warn('Cannot write config file to user home dir.')
-            return False
-    qutip_rc_file = os.path.join(qutip_conf_dir,'qutiprc')
-    qrc_exists = os.path.isfile(qutip_rc_file)
-    if qrc_exists:
-        #Do not overwrite
-        return False
-    else:
-        #Write a basic file with qutip section
-        cfgfile = open(qutip_rc_file,'w')
+    qutip_rc_file = full_path(rc_file)
+    qutip_conf_dir = os.path.dirname(rc_file)
+    os.makedirs(qutip_conf_dir, exist_ok=True)
+
+    if os.path.isfile(rc_file):
+        config.read(qutip_rc_file)
+        modified = False
+        for section, settings_object in sections:
+            if not config.has_section(section):
+                config.add_section(section)
+                modified = True
+        if modified:
+            with open(qutip_rc_file, 'w') as cfgfile:
+                config.write(cfgfile)
+
+        return modified
+
+    with open(qutip_rc_file,'w') as cfgfile:
         config = configparser.ConfigParser()
-        config.add_section('qutip')
+        for section, settings_object in sections:
+            config.add_section(section)
         config.write(cfgfile)
-        cfgfile.close()
-        return True 
-        
+    return True
+
+
+def get_reader(val, config):
+    # The type of the read value is the same as the one presently loaded.
+    if isinstance(val, bool):
+        reader = config.getboolean
+    elif isinstance(val, int):
+        reader = config.getint
+    elif isinstance(val, float):
+        reader = config.getfloat
+    elif isinstance(val, complex):
+        reader = config.getcomplex
+    elif isinstance(val, str):
+        reader = config.get
+    return reader
+
+
+def has_rc_key(key, section=None, rc_file="qutiprc"):
+    """
+    Verify if key exist in section of rc_file
+    """
+    rc_file = full_path(rc_file)
+    if not os.path.isfile(rc_file)
+        return False
+    config = configparser.ConfigParser()
+    config.read(rc_file)
+    if section is None:
+        search_sections = [section for section, _ in sections]
+    else:
+        search_sections = [section]
+    for section in search_sections:
+        if config.has_section(section):
+            opts = config.options(section)
+            if key in opts:
+                return True
+    return False
+
+
+def write_rc_key(key, value, section='qutip', rc_file="qutiprc"):
+    """
+    Writes a single key value to the qutiprc file
+
+    Parameters
+    ----------
+    key : str
+        The key name to be written.
+    value : int/float/bool
+        Value corresponding to given key.
+    section : str
+        String for which settings object the key belong to.
+        Default : qutip
+    rc_file : str
+        String specifying file location.
+        Default : qutiprc
+    """
+    rc_file = full_path(rc_file)
+    if not os.access(rc_file, os.W_OK):
+        warnings.warn("Does not have permissions to write config file")
+        return
+    config = configparser.ConfigParser()
+    config.read(rc_file)
+    if not config.has_section(section):
+        config.add_section(section)
+    config.set(section, key, str(value))
+
+    with open(rc_file, 'w') as cfgfile:
+        config.write(cfgfile)
+
+
+def read_rc_key(key, datatype, section='qutip', rc_file="qutiprc"):
+    """
+    Writes a single key value to the qutiprc file
+
+    Parameters
+    ----------
+    key : str
+        The key name to be written.
+    datatype :
+        Type of the value corresponding to given key.
+        One of [int, float, bool, complex, str]
+    section : str
+        String for which settings object the key belong to.
+    rc_file : str
+        String specifying file location.
+    """
+    rc_file = full_path(rc_file)
+    config = configparser.ConfigParser()
+    config.read(rc_file)
+    if not config.has_section(section):
+        raise ValueError("key not found")
+    reader = get_reader(datatype(0), config)
+    opts = config.options(section)
+    if not key in opts:
+        raise ValueError("key not found")
+    return reader(section, key)
+
+
+def write_rc_object(rc_file, section, object):
+    """
+    Writes all keys and values corresponding to one object qutiprc file.
+
+    Parameters
+    ----------
+    rc_file : str
+        String specifying file location.
+    section : str
+        Tags for the saved data.
+    object : Object
+        Object to save. All attribute's type must be one of bool, int, float,
+        complex, str.
+    """
+    generate_qutiprc(rc_file)
+    config = configparser.ConfigParser()
+    config.read(full_path(rc_file))
+    if not config.has_section(section):
+        config.add_section(section)
+    keys = object.__all
+    for key in keys:
+        config.set(section, key, str(getattr(object, key)))
+    with open(full_path(rc_file), 'w') as cfgfile:
+        config.write(cfgfile)
+    return
+
+
+def load_rc_object(rc_file, section, object):
+    """
+    Read keys and values corresponding to one settings location
+    to the qutiprc file.
+
+    Parameters
+    ----------
+    rc_file : str
+        String specifying file location.
+    section : str
+        Tags for the saved data.
+    object : Object
+        Object to overwrite. All attribute's type must be one of bool, int,
+        float, complex, str.
+    """
+    config = configparser.ConfigParser()
+    config.read(full_path(rc_file))
+    if not config.has_section(section):
+        raise configparser.NoSectionError(section)
+    keys = object.__all
+    opts = config.options(section)
+    for op in opts:
+        if op in keys:
+            reader = get_reader(getattr(object, op), config)
+            setattr(object, op, reader(section, op))
+        else:
+            warnings.warn("Invalid qutip config variable in qutiprc: " + op)
+
+
+def write_rc_qset(rc_file):
+    """
+    Writes qutip.settings in a qutiprc file.
+
+    Parameters
+    ----------
+    rc_file : str
+        String specifying file location.
+    """
+    write_rc_object(rc_file, "qutip", qset)
+
+
+def load_rc_qset(rc_file, section, object):
+    """
+    Read qutip.settings to a qutiprc file.
+
+    Parameters
+    ----------
+    rc_file : str
+        String specifying file location.
+    """
+    load_rc_object(rc_file, "qutip", qset)
+
+
+def write_rc_config(rc_file):
+    """
+    Writes all keys and values to the qutiprc file.
+
+    Parameters
+    ----------
+    rc_file : str
+        String specifying file location.
+    """
+    generate_qutiprc(rc_file)
+
+    config = configparser.ConfigParser()
+    config.read(full_path(rc_file))
+    for section, settings_object in sections:
+        keys = settings_object.__all
+        for key in keys:
+            config.set(section, key, str(getattr(settings_object, key)))
+
+    with open(full_path(rc_file), 'w') as cfgfile:
+        config.write(cfgfile)
+    return
+
 
 def load_rc_config(rc_file):
     """
@@ -91,22 +311,24 @@ def load_rc_config(rc_file):
     qutiprc file
     """
     config = configparser.ConfigParser()
-    _valid_keys ={'auto_tidyup' : config.getboolean, 'auto_herm' : config.getboolean, 
-            'atol': config.getfloat, 'auto_tidyup_atol' : config.getfloat,
-            'num_cpus' : config.getint, 'debug' : config.getboolean, 
-            'log_handler' : config.getboolean, 'colorblind_safe' : config.getboolean,
-            'openmp_thresh': config.getint}
-    config.read(rc_file)
-    if config.has_section('qutip'):
-        opts = config.options('qutip')
-        for op in opts:
-            if op in _valid_keys.keys():
-                setattr(qset, op, _valid_keys[op]('qutip',op))
-            else:
-                raise Exception('Invalid config variable in qutiprc.')
-    else:
-        raise configparser.NoSectionError('qutip')
-        
+    config.read(full_path(rc_file))
+    for section, settings_object in sections:
+        if config.has_section(section):
+            keys = settings_object.__all
+            opts = config.options(section)
+            for op in opts:
+                if op in keys:
+                    reader = get_reader(getattr(settings_object, op), config)
+                    setattr(settings_object, op,
+                            reader(section, op))
+                else:
+                    warnings.warn("Invalid qutip config variable in qutiprc: "
+                                  + op)
+                    # raise Exception('Invalid config variable in qutiprc.')
+        else:
+            warnings.warn("Section " section + " not found ")
+            # raise configparser.NoSectionError('qutip')
+
     if config.has_section('compiler'):
         _valid_keys = ['CC', 'CXX']
         opts = config.options('compiler')
@@ -115,42 +337,6 @@ def load_rc_config(rc_file):
             if up_op in _valid_keys:
                 os.environ[up_op] = config.get('compiler', op)
             else:
-                raise Exception('Invalid config variable in qutiprc.')
- 
- 
-def has_rc_key(rc_file, key):
-    config = configparser.ConfigParser()
-    config.read(rc_file)
-    if config.has_section('qutip'):
-        opts = config.options('qutip')
-        if key in opts:
-            return True
-        else:
-            return False
-    else:
-        raise configparser.NoSectionError('qutip')
-       
-        
-def write_rc_key(rc_file, key, value):
-    """
-    Writes a single key value to the qutiprc file
-    
-    Parameters
-    ----------
-    rc_file : str
-        String specifying file location.
-    key : str
-        The key name to be written.
-    value : int/float/bool
-        Value corresponding to given key.
-    """
-    if not os.access(os.path.expanduser("~"), os.W_OK):
-        return
-    cfgfile = open(rc_file,'w')
-    config = configparser.ConfigParser()
-    if not config.has_section('qutip'):
-        config.add_section('qutip')
-    config.set('qutip',key,str(value))
-    config.write(cfgfile)
-    cfgfile.close()
-    
+                # raise Exception('Invalid config variable in qutiprc.')
+                warnings.warn("Invalid compiler config variable in qutiprc: "
+                              + op)

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -97,12 +97,13 @@ def _valid_config(key):
         return True
     return False
 
+
 _environment_keys = ["ipython", 'has_mkl', 'has_openmp',
                      'mkl_lib', 'fortran', 'num_cpus']
 __self = locals().copy()  # Not ideal, making an object would be better
 __all_out = [key for key in __self if _valid_config(key)]
 __all = [key for key in __all_out if key not in _environment_keys]
-__default = {key:__self[key] for key in __all}
+__default = {key: __self[key] for key in __all}
 __section = "qutip"
 del _valid_config
 __self = locals()
@@ -150,7 +151,7 @@ def reset():
         num_cpus = int(os.environ['QUTIP_NUM_PROCESSES'])
     elif 'cpus' in info:
         import qutip.hardware_info
-        info =  qutip.hardware_info.hardware_info()
+        info = qutip.hardware_info.hardware_info()
         num_cpus = info['cpus']
     else:
         try:

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -180,7 +180,7 @@ def reset():
     _set_mkl()
 
 
-def list():
+def print_settings():
     out = "qutip settings:\n"
     longest = max(len(key) for key in _all_out)
     for key in _all_out:
@@ -188,7 +188,7 @@ def list():
     return out
 
 
-def QtOptionClass(name):
+def optionclass(name):
     """Make the class an Options object of Qutip and register the object
     default as qutip.settings."name".
 
@@ -276,13 +276,12 @@ class _QtOptionMaker:
         attributes_set = ["    self.{0} = {0} if {0} is not None "
                           "else self._defaultInstance.{0}".format(var)
                           for var in _all_set]
-        code = ["def __init__(self, file='', *,"] + \
-            attributes_kw + \
-            ["            ):"] + \
-            attributes_set + \
-            ["    if file:"] + \
-            ["        self.load(file)"]
-        code = "\n".join(code)
+        code = f"""
+def __init__(self, file='', *, {", ".join(attributes_kw)}):
+    {"\n    ".join(attributes_set)}
+    if file:
+        self.load(file)
+"""
         ns = {}
         exec(code, globals(), ns)
         cls.__init__ = ns["__init__"]

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -270,15 +270,16 @@ class _QtOptionMaker:
         # __init__ is dynamically build to get a meaningful signature
         _all_set = [key for key in cls.__dict__
                     if self._valid(cls, key, _set=True)]
-        attributes_kw = ["             {}=None,".format(var)
-                         for var in _all_set]
-        attributes_kw[-1] = attributes_kw[-1][:-1]
-        attributes_set = ["    self.{0} = {0} if {0} is not None "
+        attributes_kw = ",\n             ".join(["{}=None".format(var)
+                         for var in _all_set])
+        #attributes_kw[-1] = attributes_kw[-1][:-1]
+        attributes_set = "".join(["\n    self.{0} = {0} if {0} is not None "
                           "else self._defaultInstance.{0}".format(var)
-                          for var in _all_set]
+                          for var in _all_set])
         code = f"""
-def __init__(self, file='', *, {", ".join(attributes_kw)}):
-    {"\n    ".join(attributes_set)}
+def __init__(self, file='', *,
+             {attributes_kw}):
+    {attributes_set}
     if file:
         self.load(file)
 """

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -252,10 +252,10 @@ class _QtOptionMaker:
 
         # attributes that to be saved
         cls._all = [key for key in cls.__dict__
-                       if self._valid(cls, key)]
+                    if self._valid(cls, key)]
         # attributes to print
         cls._repr_keys = [key for key in cls.__dict__
-                             if self._valid(cls, key, _repr=True)]
+                          if self._valid(cls, key, _repr=True)]
         # Name in settings and in files
         cls._name = self.name
         # Name when printing
@@ -269,7 +269,7 @@ class _QtOptionMaker:
         # add methods
         # __init__ is dynamically build to get a meaningful signature
         _all_set = [key for key in cls.__dict__
-             if self._valid(cls, key, _set=True)]
+                    if self._valid(cls, key, _set=True)]
         attributes_kw = ["             {}=None,".format(var)
                          for var in _all_set]
         attributes_kw[-1] = attributes_kw[-1][:-1]
@@ -277,11 +277,11 @@ class _QtOptionMaker:
                           "else self._defaultInstance.{0}".format(var)
                           for var in _all_set]
         code = ["def __init__(self, file='', *,"] + \
-               attributes_kw + \
-               ["            ):"] + \
-               attributes_set + \
-               ["    if file:"] + \
-               ["        self.load(file)"]
+            attributes_kw + \
+            ["            ):"] + \
+            attributes_set + \
+            ["    if file:"] + \
+            ["        self.load(file)"]
         code = "\n".join(code)
         ns = {}
         exec(code, globals(), ns)
@@ -320,7 +320,6 @@ class _QtOptionMaker:
         qrc.sections.append((self.name, default))
 
 
-
 def _qoc_repr_(self):
     out = self._fullname + ":\n"
     longest = max(len(key) for key in self._repr_keys)
@@ -328,6 +327,7 @@ def _qoc_repr_(self):
         out += "{:{width}} : {}\n".format(key, getattr(self, key),
                                           width=longest)
     return out
+
 
 def _qoc_reset(self):
     """Reset instance to the default value or the default to Qutip's default"""
@@ -338,10 +338,12 @@ def _qoc_reset(self):
         [setattr(self, key, getattr(self._defaultInstance, key))
          for key in self._all]
 
+
 def _qoc_save(self, file="qutiprc"):
     """Save to desired file. 'qutiprc' if not specified"""
     import qutip.configrc as qrc
     qrc.write_rc_object(file, self._name, self)
+
 
 def _qoc_load(self, file="qutiprc"):
     """Load from desired file. 'qutiprc' if not specified"""

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -267,15 +267,14 @@ class _QtOptionMaker:
         self._make_default(cls)
 
         # add methods
-        # __init__ is dynamically build to get a meaningful signature
+        # __init__ is dynamically build to get a meaningfusl signature
         _all_set = [key for key in cls.__dict__
                     if self._valid(cls, key, _set=True)]
         attributes_kw = ",\n             ".join(["{}=None".format(var)
-                         for var in _all_set])
-        #attributes_kw[-1] = attributes_kw[-1][:-1]
+                        for var in _all_set])
         attributes_set = "".join(["\n    self.{0} = {0} if {0} is not None "
-                          "else self._defaultInstance.{0}".format(var)
-                          for var in _all_set])
+                         "else self._defaultInstance.{0}".format(var)
+                         for var in _all_set])
         code = f"""
 def __init__(self, file='', *,
              {attributes_kw}):

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -332,7 +332,7 @@ def _qoc_repr_(self):
 def _qoc_reset(self):
     """Reset instance to the default value or the default to Qutip's default"""
     if self._isDefault:
-        [setattr(self, key,getattr(self.__class__, key))
+        [setattr(self, key, getattr(self.__class__, key))
          for key in self._all]
     else:
         [setattr(self, key, getattr(self._defaultInstance, key))

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -141,7 +141,7 @@ class ExpectOps:
         return bool(self.e_num)
 
 
-@qset.QtOptionClass("options")
+@qset.optionclass("options")
 class Options:
     """
     Class of options for evolution solvers such as :func:`qutip.mesolve` and

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -255,6 +255,7 @@ class Options:
     norm_steps = 5
     # Use preexisting RHS function for time-dependent solvers
     rhs_reuse = False
+
     # Use filename for preexisting RHS function (will default to last
     # compiled function if None & rhs_exists=True)
     @property
@@ -277,6 +278,7 @@ class Options:
     store_states = False
     # average mcsolver density matricies assuming steady state evolution
     steady_state_average = False
+
     # Holds seeds for rand num gen
     @property
     def seeds(self):
@@ -290,6 +292,7 @@ class Options:
     # Normalize output of solvers
     # (turned off for batch unitary propagator mode)
     normalize_output = True
+
     # Use OPENMP for sparse matrix vector multiplication
     @property
     def use_openmp(self):

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -141,7 +141,8 @@ class ExpectOps:
         return bool(self.e_num)
 
 
-class Options(qset._QtConfig):
+@qset.QtOptionClass("options")
+class Options:
     """
     Class of options for evolution solvers such as :func:`qutip.mesolve` and
     :func:`qutip.mcsolve`. Options can be specified either as arguments to the
@@ -155,6 +156,10 @@ class Options(qset._QtConfig):
         opts.order = 10
 
     Returns options class to be used as options in evolution solvers.
+
+    The default can be changed by::
+
+        qutip.settings.options.order = 10
 
     Attributes
     ----------
@@ -299,9 +304,6 @@ class Options(qset._QtConfig):
     openmp_threads = qset.num_cpus
     # small value in mc solver for computing correlations
     mc_corr_eps = 1e-10
-
-
-qset._register(Options, "options")
 
 
 class Result():

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -141,7 +141,7 @@ class ExpectOps:
         return bool(self.e_num)
 
 
-class Options():
+class Options(qset._QtConfig):
     """
     Class of options for evolution solvers such as :func:`qutip.mesolve` and
     :func:`qutip.mcsolve`. Options can be specified either as arguments to the
@@ -217,111 +217,91 @@ class Options():
         None means auto check.
 
     """
+    # Absolute tolerance (default = 1e-8)
+    atol = 1e-8
+    # Relative tolerance (default = 1e-6)
+    rtol = 1e-6
+    # Integration method (default = 'adams', for stiff 'bdf')
+    method = 'adams'
+    # Maximum order used by integrator (<=12 for 'adams', <=5 for 'bdf')
+    order = 12
+    # Max. number of internal steps/call
+    nsteps = 1000
+    # Size of initial step (0 = determined by solver)
+    first_step = 0
+    # Max step size (0 = determined by solver)
+    max_step = 0
+    # Minimal step size (0 = determined by solver)
+    min_step = 0
+    # Average expectation values over trajectories (default = True)
+    average_expect = True
+    # average expectation values
+    average_states = False
+    # tidyup Hamiltonian before calculation (default = True)
+    tidy = True
+    # Number of processors to use (mcsolve only)
+    num_cpus = qset.num_cpus
+    # Tolerance for wavefunction norm (mcsolve only)
+    norm_tol = 1e-3
+    # Tolerance for collapse time precision (mcsolve only)
+    norm_t_tol = 1e-6
+    # Max. number of steps taken to find wavefunction norm to within
+    # norm_tol (mcsolve only)
+    norm_steps = 5
+    # Use preexisting RHS function for time-dependent solvers
+    rhs_reuse = False
+    # Use filename for preexisting RHS function (will default to last
+    # compiled function if None & rhs_exists=True)
+    @property
+    def rhs_filename(self):
+        return self._rhs_filename
 
-    def __init__(self, atol=1e-8, rtol=1e-6, method='adams', order=12,
-                 nsteps=1000, first_step=0, max_step=0, min_step=0,
-                 average_expect=True, average_states=False, tidy=True,
-                 num_cpus=0, norm_tol=1e-3, norm_t_tol=1e-6, norm_steps=5,
-                 rhs_reuse=False, rhs_filename=None, ntraj=500, gui=False,
-                 rhs_with_state=False, store_final_state=False,
-                 store_states=False, steady_state_average=False,
-                 seeds=None,
-                 normalize_output=True, use_openmp=None, openmp_threads=None):
-        # Absolute tolerance (default = 1e-8)
-        self.atol = atol
-        # Relative tolerance (default = 1e-6)
-        self.rtol = rtol
-        # Integration method (default = 'adams', for stiff 'bdf')
-        self.method = method
-        # Max. number of internal steps/call
-        self.nsteps = nsteps
-        # Size of initial step (0 = determined by solver)
-        self.first_step = first_step
-        # Minimal step size (0 = determined by solver)
-        self.min_step = min_step
-        # Max step size (0 = determined by solver)
-        self.max_step = max_step
-        # Maximum order used by integrator (<=12 for 'adams', <=5 for 'bdf')
-        self.order = order
-        # Average expectation values over trajectories (default = True)
-        self.average_states = average_states
-        # average expectation values
-        self.average_expect = average_expect
-        # Number of trajectories (default = 500)
-        self.ntraj = ntraj
-        # Holds seeds for rand num gen
-        self.seeds = seeds
-        # tidyup Hamiltonian before calculation (default = True)
-        self.tidy = tidy
-        # include the state in the function callback signature
-        self.rhs_with_state = rhs_with_state
-        # Use preexisting RHS function for time-dependent solvers
-        self.rhs_reuse = rhs_reuse
-        # Use filename for preexisting RHS function (will default to last
-        # compiled function if None & rhs_exists=True)
-        self.rhs_filename = rhs_filename
-        # small value in mc solver for computing correlations
-        self.mc_corr_eps = 1e-10
-        # Number of processors to use (mcsolve only)
-        if num_cpus:
-            self.num_cpus = num_cpus
-        else:
-            self.num_cpus = qset.num_cpus
-        # Tolerance for wavefunction norm (mcsolve only)
-        self.norm_tol = norm_tol
-        # Tolerance for collapse time precision (mcsolve only)
-        self.norm_t_tol = norm_t_tol
-        # Max. number of steps taken to find wavefunction norm to within
-        # norm_tol (mcsolve only)
-        self.norm_steps = norm_steps
-        # Number of threads for openmp
-        if openmp_threads is None:
-            self.openmp_threads = qset.num_cpus
-        else:
-            self.openmp_threads = openmp_threads
-        # store final state?
-        self.store_final_state = store_final_state
-        # store states even if expectation operators are given?
-        self.store_states = store_states
-        # average mcsolver density matricies assuming steady state evolution
-        self.steady_state_average = steady_state_average
-        # Normalize output of solvers
-        # (turned off for batch unitary propagator mode)
-        self.normalize_output = normalize_output
-        # Use OPENMP for sparse matrix vector multiplication
-        self.use_openmp = use_openmp
+    @rhs_filename.setter
+    def rhs_filename(self, val):
+        self._rhs_filename = val
 
-    def __str__(self):
-        if self.seeds is None:
-            seed_length = 0
-        else:
-            seed_length = len(self.seeds)
-        s = ""
-        s += "Options:\n"
-        s += "-----------\n"
-        s += "atol:              " + str(self.atol) + "\n"
-        s += "rtol:              " + str(self.rtol) + "\n"
-        s += "method:            " + str(self.method) + "\n"
-        s += "order:             " + str(self.order) + "\n"
-        s += "nsteps:            " + str(self.nsteps) + "\n"
-        s += "first_step:        " + str(self.first_step) + "\n"
-        s += "min_step:          " + str(self.min_step) + "\n"
-        s += "max_step:          " + str(self.max_step) + "\n"
-        s += "tidy:              " + str(self.tidy) + "\n"
-        s += "num_cpus:          " + str(self.num_cpus) + "\n"
-        s += "norm_tol:          " + str(self.norm_tol) + "\n"
-        s += "norm_steps:        " + str(self.norm_steps) + "\n"
-        s += "rhs_filename:      " + str(self.rhs_filename) + "\n"
-        s += "rhs_reuse:         " + str(self.rhs_reuse) + "\n"
-        s += "seeds:             " + str(seed_length) + "\n"
-        s += "rhs_with_state:    " + str(self.rhs_with_state) + "\n"
-        s += "average_expect:    " + str(self.average_expect) + "\n"
-        s += "average_states:    " + str(self.average_states) + "\n"
-        s += "ntraj:             " + str(self.ntraj) + "\n"
-        s += "store_states:      " + str(self.store_states) + "\n"
-        s += "store_final_state: " + str(self.store_final_state) + "\n"
+    _rhs_filename = None
+    # Number of trajectories (default = 500)
+    ntraj = 500
+    gui = False
+    # include the state in the function callback signature
+    rhs_with_state = False
+    # store final state?
+    store_final_state = False
+    # store states even if expectation operators are given?
+    store_states = False
+    # average mcsolver density matricies assuming steady state evolution
+    steady_state_average = False
+    # Holds seeds for rand num gen
+    @property
+    def seeds(self):
+        return self._seeds
 
-        return s
+    @seeds.setter
+    def seeds(self, val):
+        self._seeds = val
+
+    _seeds = None
+    # Normalize output of solvers
+    # (turned off for batch unitary propagator mode)
+    normalize_output = True
+    # Use OPENMP for sparse matrix vector multiplication
+    @property
+    def use_openmp(self):
+        return self._use_openmp
+
+    @use_openmp.setter
+    def use_openmp(self, val):
+        self._use_openmp = val
+
+    _use_openmp = None
+    # Number of threads for openmp
+    openmp_threads = qset.num_cpus
+    # small value in mc solver for computing correlations
+    mc_corr_eps = 1e-10
+
+
+qset._register(Options, "options")
 
 
 class Result():


### PR DESCRIPTION
**Description**
User-facing changes:
- Solver's `Options` defaults can be set `qutip.settings.options`.
- Add the `save`, `load`, `reset` method to Options.
- The default `Options` are read from "qutiprc" when loading qutip.
- Options object can be initiated from a saved configuration.

Example:
```
import qutip.setting as qset
from qutip.solver import Options
qset.options.atol = 1e-10
qset.options.max_step = 1
qset.save()
print(Options().atol)
>>> 1e-10
```
`atol = 1e-10` and `max_step = 1` will be kept as default in future sessions. `qset.options.reset` to go back to qutip's default.

I believe that loading custom settings when importing qutip will be appreciated with support of both `dense` and `sparse` most researchers will have a preference depending on their domain.

This also brings all settings in one place: `qutip.settings...` even if we split the code in "core", "solver", "qip?", etc.  Lastly, creating and moving around an `Options` object is no longer needed, changing the default before using the solver has the same effect. 

For developers:
Principally @jakelishman as I expect you to add settings for core. 
I went with an implementation similar to python `dataclass`. To add `core`'s settings to `qutip.settings` you would do "
```
from qutip.settings import QtOptionClass

@QtOptionClass("core")
class CoreOptions:
     basetype = "Dense"
     auto_tidyup = True
     ...
```
And it would create the `__init__`, `__repr__`, `save`, `load` and `reset` methods, and create the default instance as `qutip.settings.core`. All attributes that do not start with "_" and are one of `bool`, `str`, `int`, `float`, `complex` will be in tagged to be saved and loaded. Those are the only types available now, but other can be added if needed. In `__init__` all these + properties with a setter can be initiated as keyword arguments. '__repr__' 'print' all the saved attributes and properties.
This is for the likes of `has_openmp`, I would make it a read only property.

Another way of doing this would have been to use a parent class and a "register" functions. I went with this one because the signature of `__init__` in help was cleaner. I have both implemented so if qip of control want to use the base without registering to `qutip.settings`, I can change the PR. (@ajgpitch, @BoxiLi )

Build on top of #1289. 


**Changelog**
Solver options can be set in `qutip.settings.options`.
