### PR TITLE
Re-add scipy<1.5 test constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
       # This is why we use `setup.py develop` here, and why we don't change
       # directories.
       install:
-        - conda install mkl blas=*=mkl numpy scipy matplotlib cython pytest pytest-cov coveralls
+        - conda install mkl blas=*=mkl numpy 'scipy<1.5' matplotlib cython pytest pytest-cov coveralls
         - python setup.py develop --with-openmp
       before_script:
         - QUTIP_INSTALL="${QUTIP_DOWNLOAD}/qutip"


### PR DESCRIPTION
Fix a testing set-up regression made in #1348 - the version of SciPy was meant to be constrained to <1.5 to test compatibility with the older version of the sparse matrices, but the version constraint got omitted when I rewrote the `.travis.yml` file.

The specific bugs that that test is meant to catch (errors handling `scipy.sparse.csr_matrix` matrix multiplication) can't be present in this branch anyway, because the new data types don't use scipy internals.  Still, it's good to test against older versions of scipy as well - in 1.5 they changed some numerics in the eigenvalue solvers, which caused a whole bunch of our tests to break because we relied on the gauge and order of the vectors returned remaining constant.