### PR TITLE
Correct spelling in new options classes

### DIFF
--- a/qutip/configrc.py
+++ b/qutip/configrc.py
@@ -191,7 +191,7 @@ def has_rc_object(rc_file, name):
 
 def write_rc_object(rc_file, objs):
     """
-    Writes all keys and values corresponding to one optionclass to a
+    Writes all keys and values corresponding to one optionsclass to a
     qutiprc file.
 
     Parameters
@@ -200,8 +200,8 @@ def write_rc_object(rc_file, objs):
         String specifying file location.
     section : str
         Tags for the saved data.
-    objs : list of optionclass
-        Object to save. Must be decorated with `optionclass`.
+    objs : list of optionsclass
+        Object to save. Must be decorated with `optionsclass`.
     """
     generate_qutiprc(rc_file)
     config = ConfigParser()
@@ -223,7 +223,7 @@ def load_rc_object(rc_file, objs):
     ----------
     rc_file : str
         String specifying file location.
-    obj : list of optionclass
+    obj : list of optionsclass
         Object to overwrite.
     """
     config = ConfigParser()

--- a/qutip/core/__init__.py
+++ b/qutip/core/__init__.py
@@ -1,4 +1,4 @@
-from .option import *
+from .options import *
 from .coefficient import *
 from .interpolate import *
 from .qobj import *

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -11,7 +11,7 @@ import shutil
 import numbers
 from collections import defaultdict
 from .. import settings as qset
-from ..optionclass import optionclass
+from ..optionsclass import optionsclass
 from .data import Data
 from .interpolate import Cubic_Spline
 from .cy.coefficient import (InterpolateCoefficient, InterCoefficient,
@@ -137,7 +137,7 @@ def reduce(coeff, args):
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # %%%%%%%%%      Everything under this is for string compilation      %%%%%%%%%
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-@optionclass("compile", qset.core)
+@optionsclass("compile", qset.core)
 class CompilationOptions:
     """
     Options for compilation.
@@ -176,7 +176,7 @@ class CompilationOptions:
 
     _link_flags = ""
     _compiler_flags = ""
-    if (sys.platform == 'win32'):
+    if sys.platform == 'win32':
         _compiler_flags = ''
     elif sys.platform == 'darwin':
         _compiler_flags = '-w -O3 -funroll-loops -mmacosx-version-min=10.9'
@@ -186,7 +186,7 @@ class CompilationOptions:
 
     options = {
         # use cython for compiling string coefficient
-        "use_cython" : _use_cython,
+        "use_cython": _use_cython,
         # In compiled Coefficient, are int kept as int?
         # None indicate to look for list subscription
         "accept_int": None,

--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -1,17 +1,14 @@
-from ..optionclass import optionclass
+from ..optionsclass import optionsclass
 
-__all__ = ["CoreOption"]
+__all__ = ["CoreOptions"]
 
-@optionclass("core")
-class CoreOption:
+@optionsclass("core")
+class CoreOptions:
     """
-    Setting used by the Qobj.
-
-    Value can be changed in qutip.settings.core
+    Settings used by the Qobj.  Values can be changed in qutip.settings.core.
 
     Options
     -------
-
     auto_tidyup : bool
         use auto tidyup
 

--- a/qutip/installsettings.py
+++ b/qutip/installsettings.py
@@ -1,14 +1,14 @@
-from .optionclass import optionclass
+from .optionsclass import optionsclass
 import sys
 import os
 import logging
 import platform
 from .utilities import _blas_info
 
-@optionclass("install")
+@optionsclass("install")
 class InstallSettings:
     """
-    Qutip's settings
+    QuTiP's settings
 
     Options
     -------
@@ -74,8 +74,9 @@ class InstallSettings:
     # ------------------------------------------------------------------------
     # Check if we're in IPython.
     try:
+        __IPYTHON__
         _ipython = True
-    except:
+    except NameError:
         _ipython = False
 
     _eigh_unsafe = (_blas_info() == "OPENBLAS"

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -48,21 +48,21 @@ class Settings:
     """
     def __init__(self):
         self._isDefault = True
-        self._childs = []
+        self._children = []
         self._fullname = "qutip.settings"
         self._defaultInstance = self
 
-    def _all_childs(self):
+    def _all_children(self):
         optcls = []
-        for child in self._childs:
-             optcls += child._all_childs()
+        for child in self._children:
+            optcls += child._all_children()
         return optcls
 
     def reset(self):
         """
         Reset all options to qutip's defaults.
         """
-        for child in self._childs:
+        for child in self._children:
             child.reset(True)
 
     def save(self, file="qutiprc"):
@@ -71,7 +71,7 @@ class Settings:
         Use full path to same elsewhere.
         The file 'qutiprc' is loaded when importing qutip.
         """
-        optcls = self._all_childs()
+        optcls = self._all_children()
         qrc.write_rc_object(file, optcls)
 
     def load(self, file="qutiprc"):
@@ -79,11 +79,11 @@ class Settings:
         Load the default in a file in '$HOME/.qutip/'.
         Use full path to same elsewhere.
         """
-        optcls = self._all_childs()
+        optcls = self._all_children()
         qrc.load_rc_object(file, optcls)
 
     def __repr__(self):
-        return "".join(child.__repr__(True) for child in self._childs)
+        return "".join(child.__repr__(True) for child in self._children)
 
 
 settings = Settings()

--- a/qutip/solve/solver.py
+++ b/qutip/solve/solver.py
@@ -43,7 +43,7 @@ from collections import OrderedDict
 from types import FunctionType, BuiltinFunctionType
 
 from .. import __version__, Qobj, QobjEvo
-from ..optionclass import optionclass
+from ..optionsclass import optionsclass
 from ..core import data as _data
 
 solver_safe = {}
@@ -142,7 +142,7 @@ class ExpectOps:
         return bool(self.e_num)
 
 
-@optionclass("solver")
+@optionsclass("solver")
 class SolverOptions:
     """
     Class of options for evolution solvers such as :func:`qutip.mesolve` and
@@ -160,7 +160,7 @@ class SolverOptions:
 
     The default can be changed by::
 
-        qutip.settings.options['order'] = 10
+        qutip.settings.solver['order'] = 10
 
     Options
     -------
@@ -236,7 +236,7 @@ class SolverOptions:
     }
 
 
-@optionclass("mcsolve", SolverOptions)
+@optionsclass("mcsolve", SolverOptions)
 class McOptions:
     """
     Class of options for evolution solvers such as :func:`qutip.mesolve` and


### PR DESCRIPTION
Rename `optionclass` to `optionsclass` (plural), and `childs` to `children`.  No meaningful changes, though.