### PR TITLE
Some minor fixes

### DIFF
--- a/qutip/parallel.py
+++ b/qutip/parallel.py
@@ -193,7 +193,7 @@ def serial_map(task, values, task_args=tuple(), task_kwargs={}, **kwargs):
     return results
 
 
-def parallel_map(task, values, task_args=tuple(), task_kwargs={}, **kwargs):
+def parallel_map(task, values, task_args=tuple(), task_kwargs=None, **kwargs):
     """
     Parallel execution of a mapping of `values` to the function `task`. This
     is functionally equivalent to::
@@ -222,6 +222,8 @@ def parallel_map(task, values, task_args=tuple(), task_kwargs={}, **kwargs):
         each value in ``values``.
 
     """
+    if task_kwargs is None:
+        task_kwargs = dict()
     os.environ['QUTIP_IN_PARALLEL'] = 'TRUE'
     kw = _default_kwargs()
     if 'num_cpus' in kwargs:

--- a/qutip/tests/test_steadystate.py
+++ b/qutip/tests/test_steadystate.py
@@ -487,7 +487,7 @@ def test_driven_cavity_power_gmres():
     c_ops = [np.sqrt(Gamma) * a]
     M = build_preconditioner(H, c_ops, method='power')
     rho_ss = steadystate(H, c_ops, method='power-gmres', M=M, mtol=1e-1,
-                         use_precond=1)
+                         use_precond=1, maxiter=10000)
     rho_ss_analytic = coherent_dm(N, -1.0j * (Omega)/(Gamma/2))
     assert_((rho_ss - rho_ss_analytic).norm() < 1e-4)
 


### PR DESCRIPTION
increased ``maxiter`` at ``test_driven_cavity_power_gmres()`` to 10000 in tests/test_steadystate.py
resolved mutable default value at ``parallel_map()`` in parallel.py
resolved mutable default value at various places in qobjevo.py
cleaned up now defunct class ``_file_list`` in qobjevo.py (fixes #1354)

**Description**
Fixes #1354, increases ``maxiter`` at ``test_driven_cavity_power_gmres()`` to ``10000`` in ``tests/test_steadystate.py``.

**Related issues or PRs**
fix #1354

**Changelog**
Increased ``maxiter`` at ``test_driven_cavity_power_gmres()`` to 10000 in tests/test_steadystate.py.
Resolved mutable default value at ``parallel_map()`` in parallel.py.
Resolved mutable default value at various places in qobjevo.py.
Cleaned up now defunct class ``_file_list`` in qobjevo.py (fixes #1354).
