### PR TITLE
Fix coverage reporting on Travis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,10 @@
 [run]
-include = */qutip/*
-omit = */tests/*
+source = qutip
+omit =
+    # QuTiP test files
+    */qutip/tests/*
+
+[report]
+exclude_lines =
+    # Skip Python wrappers which help load in C extension modules.
+    __bootstrap__()

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,190 +1,91 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 
-_stage_generic_linux: &stage_generic_linux
-  os: linux
-  language: python
-  # change dir
-  before_script:
-    - QUTIP_DOWNLOAD=$(pwd -P)
-    - mkdir qutip_testing
-    - cd qutip_testing
-  # command to run tests
-  script:
-    - python -m qutip.about
-    - QUTIP_INSTALL=$(dirname $(python -c 'import qutip; print(qutip.__file__)'))
-    - pytest --verbosity=1 --cov=qutip --cov-config="${QUTIP_DOWNLOAD}/.coveragerc" --rootdir="${QUTIP_INSTALL}/qutip/tests" -c "${QUTIP_INSTALL}/qutip/tests/pytest.ini" --pyargs qutip
-  install:
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda info -a
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-    - source activate test-environment
-    - conda install mkl blas=*=mkl numpy scipy pytest pytest-cov cython coveralls
-    - python setup.py install
+# These just set the default, we'll override them for the Mac entries in the job
+# matrix.  Travis likes us to specify the defaults.
+os: linux
+dist: xenial
+language: python
 
-_stage_linux_36: &stage_linux_36
-  <<: *stage_generic_linux
-  name: "Python 3.6"
-  dist: trusty
-  python: 3.6
-  script:
-    - python -m qutip.about
-    - pytest --verbosity=1 --disable-pytest-warnings --cov=qutip --pyargs qutip -m "not slow"
+# We use our own "_PYTHON_VERSION" variable because Travis jobs on macOS don't
+# have a "language: python" available, so don't define the variable.
+env: _CONDA_SUFFIX="Linux-x86_64" _PYTHON_VERSION="$TRAVIS_PYTHON_VERSION"
 
-_stage_linux_37: &stage_linux_37
-  <<: *stage_generic_linux
-  name: "Python 3.7"
-  dist: xenial
-  python: 3.7
-  script:
-    - python -m qutip.about
-    - pytest --verbosity=1 --disable-pytest-warnings --cov=qutip --pyargs qutip -m "not slow"
+# Set up conda with the correct version of conda.
+before_install:
+  - wget "https://repo.continuum.io/miniconda/Miniconda3-latest-${_CONDA_SUFFIX}.sh" -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda info -a
+  - conda create -q -n test-environment python="$_PYTHON_VERSION"
+  - source activate test-environment
+  - QUTIP_DOWNLOAD=$(pwd -P)
 
-_stage_linux_38: &stage_linux_38
-  <<: *stage_generic_linux
-  name: "Python 3.8"
-  dist: xenial
-  python: 3.8
-  install:
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda info -a
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-    - source activate test-environment
-    - conda install numpy scipy pytest pytest-cov cython coveralls
-    - python setup.py install
+# First move away from the download location so we don't try to import the
+# non-installed version of QuTiP, then move closer to the installation location
+# so file-name reporting is nicer.
+before_script:
+  - mkdir -p _fake_dir
+  - cd _fake_dir
+  - QUTIP_INSTALL=$(dirname $(python -c 'import qutip; print(qutip.__file__)'))
+  - cd "${QUTIP_INSTALL}"
 
-_stage_linux_no_cython: &stage_linux_no_cython
-  <<: *stage_generic_linux
-  name: "Python 3.6 no cython, openblas"
-  dist: xenial
-  python: 3.6
-  install:
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda info -a
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-    - source activate test-environment
-    - conda install -c conda-forge nomkl blas=*=openblas numpy scipy pytest pytest-cov
-    - conda install -c conda-forge cython --freeze-installed
-    - conda list
-    - python setup.py install
-    - conda uninstall cython
+script:
+  - python -c "import qutip; qutip.about()"
+  - pytest --verbosity=1 --rootdir="${QUTIP_INSTALL}/tests" -c "${QUTIP_INSTALL}/tests/pytest.ini" --pyargs qutip
 
-_stage_linux_38_openblas: &stage_linux_38_openblas
-  <<: *stage_generic_linux
-  name: "Python 3.8 OpenBLAS"
-  dist: xenial
-  python: 3.8
-  install:
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda info -a
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-    - source activate test-environment
-    - conda install nomkl blas=*=openblas numpy scipy pytest pytest-cov cython
-    - python setup.py install
-
-_stage_linux_omp: &stage_linux_omp
-  <<: *stage_generic_linux
-  name: "Python 3.7 OpenMP, mkl, scipy<1.5"
-  dist: xenial
-  python: 3.7
-  install:
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda info -a
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-    - source activate test-environment
-    - conda install mkl blas=*=mkl numpy 'scipy<1.5' pytest pytest-cov cython coveralls
-    - python setup.py install --with-openmp --line-trace
-  after_success:
-    - coveralls
-
-_stage_osx_37: &stage_osx_37
+_mac_generic_setup: &mac_generic_setup
   os: osx
-  name: "Python 3.7, OSX 10.13, XCode 10"
   osx_image: xcode10
   language: generic
-  # change dir
-  before_script:
-    - QUTIP_DOWNLOAD=$(pwd -P)
-    - mkdir qutip_testing
-    - cd qutip_testing
-  # command to run tests
-  script:
-    - python -m qutip.about
-    - QUTIP_INSTALL=$(dirname $(python -c 'import qutip; print(qutip.__file__)'))
-    - pytest --verbosity=1 --cov=qutip --cov-config="${QUTIP_DOWNLOAD}/.coveragerc" --rootdir="${QUTIP_INSTALL}/qutip/tests" -c "${QUTIP_INSTALL}/qutip/tests/pytest.ini" --pyargs qutip
   install:
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda info -a
-    - conda create -q -n test-environment python=3.7
-    - source activate test-environment
-    # - conda install mkl blas=*=mkl numpy scipy pytest pytest-cov cython coveralls
-    - conda install nomkl blas=*=openblas numpy scipy pytest pytest-cov cython
+    - conda install nomkl blas=*=openblas numpy scipy matplotlib cython pytest
     - python setup.py install
-
-_stage_osx_38: &stage_osx_38
-  os: osx
-  name: "Python 3.8, OSX 10.13, XCode 10"
-  osx_image: xcode10
-  language: generic
-  # change dir
-  before_script:
-    - QUTIP_DOWNLOAD=$(pwd -P)
-    - mkdir qutip_testing
-    - cd qutip_testing
-  # command to run tests
-  script:
-    - python -m qutip.about
-    - QUTIP_INSTALL=$(dirname $(python -c 'import qutip; print(qutip.__file__)'))
-    - pytest --verbosity=1 --cov=qutip --cov-config="${QUTIP_DOWNLOAD}/.coveragerc" --rootdir="${QUTIP_INSTALL}/qutip/tests" -c "${QUTIP_INSTALL}/qutip/tests/pytest.ini" --pyargs qutip
-  install:
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda info -a
-    - conda create -q -n test-environment python=3.8
-    - source activate test-environment
-    # - conda install mkl blas=*=mkl numpy scipy pytest pytest-cov cython coveralls
-    - conda install nomkl blas=*=openblas numpy scipy pytest pytest-cov cython
-    - python setup.py install
-
-stages:
-  - test
 
 jobs:
   include:
-    - stage: test
-      <<: *stage_linux_38
-    - stage: test
-      <<: *stage_linux_omp
-    - stage: test
-      <<: *stage_linux_no_cython
-    - stage: test
-      <<: *stage_osx_37
-    - stage: test
-      <<: *stage_osx_38
+    - name: "Linux, Python 3.8: regular"
+      python: 3.8
+      install:
+        - conda install numpy scipy matplotlib pytest cython
+        - python setup.py install
+
+    - name: "Linux, Python 3.7: OpenMP, MKL, scipy<1.5 (coverage)"
+      python: 3.7
+      # For source file line analysis on Coveralls, we need to make sure all
+      # file paths are prefixed by a known prefix, and the files are relative to
+      # the git repo root.  It is enough to use the home directory on Travis,
+      # since we know this won't change, whereas the location of the installed
+      # egg _will_, because it changes based on the version number (not to
+      # mention it isn't necessarily the same file structure as the git repo).
+      # This is why we use `setup.py develop` here, and why we don't change
+      # directories.
+      install:
+        - conda install mkl blas=*=mkl numpy scipy matplotlib cython pytest pytest-cov coveralls
+        - python setup.py develop --with-openmp
+      before_script:
+        - QUTIP_INSTALL="${QUTIP_DOWNLOAD}/qutip"
+      script:
+        - python -c "import qutip; qutip.about()"
+        - pytest --verbosity=1 --cov=qutip --cov-config="${QUTIP_DOWNLOAD}/.coveragerc" --rootdir="${QUTIP_INSTALL}/tests" -c "${QUTIP_INSTALL}/tests/pytest.ini" --pyargs qutip
+      after_success:
+        - coveralls
+
+    - name: "Linux, Python 3.6: No Cython, OpenBLAS"
+      python: 3.6
+      install:
+      - conda install nomkl blas=*=openblas numpy scipy matplotlib pytest
+      - conda install cython --freeze-installed
+      - conda list
+      - python setup.py install
+      - conda uninstall cython
+
+    - name: "macOS 10.13, Python 3.7: XCode 10"
+      env: _CONDA_SUFFIX="MacOSX-x86_64" _PYTHON_VERSION="3.7"
+      <<: *mac_generic_setup
+
+    - name: "macOS 10.13, Python 3.8: XCode 10"
+      env: _CONDA_SUFFIX="MacOSX-x86_64" _PYTHON_VERSION="3.8"
+      <<: *mac_generic_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ _stage_generic_linux: &stage_generic_linux
   language: python
   # change dir
   before_script:
+    - QUTIP_DOWNLOAD=$(pwd -P)
     - mkdir qutip_testing
     - cd qutip_testing
   # command to run tests
   script:
     - python -m qutip.about
-    - pytest --verbosity=1 --disable-pytest-warnings --cov=qutip --pyargs qutip
+    - QUTIP_INSTALL=$(dirname $(python -c 'import qutip; print(qutip.__file__)'))
+    - pytest --verbosity=1 --cov=qutip --cov-config="${QUTIP_DOWNLOAD}/.coveragerc" --rootdir="${QUTIP_INSTALL}/qutip/tests" -c "${QUTIP_INSTALL}/qutip/tests/pytest.ini" --pyargs qutip
   install:
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda
@@ -111,7 +113,7 @@ _stage_linux_omp: &stage_linux_omp
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
     - source activate test-environment
     - conda install mkl blas=*=mkl numpy 'scipy<1.5' pytest pytest-cov cython coveralls
-    - python setup.py install --with-openmp
+    - python setup.py install --with-openmp --line-trace
   after_success:
     - coveralls
 
@@ -122,12 +124,14 @@ _stage_osx_37: &stage_osx_37
   language: generic
   # change dir
   before_script:
+    - QUTIP_DOWNLOAD=$(pwd -P)
     - mkdir qutip_testing
     - cd qutip_testing
   # command to run tests
   script:
     - python -m qutip.about
-    - pytest --verbosity=1 --disable-pytest-warnings --cov=qutip --pyargs qutip
+    - QUTIP_INSTALL=$(dirname $(python -c 'import qutip; print(qutip.__file__)'))
+    - pytest --verbosity=1 --cov=qutip --cov-config="${QUTIP_DOWNLOAD}/.coveragerc" --rootdir="${QUTIP_INSTALL}/qutip/tests" -c "${QUTIP_INSTALL}/qutip/tests/pytest.ini" --pyargs qutip
   install:
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda
@@ -148,12 +152,14 @@ _stage_osx_38: &stage_osx_38
   language: generic
   # change dir
   before_script:
+    - QUTIP_DOWNLOAD=$(pwd -P)
     - mkdir qutip_testing
     - cd qutip_testing
   # command to run tests
   script:
     - python -m qutip.about
-    - pytest --verbosity=1 --disable-pytest-warnings --cov=qutip --pyargs qutip -m "not slow"
+    - QUTIP_INSTALL=$(dirname $(python -c 'import qutip; print(qutip.__file__)'))
+    - pytest --verbosity=1 --cov=qutip --cov-config="${QUTIP_DOWNLOAD}/.coveragerc" --rootdir="${QUTIP_INSTALL}/qutip/tests" -c "${QUTIP_INSTALL}/qutip/tests/pytest.ini" --pyargs qutip
   install:
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ script:
 
 _mac_generic_setup: &mac_generic_setup
   os: osx
-  osx_image: xcode10
   language: generic
   install:
     - conda install nomkl blas=*=openblas numpy scipy matplotlib cython pytest
@@ -82,10 +81,12 @@ jobs:
       - python setup.py install
       - conda uninstall cython
 
-    - name: "macOS 10.13, Python 3.7: XCode 10"
+    - name: "macOS, Python 3.7: XCode 11"
+      osx_image: xcode11
       env: _CONDA_SUFFIX="MacOSX-x86_64" _PYTHON_VERSION="3.7"
       <<: *mac_generic_setup
 
-    - name: "macOS 10.13, Python 3.8: XCode 10"
+    - name: "macOS, Python 3.8: XCode 12"
+      osx_image: xcode12
       env: _CONDA_SUFFIX="MacOSX-x86_64" _PYTHON_VERSION="3.8"
       <<: *mac_generic_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
       # This is why we use `setup.py develop` here, and why we don't change
       # directories.
       install:
-        - conda install mkl blas=*=mkl numpy scipy matplotlib cython pytest pytest-cov coveralls
+        - conda install mkl blas=*=mkl numpy 'scipy<1.5' matplotlib cython pytest pytest-cov coveralls
         - python setup.py develop --with-openmp
       before_script:
         - QUTIP_INSTALL="${QUTIP_DOWNLOAD}/qutip"


### PR DESCRIPTION
In #1339 I pointed out that the test files were being incorrectly counted in the coverage statistics when running on Travis.  This transpired to be because `coverage.py` wasn't able to find our `.coveragerc` file correctly when `pytest` was called in the manner it is on Travis.

This PR then does a couple of things:
1. correctly locates the `.coveragerc` file
2. excludes the Cython bootstrapping code from being part of the coverage
3. correctly locates the pytest configuration file `pytest.ini` (although now we have a `pyproject.toml`, we could move that configuration there)
4. completely reorganises `.travis.yml` to remove dead configs, properly share common setups, and generally make it a bit easier to read and see what's going on
5. fixes file reporting in Coveralls (look at the "tree" tab in the Coveralls web report compared to the current `master`); you can now click on the files and get proper line-by-line detail on what was covered and what wasn't, e.g. [here's the report for `mcsolve.py`](https://coveralls.io/builds/32982136/source?filename=qutip/mcsolve.py)

We _don't_ enable Cython line-tracing and coverage analysis.  This is actually [quite easily possible](https://cython.readthedocs.io/en/latest/src/tutorial/profiling_tutorial.html#enabling-coverage-analysis), but enabling full tracing including on `nogil` functions absolutely tanks performance to the degree where the coverage Travis run would take well in excess of two hours to complete (I think Travis actually just kills things that run longer than 2 hours).

I might return to the Cython elements to see how much of them when _can_ reasonably do coverage analysis on.

My prediction about actual test coverage dropping once the test files are correctly omitted, which I mentioned in #1339, came true though not _quite_ as cataclysmically (`coverage.py` uses statements, not SLOC as its metric); coverage drops from ~71% to ~63%.  Technically the true percentage is higher because the Cython code is generally very well covered, but arguing between 63% and 71% when we should be aiming to get to >95% is missing the point.

Fixes #1339.