### PR TITLE
fix the wrong dtype in the lattice module on windows

### DIFF
--- a/qutip/lattice.py
+++ b/qutip/lattice.py
@@ -851,7 +851,7 @@ class Lattice1d():
         if self.period_bnd_cond_x == 0:
             raise Exception("The lattice is not periodic.")
         (knxA, qH_ks, val_kns, vec_kns, vec_xs) = self._k_space_calculations()
-        dtype = [('eigen_value', '<f16'), ('eigen_vector', Qobj)]
+        dtype = [('eigen_value', np.longdouble), ('eigen_vector', Qobj)]
         values = list()
         for i in range(self.num_cell):
             for j in range(self._length_of_unit_cell):


### PR DESCRIPTION
**Description**
`f16` does not exist on Windows. Use `np.longdouble` instead, which is `f16` on Mac/Linux and `f8` on Windows.

On windows one gets
```python
>>> np.dtype([('f', np.longdouble)])         
dtype([('f', '<f8')])
```
On Ubuntu
```python
>>> np.dtype([('f', np.longdouble)])
dtype([('f', '<f16')])
```

**Changelog**
fix the dtype error in the lattice module
