### PR TITLE
Fix zcsr_proj for bras with unsorted indices

### DIFF
--- a/qutip/cy/spmath.pyx
+++ b/qutip/cy/spmath.pyx
@@ -706,6 +706,8 @@ def zcsr_proj(object A, bool is_ket=1):
                 out.data[jj*nnz+kk] = data[jj]*conj(data[kk])
 
     else:
+        # a bra _may_ have unsorted indices (a ket may not in CSR format)
+        A.sort_indices()
         count = nnz**2
         new_idx = nrows
         for kk in range(nnz-1,-1,-1):


### PR DESCRIPTION
Due to the CSR format, it is possible for a bra to have unsorted indices (though really you'd try very hard to contrive a situation where this was the case), but it is not possible for a ket.

Sorting is (worst case) O(nnz lg(nnz)), whereas the projection itself is O(nnz**2), so there's very little runtime penalty for doing things the right way.  Also, projection of a bra is pretty uncommon - most users will have a ket, and this path wasn't broken.

Previous broken behaviour:
```python
In [1]: import qutip
   ...: n = 100
   ...: b = qutip.rand_ket(n).dag()
   ...: b2 = b.copy()
   ...: # Rearrange the indices of the b2 bra.
   ...: b2.data.data = b2.data.data[np.arange(n-1, -1, -1)]
   ...: b2.data.indices = b2.data.indices[np.arange(n-1, -1, -1)]
   ...: b.proj() == b2.proj()
Out[1]: False
```

New unbroken behaviour:
```python
In [1]: import qutip
   ...: n = 100
   ...: b = qutip.rand_ket(n).dag()
   ...: b2 = b.copy()
   ...: # Rearrange the indices of the b2 bra.
   ...: b2.data.data = b2.data.data[np.arange(n-1, -1, -1)]
   ...: b2.data.indices = b2.data.indices[np.arange(n-1, -1, -1)]
   ...: b.proj() == b2.proj()
Out[1]: True
```

**Changelog**
Fix `Qobj.proj` for bras with unsorted CSR indices.