### PR TITLE
Fix fileio tests on Windows

### DIFF
--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -189,9 +189,3 @@ def in_temporary_directory():
         # than outside to prevent the case of the directory failing to be
         # removed because it is 'busy'.
         os.chdir(previous_dir)
-
-
-@pytest.fixture
-def tmpfile():
-    with tempfile.NamedTemporaryFile() as file:
-        yield file


### PR DESCRIPTION
Windows does not allow opening a tempfile.NamedTemporaryFile more than once, so it's not really suitable for a lot of uses.  We just remove this fixture and use `in_temporary_directory` instead.

Fix #1311 

**Changelog**
Fix fileio tests on Windows