### PR TITLE
Fix zcsr_isherm for matrices with small values

### DIFF
--- a/qutip/tests/test_spmath.py
+++ b/qutip/tests/test_spmath.py
@@ -35,6 +35,7 @@ from numpy.testing import (run_module_suite, assert_,
                         assert_equal, assert_almost_equal)
 import scipy.sparse as sp
 
+from qutip.fastsparse import fast_csr_matrix, fast_identity
 from qutip.random_objects import (rand_dm, rand_herm,
                                   rand_ket, rand_unitary)
 from qutip.cy.spmath import (zcsr_kron, zcsr_transpose, zcsr_adjoint,
@@ -263,6 +264,84 @@ def test_zcsr_isherm():
         assert_(zcsr_isherm(A.data))
         assert_(zcsr_isherm(B.data)==0)
 
+
+def test_zcsr_isherm_compare_implicit_zero():
+    """
+    Regression test for gh-1350, comparing explicitly stored values in the
+    matrix (but below the tolerance for allowable Hermicity) to implicit zeros.
+    """
+    tol = 1e-12
+    n = 10
+
+    base = sp.csr_matrix(np.array([[1, tol * 1e-3j], [0, 1]]))
+    base = fast_csr_matrix((base.data, base.indices, base.indptr), base.shape)
+    # If this first line fails, the zero has been stored explicitly and so the
+    # test is invalid.
+    assert base.data.size == 3
+    assert zcsr_isherm(base, tol=tol)
+    assert zcsr_isherm(base.T, tol=tol)
+
+    # A similar test if the structures are different, but it's not
+    # Hermitian.
+    base = sp.csr_matrix(np.array([[1, 1j], [0, 1]]))
+    base = fast_csr_matrix((base.data, base.indices, base.indptr), base.shape)
+    assert base.data.size == 3
+    assert not zcsr_isherm(base, tol=tol)
+    assert not zcsr_isherm(base.T, tol=tol)
+
+    # Catch possible edge case where it shouldn't be Hermitian, but faulty loop
+    # logic doesn't fully compare all rows.
+    base = sp.csr_matrix(np.array([
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 0, 0],
+    ], dtype=np.complex128))
+    base = fast_csr_matrix((base.data, base.indices, base.indptr), base.shape)
+    assert base.data.size == 1
+    assert not zcsr_isherm(base, tol=tol)
+    assert not zcsr_isherm(base.T, tol=tol)
+
+    # Pure diagonal matrix.
+    base = fast_identity(n)
+    base.data *= np.random.rand(n)
+    assert zcsr_isherm(base, tol=tol)
+    assert not zcsr_isherm(base * 1j, tol=tol)
+
+    # Larger matrices where all off-diagonal elements are below the absolute
+    # tolerance, so everything should always appear Hermitian, but with random
+    # patterns of non-zero elements.  It doesn't matter that it isn't Hermitian
+    # if scaled up; everything is below absolute tolerance, so it should appear
+    # so.  We also set the diagonal to be larger to the tolerance to ensure
+    # isherm can't just compare everything to zero.
+    for density in np.linspace(0.2, 1, 21):
+        base = tol * 1e-2 * (np.random.rand(n, n) + 1j*np.random.rand(n, n))
+        # Mask some values out to zero.
+        base[np.random.rand(n, n) > density] = 0
+        np.fill_diagonal(base, tol * 1000)
+        nnz = np.count_nonzero(base)
+        base = sp.csr_matrix(base)
+        base = fast_csr_matrix((base.data, base.indices, base.indptr), (n, n))
+        assert base.data.size == nnz
+        assert zcsr_isherm(base, tol=tol)
+        assert zcsr_isherm(base.T, tol=tol)
+
+        # Similar test when it must be non-Hermitian.  We set the diagonal to
+        # be real because we want to test off-diagonal implicit zeros, and
+        # having an imaginary first element would automatically fail.
+        nnz = 0
+        while nnz <= n:
+            # Ensure that we don't just have the real diagonal.
+            base = tol * 1000j*np.random.rand(n, n)
+            # Mask some values out to zero.
+            base[np.random.rand(n, n) > density] = 0
+            np.fill_diagonal(base, tol * 1000)
+            nnz = np.count_nonzero(base)
+        base = sp.csr_matrix(base)
+        base = fast_csr_matrix((base.data, base.indices, base.indptr), (n, n))
+        assert base.data.size == nnz
+        assert not zcsr_isherm(base, tol=tol)
+        assert not zcsr_isherm(base.T, tol=tol)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In certain cases in matrices containing values smaller than the tolerance for Hermicity, a matrix can be considered Hermitian even if its transpose does not have the same sparsity pattern as itself.  The previous version of this function would give false negatives in these circumstances, whereas now we fall back on the more computationally and memory intensive version of constructing the transpose completely, and comparing element-wise.

We offset some of this slowdown by optimising the floating-point comparisons to avoid calls to `sqrt` (via `abs`), and by removing a redundant test of the sparsity pattern in the inner loop.

Fixes #1350 for the `master` branch, but still to do for `dev.major`.