### PR TITLE
4.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ _stage_linux_38_openblas: &stage_linux_38_openblas
 
 _stage_linux_omp: &stage_linux_omp
   <<: *stage_generic_linux
-  name: "Python 3.7 OpenMP, mkl"
+  name: "Python 3.7 OpenMP, mkl, scipy<1.5"
   dist: xenial
   python: 3.7
   install:
@@ -111,7 +111,7 @@ _stage_linux_omp: &stage_linux_omp
     - conda info -a
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
     - source activate test-environment
-    - conda install mkl blas=*=mkl numpy scipy pytest pytest-cov cython coveralls
+    - conda install mkl blas=*=mkl numpy 'scipy<1.5' pytest pytest-cov cython coveralls
     - python setup.py install --with-openmp
   after_success:
     - coveralls

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -106,7 +106,10 @@ else:
     # See Pull #652 for why this is here.
     os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
 
-
+import platform
+from .utilities import _blas_info
+qutip.settings.eigh_unsafe = (_blas_info() == "OPENBLAS" and
+                              platform.system() == 'Darwin')
 # -----------------------------------------------------------------------------
 # setup the cython environment
 #

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -63,7 +63,7 @@ import scipy.linalg as la
 import scipy.sparse as sp
 # QuTiP
 from qutip.qobj import Qobj
-from qutip.sparse import sp_eigs, _dense_eigs
+from qutip.sparse import sp_eigs, _dense_eigs, eigh
 import qutip.settings as settings
 # QuTiP logging
 import qutip.logging_utils as logging
@@ -1601,14 +1601,14 @@ class DynamicsUnitary(Dynamics):
         elif self.oper_dtype == np.ndarray:
             H = self._dyn_gen[k]
             # returns row vector of eigenvals, columns with the eigenvecs
-            eig_val, eig_vec = np.linalg.eigh(H)
+            eig_val, eig_vec = eigh(H)
         else:
             if sparse:
                 H = self._dyn_gen[k].toarray()
             else:
                 H = self._dyn_gen[k]
             # returns row vector of eigenvals, columns with the eigenvecs
-            eig_val, eig_vec = la.eigh(H)
+            eig_val, eig_vec = eigh(H)
 
         # assuming H is an nxn matrix, find n
         n = self.get_drift_dim()

