### PR TITLE
Remove trailing slash in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,8 @@ include README.md
 include LICENSE.txt
 include requirements.txt
 include qutip.bib
-recursive-include qutip/ *.pyx
-recursive-include qutip/ *.pxi
-recursive-include qutip/ *.hpp
-recursive-include qutip/ *.pxd
-recursive-include qutip/ *.ini
+recursive-include qutip *.pyx
+recursive-include qutip *.pxi
+recursive-include qutip *.hpp
+recursive-include qutip *.pxd
+recursive-include qutip *.ini


### PR DESCRIPTION
Trailing slashes aren't allowed in directory patterns on Windows, and have no effect otherwise.

Probably doesn't affect us very much, since I don't think anyone's building the PyPI package on Windows?