### PR TITLE
Use dispatchers to allow Qobj to use any backing data

### DIFF
--- a/qutip/core/cy/cqobjevo.pyx
+++ b/qutip/core/cy/cqobjevo.pyx
@@ -136,10 +136,10 @@ cdef class CQobjEvo:
         if out is None:
             out = matmul_csr_dense_dense(self.constant, matrix)
         else:
-            matmul_csr_dense_dense(self.constant, matrix, out=out)
+            matmul_csr_dense_dense(self.constant, matrix, scale=1, out=out)
         for i in range(self.n_ops):
-            matmul_csr_dense_dense(self.ops[i], matrix, out=out,
-                                   scale=self.coefficients[i])
+            matmul_csr_dense_dense(self.ops[i], matrix,
+                                   scale=self.coefficients[i], out=out)
         return out
 
     cpdef double complex expect(self, double t, Data matrix) except *:

--- a/qutip/core/data/__init__.py
+++ b/qutip/core/data/__init__.py
@@ -7,6 +7,7 @@ from .base import Data
 
 from .add import *
 from .adjoint import *
+from .constant import *
 from .eigen import *
 from .expect import *
 from .expm import *

--- a/qutip/core/data/constant.py
+++ b/qutip/core/data/constant.py
@@ -1,0 +1,73 @@
+# This module exists to supply a couple of very standard constant matrices
+# which are used in the data layer, and within `Qobj` itself.  Other matrices
+# (e.g. `create`) should not be here, but should be defined within the
+# higher-level components of QuTiP instead.
+
+from . import csr, dense
+from .csr import CSR
+from .dense import Dense
+from .dispatch import Dispatcher as _Dispatcher
+import inspect as _inspect
+
+__all__ = ['zeros', 'identity']
+
+zeros = _Dispatcher(
+    _inspect.Signature([
+        _inspect.Parameter('rows', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('cols', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    ]),
+    name='zeros',
+    module=__name__,
+    inputs=(),
+    out=True,
+)
+zeros.__doc__ =\
+    """
+    Create matrix representation of 0 with the given dimensions.
+
+    Depending on the selected output type, this may or may not actually
+    contained explicit values; sparse matrices will typically contain nothing
+    (which is their representation of 0), and dense matrices will still be
+    filled.
+
+    Arguments
+    ---------
+    rows, cols : int
+        The number of rows and columns in the output matrix.
+    """
+zeros.add_specialisations([
+    (CSR, csr.zeros),
+    (Dense, dense.zeros),
+], _defer=True)
+
+identity = _Dispatcher(
+    _inspect.Signature([
+        _inspect.Parameter('dimension',
+                           _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('scale', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                           default=1),
+    ]),
+    name='identity',
+    module=__name__,
+    inputs=(),
+    out=True,
+)
+identity.__doc__ =\
+    """
+    Create a square identity matrix of the given dimension.  Optionally, the
+    `scale` can be given, where all the diagonal elements will be that instead
+    of 1.
+
+    Arguments
+    ---------
+    dimension : int
+        The dimension of the square output identity matrix.
+    scale : complex, optional
+        The element which should be placed on the diagonal.
+    """
+identity.add_specialisations([
+    (CSR, csr.identity),
+    (Dense, dense.identity),
+], _defer=True)
+
+del _Dispatcher, _inspect

--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -761,14 +761,14 @@ cdef CSR from_coo_pointers(
     # some zeros of duplicates).  Remember we also need to shift the row_index
     # array back to what it was before as well.
     cdef Accumulator accumulator = Accumulator(n_cols)
-    ptr_in = 0
+    ptr_out = 0
     ptr_prev = 0
     for row in range(n_rows):
-        for ptr_out in range(ptr_prev, out.row_index[row]):
-            accumulator.scatter(data_tmp[ptr_out], cols_tmp[ptr_out])
+        for ptr_in in range(ptr_prev, out.row_index[row]):
+            accumulator.scatter(data_tmp[ptr_in], cols_tmp[ptr_in])
         ptr_prev = out.row_index[row]
-        out.row_index[row] = ptr_in
-        ptr_in += accumulator.gather(out.data + ptr_in, out.col_index + ptr_in)
+        out.row_index[row] = ptr_out
+        ptr_out += accumulator.gather(out.data + ptr_out, out.col_index + ptr_out)
         accumulator.reset()
-    out.row_index[n_rows] = ptr_in
+    out.row_index[n_rows] = ptr_out
     return out

--- a/qutip/core/data/dispatch.pyx
+++ b/qutip/core/data/dispatch.pyx
@@ -381,10 +381,10 @@ cdef class Dispatcher:
         if isinstance(inputs, str):
             inputs = (inputs,)
         inputs = tuple(inputs)
-        if inputs == ():
+        if inputs == () and out is False:
             warnings.warn(
                 "No parameters to dispatch on."
-                " Maybe you meant to specify 'inputs'?"
+                " Maybe you meant to specify 'inputs' or 'out'?"
             )
         self.inputs = inputs
         if isinstance(signature_source, inspect.Signature):

--- a/qutip/core/data/dispatch.pyx
+++ b/qutip/core/data/dispatch.pyx
@@ -216,22 +216,25 @@ cdef class _bind:
         return args, kwargs
 
 
-cdef double _conversion_weight(tuple froms, tuple tos, dict weight_map) except -1:
+cdef double _conversion_weight(tuple froms, tuple tos, dict weight_map, bint out) except -1:
     """
     Find the total weight of conversion if the types in `froms` are converted
     element-wise to the types in `tos`.  `weight_map` is a mapping of
     `(to_type, from_type): real`; it should almost certainly be
     `data.to.weight`.
     """
-    cdef double out = 0.0
+    cdef double weight = 0.0
     cdef Py_ssize_t i, n=len(froms)
     if len(tos) != n:
         raise ValueError(
             "number of arguments not equal: " + str(n) + " and " + str(len(tos))
         )
+    if out:
+        n = n - 1
+        weight += weight_map[froms[n], tos[n]]
     for i in range(n):
-        out += weight_map[tos[i], froms[i]]
-    return out
+        weight += weight_map[tos[i], froms[i]]
+    return weight
 
 
 cdef class _constructed_specialisation:
@@ -504,7 +507,8 @@ cdef class Dispatcher:
             types = None
             function = None
             for out_types, out_function in self._specialisations.items():
-                cur = _conversion_weight(in_types, out_types, _to.weight)
+                cur = _conversion_weight(in_types, out_types, _to.weight,
+                                         out=self.output)
                 if cur < weight:
                     weight = cur
                     types = out_types
@@ -529,7 +533,8 @@ cdef class Dispatcher:
                 types = None
                 function = None
                 for out_types, out_function in self._specialisations.items():
-                    cur = _conversion_weight(in_types, out_types[:-1], _to.weight)
+                    cur = _conversion_weight(in_types, out_types[:-1],
+                                             _to.weight, out=False)
                     if cur < weight:
                         weight = cur
                         types = out_types

--- a/qutip/core/data/matmul.pxd
+++ b/qutip/core/data/matmul.pxd
@@ -3,7 +3,6 @@
 from qutip.core.data.csr cimport CSR
 from qutip.core.data.dense cimport Dense
 
-cpdef CSR matmul_csr(CSR left, CSR right, CSR out=*, double complex scale=*)
-cpdef Dense matmul_dense(Dense left, Dense right, Dense out=*, double complex scale=*)
-cpdef Dense matmul_csr_dense_dense(CSR left, Dense right, Dense out=*,
-                                   double complex scale=*)
+cpdef CSR matmul_csr(CSR left, CSR right, double complex scale=*, CSR out=*)
+cpdef Dense matmul_dense(Dense left, Dense right, double complex scale=*, Dense out=*)
+cpdef Dense matmul_csr_dense_dense(CSR left, Dense right, double complex scale=*, Dense out=*)

--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -84,7 +84,7 @@ cdef idxint _matmul_csr_estimate_nnz(CSR left, CSR right):
     return nnz
 
 
-cpdef CSR matmul_csr(CSR left, CSR right, CSR out=None, double complex scale=1.0):
+cpdef CSR matmul_csr(CSR left, CSR right, double complex scale=1, CSR out=None):
     """
     Multiply two CSR matrices together to produce another CSR.  If `out` is
     specified, it must be pre-allocated with enough space to hold the output
@@ -165,8 +165,8 @@ cpdef CSR matmul_csr(CSR left, CSR right, CSR out=None, double complex scale=1.0
     return out
 
 
-cpdef Dense matmul_csr_dense_dense(CSR left, Dense right, Dense out=None,
-                                   double complex scale=1.0):
+cpdef Dense matmul_csr_dense_dense(CSR left, Dense right,
+                                   double complex scale=1, Dense out=None):
     """
     Perform the operation
         ``out := scale * (left @ right) + out``
@@ -221,7 +221,7 @@ cpdef Dense matmul_csr_dense_dense(CSR left, Dense right, Dense out=None,
     return tmp
 
 
-cpdef Dense matmul_dense(Dense left, Dense right, Dense out=None, double complex scale=1):
+cpdef Dense matmul_dense(Dense left, Dense right, double complex scale=1, Dense out=None):
     """
     Perform the operation
         ``out := scale * (left @ right) + out``
@@ -295,6 +295,8 @@ matmul = _Dispatcher(
     _inspect.Signature([
         _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
         _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('scale', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                           default=1),
     ]),
     name='matmul',
     module=__name__,
@@ -303,7 +305,10 @@ matmul = _Dispatcher(
 )
 matmul.__doc__ =\
     """
-    Compute the matrix multiplication of two matrices.
+    Compute the matrix multiplication of two matrices, with the operation
+        scale * (left @ right)
+    where `scale` is (optionally) a scalar, and `left` and `right` are
+    matrices.
 
     Arguments
     ---------
@@ -312,6 +317,9 @@ matmul.__doc__ =\
 
     right : Data
         The right operand as a ket matrix.
+
+    scale : complex, optional
+        The scalar to multiply the output by.
     """
 matmul.add_specialisations([
     (CSR, CSR, CSR, matmul_csr),

--- a/qutip/core/data/properties.pxd
+++ b/qutip/core/data/properties.pxd
@@ -1,6 +1,8 @@
 #cython: language_level=3
 
-from qutip.core.data.csr cimport CSR
+from qutip.core.data cimport CSR, Dense
 
 cpdef bint isherm_csr(CSR matrix, double tol=*)
 cpdef bint isdiag_csr(CSR matrix) nogil
+cpdef bint iszero_csr(CSR matrix, double tol=*) nogil
+cpdef bint iszero_dense(Dense matrix, double tol=*) nogil

--- a/qutip/core/data/tidyup.pxd
+++ b/qutip/core/data/tidyup.pxd
@@ -1,6 +1,7 @@
 #cython: language_level=3
 #cython: boundscheck=False, wraparound=False, initializedcheck=False
 
-from qutip.core.data.csr cimport CSR
+from qutip.core.data cimport CSR, Dense
 
-cpdef CSR tidyup_csr(CSR matrix, double tol)
+cpdef CSR tidyup_csr(CSR matrix, double tol, bint inplace=*)
+cpdef Dense tidyup_dense(Dense matrix, double tol, bint inplace=*)

--- a/qutip/core/data/tidyup.pyx
+++ b/qutip/core/data/tidyup.pyx
@@ -19,11 +19,10 @@ __all__ = [
 
 cpdef CSR tidyup_csr(CSR matrix, double tol, bint inplace=True):
     cdef bint re, im
-    cdef size_t row, ptr, ptr_start, ptr_end=0, nnz_new, nnz_orig
+    cdef size_t row, ptr, ptr_start, ptr_end=0, nnz
     cdef double complex value
     cdef CSR out = matrix if inplace else matrix.copy()
-    nnz_new = 0
-    nnz_orig = csr.nnz(matrix)
+    nnz = 0
     out.row_index[0] = 0
     for row in range(matrix.shape[0]):
         ptr_start, ptr_end = ptr_end, matrix.row_index[row + 1]
@@ -37,12 +36,10 @@ cpdef CSR tidyup_csr(CSR matrix, double tol, bint inplace=True):
                 im = True
                 value.imag = 0
             if not (re & im):
-                out.data[nnz_new] = value
-                out.col_index[nnz_new] = matrix.col_index[ptr]
-                nnz_new += 1
-        out.row_index[row + 1] = nnz_new
-    if nnz_new == nnz_orig:
-        return out
+                out.data[nnz] = value
+                out.col_index[nnz] = matrix.col_index[ptr]
+                nnz += 1
+        out.row_index[row + 1] = nnz
     return out
 
 

--- a/qutip/core/expect.py
+++ b/qutip/core/expect.py
@@ -98,7 +98,7 @@ def _single_qobj_expect(oper, state):
             + str(oper.dims[1]) + " and " + str(state.dims[0])
         )
         raise ValueError(msg)
-    out = _data.expect_csr(oper.data, state.data)
+    out = _data.expect(oper.data, state.data)
     return out.real if oper.isherm and (state.isket or state.isherm) else out
 
 

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1709,6 +1709,8 @@ class Qobj:
                         copy=False)
         # We use the condition from John Watrous' lecture notes,
         # Tr_1(J(Phi)) = identity_2.
+        # See: https://cs.uwaterloo.ca/~watrous/LectureNotes.html,
+        # Theory of Quantum Information (Fall 2011), theorem 5.4.
         tr_oper = qobj.ptrace([0])
         return np.allclose(tr_oper.full(), np.eye(tr_oper.shape[0]),
                            atol=settings.core['atol'])

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -73,11 +73,11 @@ _MATMUL_TYPE_LOOKUP = {
 }
 
 _NORM_FUNCTION_LOOKUP = {
-    'tr': _data.norm.trace_csr,
-    'one': _data.norm.one_csr,
-    'max': _data.norm.max_csr,
-    'fro': _data.norm.frobenius_csr,
-    'l2': _data.norm.l2_csr,
+    'tr': _data.norm.trace,
+    'one': _data.norm.one,
+    'max': _data.norm.max,
+    'fro': _data.norm.frobenius,
+    'l2': _data.norm.l2,
 }
 _NORM_ALLOWED_MATRIX = {'tr', 'fro', 'one', 'max'}
 _NORM_ALLOWED_VECTOR = {'l2', 'max'}
@@ -145,7 +145,8 @@ def _require_equal_type(method):
             and isinstance(other, numbers.Number)
         ):
             scale = complex(other)
-            other = Qobj(_data.csr.identity(self.shape[0], scale),
+            other = Qobj(_data.identity(self.shape[0], scale,
+                                        dtype=type(self.data)),
                          dims=self.dims,
                          type=self.type,
                          superrep=self.superrep,
@@ -342,7 +343,11 @@ class Qobj:
             self._data = arg.data.copy() if copy else arg.data
         elif arg is None or isinstance(arg, numbers.Number):
             self.dims = dims or [[1], [1]]
-            self._data = _data.csr.identity(1, scale=complex(arg or 0))
+            size = np.prod(self.dims[0])
+            if arg is None:
+                self._data = _data.zeros(size, size)
+            else:
+                self._data = _data.identity(size, scale=complex(arg))
         else:
             self._data = _data.create(arg)
             self.dims = dims or [[self._data.shape[0]], [self._data.shape[1]]]
@@ -436,7 +441,7 @@ class Qobj:
     @_require_equal_type
     def __add__(self, other):
         isherm = (self._isherm and other._isherm) or None
-        return Qobj(_data.add_csr(self._data, other._data),
+        return Qobj(_data.add(self._data, other._data),
                     dims=self.dims,
                     type=self.type,
                     superrep=self.superrep,
@@ -450,7 +455,7 @@ class Qobj:
     @_require_equal_type
     def __sub__(self, other):
         isherm = (self._isherm and other._isherm) or None
-        return Qobj(_data.sub_csr(self._data, other._data),
+        return Qobj(_data.sub(self._data, other._data),
                     dims=self.dims,
                     type=self.type,
                     superrep=self.superrep,
@@ -467,7 +472,7 @@ class Qobj:
         multiplier = complex(other)
         isherm = (self._isherm and multiplier.imag == 0) or None
         isunitary = (self._isunitary and abs(multiplier) == 1) or None
-        return Qobj(_data.mul_csr(self._data, multiplier),
+        return Qobj(_data.mul(self._data, multiplier),
                     dims=self.dims,
                     type=self.type,
                     superrep=self.superrep,
@@ -507,17 +512,17 @@ class Qobj:
             (self.isbra and other.isket)
             or (self.isoperbra and other.isoperket)
         ):
-            return _data.inner_csr(self.data, other.data)
+            return _data.inner(self.data, other.data)
         try:
-            type = _MATMUL_TYPE_LOOKUP[(self.type, other.type)]
+            type_ = _MATMUL_TYPE_LOOKUP[(self.type, other.type)]
         except KeyError:
             raise TypeError(
                 "incompatible matmul types "
                 + repr(self.type) + " and " + repr(other.type)
             ) from None
-        return Qobj(_data.matmul_csr(self.data, other.data),
+        return Qobj(_data.matmul(self.data, other.data),
                     dims=[self.dims[0], other.dims[1]],
-                    type=type,
+                    type=type_,
                     isunitary=self._isunitary and other._isunitary,
                     superrep=self.superrep,
                     copy=False)
@@ -530,7 +535,7 @@ class Qobj:
 
     @_tidyup
     def __neg__(self):
-        return Qobj(_data.neg_csr(self._data),
+        return Qobj(_data.neg(self._data),
                     dims=self.dims.copy(),
                     type=self.type,
                     superrep=self.superrep,
@@ -539,16 +544,28 @@ class Qobj:
                     copy=False)
 
     def __getitem__(self, ind):
-        out = self._data.as_scipy()[ind]
-        return out.toarray() if scipy.sparse.issparse(out) else out
+        # TODO: should we require that data-layer types implement this?  This
+        # isn't the right way of handling it, for sure.
+        if isinstance(self._data, _data.CSR):
+            data = self._data.as_scipy()
+        elif isinstance(self._data, _data.Dense):
+            data = self._data.as_ndarray()
+        else:
+            data = self._data
+        try:
+            out = data[ind]
+            return out.toarray() if scipy.sparse.issparse(out) else out
+        except TypeError:
+            pass
+        return data.to_array()[ind]
 
     def __eq__(self, other):
         if self is other:
             return True
         if not isinstance(other, Qobj) or self.dims != other.dims:
             return False
-        diff = _data.sub_csr(self._data, other._data)
-        return np.all(np.abs(diff.as_scipy().data) < settings.core['atol'])
+        return _data.iszero(_data.sub(self._data, other._data),
+                            tol=settings.core['atol'])
 
     @_tidyup
     def __pow__(self, n, m=None):  # calculates powers of Qobj
@@ -560,7 +577,7 @@ class Qobj:
             or n < 0
         ):
             return NotImplemented
-        return Qobj(_data.pow_csr(self._data, n),
+        return Qobj(_data.pow(self._data, n),
                     dims=self.dims,
                     type=self.type,
                     superrep=self.superrep,
@@ -586,8 +603,8 @@ class Qobj:
             # and then to string, because it is pointless and is likely going
             # to produce memory errors. Instead print the sparse data string
             # representation.
-            data = self.data.as_scipy()
-        elif all(np.imag(self.data.as_scipy().data) == 0):
+            data = _data.to(_data.CSR, self.data).as_scipy()
+        elif _data.iszero(_data.sub(self.data.conj(), self.data)):
             data = np.real(self.full())
         else:
             data = self.full()
@@ -665,7 +682,7 @@ class Qobj:
         """Get the Hermitian adjoint of the quantum object."""
         if self._isherm:
             return self.copy()
-        return Qobj(_data.adjoint_csr(self._data),
+        return Qobj(_data.adjoint(self._data),
                     dims=[self.dims[1], self.dims[0]],
                     type=_ADJOINT_TYPE_LOOKUP[self.type],
                     superrep=self.superrep,
@@ -675,7 +692,7 @@ class Qobj:
 
     def conj(self):
         """Get the element-wise conjugation of the quantum object."""
-        return Qobj(_data.conj_csr(self._data),
+        return Qobj(_data.conj(self._data),
                     dims=self.dims.copy(),
                     type=self.type,
                     superrep=self.superrep,
@@ -691,7 +708,7 @@ class Qobj:
         oper : :class:`.Qobj`
             Transpose of input operator.
         """
-        return Qobj(_data.transpose_csr(self._data),
+        return Qobj(_data.transpose(self._data),
                     dims=[self.dims[1], self.dims[0]],
                     type=_ADJOINT_TYPE_LOOKUP[self.type],
                     superrep=self.superrep,
@@ -771,7 +788,7 @@ class Qobj:
             raise TypeError("projection is only defined for bras and kets")
         dims = ([self.dims[0], self.dims[0]] if self.isket
                 else [self.dims[1], self.dims[1]])
-        return Qobj(_data.project_csr(self._data),
+        return Qobj(_data.project(self._data),
                     dims=dims,
                     type='oper',
                     isherm=True,
@@ -786,7 +803,7 @@ class Qobj:
             Returns the trace of the quantum object.
 
         """
-        out = _data.trace_csr(self._data)
+        out = _data.trace(self._data)
         return out.real if self.isherm else out
 
     def purity(self):
@@ -803,8 +820,8 @@ class Qobj:
         if self.type in ("super", "operator-ket", "operator-bra"):
             raise TypeError('purity is only defined for states.')
         if self.isket or self.isbra:
-            return _data.norm.l2_csr(self.data)**2
-        return _data.trace_csr(self.data @ self.data).real
+            return _data.norm.l2(self.data)**2
+        return _data.trace(self.data @ self.data).real
 
     def full(self, order='C', squeeze=False):
         """Dense array from quantum object.
@@ -833,25 +850,25 @@ class Qobj:
             Returns array of ``real`` values if operators is Hermitian,
             otherwise ``complex`` values are returned.
         """
-        out = self.data.as_scipy().diagonal()
+        # TODO: add a `diagonal` method to the data layer?
+        out = _data.to(_data.CSR, self.data).as_scipy().diagonal()
         if np.any(np.imag(out) > settings.core['atol']) or not self.isherm:
             return out
         else:
             return np.real(out)
 
     @_tidyup
-    def expm(self, method='dense'):
+    def expm(self, dtype=_data.Dense):
         """Matrix exponential of quantum operator.
 
         Input operator must be square.
 
         Parameters
         ----------
-        method : str {'dense', 'sparse'}
-            Use set method to use to calculate the matrix exponentiation. The
-            available choices includes 'dense' and 'sparse'.  Since the
-            exponential of a matrix is nearly always dense, method='dense'
-            is set as default.s
+        dtype : type
+            The data-layer type that should be output.  As the matrix
+            exponential is almost dense, this defaults to outputting dense
+            matrices.
 
         Returns
         -------
@@ -862,20 +879,10 @@ class Qobj:
         ------
         TypeError
             Quantum operator is not square.
-
         """
         if self.dims[0] != self.dims[1]:
             raise TypeError("expm is only valid for square operators")
-        if method == 'dense':
-            # TODO: swap back to the proper output once the dispatcher is
-            # implemented.
-            # data = _data.expm_csr_dense(self.data)
-            data = _data.create(_data.expm_csr_dense(self.data).to_array())
-        elif method == 'sparse':
-            data = _data.expm_csr(self.data)
-        else:
-            raise ValueError("method must be 'dense' or 'sparse'")
-        return Qobj(data,
+        return Qobj(_data.expm(self._data, dtype=dtype),
                     dims=self.dims,
                     type=self.type,
                     superrep=self.superrep,
@@ -1015,7 +1022,7 @@ class Qobj:
             inv_mat = scipy.sparse.linalg.inv(_sci)
         else:
             inv_mat = np.linalg.inv(self.data.to_array())
-        return Qobj(inv_mat,
+        return Qobj(_data.create(inv_mat),
                     dims=[self.dims[1], self.dims[0]],
                     type=self.type,
                     superrep=self.superrep,
@@ -1223,7 +1230,7 @@ class Qobj:
                 if self.dims[0] != self.dims[1]:
                     raise TypeError("undefined for non-square operators")
                 dims = [new_structure, new_structure]
-            data = _data.permute.dimensions_csr(self.data, structure, order)
+            data = _data.permute.dimensions(self.data, structure, order)
             return Qobj(data,
                         dims=dims,
                         type=self.type,
@@ -1245,8 +1252,7 @@ class Qobj:
             if self.dims[0] != self.dims[1]:
                 raise TypeError("undefined for non-square operators")
             dims = [new_structure, new_structure]
-        data = _data.permute.dimensions_csr(self.data,
-                                            flat_structure, flat_order)
+        data = _data.permute.dimensions(self.data, flat_structure, flat_order)
         return Qobj(data,
                     dims=dims,
                     type=self.type,
@@ -1269,7 +1275,7 @@ class Qobj:
             Quantum object with small elements removed.
         """
         atol = atol or settings.core['auto_tidyup_atol']
-        self.data = _data.tidyup_csr(self.data, atol)
+        self.data = _data.tidyup(self.data, atol)
         return self
 
     def transform(self, inpt, inverse=False):
@@ -1299,9 +1305,8 @@ class Qobj:
             if len(inpt) != max(self.shape):
                 raise TypeError(
                     'Invalid size of ket list for basis transformation')
-            sci = scipy.sparse.hstack([psi.data.as_scipy() for psi in inpt],
-                                      format='csr', dtype=np.complex128)
-            S = _data.create(sci).adjoint()
+            base = np.hstack([psi.full() for psi in inpt])
+            S = _data.adjoint(_data.create(base))
         elif isinstance(inpt, Qobj) and inpt.isoper:
             S = inpt.data
         elif isinstance(inpt, np.ndarray):
@@ -1312,18 +1317,18 @@ class Qobj:
         # transform data
         if inverse:
             if self.isket:
-                data = S.adjoint() @ self.data
+                data = _data.matmul(S.adjoint(), self.data)
             elif self.isbra:
-                data = self.data @ S
+                data = _data.matmul(self.data, S)
             else:
-                data = S.adjoint() @ self.data @ S
+                data = _data.matmul(_data.matmul(S.adjoint(), self.data), S)
         else:
             if self.isket:
-                data = S @ self.data
+                data = _data.matmul(S, self.data)
             elif self.isbra:
-                data = self.data @ S.adjoint()
+                data = _data.matmul(self.data, S.adjoint())
             else:
-                data = S @ self.data @ S.adjoint()
+                data = _data.matmul(_data.matmul(S, self.data), S.adjoint())
         return Qobj(data,
                     dims=self.dims,
                     type=self.type,
@@ -1379,13 +1384,14 @@ class Qobj:
                 acc += eigvals[idx]
                 eigvals[idx] = 0.0
             eigvals[:idx+1] += acc / (idx + 1)
-        out_data = _data.csr.zeros(*self.shape)
+        out_data = _data.zeros(*self.shape)
         for value, state in zip(eigvals, eigstates):
             if value:
                 # add in 3-argument form is fused-add-multiply
-                out_data = _data.add_csr(out_data,
-                                         _data.project_csr(state.data), value)
-        out_data /= _data.norm.trace_csr(out_data)
+                out_data = _data.add(out_data,
+                                     _data.project(state.data),
+                                     value)
+        out_data /= _data.norm.trace(out_data)
         return Qobj(out_data,
                     dims=self.dims.copy(),
                     type=self.type,
@@ -1425,7 +1431,7 @@ class Qobj:
         left, op, right = bra.data, self.data, ket.data
         if ket.isbra:
             right = right.adjoint()
-        return _data.inner_op_csr(left, op, right, bra.isket)
+        return _data.inner_op(left, op, right, bra.isket)
 
     def overlap(self, other):
         """
@@ -1466,13 +1472,13 @@ class Qobj:
         left, right = self._data.adjoint(), other.data
         if self.isoper or other.isoper:
             if not self.isoper:
-                left = _data.project_csr(left)
+                left = _data.project(left)
             if not other.isoper:
-                right = _data.project_csr(right)
-            return _data.trace_csr(left @ right)
+                right = _data.project(right)
+            return _data.trace(_data.matmul(left, right))
         if other.isbra:
             right = right.adjoint()
-        out = _data.inner_csr(left, right, self.isket)
+        out = _data.inner(left, right, self.isket)
         if self.isket and other.isbra:
             # In this particular case, we've basically doing
             #   conj(other.overlap(self))
@@ -1727,7 +1733,7 @@ class Qobj:
     def isherm(self):
         if self._isherm is not None:
             return self._isherm
-        self._isherm = _data.isherm_csr(self._data)
+        self._isherm = _data.isherm(self._data)
         return self._isherm
 
     @isherm.setter
@@ -1740,9 +1746,10 @@ class Qobj:
         """
         if not self.isoper or self._data.shape[0] != self._data.shape[1]:
             return False
-        iden = _data.csr.identity(self.shape[0])
-        cmp = self._data @ self._data.adjoint()
-        return np.all(np.abs((cmp - iden).as_scipy().data) < settings.core['atol'])
+        cmp = _data.matmul(self._data, self._data.adjoint())
+        iden = _data.identity(self.shape[0], dtype=type(cmp))
+        return _data.iszero(_data.sub(cmp, iden),
+                            tol=settings.core['atol'])
 
     @property
     def isunitary(self):

--- a/qutip/core/superop_reps.py
+++ b/qutip/core/superop_reps.py
@@ -59,7 +59,13 @@ from .operators import identity, sigmax, sigmay, sigmaz
 from .states import basis
 
 
-_SINGLE_QUBIT_PAULI_BASIS = (identity(2), sigmax(), sigmay(), sigmaz())
+# TODO: revisit when creation routines have dispatching.
+_SINGLE_QUBIT_PAULI_BASIS = (
+    identity(2).to(_data.CSR),
+    sigmax().to(_data.CSR),
+    sigmay().to(_data.CSR),
+    sigmaz().to(_data.CSR),
+)
 
 
 def _superpauli_basis(nq=1):
@@ -77,7 +83,7 @@ def _superpauli_basis(nq=1):
         basis = paulis[0].data
         for pauli in paulis[1:]:
             basis = _data.kron_csr(basis, pauli.data)
-        basis_ket_sci = stack_columns(basis).transpose().as_scipy()
+        basis_ket_sci = _data.column_stack_csr(basis).transpose().as_scipy()
         sci.data[ptr : ptr+ptr_inc] = basis_ket_sci.data
         sci.indices[ptr : ptr+ptr_inc] = basis_ket_sci.indices
         sci.indptr[i] = ptr
@@ -329,13 +335,13 @@ def _choi_to_stinespring(q_oper, threshold=1e-10):
     out_left, out_right = out_dims
     in_left, in_right = in_dims
 
-    A = Qobj(_data.csr.zeros(dK * dL, dL),
+    A = Qobj(_data.zeros(dK * dL, dL),
              dims=[out_left + [dK], out_right + [1]],
              type='oper',
              isherm=True,
              isunitary=False,
              copy=False)
-    B = Qobj(_data.csr.zeros(dK * dR, dR),
+    B = Qobj(_data.zeros(dK * dR, dR),
              dims=[in_left + [dK], in_right + [1]],
              type='oper',
              isherm=True,

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -114,7 +114,7 @@ shape = [4, 4], type = oper, isHerm = True
     dims_l = [d for arg in args for d in arg.dims[0]]
     dims_r = [d for arg in args for d in arg.dims[1]]
     for arg in args[1:]:
-        out_data = _data.kron_csr(out_data, arg.data)
+        out_data = _data.kron(out_data, arg.data)
         # If both _are_ Hermitian and/or unitary, then so is the output, but if
         # both _aren't_, then output still can be.
         isherm = (isherm and arg._isherm) or None

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -153,7 +153,7 @@ def rand_herm(N, density=0.75, dims=None, pos_def=False, seed=None):
     if seed is not None:
         np.random.seed(seed=seed)
     if isinstance(N, (np.ndarray, list)):
-        M = _data.create(sp.diags(N, 0, dtype=complex, format='csr'))
+        M = _data.CSR(sp.diags(N, 0, dtype=complex, format='csr'))
         N = len(N)
         if dims:
             _check_dims(dims, N, N)
@@ -239,7 +239,6 @@ def rand_unitary(N, density=0.75, dims=None, seed=None):
     if dims:
         _check_dims(dims, N, N)
     U = (-1.0j * rand_herm(N, density, seed=seed)).expm()
-    U.data.sort_indices()
     return Qobj(U,
                 dims=dims or [[N], [N]],
                 type='oper',
@@ -335,7 +334,7 @@ def rand_ket(N=0, density=1, dims=None, seed=None):
     Y = X.copy()
     Y.data = 1.0j * (np.random.random(len(X.data)) - 0.5)
     X = _data.csr.CSR(X + Y)
-    return Qobj(X / _data.norm.l2_csr(X),
+    return Qobj(X / _data.norm.l2(X),
                 dims=dims,
                 copy=False,
                 type='ket',

--- a/qutip/solve/_brtools.pyx
+++ b/qutip/solve/_brtools.pyx
@@ -456,7 +456,7 @@ cdef void cop_super_mult(complex[::1,:] cop, complex[::1,:] evecs,
     cdef Dense vec_d = dense.wrap(vec, nrows*nrows, 1, fortran=True)
     cdef Dense out_d = dense.wrap(out, nrows*nrows, 1, fortran=True)
     # out = kron(cd, c) @ vec
-    matmul_csr_dense_dense(kron_csr(c.conj(), c), vec_d, out=out_d)
+    matmul_csr_dense_dense(kron_csr(c.conj(), c), vec_d, scale=1, out=out_d)
     cdef CSR iden = csr.identity(nrows)
     cdef CSR cdc = matmul_csr(c.adjoint(), c)
     # out += -0.5 * (kron(eye, cdc) @ vec)
@@ -538,5 +538,5 @@ cdef void br_term_mult(double t, complex[::1,:] A, complex[::1,:] evecs,
     cdef CSR matrix = csr.from_coo_pointers(
         coo_rows.data(), coo_cols.data(), coo_data.data(),
         nrows*nrows, nrows*nrows, coo_rows.size())
-    matmul_csr_dense_dense(matrix, dense.wrap(vec, nrows*nrows, 1),
+    matmul_csr_dense_dense(matrix, dense.wrap(vec, nrows*nrows, 1), scale=1,
                            out=dense.wrap(out, nrows*nrows, 1))

--- a/qutip/solve/floquet.py
+++ b/qutip/solve/floquet.py
@@ -48,6 +48,7 @@ from types import FunctionType
 from .. import (
     Qobj, unstacked_index, stack_columns, unstack_columns, projection, expect,
 )
+from ..core import data as _data
 from .sesolve import sesolve
 from ._rhs_generate import rhs_clear
 from .steadystate import steadystate
@@ -876,9 +877,8 @@ def floquet_markov_mesolve(R, ekets, rho0, tlist, e_ops, f_modes_table=None,
 
 
 def _wrap_matmul(t, state, operator):
-    out = _data.matmul_csr_dense_dense(operator,
-                                       _data.dense.fast_from_numpy(state))
-    return out.as_ndarray()
+    return _data.matmul(operator, _data.dense.fast_from_numpy(state),
+                        dtype=_data.Dense).as_ndarray()
 
 # -----------------------------------------------------------------------------
 # Solve the Floquet-Markov master equation

--- a/qutip/solve/nonmarkov/_heom.pyx
+++ b/qutip/solve/nonmarkov/_heom.pyx
@@ -78,3 +78,25 @@ def pad_csr(CSR matrix, idxint row_scale, idxint col_scale,
         raise ValueError("insertrow must be >= 0 and < row_scale")
 
     return out
+
+
+from qutip.core.data import Dispatcher
+import inspect as _inspect
+
+pad = Dispatcher(
+    _inspect.Signature([
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('rowscale', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('colscale', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('insertrow', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('insertcol', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    ]),
+    name='pad',
+    module=__name__,
+    inputs=('matrix',),
+    out=True)
+pad.add_specialisations([
+    (CSR, CSR, pad_csr),
+])
+
+del Dispatcher, _inspect

--- a/qutip/solve/nonmarkov/transfertensor.py
+++ b/qutip/solve/nonmarkov/transfertensor.py
@@ -193,14 +193,13 @@ def ttmsolve(dynmaps, rho0, times, e_ops=[], learningtimes=None, tensors=None,
             if expt_callback:
                 # use callback method
                 e_ops(times[i], states[i])
-        rdata = _data.column_stack_csr(r.data)
+        rdata = _data.column_stack(r.data)
         for m in range(n_expt_op):
             if output.expect[m].dtype == complex:
-                output.expect[m][i] = _data.expect_super_csr(e_sops_data[m],
-                                                             rdata)
+                output.expect[m][i] = _data.expect_super(e_sops_data[m], rdata)
             else:
-                output.expect[m][i] = _data.expect_super_csr(e_sops_data[m],
-                                                             rdata).real
+                output.expect[m][i] =\
+                    _data.expect_super(e_sops_data[m], rdata).real
 
     output.solver = "ttmsolve"
     output.times = times

--- a/qutip/solve/propagator.py
+++ b/qutip/solve/propagator.py
@@ -284,8 +284,8 @@ def propagator_steadystate(U):
     shifted_vals = np.abs(evals - 1.0)
     ev_idx = np.argmin(shifted_vals)
     rho_data = unstack_columns(estates[ev_idx].data)
-    rho_data *= 0.5 / _data.trace_csr(rho_data)
-    return Qobj(rho_data + rho_data.adjoint(),
+    rho_data = _data.mul(rho_data, 0.5 / _data.trace(rho_data))
+    return Qobj(_data.add(rho_data, _data.adjoint(rho_data)),
                 dims=U.dims[0],
                 type='oper',
                 isherm=True,

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -458,7 +458,7 @@ def test_QobjExpmExplicitlySparse():
     "qutip.Qobj expm (sparse)"
     data = _random_not_singular(15)
     A = qutip.Qobj(data)
-    B = A.expm(method='sparse')
+    B = A.expm(dtype=qutip.data.CSR)
     np.testing.assert_allclose(B.full(), scipy.linalg.expm(data), atol=1e-10)
 
 

--- a/qutip/tests/solve/test_brtools.py
+++ b/qutip/tests/solve/test_brtools.py
@@ -40,6 +40,7 @@ from qutip.solve._brtools_checks import (
     _test_vec_to_eigbasis, _test_eigvec_to_fockbasis, _test_vector_roundtrip,
     _cop_super_mult, _test_br_term_mult
 )
+from qutip.core import data as _data
 import platform
 
 
@@ -133,7 +134,7 @@ def test_diag_liou_mult():
         L = qutip.liouvillian(H.transform(evecs))
         coefficients = np.ones((dimension*dimension,), dtype=np.complex128)
         calculated = np.zeros_like(coefficients)
-        target = L.data.as_scipy().dot(coefficients)
+        target = _data.to(_data.CSR, L.data).as_scipy().dot(coefficients)
         _test_diag_liou_mult(evals, coefficients, calculated, dimension)
         np.testing.assert_allclose(target, calculated, atol=1e-12)
 
@@ -147,7 +148,7 @@ def test_cop_super_mult():
         a = qutip.destroy(dimension)
         L = qutip.liouvillian(None, [a.transform(basis)])
         vec = np.ones((dimension*dimension,), dtype=np.complex128)
-        target = L.data.as_scipy().dot(vec)
+        target = _data.to(_data.CSR, L.data).as_scipy().dot(vec)
         calculated = np.zeros_like(target)
         _eigenvalues = np.empty((dimension,), dtype=np.float64)
         _cop_super_mult(a.full('F'), _test_zheevr(H.full('F'), _eigenvalues),
@@ -173,7 +174,8 @@ def test_br_term_mult(secular):
         vec = np.ones((dimension*dimension,), dtype=np.complex128)
         br_tensor, _ = qutip.bloch_redfield_tensor(H, a_ops,
                                                    use_secular=secular)
-        target = (br_tensor - L_diagonal).data.as_scipy().dot(vec)
+        _op = br_tensor - L_diagonal
+        target = _data.to(_data.CSR, _op.data).as_scipy().dot(vec)
         calculated = np.zeros_like(target)
         _test_br_term_mult(time, operator.full('F'), evecs, evals, vec,
                            calculated, secular, 0.1, atol)

--- a/qutip/tests/test_mkl.py
+++ b/qutip/tests/test_mkl.py
@@ -37,6 +37,7 @@ import scipy.linalg as la
 from numpy.testing import (assert_, run_module_suite, assert_array_almost_equal)
 import unittest
 from qutip import *
+from qutip.core import data as _data
 from qutip.settings import settings as qset
 if qset.install['has_mkl']:
     from qutip._mkl.spsolve import (mkl_splu, mkl_spsolve)
@@ -66,7 +67,7 @@ def test_mklspsolve2():
     A = rand_herm(10)
     x = rand_ket(10).full()
     b = A.full() @ x
-    y = mkl_spsolve(A.data.as_scipy(), b)
+    y = mkl_spsolve(_data.to(_data.CSR, A.data).as_scipy(), b)
     assert_array_almost_equal(x, y)
 
 
@@ -209,7 +210,7 @@ def test_mkl_spsolve9():
     """
     MKL spsolve : Hermitian (complex) solver
     """
-    A = rand_herm(np.arange(1, 11)).data.as_scipy()
+    A = _data.to(_data.CSR, rand_herm(np.arange(1, 11)).data).as_scipy()
     x = np.ones(10, dtype=complex)
     b = A.dot(x)
     y = mkl_spsolve(A, b, hermitian=1)
@@ -221,7 +222,7 @@ def test_mkl_spsolve10():
     """
     MKL spsolve : Hermitian (real) solver
     """
-    A = rand_herm(np.arange(1, 11)).data.as_scipy()
+    A = _data.to(_data.CSR, rand_herm(np.arange(1, 11)).data).as_scipy()
     A = sp.csr_matrix((np.real(A.data), A.indices, A.indptr), dtype=float)
     x = np.ones(10, dtype=float)
     b = A.dot(x)

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -125,7 +125,7 @@ def wigner_transform(psi, j, fullparity, steps, slicearray):
         for p in range(steps):
             kernel = _kernelsu2(theta[:, t], phi[:, p], N, j, pari, fullparity)
             kernel = _data.dense.fast_from_numpy(kernel)
-            wigner[t, p] = _data.expect_csr_dense(rho.data, kernel).real
+            wigner[t, p] = _data.expect(rho.data, kernel).real
     return wigner
 
 
@@ -504,7 +504,7 @@ def _wigner_clenshaw(rho, xvec, yvec, g=sqrt(2), sparse=False):
             w0 = _wig_laguerre_val(L, B, np.diag(rho, L)) + w0 * A2 * (L+1)**-0.5
     else:
         # TODO: fix dispatch.
-        _rho = rho.data.as_scipy()
+        _rho = _data.to(_data.CSR, rho.data).as_scipy()
         while L > 0:
             L -= 1
             diag = _rho.diagonal(L)


### PR DESCRIPTION
Finally, `Qobj` can use any backing data store.  This fairly small and simple PR is effectively the culmination of all the work on `dev.major` over the last few months, and effectively is just like flicking a switch to turn on all the capabilities that we've built up through #1282, #1296, #1332, #1338 and #1340.

There is still a lot of work to be done, but I'm trying to transition to smaller, easier-to-check PRs to make review easier.

Possibly incomplete to do list:
 - write a proper `data.create`
 - possibly add the dispatchers in as `data.Data` mathematical methods (e.g. `__matmul__`)
 - add options for controlling default output types from the dispatchers
 - tests for `Qobj` with both types
 - tests for creation and property routines of the data layer
 - tests for the dispatch operation
 - tests for conversion operations
 - more specialisations to be written for `Dense` and `CSR`/`Dense`
 - more ergonomic selection of _method_, not just output type (for example, you should be able to specify you want the `Dense` specialisation of `eigs` even if you pass it a `CSR`)
 - more ergonomic dispatchers for matrix creation (e.g. how exactly will `qutip.basis` function, and how will users add specialisations?)
 - documentation, both user-facing and developer-facing
 - fix algorithms in `add_csr` and `matmul_csr` to use `csr.Accumulator` (should provide a speedup and remove some sorts)
 - fix `isherm_csr` (see #1350 - `isherm_csr` uses the same algorithm, so has the same problem)