### PR TITLE
Add pyproject.toml to specify build-system as standardized in PEP 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython", "numpy", "scipy"]


### PR DESCRIPTION
**Description**
Add `pyproject.toml` to specify build-system as standardized in PEP 518. This enables building qutip in an emtpy environment i.e. without `setuptools`, `Cython`, `numpy` and `scipy` being pre-installed.

If you have a new minimal debian install you sould be able to install this version with
```
# apt-get install python3-pip
$ pip3 install $PATH_TO_QUTIP
```
I only veryfied this in WSL so please test :)

**Related issues or PRs**
This solves #1246 and #1174 and makes CI for packages that depend on qutip a lot easier.

**Changelog**
Add `pyproject.toml` so qutip can be built without prerequisites