--- a/qutip/cy/brtools.pyx
+++ b/qutip/cy/brtools.pyx
@@ -31,7 +31,7 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-from scipy.linalg.cython_lapack cimport zheevr
+from scipy.linalg.cython_lapack cimport zheevr, zgeev
 from scipy.linalg.cython_blas cimport zgemm, zgemv, zaxpy
 from qutip.cy.spmath cimport (_zcsr_kron_core, _zcsr_kron,
                     _zcsr_add, _zcsr_transpose, _zcsr_adjoint,
@@ -43,12 +43,19 @@ from libc.math cimport fabs, fmin
 from libc.float cimport DBL_MAX
 from libcpp.vector cimport vector
 from qutip.cy.sparse_structs cimport (CSR_Matrix, COO_Matrix)
+from qutip.settings import eigh_unsafe
+import numpy as np
 
 include "sparse_routines.pxi"
 
 cdef extern from "<complex>" namespace "std" nogil:
     double complex conj(double complex x)
     double cabs   "abs" (double complex x)
+    double         real(double complex x)
+    double complex sqrt(double complex x)
+
+
+cdef int use_zgeev = eigh_unsafe
 
 
 @cython.boundscheck(False)
@@ -118,6 +125,9 @@ cdef void ZHEEVR(complex[::1,:] H, double * eigvals,
     nrows : int
         Number of rows in matrix.
     """
+    if use_zgeev:
+        ZGEEVH(H, eigvals, Z, nrows)
+        return
     cdef char jobz = b'V'
     cdef char rnge = b'A'
     cdef char uplo = b'L'
@@ -145,6 +155,92 @@ cdef void ZHEEVR(complex[::1,:] H, double * eigvals,
         else:
             raise Exception("Algorithm failed to converge")
 
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef void ZGEEVH(complex[::1,:] H, double * eigvals,
+                complex[::1,:] Z, int nrows):
+    """
+    Computes the eigenvalues and vectors of a dense Hermitian matrix
+    without using zheevr.
+    Eigenvectors are returned in Z.
+    Parameters
+    ----------
+    H : array_like
+        Input Hermitian matrix.
+    eigvals : array_like
+        Input array to store eigen values.
+    Z : array_like
+        Output array of eigenvectors.
+    nrows : int
+        Number of rows in matrix.
+    """
+    cdef char jobvl = b'N'
+    cdef char jobvr = b'V'
+    cdef int i, j, k, lwork = -1
+    cdef int same_eigv = 0
+    cdef complex dot
+    cdef complex wkopt
+    cdef int info=0
+    cdef complex * work
+
+    #These need to be freed at end
+    cdef complex * eival = <complex *>PyDataMem_NEW(nrows * sizeof(complex))
+    cdef complex * vl = <complex *>PyDataMem_NEW(nrows * nrows *
+                                                 sizeof(complex))
+    cdef complex * vr = <complex *>PyDataMem_NEW(nrows * nrows *
+                                                 sizeof(complex))
+    cdef double * rwork = <double *>PyDataMem_NEW((2*nrows) * sizeof(double))
+
+    # First call to get lwork
+    zgeev(&jobvl, &jobvr, &nrows, &H[0,0], &nrows,
+          eival, vl, &nrows, vr, &nrows,
+          &wkopt, &lwork, rwork, &info)
+    lwork = int(real(wkopt))
+    work = <complex *>PyDataMem_NEW(lwork * sizeof(complex))
+    # Solving
+    zgeev(&jobvl, &jobvr, &nrows, &H[0,0], &nrows,
+          eival, vl, &nrows, vr, &nrows, #&Z[0,0],
+          work, &lwork, rwork, &info)
+    for i in range(nrows):
+        eigvals[i] = real(eival[i])
+    # After using lapack, numpy...
+    # lapack does not seems to have sorting function
+    # zheevr sort but not zgeev
+    cdef long[:] idx = np.argsort(np.array(<double[:nrows]> eigvals))
+    for i in range(nrows):
+        eigvals[i] = real(eival[idx[i]])
+        for j in range(nrows):
+            Z[j,i] = vr[j + idx[i]*nrows]
+
+    for i in range(1, nrows):
+        if cabs(eigvals[i] - eigvals[i-1]) < 1e-12:
+            same_eigv += 1
+            for j in range(same_eigv):
+                dot = 0.
+                for k in range(nrows):
+                    dot += conj(Z[k,i-j-1]) * Z[k,i]
+                for k in range(nrows):
+                    Z[k,i] -= Z[k,i-j-1] * dot
+                dot = 0.
+                for k in range(nrows):
+                    dot += conj(Z[k,i]) * Z[k,i]
+                dot = sqrt(dot)
+                for k in range(nrows):
+                    Z[k,i] /= dot
+        else:
+            same_eigv = 0
+
+    PyDataMem_FREE(work)
+    PyDataMem_FREE(rwork)
+    PyDataMem_FREE(vl)
+    PyDataMem_FREE(vr)
+    PyDataMem_FREE(eival)
+    if info != 0:
+        if info < 0:
+            raise Exception("Error in parameter : %s" & abs(info))
+        else:
+            raise Exception("Algorithm failed to converge")
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/qutip/cy/spmath.pyx
+++ b/qutip/cy/spmath.pyx
@@ -706,6 +706,8 @@ def zcsr_proj(object A, bool is_ket=1):
                 out.data[jj*nnz+kk] = data[jj]*conj(data[kk])
 
     else:
+        # a bra _may_ have unsorted indices (a ket may not in CSR format)
+        A.sort_indices()
         count = nnz**2
         new_idx = nrows
         for kk in range(nnz-1,-1,-1):

--- a/qutip/cy/spmath.pyx
+++ b/qutip/cy/spmath.pyx
@@ -743,18 +743,25 @@ def zcsr_inner(object A, object B, bool bra_ket):
     cdef int nrows = B.shape[0]
 
     cdef double complex inner = 0
-    cdef size_t jj, kk
+    cdef size_t kk
     cdef int a_idx, b_idx
 
     if bra_ket:
+        if A.shape[1] != nrows:
+            message = "".join([
+                "incompatible lengths ", str(A.shape[1]), " and ", str(nrows),
+            ])
+            raise TypeError(message)
         for kk in range(a_ind.shape[0]):
             a_idx = a_ind[kk]
-            for jj in range(nrows):
-                if (b_ptr[jj+1]-b_ptr[jj]) != 0:
-                    if jj == a_idx:
-                        inner += a_data[kk]*b_data[b_ptr[jj]]
-                        break
+            if b_ptr[a_idx + 1] != b_ptr[a_idx]:
+                inner += a_data[kk] * b_data[b_ptr[a_idx]]
     else:
+        if A.shape[0] != nrows:
+            message = "".join([
+                "incompatible lengths ", str(A.shape[0]), " and ", str(nrows),
+            ])
+            raise TypeError(message)
         for kk in range(nrows):
             a_idx = a_ptr[kk]
             b_idx = b_ptr[kk]

--- a/qutip/cy/stochastic.pyx
+++ b/qutip/cy/stochastic.pyx
@@ -1749,7 +1749,7 @@ cdef class SMESolver(StochasticSolver):
             for j in range(i, self.num_ops):
                 c_op._mul_vec(t, &b[j,0], &Lb[i,j,0])
                 trAb[i,j] = self.expect(Lb[i,j,:])
-                _axpy(-trAp[j], b[i,:], Lb[i,j,:])
+                _axpy(-trAp[i], b[j,:], Lb[i,j,:])
                 _axpy(-trAb[i,j], rho, Lb[i,j,:])
 
         # L0b La LLb

--- a/qutip/lattice.py
+++ b/qutip/lattice.py
@@ -1070,7 +1070,7 @@ class Lattice1d():
             else:
                 Phi_m_k[ks] = 2*np.pi + np.angle(mx_k[ks]+1j*my_k[ks])
 
-        if winding_number is 'defined':
+        if winding_number == 'defined':
             ddk_Phi_m_k = np.roll(Phi_m_k, -1) - Phi_m_k
             intg_over_k = -np.sum(ddk_Phi_m_k[0:knpoints//2])+np.sum(
                     ddk_Phi_m_k[knpoints//2:knpoints])

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -37,42 +37,14 @@ import inspect
 
 import numpy as np
 
-from qutip.qip import circuit_latex as _latex
-from qutip.qip.operations.gates import (rx, ry, rz, sqrtnot, snot, phasegate,
-                                        x_gate, y_gate, z_gate, cy_gate,
-                                        cz_gate, s_gate, t_gate, cs_gate,
-                                        ct_gate, cphase, cnot, csign,
-                                        berkeley, swapalpha, swap, iswap,
-                                        sqrtswap, sqrtiswap, fredkin,
-                                        toffoli, controlled_gate, globalphase,
-                                        expand_operator)
-
-try:
-    from IPython.display import Image as DisplayImage, SVG as DisplaySVG
-except ImportError:
-    # If IPython doesn't exist, then we set the nice display hooks to be simple
-    # pass-throughs.
-    def DisplayImage(data, *args, **kwargs):
-        return data
-
-    def DisplaySVG(data, *args, **kwargs):
-        return data
+from qutip.qip.circuit_latex import _latex_compile
+from qutip.qip.operations.gates import *
+from qutip.qip.qubits import qubit_states
 
 __all__ = ['Gate', 'QubitCircuit']
 
-_single_qubit_gates = ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE",
-                       "X", "Y", "Z", "S", "T"]
-_para_gates = ["RX", "RY", "RZ", "CPHASE", "SWAPalpha", "PHASEGATE",
-               "GLOBALPHASE", "CRX", "CRY", "CRZ"]
-_ctrl_gates = ["CNOT", "CSIGN", "CRX", "CRY", "CRZ", "CY", "CZ",
-               "CS", "CT"]
-_swap_like = ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
-              "SWAPalpha"]
-_toffoli_like = ["TOFFOLI"]
-_fredkin_like = ["FREDKIN"]
 
-
-class Gate:
+class Gate(object):
     """
     Representation of a quantum gate, with its required parametrs, and target
     and control qubits.
@@ -117,47 +89,36 @@ class Gate:
                 if not all_integer:
                     raise ValueError("Index of a qubit must be an integer")
 
-        if name in _single_qubit_gates:
-            if self.targets is None or len(self.targets) != 1:
-                raise ValueError("Gate %s requires one target" % name)
-            if self.controls is not None:
-                raise ValueError("Gate %s cannot have a control" % name)
-        elif name in _swap_like:
+        if name in ["SWAP", "ISWAP", "SQRTISWAP", "SQRTSWAP", "BERKELEY",
+                    "SWAPalpha"]:
             if (self.targets is None) or (len(self.targets) != 2):
                 raise ValueError("Gate %s requires two targets" % name)
             if self.controls is not None:
                 raise ValueError("Gate %s cannot have a control" % name)
-        elif name in _ctrl_gates:
+
+        elif name in ["CNOT", "CSIGN", "CRX", "CRY", "CRZ"]:
             if self.targets is None or len(self.targets) != 1:
                 raise ValueError("Gate %s requires one target" % name)
             if self.controls is None or len(self.controls) != 1:
                 raise ValueError("Gate %s requires one control" % name)
-        elif name in _fredkin_like:
-            if self.targets is None or len(self.targets) != 2:
-                raise ValueError("Gate %s requires one target" % name)
-            if self.controls is None or len(self.controls) != 1:
-                raise ValueError("Gate %s requires two control" % name)
-        elif name in _toffoli_like:
-            if self.targets is None or len(self.targets) != 1:
-                raise ValueError("Gate %s requires one target" % name)
-            if self.controls is None or len(self.controls) != 2:
-                raise ValueError("Gate %s requires two control" % name)
 
-        if name in _para_gates:
+        elif name in ["SNOT", "RX", "RY", "RZ", "PHASEGATE"]:
+            if self.controls is not None:
+                raise ValueError("Gate %s does not take controls" % name)
+
+        elif name in ["RX", "RY", "RZ", "CPHASE", "SWAPalpha", "PHASEGATE",
+                            "GLOBALPHASE", "CRX", "CRY", "CRZ"]:
             if arg_value is None:
                 raise ValueError("Gate %s requires an argument value" % name)
-        else:
-            if (name in _GATE_NAME_TO_LABEL) and (arg_value is not None):
-                raise ValueError("Gate %s does not take argument value" % name)
 
         self.arg_value = arg_value
         self.arg_label = arg_label
 
     def __str__(self):
-        string_name = "Gate(%s, targets=%s, controls=%s)" % (self.name,
-                                                             self.targets,
-                                                             self.controls)
-        return string_name
+        s = "Gate(%s, targets=%s, controls=%s)" % (self.name,
+                                                   self.targets,
+                                                   self.controls)
+        return s
 
     def __repr__(self):
         return str(self)
@@ -166,16 +127,7 @@ class Gate:
         return str(self)
 
 
-_GATE_NAME_TO_LABEL = {
-    'X': r'X',
-    'Y': r'Y',
-    'CY': r'C_y',
-    'Z': r'Z',
-    'CZ': r'C_z',
-    'S': r'S',
-    'CS': r'C_s',
-    'T': r'T',
-    'CT': r'C_t',
+_gate_name_to_label = {
     'RX': r'R_x',
     'RY': r'R_y',
     'RZ': r'R_z',
@@ -202,18 +154,19 @@ _GATE_NAME_TO_LABEL = {
 
 def _gate_label(name, arg_label):
 
-    if name in _GATE_NAME_TO_LABEL:
-        gate_label = _GATE_NAME_TO_LABEL[name]
+    if name in _gate_name_to_label:
+        gate_label = _gate_name_to_label[name]
     else:
         warnings.warn("Unknown gate %s" % name)
         gate_label = name
 
     if arg_label:
         return r'%s(%s)' % (gate_label, arg_label)
-    return r'%s' % gate_label
+    else:
+        return r'%s' % gate_label
 
 
-class QubitCircuit:
+class QubitCircuit(object):
     """
     Representation of a quantum program/algorithm, maintaining a sequence
     of gates.
@@ -237,8 +190,8 @@ class QubitCircuit:
     ...     mat = np.array([[1.,   0],
     ...                     [0., 1.j]])
     ...     return Qobj(mat, dims=[[2], [2]])
-    >>> qubit_circuit.QubitCircuit(2, user_gates={"T":user_gate})
-    >>> qubit_circuit.add_gate("T", targets=[0])
+    >>> qc.QubitCircuit(2, user_gates={"T":user_gate})
+    >>> qc.add_gate("T", targets=[0])
     """
 
     def __init__(self, N, input_states=None, output_states=None,
@@ -352,12 +305,11 @@ class QubitCircuit:
         arg_label : string
             Label for gate representation.
         """
-        if name not in ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE",
-                        "X", "Y", "Z", "S", "T"]:
+        if name not in ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE"]:
             raise ValueError("%s is not a single qubit gate" % name)
 
         if qubits is not None:
-            for _, i in enumerate(qubits):
+            for i in range(len(qubits)):
                 self.gates.append(Gate(name, targets=qubits[i], controls=None,
                                        arg_value=arg_value,
                                        arg_label=arg_label))
@@ -365,7 +317,7 @@ class QubitCircuit:
         else:
             if end is None:
                 end = self.N - 1
-            for i in range(start, end+1):
+            for i in range(start, end):
                 self.gates.append(Gate(name, targets=i, controls=None,
                                        arg_value=arg_value,
                                        arg_label=arg_label))
@@ -389,18 +341,15 @@ class QubitCircuit:
             if gate.name in ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE"]:
                 self.add_gate(gate.name, gate.targets[0] + start, None,
                               gate.arg_value, gate.arg_label)
-            elif gate.name in ["X", "Y", "Z", "S", "T"]:
-                self.add_gate(gate.name, gate.targets[0] + start, None,
-                              None, gate.arg_label)
-            elif gate.name in ["CPHASE", "CNOT", "CSIGN", "CRX", "CRY",
-                               "CRZ", "CY", "CZ", "CS", "CT"]:
+            elif gate.name in ["CPHASE", "CNOT", "CSIGN", "CRX", "CRY", "CRZ"]:
                 self.add_gate(gate.name, gate.targets[0] + start,
                               gate.controls[0] + start, gate.arg_value,
                               gate.arg_label)
             elif gate.name in ["BERKELEY", "SWAPalpha", "SWAP", "ISWAP",
                                "SQRTSWAP", "SQRTISWAP"]:
-                self.add_gate(gate.name, [gate.targets[0] + start,
-                              gate.targets[1] + start], None, None)
+                self.add_gate(gate.name, None,
+                              [gate.controls[0] + start,
+                               gate.controls[1] + start], None, None)
             elif gate.name in ["TOFFOLI"]:
                 self.add_gate(gate.name, gate.targets[0] + start,
                               [gate.controls[0] + start,
@@ -412,8 +361,8 @@ class QubitCircuit:
                               gate.controls + start, None, None)
             elif gate.name in self.user_gates:
                 self.add_gate(
-                    gate.name, targets=gate.targets,
-                    arg_value=gate.arg_value)
+                              gate.name, targets=gate.targets,
+                              arg_value=gate.arg_value)
 
     def remove_gate(self, index=None, end=None, name=None, remove="first"):
         """
@@ -429,10 +378,8 @@ class QubitCircuit:
         remove : string
             If first or all gate are to be removed.
         """
-        if index is not None:
-            if index > len(self.gates):
-                raise ValueError("Index exceeds number of gates.")
-            if end is not None and end <= len(self.gates):
+        if index is not None and index <= self.N:
+            if end is not None and end <= self.N:
                 for i in range(end - index):
                     self.gates.pop(index + i)
             elif end is not None and end > self.N:
@@ -447,15 +394,15 @@ class QubitCircuit:
                     break
 
         elif name is not None and remove == "last":
-            for i in reversed(range(len(self.gates))):
-                if name == self.gates[i].name:
-                    self.gates.pop(i)
+            for i in range(self.N + 1):
+                if name == self.gates[self.N - i].name:
+                    self.gates.remove(self.gates[self.N - i])
                     break
 
         elif name is not None and remove == "all":
-            for i in reversed(range(len(self.gates))):
-                if name == self.gates[i].name:
-                    self.gates.pop(i)
+            for j in range(self.N + 1):
+                if name == self.gates[self.N - j].name:
+                    self.gates.remove(self.gates[self.N - j])
 
         else:
             self.gates.pop()
@@ -466,7 +413,7 @@ class QubitCircuit:
 
         Returns
         -------
-        qubit_circuit : QubitCircuit
+        qc : QubitCircuit
             Return QubitCircuit of resolved gates for the qubit circuit in the
             reverse order.
 
@@ -478,389 +425,17 @@ class QubitCircuit:
 
         return temp
 
-    def _resolve_to_universal(self, gate, temp_resolved, basis_1q, basis_2q):
-        """A dispatch method"""
-        if gate.name in basis_2q:
-            method = getattr(self, '_gate_basis_2q')
-        else:
-            if gate.name == "SWAP" and "ISWAP" in basis_2q:
-                method = getattr(self, '_gate_IGNORED')
-            else:
-                method = getattr(self, '_gate_' + str(gate.name))
-        method(gate, temp_resolved)
-
-    def _gate_IGNORED(self, gate, temp_resolved):
-        temp_resolved.append(gate)
-    _gate_RY = _gate_RZ = _gate_basis_2q = _gate_IGNORED
-    _gate_CNOT = _gate_RX = _gate_IGNORED
-
-    def _gate_SQRTNOT(self, gate, temp_resolved):
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=np.pi / 4, arg_label=r"\pi/4"))
-        temp_resolved.append(Gate("RX", gate.targets, None,
-                                  arg_value=np.pi / 2, arg_label=r"\pi/2"))
-
-    def _gate_SNOT(self, gate, temp_resolved):
-        half_pi = np.pi / 2
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RY", gate.targets, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets, None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-
-    def _gate_PHASEGATE(self, gate, temp_resolved):
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=gate.arg_value / 2,
-                                  arg_label=gate.arg_label))
-        temp_resolved.append(Gate("RZ", gate.targets, None,
-                                  gate.arg_value, gate.arg_label))
-
-    def _gate_NOTIMPLEMENTED(self, gate, temp_resolved):
-        raise NotImplementedError("Cannot be resolved in this basis")
-    _gate_PHASEGATE = _gate_BERKELEY = _gate_SWAPalpha = _gate_NOTIMPLEMENTED
-    _gate_SQRTSWAP = _gate_SQRTISWAP = _gate_NOTIMPLEMENTED
-
-    def _gate_CSIGN(self, gate, temp_resolved):
-        half_pi = np.pi / 2
-        temp_resolved.append(Gate("RY", gate.targets, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets, None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-        temp_resolved.append(Gate("CNOT", gate.targets, gate.controls))
-        temp_resolved.append(Gate("RY", gate.targets, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets, None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-
-    def _gate_SWAP(self, gate, temp_resolved):
-        temp_resolved.append(
-            Gate("CNOT", gate.targets[0], gate.targets[1]))
-        temp_resolved.append(
-            Gate("CNOT", gate.targets[1], gate.targets[0]))
-        temp_resolved.append(
-            Gate("CNOT", gate.targets[0], gate.targets[1]))
-
-    def _gate_ISWAP(self, gate, temp_resolved):
-        half_pi = np.pi / 2
-        temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                  gate.targets[1]))
-        temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                  gate.targets[0]))
-        temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                  gate.targets[1]))
-        temp_resolved.append(Gate("RZ", gate.targets[0], None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RZ", gate.targets[1], None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RY", gate.targets[0], None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets[0], None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-        temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                  gate.targets[1]))
-        temp_resolved.append(Gate("RY", gate.targets[0], None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets[0], None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-
-    def _gate_FREDKIN(self, gate, temp_resolved):
-        half_pi = np.pi / 2
-        eigth_pi = np.pi / 8
-        temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                  gate.targets[1]))
-        temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                  gate.controls))
-        temp_resolved.append(Gate("RZ", gate.controls, None,
-                                  arg_value=eigth_pi,
-                                  arg_label=r"\pi/8"))
-        temp_resolved.append(Gate("RZ", [gate.targets[0]], None,
-                                  arg_value=-eigth_pi,
-                                  arg_label=r"-\pi/8"))
-        temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                  gate.controls))
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RY", gate.targets[1], None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RY", gate.targets, None,
-                                  arg_value=-half_pi,
-                                  arg_label=r"-\pi/2"))
-        temp_resolved.append(Gate("RZ", gate.targets, None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-        temp_resolved.append(Gate("RY", gate.targets, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RZ", gate.targets[0], None,
-                                  arg_value=eigth_pi,
-                                  arg_label=r"\pi/8"))
-        temp_resolved.append(Gate("RZ", gate.targets[1], None,
-                                  arg_value=eigth_pi,
-                                  arg_label=r"\pi/8"))
-        temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                  gate.controls))
-        temp_resolved.append(Gate("RZ", gate.targets[1], None,
-                                  arg_value=-eigth_pi,
-                                  arg_label=r"-\pi/8"))
-        temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                  gate.targets[0]))
-        temp_resolved.append(Gate("RZ", gate.targets[1], None,
-                                  arg_value=eigth_pi,
-                                  arg_label=r"\pi/8"))
-        temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                  gate.controls))
-        temp_resolved.append(Gate("RZ", gate.targets[1], None,
-                                  arg_value=-eigth_pi,
-                                  arg_label=r"-\pi/8"))
-        temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                  gate.targets[0]))
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RY", gate.targets[1], None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RY", gate.targets, None,
-                                  arg_value=-half_pi,
-                                  arg_label=r"-\pi/2"))
-        temp_resolved.append(Gate("RZ", gate.targets, None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-        temp_resolved.append(Gate("RY", gate.targets, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                  gate.targets[1]))
-
-    def _gate_TOFFOLI(self, gate, temp_resolved):
-        half_pi = np.pi / 2
-        quarter_pi = np.pi / 4
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=np.pi / 8,
-                                  arg_label=r"\pi/8"))
-        temp_resolved.append(Gate("RZ", gate.controls[1], None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RZ", gate.controls[0], None,
-                                  arg_value=quarter_pi,
-                                  arg_label=r"\pi/4"))
-        temp_resolved.append(Gate("CNOT", gate.controls[1],
-                                  gate.controls[0]))
-        temp_resolved.append(Gate("RZ", gate.controls[1], None,
-                                  arg_value=-quarter_pi,
-                                  arg_label=r"-\pi/4"))
-        temp_resolved.append(Gate("CNOT", gate.controls[1],
-                                  gate.controls[0]))
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RY", gate.targets, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets, None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-        temp_resolved.append(Gate("RZ", gate.controls[1], None,
-                                  arg_value=-quarter_pi,
-                                  arg_label=r"-\pi/4"))
-        temp_resolved.append(Gate("RZ", gate.targets, None,
-                                  arg_value=quarter_pi,
-                                  arg_label=r"\pi/4"))
-        temp_resolved.append(Gate("CNOT", gate.targets,
-                                  gate.controls[0]))
-        temp_resolved.append(Gate("RZ", gate.targets, None,
-                                  arg_value=-quarter_pi,
-                                  arg_label=r"-\pi/4"))
-        temp_resolved.append(Gate("CNOT", gate.targets,
-                                  gate.controls[1]))
-        temp_resolved.append(Gate("RZ", gate.targets, None,
-                                  arg_value=quarter_pi,
-                                  arg_label=r"\pi/4"))
-        temp_resolved.append(Gate("CNOT", gate.targets,
-                                  gate.controls[0]))
-        temp_resolved.append(Gate("RZ", gate.targets, None,
-                                  arg_value=-quarter_pi,
-                                  arg_label=r"-\pi/4"))
-        temp_resolved.append(Gate("CNOT", gate.targets,
-                                  gate.controls[1]))
-        temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RY", gate.targets, None,
-                                  arg_value=half_pi,
-                                  arg_label=r"\pi/2"))
-        temp_resolved.append(Gate("RX", gate.targets, None,
-                                  arg_value=np.pi, arg_label=r"\pi"))
-
-    def _gate_GLOBALPHASE(self, gate, temp_resolved):
-        temp_resolved.append(Gate(gate.name, gate.targets,
-                                  gate.controls,
-                                  gate.arg_value, gate.arg_label))
-
-    def _resolve_2q_basis(self, basis, qc_temp, temp_resolved):
-        """Dispatch method"""
-        method = getattr(self, '_basis_' + str(basis), temp_resolved)
-        method(qc_temp, temp_resolved)
-
-    def _basis_CSIGN(self, qc_temp, temp_resolved):
-        half_pi = np.pi / 2
-        for gate in temp_resolved:
-            if gate.name == "CNOT":
-                qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-                qc_temp.gates.append(Gate("CSIGN", gate.targets,
-                                          gate.controls))
-                qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                          arg_value=half_pi,
-                                          arg_label=r"\pi/2"))
-            else:
-                qc_temp.gates.append(gate)
-
-    def _basis_ISWAP(self, qc_temp, temp_resolved):
-        half_pi = np.pi / 2
-        quarter_pi = np.pi / 4
-        for gate in temp_resolved:
-            if gate.name == "CNOT":
-                qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=quarter_pi,
-                                          arg_label=r"\pi/4"))
-                qc_temp.gates.append(Gate("ISWAP", [gate.controls[0],
-                                                    gate.targets[0]],
-                                          None))
-                qc_temp.gates.append(Gate("RZ", gate.targets, None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-                qc_temp.gates.append(Gate("RY", gate.controls, None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-                qc_temp.gates.append(Gate("RZ", gate.controls, None,
-                                          arg_value=half_pi,
-                                          arg_label=r"\pi/2"))
-                qc_temp.gates.append(Gate("ISWAP", [gate.controls[0],
-                                                    gate.targets[0]],
-                                          None))
-                qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-                qc_temp.gates.append(Gate("RZ", gate.targets, None,
-                                          arg_value=half_pi,
-                                          arg_label=r"\pi/2"))
-            elif gate.name == "SWAP":
-                qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=quarter_pi,
-                                          arg_label=r"\pi/4"))
-                qc_temp.gates.append(Gate("ISWAP", gate.targets, None))
-                qc_temp.gates.append(Gate("RX", gate.targets[0], None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-                qc_temp.gates.append(Gate("ISWAP", gate.targets, None))
-                qc_temp.gates.append(Gate("RX", gate.targets[1], None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-                qc_temp.gates.append(Gate("ISWAP", [gate.targets[1],
-                                                    gate.targets[0]],
-                                          None))
-                qc_temp.gates.append(Gate("RX", gate.targets[0], None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-            else:
-                qc_temp.gates.append(gate)
-
-    def _basis_SQRTSWAP(self, qc_temp, temp_resolved):
-        half_pi = np.pi / 2
-        for gate in temp_resolved:
-            if gate.name == "CNOT":
-                qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                          arg_value=half_pi,
-                                          arg_label=r"\pi/2"))
-                qc_temp.gates.append(Gate("SQRTSWAP", [gate.controls[0],
-                                                       gate.targets[0]],
-                                          None))
-                qc_temp.gates.append(Gate("RZ", gate.controls, None,
-                                          arg_value=np.pi,
-                                          arg_label=r"\pi"))
-                qc_temp.gates.append(Gate("SQRTSWAP", [gate.controls[0],
-                                                       gate.targets[0]],
-                                          None))
-                qc_temp.gates.append(Gate("RZ", gate.targets, None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-                qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-                qc_temp.gates.append(Gate("RZ", gate.controls, None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-            else:
-                qc_temp.gates.append(gate)
-
-    def _basis_SQRTISWAP(self, qc_temp, temp_resolved):
-        half_pi = np.pi / 2
-        quarter_pi = np.pi / 4
-        for gate in temp_resolved:
-            if gate.name == "CNOT":
-                qc_temp.gates.append(Gate("RY", gate.controls, None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-                qc_temp.gates.append(Gate("RX", gate.controls, None,
-                                          arg_value=half_pi,
-                                          arg_label=r"\pi/2"))
-                qc_temp.gates.append(Gate("RX", gate.targets, None,
-                                          arg_value=-half_pi,
-                                          arg_label=r"-\pi/2"))
-                qc_temp.gates.append(Gate("SQRTISWAP", [gate.controls[0],
-                                                        gate.targets[0]],
-                                          None))
-                qc_temp.gates.append(Gate("RX", gate.controls, None,
-                                          arg_value=np.pi,
-                                          arg_label=r"\pi"))
-                qc_temp.gates.append(Gate("SQRTISWAP", [gate.controls[0],
-                                                        gate.targets[0]],
-                                          None))
-                qc_temp.gates.append(Gate("RY", gate.controls, None,
-                                          arg_value=half_pi,
-                                          arg_label=r"\pi/2"))
-                qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=quarter_pi,
-                                          arg_label=r"\pi/4"))
-                qc_temp.gates.append(Gate("RZ", gate.controls, None,
-                                          arg_value=np.pi,
-                                          arg_label=r"\pi"))
-                qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=3 * half_pi,
-                                          arg_label=r"3\pi/2"))
-            else:
-                qc_temp.gates.append(gate)
-
     def resolve_gates(self, basis=["CNOT", "RX", "RY", "RZ"]):
         """
         Unitary matrix calculator for N qubits returning the individual
         steps as unitary matrices operating from left to right in the specified
         basis.
-        Calls '_resolve_to_universal' for each gate, this function maps
-        each 'GATENAME' with its corresponding '_gate_basis_2q'
-        Subsequently calls _resolve_2q_basis for each basis, this function maps
-        each '2QGATENAME' with its corresponding '_basis_'
+
         Parameters
         ----------
         basis : list.
             Basis of the resolved circuit.
+
         Returns
         -------
         qc : QubitCircuit
@@ -886,7 +461,7 @@ class QubitCircuit:
                         "%s is not a valid basis gate" % gate)
             if len(basis_1q) == 1:
                 raise ValueError("Not sufficient single-qubit gates in basis")
-            if len(basis_1q) == 0:
+            elif len(basis_1q) == 0:
                 basis_1q = ["RX", "RY", "RZ"]
 
         else:  # only one 2q gate is given as basis
@@ -898,53 +473,389 @@ class QubitCircuit:
                                  % basis)
 
         for gate in self.gates:
-            try:
-                self._resolve_to_universal(gate, temp_resolved,
-                                           basis_1q, basis_2q)
-            except AttributeError:
-                exception = f"Gate {gate.name} cannot be resolved."
-                raise NotImplementedError(exception)
+            if gate.name == "RX":
+                temp_resolved.append(gate)
+            elif gate.name == "RY":
+                temp_resolved.append(gate)
+            elif gate.name == "RZ":
+                temp_resolved.append(gate)
+            elif gate.name == "SQRTNOT":
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=np.pi / 4,
+                                          arg_label=r"\pi/4"))
+                temp_resolved.append(Gate("RX", gate.targets, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+            elif gate.name == "SNOT":
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RY", gate.targets, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RX", gate.targets, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+            elif gate.name == "PHASEGATE":
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=gate.arg_value / 2,
+                                          arg_label=gate.arg_label))
+                temp_resolved.append(Gate("RZ", gate.targets, None,
+                                          gate.arg_value, gate.arg_label))
+            elif gate.name in basis_2q:  # ignore all gate in 2q basis
+                temp_resolved.append(gate)
+            elif gate.name == "CPHASE":
+                raise NotImplementedError("Cannot be resolved in this basis")
+            elif gate.name == "CNOT":
+                temp_resolved.append(gate)
+            elif gate.name == "CSIGN":
+                temp_resolved.append(Gate("RY", gate.targets, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RX", gate.targets, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+                temp_resolved.append(Gate("CNOT", gate.targets, gate.controls))
+                temp_resolved.append(Gate("RY", gate.targets, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RX", gate.targets, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+            elif gate.name == "BERKELEY":
+                raise NotImplementedError("Cannot be resolved in this basis")
+            elif gate.name == "SWAPalpha":
+                raise NotImplementedError("Cannot be resolved in this basis")
+            elif gate.name == "SWAP":
+                if "ISWAP" in basis_2q:  # dealed with separately
+                    temp_resolved.append(gate)
+                else:
+                    temp_resolved.append(
+                        Gate("CNOT", gate.targets[0], gate.targets[1]))
+                    temp_resolved.append(
+                        Gate("CNOT", gate.targets[1], gate.targets[0]))
+                    temp_resolved.append(
+                        Gate("CNOT", gate.targets[0], gate.targets[1]))
+            elif gate.name == "ISWAP":
+                temp_resolved.append(Gate("CNOT", gate.targets[0],
+                                          gate.targets[1]))
+                temp_resolved.append(Gate("CNOT", gate.targets[1],
+                                          gate.targets[0]))
+                temp_resolved.append(Gate("CNOT", gate.targets[0],
+                                          gate.targets[1]))
+                temp_resolved.append(Gate("RZ", gate.targets[0], None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RZ", gate.targets[1], None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RY", gate.targets[0], None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RX", gate.targets, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+                temp_resolved.append(Gate("CNOT", gate.targets[0],
+                                          gate.targets[1]))
+                temp_resolved.append(Gate("RY", gate.targets[0], None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RX", gate.targets, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+            elif gate.name == "SQRTSWAP":
+                raise NotImplementedError("Cannot be resolved in this basis")
+            elif gate.name == "SQRTISWAP":
+                raise NotImplementedError("Cannot be resolved in this basis")
+            elif gate.name == "FREDKIN":
+                temp_resolved.append(Gate("CNOT", gate.targets[0],
+                                          gate.targets[1]))
+                temp_resolved.append(Gate("CNOT", gate.targets[0],
+                                          gate.controls))
+                temp_resolved.append(Gate("RZ", gate.controls, None,
+                                          arg_value=np.pi / 8,
+                                          arg_label=r"\pi/8"))
+                temp_resolved.append(Gate("RZ", [gate.targets[0]], None,
+                                          arg_value=-np.pi / 8,
+                                          arg_label=r"-\pi/8"))
+                temp_resolved.append(Gate("CNOT", gate.targets[0],
+                                          gate.controls))
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RY", gate.targets[1], None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RY", gate.targets, None,
+                                          arg_value=-np.pi / 2,
+                                          arg_label=r"-\pi/2"))
+                temp_resolved.append(Gate("RZ", gate.targets, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+                temp_resolved.append(Gate("RY", gate.targets, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RZ", gate.targets[0], None,
+                                          arg_value=np.pi / 8,
+                                          arg_label=r"\pi/8"))
+                temp_resolved.append(Gate("RZ", gate.targets[1], None,
+                                          arg_value=np.pi / 8,
+                                          arg_label=r"\pi/8"))
+                temp_resolved.append(Gate("CNOT", gate.targets[1],
+                                          gate.controls))
+                temp_resolved.append(Gate("RZ", gate.targets[1], None,
+                                          arg_value=-np.pi / 8,
+                                          arg_label=r"-\pi/8"))
+                temp_resolved.append(Gate("CNOT", gate.targets[1],
+                                          gate.targets[0]))
+                temp_resolved.append(Gate("RZ", gate.targets[1], None,
+                                          arg_value=np.pi / 8,
+                                          arg_label=r"\pi/8"))
+                temp_resolved.append(Gate("CNOT", gate.targets[1],
+                                          gate.controls))
+                temp_resolved.append(Gate("RZ", gate.targets[1], None,
+                                          arg_value=-np.pi / 8,
+                                          arg_label=r"-\pi/8"))
+                temp_resolved.append(Gate("CNOT", gate.targets[1],
+                                          gate.targets[0]))
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RY", gate.targets[1], None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RY", gate.targets, None,
+                                          arg_value=-np.pi / 2,
+                                          arg_label=r"-\pi/2"))
+                temp_resolved.append(Gate("RZ", gate.targets, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+                temp_resolved.append(Gate("RY", gate.targets, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("CNOT", gate.targets[0],
+                                          gate.targets[1]))
 
-        match = False
-        for basis_unit in ["CSIGN", "ISWAP", "SQRTSWAP", "SQRTISWAP"]:
-            if basis_unit in basis_2q:
-                match = True
-                self._resolve_2q_basis(basis_unit, qc_temp, temp_resolved)
-                break
-        if not match:
+            elif gate.name == "TOFFOLI":
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=1 * np.pi / 8,
+                                          arg_label=r"\pi/8"))
+                temp_resolved.append(Gate("RZ", gate.controls[1], None,
+                                          arg_value=np.pi/2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RZ", gate.controls[0], None,
+                                          arg_value=np.pi / 4,
+                                          arg_label=r"\pi/4"))
+                temp_resolved.append(Gate("CNOT", gate.controls[1],
+                                          gate.controls[0]))
+                temp_resolved.append(Gate("RZ", gate.controls[1], None,
+                                          arg_value=-np.pi / 4,
+                                          arg_label=r"-\pi/4"))
+                temp_resolved.append(Gate("CNOT", gate.controls[1],
+                                          gate.controls[0]))
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RY", gate.targets, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RX", gate.targets, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+                temp_resolved.append(Gate("RZ", gate.controls[1], None,
+                                          arg_value=-np.pi / 4,
+                                          arg_label=r"-\pi/4"))
+                temp_resolved.append(Gate("RZ", gate.targets, None,
+                                          arg_value=np.pi / 4,
+                                          arg_label=r"\pi/4"))
+                temp_resolved.append(Gate("CNOT", gate.targets,
+                                          gate.controls[0]))
+                temp_resolved.append(Gate("RZ", gate.targets, None,
+                                          arg_value=-np.pi / 4,
+                                          arg_label=r"-\pi/4"))
+                temp_resolved.append(Gate("CNOT", gate.targets,
+                                          gate.controls[1]))
+                temp_resolved.append(Gate("RZ", gate.targets, None,
+                                          arg_value=np.pi / 4,
+                                          arg_label=r"\pi/4"))
+                temp_resolved.append(Gate("CNOT", gate.targets,
+                                          gate.controls[0]))
+                temp_resolved.append(Gate("RZ", gate.targets, None,
+                                          arg_value=-np.pi / 4,
+                                          arg_label=r"-\pi/4"))
+                temp_resolved.append(Gate("CNOT", gate.targets,
+                                          gate.controls[1]))
+                temp_resolved.append(Gate("GLOBALPHASE", None, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RY", gate.targets, None,
+                                          arg_value=np.pi / 2,
+                                          arg_label=r"\pi/2"))
+                temp_resolved.append(Gate("RX", gate.targets, None,
+                                          arg_value=np.pi, arg_label=r"\pi"))
+
+            elif gate.name == "GLOBALPHASE":
+                temp_resolved.append(Gate(gate.name, gate.targets,
+                                          gate.controls,
+                                          gate.arg_value, gate.arg_label))
+            else:
+                raise NotImplementedError(
+                    "Gate {} "
+                    "cannot be resolved.".format(gate.name))
+
+        if "CSIGN" in basis_2q:
+            for gate in temp_resolved:
+                if gate.name == "CNOT":
+                    qc_temp.gates.append(Gate("RY", gate.targets, None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                    qc_temp.gates.append(Gate("CSIGN", gate.targets,
+                                              gate.controls))
+                    qc_temp.gates.append(Gate("RY", gate.targets, None,
+                                              arg_value=np.pi / 2,
+                                              arg_label=r"\pi/2"))
+                else:
+                    qc_temp.gates.append(gate)
+        elif "ISWAP" in basis_2q:
+            for gate in temp_resolved:
+                if gate.name == "CNOT":
+                    qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
+                                              arg_value=np.pi / 4,
+                                              arg_label=r"\pi/4"))
+                    qc_temp.gates.append(Gate("ISWAP", [gate.controls[0],
+                                                        gate.targets[0]],
+                                              None))
+                    qc_temp.gates.append(Gate("RZ", gate.targets, None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                    qc_temp.gates.append(Gate("RY", gate.controls, None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                    qc_temp.gates.append(Gate("RZ", gate.controls, None,
+                                              arg_value=np.pi / 2,
+                                              arg_label=r"\pi/2"))
+                    qc_temp.gates.append(Gate("ISWAP", [gate.controls[0],
+                                                        gate.targets[0]],
+                                              None))
+                    qc_temp.gates.append(Gate("RY", gate.targets, None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                    qc_temp.gates.append(Gate("RZ", gate.targets, None,
+                                              arg_value=np.pi / 2,
+                                              arg_label=r"\pi/2"))
+                elif gate.name == "SWAP":
+                    qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
+                                              arg_value=np.pi / 4,
+                                              arg_label=r"\pi/4"))
+                    qc_temp.gates.append(Gate("ISWAP", gate.targets, None))
+                    qc_temp.gates.append(Gate("RX", gate.targets[0], None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                    qc_temp.gates.append(Gate("ISWAP", gate.targets, None))
+                    qc_temp.gates.append(Gate("RX", gate.targets[1], None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                    qc_temp.gates.append(Gate("ISWAP", [gate.targets[1],
+                                                        gate.targets[0]],
+                                              None))
+                    qc_temp.gates.append(Gate("RX", gate.targets[0], None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                else:
+                    qc_temp.gates.append(gate)
+        elif "SQRTSWAP" in basis_2q:
+            for gate in temp_resolved:
+                if gate.name == "CNOT":
+                    qc_temp.gates.append(Gate("RY", gate.targets, None,
+                                              arg_value=np.pi / 2,
+                                              arg_label=r"\pi/2"))
+                    qc_temp.gates.append(Gate("SQRTSWAP", [gate.controls[0],
+                                                           gate.targets[0]],
+                                              None))
+                    qc_temp.gates.append(Gate("RZ", gate.controls, None,
+                                              arg_value=np.pi,
+                                              arg_label=r"\pi"))
+                    qc_temp.gates.append(Gate("SQRTSWAP", [gate.controls[0],
+                                                           gate.targets[0]],
+                                              None))
+                    qc_temp.gates.append(Gate("RZ", gate.targets, None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                    qc_temp.gates.append(Gate("RY", gate.targets, None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                    qc_temp.gates.append(Gate("RZ", gate.controls, None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                else:
+                    qc_temp.gates.append(gate)
+        elif "SQRTISWAP" in basis_2q:
+            for gate in temp_resolved:
+                if gate.name == "CNOT":
+                    qc_temp.gates.append(Gate("RY", gate.controls, None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                    qc_temp.gates.append(Gate("RX", gate.controls, None,
+                                              arg_value=np.pi / 2,
+                                              arg_label=r"\pi/2"))
+                    qc_temp.gates.append(Gate("RX", gate.targets, None,
+                                              arg_value=-np.pi / 2,
+                                              arg_label=r"-\pi/2"))
+                    qc_temp.gates.append(Gate("SQRTISWAP", [gate.controls[0],
+                                                            gate.targets[0]],
+                                              None))
+                    qc_temp.gates.append(Gate("RX", gate.controls, None,
+                                              arg_value=np.pi,
+                                              arg_label=r"\pi"))
+                    qc_temp.gates.append(Gate("SQRTISWAP", [gate.controls[0],
+                                                            gate.targets[0]],
+                                              None))
+                    qc_temp.gates.append(Gate("RY", gate.controls, None,
+                                              arg_value=np.pi / 2,
+                                              arg_label=r"\pi/2"))
+                    qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
+                                              arg_value=np.pi / 4,
+                                              arg_label=r"\pi/4"))
+                    qc_temp.gates.append(Gate("RZ", gate.controls, None,
+                                              arg_value=np.pi,
+                                              arg_label=r"\pi"))
+                    qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
+                                              arg_value=3 * np.pi / 2,
+                                              arg_label=r"3\pi/2"))
+                else:
+                    qc_temp.gates.append(gate)
+        else:
             qc_temp.gates = temp_resolved
 
         if len(basis_1q) == 2:
             temp_resolved = qc_temp.gates
             qc_temp.gates = []
-            half_pi = np.pi / 2
             for gate in temp_resolved:
                 if gate.name == "RX" and "RX" not in basis_1q:
                     qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                              arg_value=-half_pi,
+                                              arg_value=-np.pi / 2,
                                               arg_label=r"-\pi/2"))
                     qc_temp.gates.append(Gate("RZ", gate.targets, None,
                                               gate.arg_value, gate.arg_label))
                     qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                              arg_value=half_pi,
+                                              arg_value=np.pi / 2,
                                               arg_label=r"\pi/2"))
                 elif gate.name == "RY" and "RY" not in basis_1q:
                     qc_temp.gates.append(Gate("RZ", gate.targets, None,
-                                              arg_value=-half_pi,
+                                              arg_value=-np.pi / 2,
                                               arg_label=r"-\pi/2"))
                     qc_temp.gates.append(Gate("RX", gate.targets, None,
                                               gate.arg_value, gate.arg_label))
                     qc_temp.gates.append(Gate("RZ", gate.targets, None,
-                                              arg_value=half_pi,
+                                              arg_value=np.pi / 2,
                                               arg_label=r"\pi/2"))
                 elif gate.name == "RZ" and "RZ" not in basis_1q:
                     qc_temp.gates.append(Gate("RX", gate.targets, None,
-                                              arg_value=-half_pi,
+                                              arg_value=-np.pi / 2,
                                               arg_label=r"-\pi/2"))
                     qc_temp.gates.append(Gate("RY", gate.targets, None,
                                               gate.arg_value, gate.arg_label))
                     qc_temp.gates.append(Gate("RX", gate.targets, None,
-                                              arg_value=half_pi,
+                                              arg_value=np.pi / 2,
                                               arg_label=r"\pi/2"))
                 else:
                     qc_temp.gates.append(gate)
@@ -958,7 +869,7 @@ class QubitCircuit:
 
         Returns
         -------
-        qubit_circuit : QubitCircuit
+        qc : QubitCircuit
             Return QubitCircuit of the gates for the qubit circuit with the
             resolved non-adjacent gates.
 
@@ -1049,36 +960,11 @@ class QubitCircuit:
 
         for gate in self.gates:
             if gate.name == "RX":
-                self.U_list.append(rx(
-                    gate.arg_value, self.N, gate.targets[0]))
+                self.U_list.append(rx(gate.arg_value, self.N, gate.targets[0]))
             elif gate.name == "RY":
-                self.U_list.append(ry(
-                    gate.arg_value, self.N, gate.targets[0]))
+                self.U_list.append(ry(gate.arg_value, self.N, gate.targets[0]))
             elif gate.name == "RZ":
-                self.U_list.append(rz(
-                    gate.arg_value, self.N, gate.targets[0]))
-            elif gate.name == "X":
-                self.U_list.append(x_gate(self.N, gate.targets[0]))
-            elif gate.name == "Y":
-                self.U_list.append(y_gate(self.N, gate.targets[0]))
-            elif gate.name == "CY":
-                self.U_list.append(cy_gate(
-                    self.N, gate.controls[0], gate.targets[0]))
-            elif gate.name == "Z":
-                self.U_list.append(z_gate(self.N, gate.targets[0]))
-            elif gate.name == "CZ":
-                self.U_list.append(cz_gate(
-                    self.N, gate.controls[0], gate.targets[0]))
-            elif gate.name == "T":
-                self.U_list.append(t_gate(self.N, gate.targets[0]))
-            elif gate.name == "CT":
-                self.U_list.append(ct_gate(
-                    self.N, gate.controls[0], gate.targets[0]))
-            elif gate.name == "S":
-                self.U_list.append(s_gate(self.N, gate.targets[0]))
-            elif gate.name == "CS":
-                self.U_list.append(cs_gate(
-                    self.N, gate.controls[0], gate.targets[0]))
+                self.U_list.append(rz(gate.arg_value, self.N, gate.targets[0]))
             elif gate.name == "SQRTNOT":
                 self.U_list.append(sqrtnot(self.N, gate.targets[0]))
             elif gate.name == "SNOT":
@@ -1146,7 +1032,8 @@ class QubitCircuit:
                     raise ValueError(
                         "gate function takes at most one parameters.")
                 self.U_list.append(expand_operator(
-                    oper, N=self.N, targets=gate.targets, dims=self.dims))
+                        oper, N=self.N,
+                        targets=gate.targets, dims=self.dims))
 
             else:
                 raise NotImplementedError(
@@ -1169,9 +1056,9 @@ class QubitCircuit:
                             col.append(r" \qswap \qwx ")
 
                         elif ((self.reverse_states and
-                               n == max(gate.targets)) or
-                              (not self.reverse_states and
-                               n == min(gate.targets))):
+                                n == max(gate.targets)) or
+                                (not self.reverse_states and
+                                    n == min(gate.targets))):
                             col.append(r" \multigate{%d}{%s} " %
                                        (len(gate.targets) - 1,
                                         _gate_label(gate.name,
@@ -1183,14 +1070,6 @@ class QubitCircuit:
 
                     elif gate.name == "CNOT":
                         col.append(r" \targ ")
-                    elif gate.name == "CY":
-                        col.append(r" \targ ")
-                    elif gate.name == "CZ":
-                        col.append(r" \targ ")
-                    elif gate.name == "CS":
-                        col.append(r" \targ ")
-                    elif gate.name == "CT":
-                        col.append(r" \targ ")
                     elif gate.name == "TOFFOLI":
                         col.append(r" \targ ")
                     else:
@@ -1198,10 +1077,9 @@ class QubitCircuit:
                                    _gate_label(gate.name, gate.arg_label))
 
                 elif gate.controls and n in gate.controls:
-                    control_tag = (-1 if
-                                   self.reverse_states
-                                   else 1) * (gate.targets[0] - n)
-                    col.append(r" \ctrl{%d} " % control_tag)
+                    m = (gate.targets[0] - n) * (-1 if self.reverse_states
+                                                 else 1)
+                    col.append(r" \ctrl{%d} " % m)
 
                 elif (not gate.controls and not gate.targets):
                     # global gate
@@ -1220,7 +1098,7 @@ class QubitCircuit:
             col.append(r" \qw ")
             rows.append(col)
 
-        input_states = [r"\lstick{\ket{" + x + "}}" if x is not None
+        input_states = ["\lstick{\ket{" + x + "}}" if x is not None
                         else "" for x in self.input_states]
 
         code = ""
@@ -1234,34 +1112,21 @@ class QubitCircuit:
 
         return code
 
-    # This slightly convoluted dance with the conversion formats is because
-    # image conversion has optional dependencies.  We always want the `png` and
-    # `svg` methods to be available so that they are discoverable by the user,
-    # however if one is called without the required dependency, then they'll
-    # get a `RuntimeError` explaining the problem.  We only want the IPython
-    # magic methods `_repr_xxx_` to be defined if we know that the image
-    # conversion is available, so the user doesn't get exceptions on display
-    # because IPython tried to do something behind their back.
+    def _repr_png_(self):
+        return _latex_compile(self.latex_code(), format="png")
 
-    def _raw_png(self):
-        return _latex.image_from_latex(self.latex_code(), "png")
-
-    if 'png' in _latex.CONVERTERS:
-        _repr_png_ = _raw_png
+    def _repr_svg_(self):
+        return _latex_compile(self.latex_code(), format="svg")
 
     @property
     def png(self):
-        return DisplayImage(self._raw_png(), embed=True)
-
-    def _raw_svg(self):
-        return _latex.image_from_latex(self.latex_code(), "svg")
-
-    if 'svg' in _latex.CONVERTERS:
-        _repr_svg_ = _raw_svg
+        from IPython.display import Image
+        return Image(self._repr_png_(), embed=True)
 
     @property
     def svg(self):
-        return DisplaySVG(self._raw_svg())
+        from IPython.display import SVG
+        return SVG(self._repr_svg_())
 
     def qasm(self):
 

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -378,8 +378,10 @@ class QubitCircuit(object):
         remove : string
             If first or all gate are to be removed.
         """
-        if index is not None and index <= self.N:
-            if end is not None and end <= self.N:
+        if index is not None:
+            if index > len(self.gates):
+                raise ValueError("Index exceeds number of gates.")
+            if end is not None and end <= len(self.gates):
                 for i in range(end - index):
                     self.gates.pop(index + i)
             elif end is not None and end > self.N:
@@ -394,15 +396,15 @@ class QubitCircuit(object):
                     break
 
         elif name is not None and remove == "last":
-            for i in range(self.N + 1):
-                if name == self.gates[self.N - i].name:
-                    self.gates.remove(self.gates[self.N - i])
+            for i in reversed(range(len(self.gates))):
+                if name == self.gates[i].name:
+                    self.gates.pop(i)
                     break
 
         elif name is not None and remove == "all":
-            for j in range(self.N + 1):
-                if name == self.gates[self.N - j].name:
-                    self.gates.remove(self.gates[self.N - j])
+            for i in reversed(range(len(self.gates))):
+                if name == self.gates[i].name:
+                    self.gates.pop(i)
 
         else:
             self.gates.pop()

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -37,9 +37,26 @@ import inspect
 
 import numpy as np
 
-from qutip.qip.circuit_latex import _latex_compile
-from qutip.qip.operations.gates import *
-from qutip.qip.qubits import qubit_states
+from qutip.qip import circuit_latex as _latex
+from qutip.qip.operations.gates import (rx, ry, rz, sqrtnot, snot, phasegate,
+                                        x_gate, y_gate, z_gate, cy_gate,
+                                        cz_gate, s_gate, t_gate, cs_gate,
+                                        ct_gate, cphase, cnot, csign,
+                                        berkeley, swapalpha, swap, iswap,
+                                        sqrtswap, sqrtiswap, fredkin,
+                                        toffoli, controlled_gate, globalphase,
+                                        expand_operator)
+
+try:
+    from IPython.display import Image as DisplayImage, SVG as DisplaySVG
+except ImportError:
+    # If IPython doesn't exist, then we set the nice display hooks to be simple
+    # pass-throughs.
+    def DisplayImage(data, *args, **kwargs):
+        return data
+
+    def DisplaySVG(data, *args, **kwargs):
+        return data
 
 __all__ = ['Gate', 'QubitCircuit']
 
@@ -55,7 +72,7 @@ _toffoli_like = ["TOFFOLI"]
 _fredkin_like = ["FREDKIN"]
 
 
-class Gate(object):
+class Gate:
     """
     Representation of a quantum gate, with its required parametrs, and target
     and control qubits.
@@ -137,10 +154,10 @@ class Gate(object):
         self.arg_label = arg_label
 
     def __str__(self):
-        s = "Gate(%s, targets=%s, controls=%s)" % (self.name,
-                                                   self.targets,
-                                                   self.controls)
-        return s
+        string_name = "Gate(%s, targets=%s, controls=%s)" % (self.name,
+                                                             self.targets,
+                                                             self.controls)
+        return string_name
 
     def __repr__(self):
         return str(self)
@@ -149,7 +166,16 @@ class Gate(object):
         return str(self)
 
 
-_gate_name_to_label = {
+_GATE_NAME_TO_LABEL = {
+    'X': r'X',
+    'Y': r'Y',
+    'CY': r'C_y',
+    'Z': r'Z',
+    'CZ': r'C_z',
+    'S': r'S',
+    'CS': r'C_s',
+    'T': r'T',
+    'CT': r'C_t',
     'RX': r'R_x',
     'RY': r'R_y',
     'RZ': r'R_z',
@@ -176,19 +202,18 @@ _gate_name_to_label = {
 
 def _gate_label(name, arg_label):
 
-    if name in _gate_name_to_label:
-        gate_label = _gate_name_to_label[name]
+    if name in _GATE_NAME_TO_LABEL:
+        gate_label = _GATE_NAME_TO_LABEL[name]
     else:
         warnings.warn("Unknown gate %s" % name)
         gate_label = name
 
     if arg_label:
         return r'%s(%s)' % (gate_label, arg_label)
-    else:
-        return r'%s' % gate_label
+    return r'%s' % gate_label
 
 
-class QubitCircuit(object):
+class QubitCircuit:
     """
     Representation of a quantum program/algorithm, maintaining a sequence
     of gates.
@@ -212,8 +237,8 @@ class QubitCircuit(object):
     ...     mat = np.array([[1.,   0],
     ...                     [0., 1.j]])
     ...     return Qobj(mat, dims=[[2], [2]])
-    >>> qc.QubitCircuit(2, user_gates={"T":user_gate})
-    >>> qc.add_gate("T", targets=[0])
+    >>> qubit_circuit.QubitCircuit(2, user_gates={"T":user_gate})
+    >>> qubit_circuit.add_gate("T", targets=[0])
     """
 
     def __init__(self, N, input_states=None, output_states=None,
@@ -327,11 +352,12 @@ class QubitCircuit(object):
         arg_label : string
             Label for gate representation.
         """
-        if name not in ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE"]:
+        if name not in ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE",
+                        "X", "Y", "Z", "S", "T"]:
             raise ValueError("%s is not a single qubit gate" % name)
 
         if qubits is not None:
-            for i in range(len(qubits)):
+            for _, i in enumerate(qubits):
                 self.gates.append(Gate(name, targets=qubits[i], controls=None,
                                        arg_value=arg_value,
                                        arg_label=arg_label))
@@ -339,7 +365,7 @@ class QubitCircuit(object):
         else:
             if end is None:
                 end = self.N - 1
-            for i in range(start, end):
+            for i in range(start, end+1):
                 self.gates.append(Gate(name, targets=i, controls=None,
                                        arg_value=arg_value,
                                        arg_label=arg_label))
@@ -363,7 +389,11 @@ class QubitCircuit(object):
             if gate.name in ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE"]:
                 self.add_gate(gate.name, gate.targets[0] + start, None,
                               gate.arg_value, gate.arg_label)
-            elif gate.name in ["CPHASE", "CNOT", "CSIGN", "CRX", "CRY", "CRZ"]:
+            elif gate.name in ["X", "Y", "Z", "S", "T"]:
+                self.add_gate(gate.name, gate.targets[0] + start, None,
+                              None, gate.arg_label)
+            elif gate.name in ["CPHASE", "CNOT", "CSIGN", "CRX", "CRY",
+                               "CRZ", "CY", "CZ", "CS", "CT"]:
                 self.add_gate(gate.name, gate.targets[0] + start,
                               gate.controls[0] + start, gate.arg_value,
                               gate.arg_label)
@@ -382,8 +412,8 @@ class QubitCircuit(object):
                               gate.controls + start, None, None)
             elif gate.name in self.user_gates:
                 self.add_gate(
-                              gate.name, targets=gate.targets,
-                              arg_value=gate.arg_value)
+                    gate.name, targets=gate.targets,
+                    arg_value=gate.arg_value)
 
     def remove_gate(self, index=None, end=None, name=None, remove="first"):
         """
@@ -436,7 +466,7 @@ class QubitCircuit(object):
 
         Returns
         -------
-        qc : QubitCircuit
+        qubit_circuit : QubitCircuit
             Return QubitCircuit of resolved gates for the qubit circuit in the
             reverse order.
 
@@ -823,12 +853,14 @@ class QubitCircuit(object):
         Unitary matrix calculator for N qubits returning the individual
         steps as unitary matrices operating from left to right in the specified
         basis.
-
+        Calls '_resolve_to_universal' for each gate, this function maps
+        each 'GATENAME' with its corresponding '_gate_basis_2q'
+        Subsequently calls _resolve_2q_basis for each basis, this function maps
+        each '2QGATENAME' with its corresponding '_basis_'
         Parameters
         ----------
         basis : list.
             Basis of the resolved circuit.
-
         Returns
         -------
         qc : QubitCircuit
@@ -854,7 +886,7 @@ class QubitCircuit(object):
                         "%s is not a valid basis gate" % gate)
             if len(basis_1q) == 1:
                 raise ValueError("Not sufficient single-qubit gates in basis")
-            elif len(basis_1q) == 0:
+            if len(basis_1q) == 0:
                 basis_1q = ["RX", "RY", "RZ"]
 
         else:  # only one 2q gate is given as basis
@@ -866,389 +898,53 @@ class QubitCircuit(object):
                                  % basis)
 
         for gate in self.gates:
-            if gate.name == "RX":
-                temp_resolved.append(gate)
-            elif gate.name == "RY":
-                temp_resolved.append(gate)
-            elif gate.name == "RZ":
-                temp_resolved.append(gate)
-            elif gate.name == "SQRTNOT":
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=np.pi / 4,
-                                          arg_label=r"\pi/4"))
-                temp_resolved.append(Gate("RX", gate.targets, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-            elif gate.name == "SNOT":
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RY", gate.targets, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RX", gate.targets, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-            elif gate.name == "PHASEGATE":
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=gate.arg_value / 2,
-                                          arg_label=gate.arg_label))
-                temp_resolved.append(Gate("RZ", gate.targets, None,
-                                          gate.arg_value, gate.arg_label))
-            elif gate.name in basis_2q:  # ignore all gate in 2q basis
-                temp_resolved.append(gate)
-            elif gate.name == "CPHASE":
-                raise NotImplementedError("Cannot be resolved in this basis")
-            elif gate.name == "CNOT":
-                temp_resolved.append(gate)
-            elif gate.name == "CSIGN":
-                temp_resolved.append(Gate("RY", gate.targets, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RX", gate.targets, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-                temp_resolved.append(Gate("CNOT", gate.targets, gate.controls))
-                temp_resolved.append(Gate("RY", gate.targets, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RX", gate.targets, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-            elif gate.name == "BERKELEY":
-                raise NotImplementedError("Cannot be resolved in this basis")
-            elif gate.name == "SWAPalpha":
-                raise NotImplementedError("Cannot be resolved in this basis")
-            elif gate.name == "SWAP":
-                if "ISWAP" in basis_2q:  # dealed with separately
-                    temp_resolved.append(gate)
-                else:
-                    temp_resolved.append(
-                        Gate("CNOT", gate.targets[0], gate.targets[1]))
-                    temp_resolved.append(
-                        Gate("CNOT", gate.targets[1], gate.targets[0]))
-                    temp_resolved.append(
-                        Gate("CNOT", gate.targets[0], gate.targets[1]))
-            elif gate.name == "ISWAP":
-                temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                          gate.targets[1]))
-                temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                          gate.targets[0]))
-                temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                          gate.targets[1]))
-                temp_resolved.append(Gate("RZ", gate.targets[0], None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RZ", gate.targets[1], None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RY", gate.targets[0], None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RX", gate.targets, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-                temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                          gate.targets[1]))
-                temp_resolved.append(Gate("RY", gate.targets[0], None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RX", gate.targets, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-            elif gate.name == "SQRTSWAP":
-                raise NotImplementedError("Cannot be resolved in this basis")
-            elif gate.name == "SQRTISWAP":
-                raise NotImplementedError("Cannot be resolved in this basis")
-            elif gate.name == "FREDKIN":
-                temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                          gate.targets[1]))
-                temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                          gate.controls))
-                temp_resolved.append(Gate("RZ", gate.controls, None,
-                                          arg_value=np.pi / 8,
-                                          arg_label=r"\pi/8"))
-                temp_resolved.append(Gate("RZ", [gate.targets[0]], None,
-                                          arg_value=-np.pi / 8,
-                                          arg_label=r"-\pi/8"))
-                temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                          gate.controls))
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RY", gate.targets[1], None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RY", gate.targets, None,
-                                          arg_value=-np.pi / 2,
-                                          arg_label=r"-\pi/2"))
-                temp_resolved.append(Gate("RZ", gate.targets, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-                temp_resolved.append(Gate("RY", gate.targets, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RZ", gate.targets[0], None,
-                                          arg_value=np.pi / 8,
-                                          arg_label=r"\pi/8"))
-                temp_resolved.append(Gate("RZ", gate.targets[1], None,
-                                          arg_value=np.pi / 8,
-                                          arg_label=r"\pi/8"))
-                temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                          gate.controls))
-                temp_resolved.append(Gate("RZ", gate.targets[1], None,
-                                          arg_value=-np.pi / 8,
-                                          arg_label=r"-\pi/8"))
-                temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                          gate.targets[0]))
-                temp_resolved.append(Gate("RZ", gate.targets[1], None,
-                                          arg_value=np.pi / 8,
-                                          arg_label=r"\pi/8"))
-                temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                          gate.controls))
-                temp_resolved.append(Gate("RZ", gate.targets[1], None,
-                                          arg_value=-np.pi / 8,
-                                          arg_label=r"-\pi/8"))
-                temp_resolved.append(Gate("CNOT", gate.targets[1],
-                                          gate.targets[0]))
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RY", gate.targets[1], None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RY", gate.targets, None,
-                                          arg_value=-np.pi / 2,
-                                          arg_label=r"-\pi/2"))
-                temp_resolved.append(Gate("RZ", gate.targets, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-                temp_resolved.append(Gate("RY", gate.targets, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("CNOT", gate.targets[0],
-                                          gate.targets[1]))
+            try:
+                self._resolve_to_universal(gate, temp_resolved,
+                                           basis_1q, basis_2q)
+            except AttributeError:
+                exception = f"Gate {gate.name} cannot be resolved."
+                raise NotImplementedError(exception)
 
-            elif gate.name == "TOFFOLI":
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=1 * np.pi / 8,
-                                          arg_label=r"\pi/8"))
-                temp_resolved.append(Gate("RZ", gate.controls[1], None,
-                                          arg_value=np.pi/2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RZ", gate.controls[0], None,
-                                          arg_value=np.pi / 4,
-                                          arg_label=r"\pi/4"))
-                temp_resolved.append(Gate("CNOT", gate.controls[1],
-                                          gate.controls[0]))
-                temp_resolved.append(Gate("RZ", gate.controls[1], None,
-                                          arg_value=-np.pi / 4,
-                                          arg_label=r"-\pi/4"))
-                temp_resolved.append(Gate("CNOT", gate.controls[1],
-                                          gate.controls[0]))
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RY", gate.targets, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RX", gate.targets, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-                temp_resolved.append(Gate("RZ", gate.controls[1], None,
-                                          arg_value=-np.pi / 4,
-                                          arg_label=r"-\pi/4"))
-                temp_resolved.append(Gate("RZ", gate.targets, None,
-                                          arg_value=np.pi / 4,
-                                          arg_label=r"\pi/4"))
-                temp_resolved.append(Gate("CNOT", gate.targets,
-                                          gate.controls[0]))
-                temp_resolved.append(Gate("RZ", gate.targets, None,
-                                          arg_value=-np.pi / 4,
-                                          arg_label=r"-\pi/4"))
-                temp_resolved.append(Gate("CNOT", gate.targets,
-                                          gate.controls[1]))
-                temp_resolved.append(Gate("RZ", gate.targets, None,
-                                          arg_value=np.pi / 4,
-                                          arg_label=r"\pi/4"))
-                temp_resolved.append(Gate("CNOT", gate.targets,
-                                          gate.controls[0]))
-                temp_resolved.append(Gate("RZ", gate.targets, None,
-                                          arg_value=-np.pi / 4,
-                                          arg_label=r"-\pi/4"))
-                temp_resolved.append(Gate("CNOT", gate.targets,
-                                          gate.controls[1]))
-                temp_resolved.append(Gate("GLOBALPHASE", None, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RY", gate.targets, None,
-                                          arg_value=np.pi / 2,
-                                          arg_label=r"\pi/2"))
-                temp_resolved.append(Gate("RX", gate.targets, None,
-                                          arg_value=np.pi, arg_label=r"\pi"))
-
-            elif gate.name == "GLOBALPHASE":
-                temp_resolved.append(Gate(gate.name, gate.targets,
-                                          gate.controls,
-                                          gate.arg_value, gate.arg_label))
-            else:
-                raise NotImplementedError(
-                    "Gate {} "
-                    "cannot be resolved.".format(gate.name))
-
-        if "CSIGN" in basis_2q:
-            for gate in temp_resolved:
-                if gate.name == "CNOT":
-                    qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                    qc_temp.gates.append(Gate("CSIGN", gate.targets,
-                                              gate.controls))
-                    qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                              arg_value=np.pi / 2,
-                                              arg_label=r"\pi/2"))
-                else:
-                    qc_temp.gates.append(gate)
-        elif "ISWAP" in basis_2q:
-            for gate in temp_resolved:
-                if gate.name == "CNOT":
-                    qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
-                                              arg_value=np.pi / 4,
-                                              arg_label=r"\pi/4"))
-                    qc_temp.gates.append(Gate("ISWAP", [gate.controls[0],
-                                                        gate.targets[0]],
-                                              None))
-                    qc_temp.gates.append(Gate("RZ", gate.targets, None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                    qc_temp.gates.append(Gate("RY", gate.controls, None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                    qc_temp.gates.append(Gate("RZ", gate.controls, None,
-                                              arg_value=np.pi / 2,
-                                              arg_label=r"\pi/2"))
-                    qc_temp.gates.append(Gate("ISWAP", [gate.controls[0],
-                                                        gate.targets[0]],
-                                              None))
-                    qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                    qc_temp.gates.append(Gate("RZ", gate.targets, None,
-                                              arg_value=np.pi / 2,
-                                              arg_label=r"\pi/2"))
-                elif gate.name == "SWAP":
-                    qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
-                                              arg_value=np.pi / 4,
-                                              arg_label=r"\pi/4"))
-                    qc_temp.gates.append(Gate("ISWAP", gate.targets, None))
-                    qc_temp.gates.append(Gate("RX", gate.targets[0], None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                    qc_temp.gates.append(Gate("ISWAP", gate.targets, None))
-                    qc_temp.gates.append(Gate("RX", gate.targets[1], None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                    qc_temp.gates.append(Gate("ISWAP", [gate.targets[1],
-                                                        gate.targets[0]],
-                                              None))
-                    qc_temp.gates.append(Gate("RX", gate.targets[0], None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                else:
-                    qc_temp.gates.append(gate)
-        elif "SQRTSWAP" in basis_2q:
-            for gate in temp_resolved:
-                if gate.name == "CNOT":
-                    qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                              arg_value=np.pi / 2,
-                                              arg_label=r"\pi/2"))
-                    qc_temp.gates.append(Gate("SQRTSWAP", [gate.controls[0],
-                                                           gate.targets[0]],
-                                              None))
-                    qc_temp.gates.append(Gate("RZ", gate.controls, None,
-                                              arg_value=np.pi,
-                                              arg_label=r"\pi"))
-                    qc_temp.gates.append(Gate("SQRTSWAP", [gate.controls[0],
-                                                           gate.targets[0]],
-                                              None))
-                    qc_temp.gates.append(Gate("RZ", gate.targets, None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                    qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                    qc_temp.gates.append(Gate("RZ", gate.controls, None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                else:
-                    qc_temp.gates.append(gate)
-        elif "SQRTISWAP" in basis_2q:
-            for gate in temp_resolved:
-                if gate.name == "CNOT":
-                    qc_temp.gates.append(Gate("RY", gate.controls, None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                    qc_temp.gates.append(Gate("RX", gate.controls, None,
-                                              arg_value=np.pi / 2,
-                                              arg_label=r"\pi/2"))
-                    qc_temp.gates.append(Gate("RX", gate.targets, None,
-                                              arg_value=-np.pi / 2,
-                                              arg_label=r"-\pi/2"))
-                    qc_temp.gates.append(Gate("SQRTISWAP", [gate.controls[0],
-                                                            gate.targets[0]],
-                                              None))
-                    qc_temp.gates.append(Gate("RX", gate.controls, None,
-                                              arg_value=np.pi,
-                                              arg_label=r"\pi"))
-                    qc_temp.gates.append(Gate("SQRTISWAP", [gate.controls[0],
-                                                            gate.targets[0]],
-                                              None))
-                    qc_temp.gates.append(Gate("RY", gate.controls, None,
-                                              arg_value=np.pi / 2,
-                                              arg_label=r"\pi/2"))
-                    qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
-                                              arg_value=np.pi / 4,
-                                              arg_label=r"\pi/4"))
-                    qc_temp.gates.append(Gate("RZ", gate.controls, None,
-                                              arg_value=np.pi,
-                                              arg_label=r"\pi"))
-                    qc_temp.gates.append(Gate("GLOBALPHASE", None, None,
-                                              arg_value=3 * np.pi / 2,
-                                              arg_label=r"3\pi/2"))
-                else:
-                    qc_temp.gates.append(gate)
-        else:
+        match = False
+        for basis_unit in ["CSIGN", "ISWAP", "SQRTSWAP", "SQRTISWAP"]:
+            if basis_unit in basis_2q:
+                match = True
+                self._resolve_2q_basis(basis_unit, qc_temp, temp_resolved)
+                break
+        if not match:
             qc_temp.gates = temp_resolved
 
         if len(basis_1q) == 2:
             temp_resolved = qc_temp.gates
             qc_temp.gates = []
+            half_pi = np.pi / 2
             for gate in temp_resolved:
                 if gate.name == "RX" and "RX" not in basis_1q:
                     qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                              arg_value=-np.pi / 2,
+                                              arg_value=-half_pi,
                                               arg_label=r"-\pi/2"))
                     qc_temp.gates.append(Gate("RZ", gate.targets, None,
                                               gate.arg_value, gate.arg_label))
                     qc_temp.gates.append(Gate("RY", gate.targets, None,
-                                              arg_value=np.pi / 2,
+                                              arg_value=half_pi,
                                               arg_label=r"\pi/2"))
                 elif gate.name == "RY" and "RY" not in basis_1q:
                     qc_temp.gates.append(Gate("RZ", gate.targets, None,
-                                              arg_value=-np.pi / 2,
+                                              arg_value=-half_pi,
                                               arg_label=r"-\pi/2"))
                     qc_temp.gates.append(Gate("RX", gate.targets, None,
                                               gate.arg_value, gate.arg_label))
                     qc_temp.gates.append(Gate("RZ", gate.targets, None,
-                                              arg_value=np.pi / 2,
+                                              arg_value=half_pi,
                                               arg_label=r"\pi/2"))
                 elif gate.name == "RZ" and "RZ" not in basis_1q:
                     qc_temp.gates.append(Gate("RX", gate.targets, None,
-                                              arg_value=-np.pi / 2,
+                                              arg_value=-half_pi,
                                               arg_label=r"-\pi/2"))
                     qc_temp.gates.append(Gate("RY", gate.targets, None,
                                               gate.arg_value, gate.arg_label))
                     qc_temp.gates.append(Gate("RX", gate.targets, None,
-                                              arg_value=np.pi / 2,
+                                              arg_value=half_pi,
                                               arg_label=r"\pi/2"))
                 else:
                     qc_temp.gates.append(gate)
@@ -1262,7 +958,7 @@ class QubitCircuit(object):
 
         Returns
         -------
-        qc : QubitCircuit
+        qubit_circuit : QubitCircuit
             Return QubitCircuit of the gates for the qubit circuit with the
             resolved non-adjacent gates.
 
@@ -1353,11 +1049,36 @@ class QubitCircuit(object):
 
         for gate in self.gates:
             if gate.name == "RX":
-                self.U_list.append(rx(gate.arg_value, self.N, gate.targets[0]))
+                self.U_list.append(rx(
+                    gate.arg_value, self.N, gate.targets[0]))
             elif gate.name == "RY":
-                self.U_list.append(ry(gate.arg_value, self.N, gate.targets[0]))
+                self.U_list.append(ry(
+                    gate.arg_value, self.N, gate.targets[0]))
             elif gate.name == "RZ":
-                self.U_list.append(rz(gate.arg_value, self.N, gate.targets[0]))
+                self.U_list.append(rz(
+                    gate.arg_value, self.N, gate.targets[0]))
+            elif gate.name == "X":
+                self.U_list.append(x_gate(self.N, gate.targets[0]))
+            elif gate.name == "Y":
+                self.U_list.append(y_gate(self.N, gate.targets[0]))
+            elif gate.name == "CY":
+                self.U_list.append(cy_gate(
+                    self.N, gate.controls[0], gate.targets[0]))
+            elif gate.name == "Z":
+                self.U_list.append(z_gate(self.N, gate.targets[0]))
+            elif gate.name == "CZ":
+                self.U_list.append(cz_gate(
+                    self.N, gate.controls[0], gate.targets[0]))
+            elif gate.name == "T":
+                self.U_list.append(t_gate(self.N, gate.targets[0]))
+            elif gate.name == "CT":
+                self.U_list.append(ct_gate(
+                    self.N, gate.controls[0], gate.targets[0]))
+            elif gate.name == "S":
+                self.U_list.append(s_gate(self.N, gate.targets[0]))
+            elif gate.name == "CS":
+                self.U_list.append(cs_gate(
+                    self.N, gate.controls[0], gate.targets[0]))
             elif gate.name == "SQRTNOT":
                 self.U_list.append(sqrtnot(self.N, gate.targets[0]))
             elif gate.name == "SNOT":
@@ -1425,8 +1146,7 @@ class QubitCircuit(object):
                     raise ValueError(
                         "gate function takes at most one parameters.")
                 self.U_list.append(expand_operator(
-                        oper, N=self.N,
-                        targets=gate.targets, dims=self.dims))
+                    oper, N=self.N, targets=gate.targets, dims=self.dims))
 
             else:
                 raise NotImplementedError(
@@ -1449,9 +1169,9 @@ class QubitCircuit(object):
                             col.append(r" \qswap \qwx ")
 
                         elif ((self.reverse_states and
-                                n == max(gate.targets)) or
-                                (not self.reverse_states and
-                                    n == min(gate.targets))):
+                               n == max(gate.targets)) or
+                              (not self.reverse_states and
+                               n == min(gate.targets))):
                             col.append(r" \multigate{%d}{%s} " %
                                        (len(gate.targets) - 1,
                                         _gate_label(gate.name,
@@ -1463,6 +1183,14 @@ class QubitCircuit(object):
 
                     elif gate.name == "CNOT":
                         col.append(r" \targ ")
+                    elif gate.name == "CY":
+                        col.append(r" \targ ")
+                    elif gate.name == "CZ":
+                        col.append(r" \targ ")
+                    elif gate.name == "CS":
+                        col.append(r" \targ ")
+                    elif gate.name == "CT":
+                        col.append(r" \targ ")
                     elif gate.name == "TOFFOLI":
                         col.append(r" \targ ")
                     else:
@@ -1470,9 +1198,10 @@ class QubitCircuit(object):
                                    _gate_label(gate.name, gate.arg_label))
 
                 elif gate.controls and n in gate.controls:
-                    m = (gate.targets[0] - n) * (-1 if self.reverse_states
-                                                 else 1)
-                    col.append(r" \ctrl{%d} " % m)
+                    control_tag = (-1 if
+                                   self.reverse_states
+                                   else 1) * (gate.targets[0] - n)
+                    col.append(r" \ctrl{%d} " % control_tag)
 
                 elif (not gate.controls and not gate.targets):
                     # global gate
@@ -1491,7 +1220,7 @@ class QubitCircuit(object):
             col.append(r" \qw ")
             rows.append(col)
 
-        input_states = ["\lstick{\ket{" + x + "}}" if x is not None
+        input_states = [r"\lstick{\ket{" + x + "}}" if x is not None
                         else "" for x in self.input_states]
 
         code = ""
@@ -1505,21 +1234,34 @@ class QubitCircuit(object):
 
         return code
 
-    def _repr_png_(self):
-        return _latex_compile(self.latex_code(), format="png")
+    # This slightly convoluted dance with the conversion formats is because
+    # image conversion has optional dependencies.  We always want the `png` and
+    # `svg` methods to be available so that they are discoverable by the user,
+    # however if one is called without the required dependency, then they'll
+    # get a `RuntimeError` explaining the problem.  We only want the IPython
+    # magic methods `_repr_xxx_` to be defined if we know that the image
+    # conversion is available, so the user doesn't get exceptions on display
+    # because IPython tried to do something behind their back.
 
-    def _repr_svg_(self):
-        return _latex_compile(self.latex_code(), format="svg")
+    def _raw_png(self):
+        return _latex.image_from_latex(self.latex_code(), "png")
+
+    if 'png' in _latex.CONVERTERS:
+        _repr_png_ = _raw_png
 
     @property
     def png(self):
-        from IPython.display import Image
-        return Image(self._repr_png_(), embed=True)
+        return DisplayImage(self._raw_png(), embed=True)
+
+    def _raw_svg(self):
+        return _latex.image_from_latex(self.latex_code(), "svg")
+
+    if 'svg' in _latex.CONVERTERS:
+        _repr_svg_ = _raw_svg
 
     @property
     def svg(self):
-        from IPython.display import SVG
-        return SVG(self._repr_svg_())
+        return DisplaySVG(self._raw_svg())
 
     def qasm(self):
 

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -808,7 +808,7 @@ class QobjEvo:
                               if dargs[0] not in new_args]
         self.args.update(new_args)
         self._args_checks()
-        if self.compiled and self.compiled.split()[2] is not "cte":
+        if self.compiled and self.compiled.split()[2] != "cte":
             if isinstance(self.coeff_get, StrCoeff):
                 self.coeff_get.set_args(self.args)
                 self.coeff_get._set_dyn_args(self.dynamics_args)
@@ -826,7 +826,7 @@ class QobjEvo:
                 if self.compiled:
                     self.dynamics_args[i][2].compile()
         self._dynamics_args_update(0., state)
-        if self.compiled and self.compiled.split()[2] is not "cte":
+        if self.compiled and self.compiled.split()[2] != "cte":
             if isinstance(self.coeff_get, StrCoeff):
                 self.coeff_get.set_args(self.args)
                 self.coeff_get._set_dyn_args(self.dynamics_args)
@@ -1092,7 +1092,7 @@ class QobjEvo:
                 for j, op2 in enumerate(self.ops[i+1:]):
                     if op1.type != op2.type:
                         pass
-                    elif op1.type is "array":
+                    elif op1.type == "array":
                         if np.allclose(op1.coeff, op2.coeff):
                             this_set.append(j+i+1)
                     else:
@@ -1117,7 +1117,7 @@ class QobjEvo:
                 new_op[2] = new_op[1]
                 new_ops.append(EvoElement.make(new_op))
 
-            elif self.ops[_set[0]].type is "string":
+            elif self.ops[_set[0]].type == "string":
                 new_op = [self.ops[_set[0]].qobj, None, None, "string"]
                 new_str = "(" + self.ops[_set[0]].coeff + ")"
                 for i in _set[1:]:
@@ -1126,7 +1126,7 @@ class QobjEvo:
                 new_op[2] = new_str
                 new_ops.append(EvoElement.make(new_op))
 
-            elif self.ops[_set[0]].type is "array":
+            elif self.ops[_set[0]].type == "array":
                 new_op = [self.ops[_set[0]].qobj, None, None, "array"]
                 new_array = (self.ops[_set[0]].coeff).copy()
                 for i in _set[1:]:
@@ -1620,7 +1620,7 @@ class QobjEvo:
 
     def __getstate__(self):
         _dict_ = {key: self.__dict__[key]
-                  for key in self.__dict__ if key is not "compiled_qobjevo"}
+                  for key in self.__dict__ if key != "compiled_qobjevo"}
         if self.compiled:
             return (_dict_, self.compiled_qobjevo.__getstate__())
         else:

--- a/qutip/scattering.py
+++ b/qutip/scattering.py
@@ -276,9 +276,9 @@ def temporal_scattered_state(H, psi0, n_emissions, c_ops, tlist,
 
     if construct_effective_hamiltonian:
         # Construct an effective Hamiltonian from system hamiltonian and c_ops
-        if type(H) is Qobj:
+        if isinstance(H, Qobj):
             Heff = H - 1j / 2 * sum([op.dag() * op for op in c_ops])
-        elif type(H) is list:
+        elif isinstance(H, list):
             Heff = H + [-1j / 2 * sum([op.dag() * op for op in c_ops])]
         else:
             raise TypeError("Hamiltonian must be Qobj or list-callback format")

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -57,6 +57,8 @@ has_mkl = False
 has_openmp = False
 # debug mode for development
 debug = False
+# Running on mac with openblas make eigh unsafe
+eigh_unsafe = False
 # are we in IPython? Note that this cannot be
 # set by the RC file.
 ipython = False
@@ -70,7 +72,7 @@ log_handler = 'default'
 # and plotting options by default.
 colorblind_safe = False
 # Sets the threshold for matrix NNZ where OPENMP
-# turns on. This is automatically calculated and 
+# turns on. This is automatically calculated and
 # put in the qutiprc file.  This value is here in case
 # that failts
 openmp_thresh = 10000

--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -43,7 +43,6 @@ from qutip.cy.brtools_checks import (
 )
 
 
-@pytest.mark.skipif("platform.system() == 'Darwin'")
 def test_zheevr():
     """
     zheevr: store eigenvalues in the passed array, and return the eigenvectors

--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -51,11 +51,18 @@ def test_zheevr():
     """
     for dimension in range(2, 100):
         H = qutip.rand_herm(dimension, 1/dimension)
-        our_evals = np.zeros(dimension, dtype=np.float64)
-        our_evecs = _test_zheevr(H.full('F'), our_evals)
-        scipy_evals, scipy_evecs = scipy.linalg.eigh(H.full())
-        assert np.allclose(scipy_evals, our_evals)
-        assert np.allclose(scipy_evecs, our_evecs)
+        Hf = H.full()
+        evals = np.zeros(dimension, dtype=np.float64)
+        # This routine modifies its arguments inplace, so we must make a copy.
+        evecs = _test_zheevr(Hf.copy(order='F'), evals).T
+        # Assert linear independence of all the eigenvectors.
+        assert abs(scipy.linalg.det(evecs)) > 1e-12
+        for value, vector in zip(evals, evecs):
+            # Assert the eigenvector satisfies the eigenvalue equation.
+            unit = vector / scipy.linalg.norm(vector)
+            test_value = np.conj(unit.T) @ Hf @ unit
+            assert abs(test_value.imag) < 1e-12
+            assert abs(test_value - value) < 1e-12
 
 
 @pytest.mark.parametrize("operator", [

--- a/qutip/tests/test_cavityqed.py
+++ b/qutip/tests/test_cavityqed.py
@@ -133,7 +133,7 @@ class Testcqed:
             fidelity(result, rho1), 1., rtol=1e-2,
             err_msg="Analytical run_state fails in DispersiveCavityQED")
 
-    @pytest.mark.skipif("platform.system() == 'Darwin'")
+
     def test_numerical_evo(self):
         """
         Test of run_state with qutip solver

--- a/qutip/tests/test_control_pulseoptim.py
+++ b/qutip/tests/test_control_pulseoptim.py
@@ -432,7 +432,7 @@ class TestPulseOptim:
         assert_(dyn.dump is not None, msg='dynamics dump not created')
 
         # Use the dump to check unitarity of all propagators and evo_ops
-        dyn.unitarity_tol = 1e-14
+        dyn.unitarity_tol = 1e-13
         nu_prop = 0
         nu_fwd_evo = 0
         nu_onto_evo = 0
@@ -1026,4 +1026,3 @@ class TestPulseOptim:
 
 if __name__ == "__main__":
     run_module_suite()
-

--- a/qutip/tests/test_metrics.py
+++ b/qutip/tests/test_metrics.py
@@ -296,7 +296,6 @@ def test_hellinger_inequality():
         assert_(hellinger >= bures)
 
 
-@pytest.mark.skipif("platform.system() == 'Darwin'")
 def test_hellinger_monotonicity():
     """
     Metrics: Hellinger dist.: check monotonicity

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -32,9 +32,9 @@
 ###############################################################################
 
 import numpy as np
-from numpy.testing import assert_, assert_allclose, run_module_suite
+from numpy.testing import assert_raises, assert_, assert_allclose, run_module_suite
 from qutip.qip.operations.gates import (
-    gate_sequence_product, rx, expand_operator)
+    gate_sequence_product, rx)
 from qutip.operators import identity
 from qutip.qip.circuit import (
     QubitCircuit, Gate, _ctrl_gates, _single_qubit_gates, _swap_like, _toffoli_like,
@@ -163,13 +163,14 @@ class TestQubitCircuit:
         """
         Addition of a gate object directly to a `QubitCircuit`
         """
-        qc = QubitCircuit(3)
+        qc = QubitCircuit(6)
         qc.add_gate("CNOT", targets=[1], controls=[0])
         test_gate = Gate("SWAP", targets=[1,4])
         qc.add_gate(test_gate)
         qc.add_gate("TOFFOLI", controls=[0, 1], targets=[2])
         qc.add_gate("SNOT", targets=[3])
-        qc.add_gate(test_gate, index = [3])
+        qc.add_gate(test_gate, index=[3])
+        qc.add_1q_gate("RY", start=4, end=5, arg_value=1.570796)
 
         # Test explicit gate addition
         assert_(qc.gates[0].name == "CNOT")
@@ -240,7 +241,7 @@ class TestQubitCircuit:
             assert_raises(ValueError, qc.add_gate, gate,None,[1,2])
             # Single control
             assert_raises(ValueError, qc.add_gate, gate,[0],[1])
-
+    
     def test_add_circuit(self):
         """
         Addition of a circuit to a `QubitCircuit`
@@ -294,17 +295,17 @@ class TestQubitCircuit:
         qc.add_state("-", targets=[1])
 
         assert_(qc.input_states[0] == "0")
-        assert_(qc.input_states[2] == None)
+        assert_(qc.input_states[2] is None)
         assert_(qc.output_states[1] == "+")
 
         qc1 = QubitCircuit(10)
 
         qc1.add_state("0", targets=[2, 3, 5, 6])
-        qc1.add_state("+", targets=[1,4,9])
-        qc1.add_state("A", targets=[1,4,9], state_type="output")
-        qc1.add_state("A", targets=[1,4,9], state_type="output")
+        qc1.add_state("+", targets=[1, 4, 9])
+        qc1.add_state("A", targets=[1, 4, 9], state_type="output")
+        qc1.add_state("A", targets=[1, 4, 9], state_type="output")
         qc1.add_state("beta", targets=[0], state_type="output")
-        assert_(qc1.input_states[0] == None)
+        assert_(qc1.input_states[0] is None)
 
         assert_(qc1.input_states[2] == "0")
         assert_(qc1.input_states[3] == "0")
@@ -312,12 +313,69 @@ class TestQubitCircuit:
         assert_(qc1.input_states[1] == "+")
         assert_(qc1.input_states[4] == "+")
 
-        assert_(qc1.output_states[2] == None)
+        assert_(qc1.output_states[2] is None)
         assert_(qc1.output_states[1] == "A")
         assert_(qc1.output_states[4] == "A")
         assert_(qc1.output_states[9] == "A")
 
         assert_(qc1.output_states[0] == "beta")
+
+    def test_exceptions(self):
+        """
+        Text exceptions are thrown correctly for inadequate inputs
+        """
+        qc = QubitCircuit(2)
+        for gate in ["X", "Y", "Z", "S", "T"]:
+            assert_raises(ValueError, qc.add_gate, gate,
+                          targets=[1], controls=[0])
+
+        for gate in ["CY", "CZ", "CS", "CT"]:
+            assert_raises(ValueError, qc.add_gate, gate,
+                          targets=[1])
+            assert_raises(ValueError, qc.add_gate, gate)
+
+
+    def test_single_qubit_gates(self):
+        """
+        Text single qubit gates are added correctly
+        """
+        qc = QubitCircuit(3)
+
+        qc.add_gate("X", targets=[0])
+        qc.add_gate("CY", targets=[1], controls=[0])
+        qc.add_gate("Y", targets=[2])
+        qc.add_gate("CS", targets=[0], controls=[1])
+        qc.add_gate("Z", targets=[1])
+        qc.add_gate("CT", targets=[2], controls=[2])
+        qc.add_gate("CZ", targets=[0], controls=[0])
+        qc.add_gate("S", targets=[1])
+        qc.add_gate("T", targets=[2])
+
+        assert_(qc.gates[8].name == "T")
+        assert_(qc.gates[7].name == "S")
+        assert_(qc.gates[6].name == "CZ")
+        assert_(qc.gates[5].name == "CT")
+        assert_(qc.gates[4].name == "Z")
+        assert_(qc.gates[3].name == "CS")
+        assert_(qc.gates[2].name == "Y")
+        assert_(qc.gates[1].name == "CY")
+        assert_(qc.gates[0].name == "X")
+
+        assert_(qc.gates[8].targets == [2])
+        assert_(qc.gates[7].targets == [1])
+        assert_(qc.gates[6].targets == [0])
+        assert_(qc.gates[5].targets == [2])
+        assert_(qc.gates[4].targets == [1])
+        assert_(qc.gates[3].targets == [0])
+        assert_(qc.gates[2].targets == [2])
+        assert_(qc.gates[1].targets == [1])
+        assert_(qc.gates[0].targets == [0])
+
+        assert_(qc.gates[6].controls == [0])
+        assert_(qc.gates[5].controls == [2])
+        assert_(qc.gates[3].controls == [1])
+        assert_(qc.gates[1].controls == [0])
+
 
     def test_reverse(self):
         """
@@ -342,8 +400,9 @@ class TestQubitCircuit:
         assert_(qc.gates[0].name == "RX")
 
         assert_(qc.input_states[0] == "0")
-        assert_(qc.input_states[2] == None)
+        assert_(qc.input_states[2] is None)
         assert_(qc.output_states[1] == "+")
+
 
     def test_user_gate(self):
         """
@@ -355,20 +414,20 @@ class TestQubitCircuit:
             mat[2:4, 2:4] = rx(arg_values)
             return Qobj(mat, dims=[[2, 2], [2, 2]])
 
-        def customer_gate2(arg_values):
-            mat = np.array([[1.,   0],
+        def customer_gate2():
+            mat = np.array([[1., 0],
                             [0., 1.j]])
             return Qobj(mat, dims=[[2], [2]])
 
         qc = QubitCircuit(3)
         qc.user_gates = {"CTRLRX": customer_gate1,
-                         "T": customer_gate2}
+                         "T1": customer_gate2}
         qc.add_gate("CTRLRX", targets=[1, 2], arg_value=np.pi/2)
-        qc.add_gate("T", targets=[1])
+        qc.add_gate("T1", targets=[1])
         props = qc.propagators()
         result1 = tensor(identity(2), customer_gate1(np.pi/2))
         assert_allclose(props[0], result1)
-        result2 = tensor(identity(2), customer_gate2(None), identity(2))
+        result2 = tensor(identity(2), customer_gate2(), identity(2))
         assert_allclose(props[1], result2)
 
     def test_N_level_system(self):

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -32,13 +32,11 @@
 ###############################################################################
 
 import numpy as np
-from numpy.testing import assert_raises, assert_, assert_allclose, run_module_suite
+from numpy.testing import assert_, assert_allclose, run_module_suite
 from qutip.qip.operations.gates import (
-    gate_sequence_product, rx)
+    gate_sequence_product, rx, expand_operator)
 from qutip.operators import identity
-from qutip.qip.circuit import (
-    QubitCircuit, Gate, _ctrl_gates, _single_qubit_gates, _swap_like, _toffoli_like,
-    _fredkin_like, _para_gates)
+from qutip.qip.circuit import QubitCircuit, Gate
 from qutip.tensor import tensor
 from qutip.qobj import Qobj, ptrace
 from qutip.random_objects import rand_dm
@@ -161,16 +159,16 @@ class TestQubitCircuit:
 
     def test_add_gate(self):
         """
-        Addition of a gate object directly to a `QubitCircuit`
+        Addition of a gate object directly to a `QubitCircuit` 
         """
-        qc = QubitCircuit(6)
+        qc = QubitCircuit(3)
         qc.add_gate("CNOT", targets=[1], controls=[0])
-        test_gate = Gate("SWAP", targets=[1,4])
+        test_gate = Gate("RZ", targets=[1], arg_value = 1.570796,
+                         arg_label="P")
         qc.add_gate(test_gate)
         qc.add_gate("TOFFOLI", controls=[0, 1], targets=[2])
         qc.add_gate("SNOT", targets=[3])
-        qc.add_gate(test_gate, index=[3])
-        qc.add_1q_gate("RY", start=4, end=5, arg_value=1.570796)
+        qc.add_gate(test_gate, index = [3])
 
         # Test explicit gate addition
         assert_(qc.gates[0].name == "CNOT")
@@ -180,109 +178,12 @@ class TestQubitCircuit:
         # Test direct gate addition
         assert_(qc.gates[1].name == test_gate.name)
         assert_(qc.gates[1].targets == test_gate.targets)
+        assert_(qc.gates[1].controls == test_gate.controls)
 
         # Test specified position gate addition
         assert_(qc.gates[3].name == test_gate.name)
         assert_(qc.gates[3].targets == test_gate.targets)
-
-        # Test adding 1 qubit gate on [start, end] qubits
-        assert_(qc.gates[5].name == "RY")
-        assert_(qc.gates[5].targets == [4])
-        assert_(qc.gates[5].arg_value == 1.570796)
-        assert_(qc.gates[6].name == "RY")
-        assert_(qc.gates[6].targets == [5])
-        assert_(qc.gates[5].arg_value == 1.570796)
-
-        # Test Exceptions  # Global phase is not included
-        for gate in _single_qubit_gates:
-            if gate not in _para_gates:
-                # No target
-                assert_raises(ValueError, qc.add_gate, gate,None,None)
-                # Multiple targets
-                assert_raises(ValueError, qc.add_gate, gate,[0,1,2],None)
-                # With control
-                assert_raises(ValueError, qc.add_gate, gate,[0],[1])
-            else:
-                # No target
-                assert_raises(ValueError, qc.add_gate, gate,None,None,1)
-                # Multiple targets
-                assert_raises(ValueError, qc.add_gate, gate,[0,1,2],None,1)
-                # With control
-                assert_raises(ValueError, qc.add_gate, gate,[0],[1],1)
-        for gate in _ctrl_gates:
-            if gate not in _para_gates:
-                # No target
-                assert_raises(ValueError, qc.add_gate, gate,None,[1])
-                # No control
-                assert_raises(ValueError, qc.add_gate, gate,[0],None)
-            else:
-                # No target
-                assert_raises(ValueError, qc.add_gate, gate,None,[1],1)
-                # No control
-                assert_raises(ValueError, qc.add_gate, gate,[0],None,1)
-        for gate in _swap_like:
-            if gate not in _para_gates:
-                # Single target
-                assert_raises(ValueError, qc.add_gate, gate,[0],None)
-                # With control
-                assert_raises(ValueError, qc.add_gate, gate,[0,1],[3])
-            else:
-                # Single target
-                assert_raises(ValueError, qc.add_gate, gate,[0],None,1)
-                # With control
-                assert_raises(ValueError, qc.add_gate, gate,[0,1],[3],1)
-        for gate in _fredkin_like:
-            # Single target
-            assert_raises(ValueError, qc.add_gate, gate,[0],[2])
-            # No control
-            assert_raises(ValueError, qc.add_gate, gate,[0,1],None)
-        for gate in _toffoli_like:
-            # No target
-            assert_raises(ValueError, qc.add_gate, gate,None,[1,2])
-            # Single control
-            assert_raises(ValueError, qc.add_gate, gate,[0],[1])
-    
-    def test_add_circuit(self):
-        """
-        Addition of a circuit to a `QubitCircuit`
-        """
-        qc = QubitCircuit(6)
-        qc.add_gate("CNOT", targets=[1], controls=[0])
-        test_gate = Gate("SWAP", targets=[1,4])
-        qc.add_gate(test_gate)
-        qc.add_gate("TOFFOLI", controls=[0, 1], targets=[2])
-        qc.add_gate("SNOT", targets=[3])
-        qc.add_gate(test_gate, index=[3])
-        qc.add_1q_gate("RY", start=4, end=5, arg_value=1.570796)
-
-        qc1 = QubitCircuit(6)
-
-        qc1.add_circuit(qc)
-
-        # Test if all gates are added
-        assert_(len(qc1.gates) == len(qc.gates))
-
-        # Test each gate
-        for i in range(len(qc1.gates)):
-            assert_(qc1.gates[i].name == qc.gates[i].name)
-            assert_(qc1.gates[i].targets == qc.gates[i].targets)
-            assert_(qc1.gates[i].controls == qc.gates[i].controls)
-
-        # Test exception when qubit out of range
-        assert_raises(NotImplementedError, qc1.add_circuit, qc,start=4)
-
-        qc2 = QubitCircuit(8)
-        qc2.add_circuit(qc,start=2)
-
-        # Test if all gates are added
-        assert_(len(qc2.gates) == len(qc.gates))
-
-        # Test if the positions are correct
-        for i in range(len(qc2.gates)):
-            if qc.gates[i].targets is not None:
-                assert_(qc2.gates[i].targets[0] == qc.gates[i].targets[0]+2)
-            if qc.gates[i].controls is not None:
-                assert_(qc2.gates[i].controls[0] == qc.gates[i].controls[0]+2)
+        assert_(qc.gates[3].controls == test_gate.controls)
 
     def test_add_state(self):
         """
@@ -295,87 +196,30 @@ class TestQubitCircuit:
         qc.add_state("-", targets=[1])
 
         assert_(qc.input_states[0] == "0")
-        assert_(qc.input_states[2] is None)
+        assert_(qc.input_states[2] == None)
         assert_(qc.output_states[1] == "+")
 
         qc1 = QubitCircuit(10)
 
         qc1.add_state("0", targets=[2, 3, 5, 6])
-        qc1.add_state("+", targets=[1, 4, 9])
-        qc1.add_state("A", targets=[1, 4, 9], state_type="output")
-        qc1.add_state("A", targets=[1, 4, 9], state_type="output")
+        qc1.add_state("+", targets=[1,4,9])
+        qc1.add_state("A", targets=[1,4,9], state_type="output")
+        qc1.add_state("A", targets=[1,4,9], state_type="output")
         qc1.add_state("beta", targets=[0], state_type="output")
-        assert_(qc1.input_states[0] is None)
-
+        assert_(qc1.input_states[0] == None)
+        
         assert_(qc1.input_states[2] == "0")
         assert_(qc1.input_states[3] == "0")
         assert_(qc1.input_states[6] == "0")
         assert_(qc1.input_states[1] == "+")
         assert_(qc1.input_states[4] == "+")
 
-        assert_(qc1.output_states[2] is None)
+        assert_(qc1.output_states[2] == None)        
         assert_(qc1.output_states[1] == "A")
         assert_(qc1.output_states[4] == "A")
         assert_(qc1.output_states[9] == "A")
 
         assert_(qc1.output_states[0] == "beta")
-
-    def test_exceptions(self):
-        """
-        Text exceptions are thrown correctly for inadequate inputs
-        """
-        qc = QubitCircuit(2)
-        for gate in ["X", "Y", "Z", "S", "T"]:
-            assert_raises(ValueError, qc.add_gate, gate,
-                          targets=[1], controls=[0])
-
-        for gate in ["CY", "CZ", "CS", "CT"]:
-            assert_raises(ValueError, qc.add_gate, gate,
-                          targets=[1])
-            assert_raises(ValueError, qc.add_gate, gate)
-
-
-    def test_single_qubit_gates(self):
-        """
-        Text single qubit gates are added correctly
-        """
-        qc = QubitCircuit(3)
-
-        qc.add_gate("X", targets=[0])
-        qc.add_gate("CY", targets=[1], controls=[0])
-        qc.add_gate("Y", targets=[2])
-        qc.add_gate("CS", targets=[0], controls=[1])
-        qc.add_gate("Z", targets=[1])
-        qc.add_gate("CT", targets=[2], controls=[2])
-        qc.add_gate("CZ", targets=[0], controls=[0])
-        qc.add_gate("S", targets=[1])
-        qc.add_gate("T", targets=[2])
-
-        assert_(qc.gates[8].name == "T")
-        assert_(qc.gates[7].name == "S")
-        assert_(qc.gates[6].name == "CZ")
-        assert_(qc.gates[5].name == "CT")
-        assert_(qc.gates[4].name == "Z")
-        assert_(qc.gates[3].name == "CS")
-        assert_(qc.gates[2].name == "Y")
-        assert_(qc.gates[1].name == "CY")
-        assert_(qc.gates[0].name == "X")
-
-        assert_(qc.gates[8].targets == [2])
-        assert_(qc.gates[7].targets == [1])
-        assert_(qc.gates[6].targets == [0])
-        assert_(qc.gates[5].targets == [2])
-        assert_(qc.gates[4].targets == [1])
-        assert_(qc.gates[3].targets == [0])
-        assert_(qc.gates[2].targets == [2])
-        assert_(qc.gates[1].targets == [1])
-        assert_(qc.gates[0].targets == [0])
-
-        assert_(qc.gates[6].controls == [0])
-        assert_(qc.gates[5].controls == [2])
-        assert_(qc.gates[3].controls == [1])
-        assert_(qc.gates[1].controls == [0])
-
 
     def test_reverse(self):
         """
@@ -400,9 +244,8 @@ class TestQubitCircuit:
         assert_(qc.gates[0].name == "RX")
 
         assert_(qc.input_states[0] == "0")
-        assert_(qc.input_states[2] is None)
+        assert_(qc.input_states[2] == None)
         assert_(qc.output_states[1] == "+")
-
 
     def test_user_gate(self):
         """
@@ -414,20 +257,20 @@ class TestQubitCircuit:
             mat[2:4, 2:4] = rx(arg_values)
             return Qobj(mat, dims=[[2, 2], [2, 2]])
 
-        def customer_gate2():
-            mat = np.array([[1., 0],
+        def customer_gate2(arg_values):
+            mat = np.array([[1.,   0],
                             [0., 1.j]])
             return Qobj(mat, dims=[[2], [2]])
 
         qc = QubitCircuit(3)
         qc.user_gates = {"CTRLRX": customer_gate1,
-                         "T1": customer_gate2}
+                         "T": customer_gate2}
         qc.add_gate("CTRLRX", targets=[1, 2], arg_value=np.pi/2)
-        qc.add_gate("T1", targets=[1])
+        qc.add_gate("T", targets=[1])
         props = qc.propagators()
         result1 = tensor(identity(2), customer_gate1(np.pi/2))
         assert_allclose(props[0], result1)
-        result2 = tensor(identity(2), customer_gate2(), identity(2))
+        result2 = tensor(identity(2), customer_gate2(None), identity(2))
         assert_allclose(props[1], result2)
 
     def test_N_level_system(self):
@@ -443,7 +286,7 @@ class TestQubitCircuit:
             control_value = arg_value
             dim = mat3.dims[0][0]
             return (tensor(fock_dm(2, control_value), mat3) +
-                    tensor(fock_dm(2, 1 - control_value), identity(dim)))
+                    tensor(fock_dm(2, 1 - control_value), identity(dim)))        
 
         qc = QubitCircuit(2, dims=[3, 2])
         qc.user_gates = {"CTRLMAT3": controlled_mat3}

--- a/qutip/utilities.py
+++ b/qutip/utilities.py
@@ -68,7 +68,7 @@ def n_thermal(w, w_th):
 
     """
 
-    if type(w) is np.ndarray:
+    if isinstance(w, np.ndarray):
         return 1.0 / (np.exp(w / w_th) - 1.0)
 
     else:

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -445,7 +445,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     dx = dy = 0.8 * np.ones(n)
     dz = np.real(M.flatten())
 
-    if limits and type(limits) is list and len(limits) == 2:
+    if isinstance(limits, list) and len(limits) == 2:
         z_min = limits[0]
         z_max = limits[1]
     else:
@@ -845,7 +845,7 @@ def plot_wigner(rho, fig=None, ax=None, figsize=(6, 6),
     xvec = np.linspace(-alpha_max, alpha_max, 200)
     W0 = wigner(rho, xvec, xvec, method=method)
 
-    W, yvec = W0 if type(W0) is tuple else (W0, xvec)
+    W, yvec = W0 if isinstance(W0, tuple) else (W0, xvec)
 
     wlim = abs(W).max()
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -54,6 +54,7 @@ from qutip.operators import jmat
 from scipy.special import factorial
 from qutip.cy.sparse_utils import _csr_get_diag
 import qutip as qt
+from qutip.sparse import eigh
 
 
 def wigner_transform(psi, j, fullparity, steps, slicearray):
@@ -416,7 +417,7 @@ def _wigner_fourier(psi, xvec, g=np.sqrt(2)):
     if psi.type == 'ket':
         return _psi_wigner_fft(psi.full(), xvec, g)
     elif psi.type == 'oper':
-        eig_vals, eig_vecs = la.eigh(psi.full())
+        eig_vals, eig_vecs = eigh(psi.full())
         W = 0
         for ii in range(psi.shape[0]):
             W1, yvec = _psi_wigner_fft(

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ REQUIRES = ['numpy (>=1.12)', 'scipy (>=1.0)', 'cython (>=0.21)']
 EXTRAS_REQUIRE = {'graphics':['matplotlib(>=1.2.1)']}
 INSTALL_REQUIRES = ['numpy>=1.12', 'scipy>=1.0', 'cython>=0.21']
 PACKAGES = ['qutip', 'qutip/ui', 'qutip/cy', 'qutip/cy/src',
-            'qutip/qip', 'qutip/qip/device',
             'qutip/qip', 'qutip/qip/device', 'qutip/qip/operations',
             'qutip/qip/compiler',
             'qutip/qip/algorithms', 'qutip/control', 'qutip/nonmarkov',

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ from Cython.Distutils import build_ext
 # all information about QuTiP goes here
 MAJOR = 4
 MINOR = 5
-MICRO = 1
+MICRO = 2
 ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 REQUIRES = ['numpy (>=1.12)', 'scipy (>=1.0)', 'cython (>=0.21)']


### PR DESCRIPTION
**Description**
Upgrade from 4.5.1 to 4.5.2.
Include cherry picked commit from the following PR:

#1307 Fix zcsr_proj for bras with unsorted indices
#1306 Fix quadratic complexity in zcsr_inner
#1302 Enforce a CI test with scipy<1.5
#1301 Fix brtools zheevr test
#1298 Support scipy >= 1.5 in fast_csr_matrix matmul and legacy.ptrace
#1283 Milstein's heterodyne index fix
#1271 Remove duplicate line in setup.py
#1264 Remove incorrect use of 'is' in comparisons

Code from #1288 was added manually to evade conflict and related test were reinstalled. (removed in 4.5.1, not in master)

#1269 and #1242 are not included since they depend on #1209 which is more that a bugfix and is not in 4.5.0.


**Changelog**
Bug Fixes
-------
- `zcsr_proj` does not fail with unsorted indices (by **Jake Lishman**)
- Fixed Milstein's heterodyne errors (by **Eric Giguère**)
- Removed risky code (by **Jake Lishman**)
<!-- - Fix `add_circuit` and `remove_gate` (by **Canoming**) -->

Improvements
-------
- Faster `zcsr_inner` (by **Jake Lishman**)
- Support for Scipy 1.5 (by **Jake Lishman**)
