### PR TITLE
Enforce a CI test with scipy<1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ _stage_linux_38_openblas: &stage_linux_38_openblas
 
 _stage_linux_omp: &stage_linux_omp
   <<: *stage_generic_linux
-  name: "Python 3.7 OpenMP, mkl"
+  name: "Python 3.7 OpenMP, mkl, scipy<1.5"
   dist: xenial
   python: 3.7
   install:
@@ -110,7 +110,7 @@ _stage_linux_omp: &stage_linux_omp
     - conda info -a
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
     - source activate test-environment
-    - conda install mkl blas=*=mkl numpy scipy pytest pytest-cov cython coveralls
+    - conda install mkl blas=*=mkl numpy 'scipy<1.5' pytest pytest-cov cython coveralls
     - python setup.py install --with-openmp
   after_success:
     - coveralls


### PR DESCRIPTION
There are "breaking" changes within the scipy private code which various parts of QuTiP depended on (see gh-1298, gh-1301 and commits 46e04a1, 6c85261 and 663d7d2).  We ensure that at least one test on Travis uses a scipy version before 1.5 so that we always maintain support for it - the other tests will typically install scipy>=1.5.

This particular test is chosen by elimination:
- we want the "default" case testing against the newest versions of Python to use the newest versions of the libraries available
- we want the Cython parts to be tested against both versions of scipy, since we link against their versions of LAPACK/BLAS.
- the Mac tests (at the time of writing) skip some tests which are problematic because of intermittent segfaults, including at least one which has issues with scipy 1.5.  The MKL/OMP one skips some tests, but not any which use scipy.
