### PR TITLE
Fix quadratic complexity in zcsr_inner

### DIFF
--- a/qutip/cy/spmath.pyx
+++ b/qutip/cy/spmath.pyx
@@ -745,11 +745,21 @@ def zcsr_inner(object A, object B, bool bra_ket):
     cdef int a_idx, b_idx
 
     if bra_ket:
+        if A.shape[1] != nrows:
+            message = "".join([
+                "incompatible lengths ", str(A.shape[1]), " and ", str(nrows),
+            ])
+            raise TypeError(message)
         for kk in range(a_ind.shape[0]):
             a_idx = a_ind[kk]
             if b_ptr[a_idx + 1] != b_ptr[a_idx]:
                 inner += a_data[kk] * b_data[b_ptr[a_idx]]
     else:
+        if A.shape[0] != nrows:
+            message = "".join([
+                "incompatible lengths ", str(A.shape[0]), " and ", str(nrows),
+            ])
+            raise TypeError(message)
         for kk in range(nrows):
             a_idx = a_ptr[kk]
             b_idx = b_ptr[kk]

--- a/qutip/cy/spmath.pyx
+++ b/qutip/cy/spmath.pyx
@@ -741,17 +741,14 @@ def zcsr_inner(object A, object B, bool bra_ket):
     cdef int nrows = B.shape[0]
 
     cdef double complex inner = 0
-    cdef size_t jj, kk
+    cdef size_t kk
     cdef int a_idx, b_idx
 
     if bra_ket:
         for kk in range(a_ind.shape[0]):
             a_idx = a_ind[kk]
-            for jj in range(nrows):
-                if (b_ptr[jj+1]-b_ptr[jj]) != 0:
-                    if jj == a_idx:
-                        inner += a_data[kk]*b_data[b_ptr[jj]]
-                        break
+            if b_ptr[a_idx + 1] != b_ptr[a_idx]:
+                inner += a_data[kk] * b_data[b_ptr[a_idx]]
     else:
         for kk in range(nrows):
             a_idx = a_ptr[kk]


### PR DESCRIPTION
The bra--ket inner product had an unnecessary loop when looking up the row in the ket, where we already knew which element we needed to lookup.

This function does not check the shapes of the inputs are valid and can therefore segfault on improper input, but it's a low-level Cython function, so that's expected behaviour. The previous version could segfault only in the ket--ket product, not the bra--ket product, but now it's both.

This only affected `qutip.overlap` when neither input was a ket.  Original timing:
```python
In [1]: import qutip
   ...: b, k = qutip.rand_ket(1000).dag(), qutip.rand_ket(1000)
   ...: %timeit b.overlap(k)
233 µs ± 214 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
New timing:
```python
In [1]: import qutip
   ...: b, k = qutip.rand_ket(1000).dag(), qutip.rand_ket(1000)
   ...: %timeit b.overlap(k)
8.35 µs ± 47 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

Compare ket--ket timing (which is unchanged):
```python
In [2]: k1, k2 = qutip.rand_ket(1000), qutip.rand_ket(1000)
   ...: %timeit k1.overlap(k2)
8.86 µs ± 119 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

**Changelog**
 - Fix quadratic dependency affecting `Qobj.overlap` with bra inputs.
 - Fix segfault in `Qobj.overlap` when passed `Qobj` of incompatible shapes.