### PR TITLE
Fix brtools zheevr test

### DIFF
--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -49,11 +49,18 @@ def test_zheevr():
     """
     for dimension in range(2, 100):
         H = qutip.rand_herm(dimension, 1/dimension)
-        our_evals = np.zeros(dimension, dtype=np.float64)
-        our_evecs = _test_zheevr(H.full('F'), our_evals)
-        scipy_evals, scipy_evecs = scipy.linalg.eigh(H.full())
-        np.testing.assert_allclose(scipy_evals, our_evals, atol=1e-12)
-        np.testing.assert_allclose(scipy_evecs, our_evecs, atol=1e-12)
+        Hf = H.full()
+        evals = np.zeros(dimension, dtype=np.float64)
+        # This routine modifies its arguments inplace, so we must make a copy.
+        evecs = _test_zheevr(Hf.copy(order='F'), evals).T
+        # Assert linear independence of all the eigenvectors.
+        assert abs(scipy.linalg.det(evecs)) > 1e-12
+        for value, vector in zip(evals, evecs):
+            # Assert the eigenvector satisfies the eigenvalue equation.
+            unit = vector / scipy.linalg.norm(vector)
+            test_value = np.conj(unit.T) @ Hf @ unit
+            assert abs(test_value.imag) < 1e-12
+            assert abs(test_value - value) < 1e-12
 
 
 @pytest.mark.parametrize("operator", [


### PR DESCRIPTION
The new test explicitly checks the eigenvalue equation for each generated eigenvalue/vector pair, and tests (via the determinant) that all eigenvectors are linearly independent, as they must be since they are eigenvectors of a Hermitian matrix.

The previous test relied on the implementation of `zheevr` producing _exactly_ the same result as `scipy.linalg.eigh`, which was very fragile, and indeed broken by scipy 1.5.

Fixes #1299.
Deprecates PR #1300, since this actually turned out to be a much easier fix than I had feared.  Intermittent segfaults on Mac persist, unfortunately, so this still requires #1288.