### PR TITLE
make sure the specified solver in Processor.run_state is used (not always mesolve)

### DIFF
--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -703,7 +703,7 @@ class Processor(object):
         elif solver == "mcsolve":
             solver = mcsolve
 
-        evo_result = mesolve(
+        evo_result = solver(
             H=noisy_qobjevo, rho0=init_state,
             tlist=noisy_qobjevo.tlist, **kwargs)
         return evo_result


### PR DESCRIPTION
**Description**
Spotted the `solver` in `Processor.run_state` was set but not used, so it would always use `mesolve` even if `mcsolve` was specified, so I fixed it.

**Related issues or PRs**
Not sure if this fixes any issues - I doubt it? - I guess no one had tried to use the `mcsolve` option here yet.

**Changelog**
Ensured `solver` kwarg of `Processor.run_state` correctly sets the solver to `mesolve` or `mcsolve` (`mesolve` was hardcoded in before).
