### PR TITLE
fail earlier when installing without numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ except:
 
 try:
     import numpy as np
-except:
-    np = None
+except ImportError as e:
+    raise ImportError("numpy is required at installation") from e
 
 from Cython.Build import cythonize
 from Cython.Distutils import build_ext


### PR DESCRIPTION
**Description**
Fail with a more descriptive message when trying to install from source without numpy. Hopefully will not be used with #1309

**Related issues or PRs**
Discussion in dev-core


