### PR TITLE
Custom Initial Pulses in Control

### DIFF
--- a/qutip/control/pulsegen.py
+++ b/qutip/control/pulsegen.py
@@ -45,8 +45,8 @@ size num_tslots. Each class produces a differ type of pulse.
 See the class and gen_pulse function descriptions for details
 """
 
-import qutip.control.errors as errors
 import qutip.control.dynamics as dynamics
+import qutip.control.errors as errors
 import numpy as np
 
 import qutip.logging_utils as logging
@@ -59,20 +59,20 @@ def create_pulse_gen(pulse_type='RND', dyn=None, pulse_params=None):
     The pulse generators each produce a different type of pulse,
     see the gen_pulse function description for details.
     These are the random pulse options:
-
+        
         RND - Independent random value in each timeslot
         RNDFOURIER - Fourier series with random coefficients
         RNDWAVES - Summation of random waves
         RNDWALK1 - Random change in amplitude each timeslot
         RNDWALK2 - Random change in amp gradient each timeslot
-
+    
     These are the other non-periodic options:
-
+        
         LIN - Linear, i.e. contant gradient over the time
         ZERO - special case of the LIN pulse, where the gradient is 0
-
+    
     These are the periodic options:
-
+        
         SINE - Sine wave
         SQUARE - Square wave
         SAW - Saw tooth wave
@@ -1008,7 +1008,8 @@ class PulseGenCustom(PulseGen):
             self.call_index = 0
 
         if ((self.init_custom_pulse.shape[0] != self.tau.shape[0]) or
-                (self.call_index not in range(self.init_custom_pulse.shape[1]))):
+                (self.call_index not in 
+                 range(self.init_custom_pulse.shape[1]))):
             raise ValueError("The initial custom pulse array should be of "
                              "size (num_tslots x num_ctrls).")
 
@@ -1017,6 +1018,7 @@ class PulseGenCustom(PulseGen):
 
         pulse = self.init_custom_pulse[:, self.call_index]
         self.call_index += 1
+
         return self._apply_bounds_and_offset(pulse)
 
 

--- a/qutip/control/pulsegen.py
+++ b/qutip/control/pulsegen.py
@@ -71,12 +71,18 @@ def create_pulse_gen(pulse_type='RND', dyn=None, pulse_params=None):
         LIN - Linear, i.e. contant gradient over the time
         ZERO - special case of the LIN pulse, where the gradient is 0
 
-    These are the periodic options
+    These are the periodic options:
 
         SINE - Sine wave
         SQUARE - Square wave
         SAW - Saw tooth wave
         TRIANGLE - Triangular wave
+
+    This is the custom pulse option:
+
+        CUSTOM - Custom pulse. Requires the additional "init_custom_pulse" 
+            parameter given in pulse_params. init_custom_pulse is an array
+            of size (num_tslots x num_ctrls).
 
     If a Dynamics object is passed in then this is used in instantiate
     the PulseGen, meaning that some timeslot and amplitude properties

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -59,20 +59,20 @@ The default algorithm (as it was implemented here first) is GRAPE
 GRadient Ascent Pulse Engineering [1][2]. It uses a gradient based method such
 as BFGS to minimise the fidelity error. This makes convergence very quick
 when an exact gradient can be calculated, but this limits the factors that can
-taken into account in the fidelity.
+to account in the fidelity.
 
 CRAB
 ----
 The CRAB [3][4] algorithm was developed at the University of Ulm.
 In full it is the Chopped RAndom Basis algorithm.
-The main difference is that it reduces the number of optimisation variables 
+main difference is that it reduces the number of optimisation variables 
 by defining the control pulses by expansions of basis functions, 
-where the variables are the coefficients. Typically a Fourier series is chosen, 
+e variables are the coefficients. Typically a Fourier series is chosen, 
 i.e. the variables are the Fourier coefficients. 
 Therefore it does not need to compute an explicit gradient. 
-By default it uses the Nelder-Mead method for fidelity error minimisation. 
+efault it uses the Nelder-Mead method for fidelity error minimisation. 
 
-References
+es
 ----------
 1.  N Khaneja et. al. 
     Optimal control of coupled spin dynamics: Design of NMR pulse sequences 
@@ -88,6 +88,15 @@ References
     Phys. Rev. A - At. Mol. Opt. Phys. 84, (2011).
 
 """
+import qutip.control.pulsegen as pulsegen
+import qutip.control.propcomp as propcomp
+import qutip.control.fidcomp as fidcomp
+import qutip.control.errors as errors
+import qutip.control.stats as stats
+import qutip.control.optimizer as optimizer
+import qutip.control.termcond as termcond
+import qutip.control.dynamics as dynamics
+import qutip.control.optimconfig as optimconfig
 import numpy as np
 import warnings
 
@@ -96,18 +105,11 @@ from qutip.qobj import Qobj
 import qutip.logging_utils as logging
 logger = logging.get_logger()
 # QuTiP control modules
-import qutip.control.optimconfig as optimconfig
-import qutip.control.dynamics as dynamics
-import qutip.control.termcond as termcond
-import qutip.control.optimizer as optimizer
-import qutip.control.stats as stats
-import qutip.control.errors as errors
-import qutip.control.fidcomp as fidcomp
-import qutip.control.propcomp as propcomp
-import qutip.control.pulsegen as pulsegen
 #import qutip.control.pulsegencrab as pulsegencrab
 
-warnings.simplefilter('always', DeprecationWarning) #turn off filter 
+warnings.simplefilter('always', DeprecationWarning)  # turn off filter
+
+
 def _param_deprecation(message, stacklevel=3):
     """
     Issue deprecation warning
@@ -115,14 +117,16 @@ def _param_deprecation(message, stacklevel=3):
     calling with the deprecated parameter,
     """
     warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
-    
+
+
 def _upper_safe(s):
     try:
         s = s.upper()
     except:
         pass
     return s
-            
+
+
 def optimize_pulse(
         drift, ctrls, initial, target,
         num_tslots=None, evo_time=None, tau=None,
@@ -215,20 +219,20 @@ def optimize_pulse(
     alg : string
         Algorithm to use in pulse optimisation.
         Options are:
-            
+
             'GRAPE' (default) - GRadient Ascent Pulse Engineering
             'CRAB' - Chopped RAndom Basis
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
-        
+
     optim_params : Dictionary
         The key value pairs are the attribute name and value
         used to set attribute values
         Note: attributes are created if they do not exist already,
         and are overwritten if they do.
         Note: method_params are applied afterwards and so may override these
-        
+
     optim_method : string
         a scipy.optimize.minimize method that will be used to optimise
         the pulse for minimum fidelity error
@@ -239,7 +243,7 @@ def optimize_pulse(
         Supplying DEF will given alg dependent result:
             GRAPE - Default optim_method is FMIN_L_BFGS_B
             CRAB - Default optim_method is FMIN
-        
+
     method_params : dict
         Parameters for the optim_method. 
         Note that where there is an attribute of the
@@ -247,7 +251,7 @@ def optimize_pulse(
         that attribute. Otherwise, and in some case also, 
         they are assumed to be method_options
         for the scipy.optimize.minimize method.        
-        
+
     optim_alg : string
         Deprecated. Use optim_method.
 
@@ -261,7 +265,7 @@ def optimize_pulse(
         Dynamics type, i.e. the type of matrix used to describe
         the dynamics. Options are UNIT, GEN_MAT, SYMPL
         (see Dynamics classes for details)
-        
+
     dyn_params : dict
         Parameters for the Dynamics object
         The key value pairs are assumed to be attribute name value pairs
@@ -278,7 +282,7 @@ def optimize_pulse(
         Parameters for the PropagatorComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     fid_type : string
         Fidelity error (and fidelity error gradient) computation method
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX
@@ -289,7 +293,7 @@ def optimize_pulse(
         Parameters for the FidelityComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     phase_option : string
         Deprecated. Pass in fid_params instead.
 
@@ -302,15 +306,15 @@ def optimize_pulse(
         Options: DEF, UPDATE_ALL, DYNAMIC
         UPDATE_ALL is the only one that currently works
         (See TimeslotComputer classes for details)
-        
+
     tslot_params : dict
         Parameters for the TimeslotComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     amp_update_mode : string
         Deprecated. Use tslot_type instead.
-        
+
     init_pulse_type : string
         type / shape of pulse(s) used to initialise the
         the control amplitudes. 
@@ -333,14 +337,14 @@ def optimize_pulse(
     pulse_offset : float
         Linear offset for the pulse. That is this value will be added
         to any initial / guess pulses generated.
-        
+
     ramping_pulse_type : string
         Type of pulse used to modulate the control pulse.
         It's intended use for a ramping modulation, which is often required in 
         experimental setups.
         This is only currently implemented in CRAB.
         GAUSSIAN_EDGE was added for this purpose.
-        
+
     ramping_pulse_params : dict
         Parameters for the ramping pulse generator object
         The key value pairs are assumed to be attribute name value pairs
@@ -373,13 +377,13 @@ def optimize_pulse(
         Returns instance of OptimResult, which has attributes giving the
         reason for termination, final fidelity error, final evolution
         final amplitudes, statistics etc
-    
+
     """
     if log_level == logging.NOTSET:
         log_level = logger.getEffectiveLevel()
     else:
         logger.setLevel(log_level)
-        
+
     # The parameters types are checked in create_pulse_optimizer
     # so no need to do so here
     # However, the deprecation management is repeated here
@@ -389,49 +393,49 @@ def optimize_pulse(
         _param_deprecation(
             "The 'optim_alg' parameter is deprecated. "
             "Use 'optim_method' instead")
-            
+
     if not max_metric_corr is None:
         if isinstance(method_params, dict):
             if not 'max_metric_corr' in method_params:
-                 method_params['max_metric_corr'] = max_metric_corr
+                method_params['max_metric_corr'] = max_metric_corr
         else:
-            method_params = {'max_metric_corr':max_metric_corr}
+            method_params = {'max_metric_corr': max_metric_corr}
         _param_deprecation(
             "The 'max_metric_corr' parameter is deprecated. "
             "Use 'max_metric_corr' in method_params instead")
-            
+
     if not accuracy_factor is None:
         if isinstance(method_params, dict):
             if not 'accuracy_factor' in method_params:
-                 method_params['accuracy_factor'] = accuracy_factor
+                method_params['accuracy_factor'] = accuracy_factor
         else:
-            method_params = {'accuracy_factor':accuracy_factor}
+            method_params = {'accuracy_factor': accuracy_factor}
         _param_deprecation(
             "The 'accuracy_factor' parameter is deprecated. "
             "Use 'accuracy_factor' in method_params instead")
-    
+
     # phase_option
     if not phase_option is None:
         if isinstance(fid_params, dict):
             if not 'phase_option' in fid_params:
-                 fid_params['phase_option'] = phase_option
+                fid_params['phase_option'] = phase_option
         else:
-            fid_params = {'phase_option':phase_option}
+            fid_params = {'phase_option': phase_option}
         _param_deprecation(
             "The 'phase_option' parameter is deprecated. "
             "Use 'phase_option' in fid_params instead")
-            
+
     # fid_err_scale_factor
     if not fid_err_scale_factor is None:
         if isinstance(fid_params, dict):
             if not 'fid_err_scale_factor' in fid_params:
-                 fid_params['scale_factor'] = fid_err_scale_factor
+                fid_params['scale_factor'] = fid_err_scale_factor
         else:
-            fid_params = {'scale_factor':fid_err_scale_factor}
+            fid_params = {'scale_factor': fid_err_scale_factor}
         _param_deprecation(
             "The 'fid_err_scale_factor' parameter is deprecated. "
             "Use 'scale_factor' in fid_params instead")
-            
+
     # amp_update_mode
     if not amp_update_mode is None:
         amp_update_mode_up = _upper_safe(amp_update_mode)
@@ -451,12 +455,12 @@ def optimize_pulse(
         max_iter=max_iter, max_wall_time=max_wall_time,
         alg=alg, alg_params=alg_params, optim_params=optim_params,
         optim_method=optim_method, method_params=method_params,
-        dyn_type=dyn_type, dyn_params=dyn_params, 
+        dyn_type=dyn_type, dyn_params=dyn_params,
         prop_type=prop_type, prop_params=prop_params,
         fid_type=fid_type, fid_params=fid_params,
         init_pulse_type=init_pulse_type, init_pulse_params=init_pulse_params,
         pulse_scaling=pulse_scaling, pulse_offset=pulse_offset,
-        ramping_pulse_type=ramping_pulse_type, 
+        ramping_pulse_type=ramping_pulse_type,
         ramping_pulse_params=ramping_pulse_params,
         log_level=log_level, gen_stats=gen_stats)
 
@@ -465,7 +469,7 @@ def optimize_pulse(
     dyn.init_timeslots()
     # Generate initial pulses for each control
     init_amps = np.zeros([dyn.num_tslots, dyn.num_ctrls])
-    
+
     if alg == 'CRAB':
         for j in range(dyn.num_ctrls):
             pgen = optim.pulse_generator[j]
@@ -475,10 +479,10 @@ def optimize_pulse(
         pgen = optim.pulse_generator
         for j in range(dyn.num_ctrls):
             init_amps[:, j] = pgen.gen_pulse()
-        
+
     # Initialise the starting amplitudes
     dyn.initialize_controls(init_amps)
-    
+
     if log_level <= logging.INFO:
         msg = "System configuration:\n"
         dg_name = "dynamics generator"
@@ -518,6 +522,7 @@ def optimize_pulse(
 
     return result
 
+
 def optimize_pulse_unitary(
         H_d, H_c, U_0, U_targ,
         num_tslots=None, evo_time=None, tau=None,
@@ -527,7 +532,7 @@ def optimize_pulse_unitary(
         alg='GRAPE', alg_params=None,
         optim_params=None, optim_method='DEF', method_params=None,
         optim_alg=None, max_metric_corr=None, accuracy_factor=None,
-        phase_option='PSU', 
+        phase_option='PSU',
         dyn_params=None, prop_params=None, fid_params=None,
         tslot_type='DEF', tslot_params=None,
         amp_update_mode=None,
@@ -535,7 +540,6 @@ def optimize_pulse_unitary(
         pulse_scaling=1.0, pulse_offset=0.0,
         ramping_pulse_type=None, ramping_pulse_params=None,
         log_level=logging.NOTSET, out_file_ext=None, gen_stats=False):
-
     """
     Optimise a control pulse to minimise the fidelity error, assuming that
     the dynamics of the system are generated by unitary operators.
@@ -558,7 +562,7 @@ def optimize_pulse_unitary(
     H_d : Qobj or list of Qobj
         Drift (aka system) the underlying Hamiltonian of the system
         can provide list (of length num_tslots) for time dependent drift
-        
+
     H_c : List of Qobj or array like [num_tslots, evo_time]
         a list of control Hamiltonians. These are scaled by
         the amplitudes to alter the overall dynamics
@@ -619,14 +623,14 @@ def optimize_pulse_unitary(
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
-        
+
     optim_params : Dictionary
         The key value pairs are the attribute name and value
         used to set attribute values
         Note: attributes are created if they do not exist already,
         and are overwritten if they do.
         Note: method_params are applied afterwards and so may override these
-        
+
     optim_method : string
         a scipy.optimize.minimize method that will be used to optimise
         the pulse for minimum fidelity error
@@ -635,10 +639,10 @@ def optimize_pulse_unitary(
         Note the LBFGSB is equivalent to FMIN_L_BFGS_B for backwards 
         capatibility reasons.
         Supplying DEF will given alg dependent result:
-            
+
             GRAPE - Default optim_method is FMIN_L_BFGS_B
             CRAB - Default optim_method is FMIN
-        
+
     method_params : dict
         Parameters for the optim_method. 
         Note that where there is an attribute of the
@@ -646,7 +650,7 @@ def optimize_pulse_unitary(
         that attribute. Otherwise, and in some case also, 
         they are assumed to be method_options
         for the scipy.optimize.minimize method.        
-        
+
     optim_alg : string
         Deprecated. Use optim_method.
 
@@ -659,7 +663,7 @@ def optimize_pulse_unitary(
     phase_option : string
         determines how global phase is treated in fidelity
         calculations (fid_type='UNIT' only). Options:
-            
+
             PSU - global phase ignored
             SU - global phase included
 
@@ -677,30 +681,30 @@ def optimize_pulse_unitary(
         Parameters for the FidelityComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     tslot_type : string
         Method for computing the dynamics generators, propagators and 
         evolution in the timeslots.
         Options: DEF, UPDATE_ALL, DYNAMIC
         UPDATE_ALL is the only one that currently works
         (See TimeslotComputer classes for details)
-        
+
     tslot_params : dict
         Parameters for the TimeslotComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     amp_update_mode : string
         Deprecated. Use tslot_type instead.
-        
+
     init_pulse_type : string
         type / shape of pulse(s) used to initialise the
         the control amplitudes. 
         Options (GRAPE) include:
-            
+
             RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW
             DEF is RND
-        
+
         (see PulseGen classes for details)
         For the CRAB the this the guess_pulse_type. 
 
@@ -717,14 +721,14 @@ def optimize_pulse_unitary(
     pulse_offset : float
         Linear offset for the pulse. That is this value will be added
         to any initial / guess pulses generated.
-        
+
     ramping_pulse_type : string
         Type of pulse used to modulate the control pulse.
         It's intended use for a ramping modulation, which is often required in 
         experimental setups.
         This is only currently implemented in CRAB.
         GAUSSIAN_EDGE was added for this purpose.
-        
+
     ramping_pulse_params : dict
         Parameters for the ramping pulse generator object
         The key value pairs are assumed to be attribute name value pairs
@@ -757,11 +761,11 @@ def optimize_pulse_unitary(
         Returns instance of OptimResult, which has attributes giving the
         reason for termination, final fidelity error, final evolution
         final amplitudes, statistics etc
-    
+
     """
 
     # parameters are checked in create pulse optimiser
-        
+
     # The deprecation management is repeated here
     # so that the stack level is correct
     if not optim_alg is None:
@@ -769,27 +773,27 @@ def optimize_pulse_unitary(
         _param_deprecation(
             "The 'optim_alg' parameter is deprecated. "
             "Use 'optim_method' instead")
-            
+
     if not max_metric_corr is None:
         if isinstance(method_params, dict):
             if not 'max_metric_corr' in method_params:
-                 method_params['max_metric_corr'] = max_metric_corr
+                method_params['max_metric_corr'] = max_metric_corr
         else:
-            method_params = {'max_metric_corr':max_metric_corr}
+            method_params = {'max_metric_corr': max_metric_corr}
         _param_deprecation(
             "The 'max_metric_corr' parameter is deprecated. "
             "Use 'max_metric_corr' in method_params instead")
-            
+
     if not accuracy_factor is None:
         if isinstance(method_params, dict):
             if not 'accuracy_factor' in method_params:
-                 method_params['accuracy_factor'] = accuracy_factor
+                method_params['accuracy_factor'] = accuracy_factor
         else:
-            method_params = {'accuracy_factor':accuracy_factor}
+            method_params = {'accuracy_factor': accuracy_factor}
         _param_deprecation(
             "The 'accuracy_factor' parameter is deprecated. "
             "Use 'accuracy_factor' in method_params instead")
-            
+
     # amp_update_mode
     if not amp_update_mode is None:
         amp_update_mode_up = _upper_safe(amp_update_mode)
@@ -800,34 +804,34 @@ def optimize_pulse_unitary(
         _param_deprecation(
             "The 'amp_update_mode' parameter is deprecated. "
             "Use 'tslot_type' instead")
-            
+
     # phase_option is still valid for this method
     # pass it via the fid_params
     if not phase_option is None:
         if fid_params is None:
-            fid_params = {'phase_option':phase_option}
+            fid_params = {'phase_option': phase_option}
         else:
             if not 'phase_option' in fid_params:
                 fid_params['phase_option'] = phase_option
-            
-            
+
     return optimize_pulse(
-            drift=H_d, ctrls=H_c, initial=U_0, target=U_targ,
-            num_tslots=num_tslots, evo_time=evo_time, tau=tau,
-            amp_lbound=amp_lbound, amp_ubound=amp_ubound,
-            fid_err_targ=fid_err_targ, min_grad=min_grad,
-            max_iter=max_iter, max_wall_time=max_wall_time,
-            alg=alg, alg_params=alg_params, optim_params=optim_params,
-            optim_method=optim_method, method_params=method_params,
-            dyn_type='UNIT', dyn_params=dyn_params,
-            prop_params=prop_params, fid_params=fid_params,
+        drift=H_d, ctrls=H_c, initial=U_0, target=U_targ,
+        num_tslots=num_tslots, evo_time=evo_time, tau=tau,
+        amp_lbound=amp_lbound, amp_ubound=amp_ubound,
+        fid_err_targ=fid_err_targ, min_grad=min_grad,
+        max_iter=max_iter, max_wall_time=max_wall_time,
+        alg=alg, alg_params=alg_params, optim_params=optim_params,
+        optim_method=optim_method, method_params=method_params,
+        dyn_type='UNIT', dyn_params=dyn_params,
+        prop_params=prop_params, fid_params=fid_params,
         init_pulse_type=init_pulse_type, init_pulse_params=init_pulse_params,
         pulse_scaling=pulse_scaling, pulse_offset=pulse_offset,
-            ramping_pulse_type=ramping_pulse_type, 
-            ramping_pulse_params=ramping_pulse_params,
-            log_level=log_level, out_file_ext=out_file_ext,
-            gen_stats=gen_stats)
-            
+        ramping_pulse_type=ramping_pulse_type,
+        ramping_pulse_params=ramping_pulse_params,
+        log_level=log_level, out_file_ext=out_file_ext,
+        gen_stats=gen_stats)
+
+
 def opt_pulse_crab(
         drift, ctrls, initial, target,
         num_tslots=None, evo_time=None, tau=None,
@@ -835,7 +839,7 @@ def opt_pulse_crab(
         fid_err_targ=1e-5,
         max_iter=500, max_wall_time=180,
         alg_params=None,
-        num_coeffs=None, init_coeff_scaling=1.0, 
+        num_coeffs=None, init_coeff_scaling=1.0,
         optim_params=None, optim_method='fmin', method_params=None,
         dyn_type='GEN_MAT', dyn_params=None,
         prop_type='DEF', prop_params=None,
@@ -843,7 +847,7 @@ def opt_pulse_crab(
         tslot_type='DEF', tslot_params=None,
         guess_pulse_type=None, guess_pulse_params=None,
         guess_pulse_scaling=1.0, guess_pulse_offset=0.0,
-        guess_pulse_action='MODULATE', 
+        guess_pulse_action='MODULATE',
         ramping_pulse_type=None, ramping_pulse_params=None,
         log_level=logging.NOTSET, out_file_ext=None, gen_stats=False):
     """
@@ -914,7 +918,7 @@ def opt_pulse_crab(
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
-        
+
     optim_params : Dictionary
         The key value pairs are the attribute name and value
         used to set attribute values
@@ -926,7 +930,7 @@ def opt_pulse_crab(
         Linear scale factor for the random basis coefficients
         By default these range from -1.0 to 1.0
         Note this is overridden by alg_params (if given there)
-        
+
     num_coeffs : integer
         Number of coefficients used for each basis function
         Note this is calculated automatically based on the dimension of the
@@ -934,7 +938,7 @@ def opt_pulse_crab(
         algorithm that it is set as low as possible, while still giving
         high enough frequencies.
         Note this is overridden by alg_params (if given there)
-        
+
     optim_method : string
         Multi-variable optimisation method
         The only tested options are 'fmin' and 'Nelder-mead'
@@ -951,12 +955,12 @@ def opt_pulse_crab(
         The commonly used parameter are:
             xtol - limit on variable change for convergence
             ftol - limit on fidelity error change for convergence
-            
+
     dyn_type : string
         Dynamics type, i.e. the type of matrix used to describe
         the dynamics. Options are UNIT, GEN_MAT, SYMPL
         (see Dynamics classes for details)
-        
+
     dyn_params : dict
         Parameters for the Dynamics object
         The key value pairs are assumed to be attribute name value pairs
@@ -973,7 +977,7 @@ def opt_pulse_crab(
         Parameters for the PropagatorComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     fid_type : string
         Fidelity error (and fidelity error gradient) computation method
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX
@@ -984,30 +988,30 @@ def opt_pulse_crab(
         Parameters for the FidelityComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     tslot_type : string
         Method for computing the dynamics generators, propagators and 
         evolution in the timeslots.
         Options: DEF, UPDATE_ALL, DYNAMIC
         UPDATE_ALL is the only one that currently works
         (See TimeslotComputer classes for details)
-        
+
     tslot_params : dict
         Parameters for the TimeslotComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     guess_pulse_type : string
         type / shape of pulse(s) used modulate the control amplitudes. 
         Options include:
             RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW, GAUSSIAN
         Default is None
-        
+
     guess_pulse_params : dict
         Parameters for the guess pulse generator object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     guess_pulse_action : string
         Determines how the guess pulse is applied to the pulse generated
         by the basis expansion.
@@ -1022,14 +1026,14 @@ def opt_pulse_crab(
     pulse_offset : float
         Linear offset for the pulse. That is this value will be added
         to any guess pulses generated.
-        
+
     ramping_pulse_type : string
         Type of pulse used to modulate the control pulse.
         It's intended use for a ramping modulation, which is often required in 
         experimental setups.
         This is only currently implemented in CRAB.
         GAUSSIAN_EDGE was added for this purpose.
-        
+
     ramping_pulse_params : dict
         Parameters for the ramping pulse generator object
         The key value pairs are assumed to be attribute name value pairs
@@ -1062,7 +1066,7 @@ def opt_pulse_crab(
         Returns instance of OptimResult, which has attributes giving the
         reason for termination, final fidelity error, final evolution
         final amplitudes, statistics etc
-    
+
     """
 
     # The parameters are checked in create_pulse_optimizer
@@ -1074,33 +1078,33 @@ def opt_pulse_crab(
         logger.setLevel(log_level)
 
     # build the algorithm options
-    if not isinstance(alg_params, dict): 
-        alg_params = {'num_coeffs':num_coeffs, 
-                       'init_coeff_scaling':init_coeff_scaling}
+    if not isinstance(alg_params, dict):
+        alg_params = {'num_coeffs': num_coeffs,
+                      'init_coeff_scaling': init_coeff_scaling}
     else:
-        if (num_coeffs is not None and 
-            not 'num_coeffs' in alg_params):
+        if (num_coeffs is not None and
+                not 'num_coeffs' in alg_params):
             alg_params['num_coeffs'] = num_coeffs
-        if (init_coeff_scaling is not None and 
-            not 'init_coeff_scaling' in alg_params):
+        if (init_coeff_scaling is not None and
+                not 'init_coeff_scaling' in alg_params):
             alg_params['init_coeff_scaling'] = init_coeff_scaling
-            
+
     # Build the guess pulse options
     # Any options passed in the guess_pulse_params take precedence
     # over the parameter values.
-    if guess_pulse_type: 
+    if guess_pulse_type:
         if not isinstance(guess_pulse_params, dict):
             guess_pulse_params = {}
-        if (guess_pulse_scaling is not None and 
-            not 'scaling' in guess_pulse_params):
+        if (guess_pulse_scaling is not None and
+                not 'scaling' in guess_pulse_params):
             guess_pulse_params['scaling'] = guess_pulse_scaling
-        if (guess_pulse_offset is not None and 
-            not 'offset' in guess_pulse_params):
+        if (guess_pulse_offset is not None and
+                not 'offset' in guess_pulse_params):
             guess_pulse_params['offset'] = guess_pulse_offset
-        if (guess_pulse_action is not None and 
-            not 'pulse_action' in guess_pulse_params):
+        if (guess_pulse_action is not None and
+                not 'pulse_action' in guess_pulse_params):
             guess_pulse_params['pulse_action'] = guess_pulse_action
-         
+
     return optimize_pulse(
         drift, ctrls, initial, target,
         num_tslots=num_tslots, evo_time=evo_time, tau=tau,
@@ -1109,16 +1113,17 @@ def opt_pulse_crab(
         max_iter=max_iter, max_wall_time=max_wall_time,
         alg='CRAB', alg_params=alg_params, optim_params=optim_params,
         optim_method=optim_method, method_params=method_params,
-        dyn_type=dyn_type, dyn_params=dyn_params, 
+        dyn_type=dyn_type, dyn_params=dyn_params,
         prop_type=prop_type, prop_params=prop_params,
         fid_type=fid_type, fid_params=fid_params,
         tslot_type=tslot_type, tslot_params=tslot_params,
-        init_pulse_type=guess_pulse_type, 
+        init_pulse_type=guess_pulse_type,
         init_pulse_params=guess_pulse_params,
-        ramping_pulse_type=ramping_pulse_type, 
+        ramping_pulse_type=ramping_pulse_type,
         ramping_pulse_params=ramping_pulse_params,
         log_level=log_level, out_file_ext=out_file_ext, gen_stats=gen_stats)
-          
+
+
 def opt_pulse_crab_unitary(
         H_d, H_c, U_0, U_targ,
         num_tslots=None, evo_time=None, tau=None,
@@ -1126,14 +1131,14 @@ def opt_pulse_crab_unitary(
         fid_err_targ=1e-5,
         max_iter=500, max_wall_time=180,
         alg_params=None,
-        num_coeffs=None, init_coeff_scaling=1.0, 
+        num_coeffs=None, init_coeff_scaling=1.0,
         optim_params=None, optim_method='fmin', method_params=None,
-        phase_option='PSU', 
+        phase_option='PSU',
         dyn_params=None, prop_params=None, fid_params=None,
         tslot_type='DEF', tslot_params=None,
         guess_pulse_type=None, guess_pulse_params=None,
         guess_pulse_scaling=1.0, guess_pulse_offset=0.0,
-        guess_pulse_action='MODULATE', 
+        guess_pulse_action='MODULATE',
         ramping_pulse_type=None, ramping_pulse_params=None,
         log_level=logging.NOTSET, out_file_ext=None, gen_stats=False):
     """
@@ -1146,7 +1151,7 @@ def opt_pulse_crab_unitary(
     by the combined Hamiltonian,
     i.e. the sum of the H_d + ctrl_amp[j]*H_c[j]
     The control pulse is an [n_ts, n_ctrls] array of piecewise amplitudes
-    
+
     The CRAB algorithm uses basis function coefficents as the variables to
     optimise. It does NOT use any gradient function.
     A multivariable optimisation algorithm attempts to determines the
@@ -1210,7 +1215,7 @@ def opt_pulse_crab_unitary(
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
-        
+
     optim_params : Dictionary
         The key value pairs are the attribute name and value
         used to set attribute values
@@ -1222,7 +1227,7 @@ def opt_pulse_crab_unitary(
         Linear scale factor for the random basis coefficients
         By default these range from -1.0 to 1.0
         Note this is overridden by alg_params (if given there)
-        
+
     num_coeffs : integer
         Number of coefficients used for each basis function
         Note this is calculated automatically based on the dimension of the
@@ -1230,7 +1235,7 @@ def opt_pulse_crab_unitary(
         algorithm that it is set as low as possible, while still giving
         high enough frequencies.
         Note this is overridden by alg_params (if given there)
-        
+
     optim_method : string
         Multi-variable optimisation method
         The only tested options are 'fmin' and 'Nelder-mead'
@@ -1268,30 +1273,30 @@ def opt_pulse_crab_unitary(
         Parameters for the FidelityComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     tslot_type : string
         Method for computing the dynamics generators, propagators and 
         evolution in the timeslots.
         Options: DEF, UPDATE_ALL, DYNAMIC
         UPDATE_ALL is the only one that currently works
         (See TimeslotComputer classes for details)
-        
+
     tslot_params : dict
         Parameters for the TimeslotComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     guess_pulse_type : string
         type / shape of pulse(s) used modulate the control amplitudes. 
         Options include:
             RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW, GAUSSIAN
         Default is None
-        
+
     guess_pulse_params : dict
         Parameters for the guess pulse generator object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     guess_pulse_action : string
         Determines how the guess pulse is applied to the pulse generated
         by the basis expansion.
@@ -1306,14 +1311,14 @@ def opt_pulse_crab_unitary(
     pulse_offset : float
         Linear offset for the pulse. That is this value will be added
         to any guess pulses generated.
-        
+
     ramping_pulse_type : string
         Type of pulse used to modulate the control pulse.
         It's intended use for a ramping modulation, which is often required in 
         experimental setups.
         This is only currently implemented in CRAB.
         GAUSSIAN_EDGE was added for this purpose.
-        
+
     ramping_pulse_params : dict
         Parameters for the ramping pulse generator object
         The key value pairs are assumed to be attribute name value pairs
@@ -1346,7 +1351,7 @@ def opt_pulse_crab_unitary(
         Returns instance of OptimResult, which has attributes giving the
         reason for termination, final fidelity error, final evolution
         final amplitudes, statistics etc
-    
+
     """
 
     # The parameters are checked in create_pulse_optimizer
@@ -1358,33 +1363,33 @@ def opt_pulse_crab_unitary(
         logger.setLevel(log_level)
 
     # build the algorithm options
-    if not isinstance(alg_params, dict): 
-        alg_params = {'num_coeffs':num_coeffs, 
-                       'init_coeff_scaling':init_coeff_scaling}
+    if not isinstance(alg_params, dict):
+        alg_params = {'num_coeffs': num_coeffs,
+                      'init_coeff_scaling': init_coeff_scaling}
     else:
-        if (num_coeffs is not None and 
-            not 'num_coeffs' in alg_params):
+        if (num_coeffs is not None and
+                not 'num_coeffs' in alg_params):
             alg_params['num_coeffs'] = num_coeffs
-        if (init_coeff_scaling is not None and 
-            not 'init_coeff_scaling' in alg_params):
+        if (init_coeff_scaling is not None and
+                not 'init_coeff_scaling' in alg_params):
             alg_params['init_coeff_scaling'] = init_coeff_scaling
-            
+
     # Build the guess pulse options
     # Any options passed in the guess_pulse_params take precedence
     # over the parameter values.
-    if guess_pulse_type: 
+    if guess_pulse_type:
         if not isinstance(guess_pulse_params, dict):
             guess_pulse_params = {}
-        if (guess_pulse_scaling is not None and 
-            not 'scaling' in guess_pulse_params):
+        if (guess_pulse_scaling is not None and
+                not 'scaling' in guess_pulse_params):
             guess_pulse_params['scaling'] = guess_pulse_scaling
-        if (guess_pulse_offset is not None and 
-            not 'offset' in guess_pulse_params):
+        if (guess_pulse_offset is not None and
+                not 'offset' in guess_pulse_params):
             guess_pulse_params['offset'] = guess_pulse_offset
-        if (guess_pulse_action is not None and 
-            not 'pulse_action' in guess_pulse_params):
+        if (guess_pulse_action is not None and
+                not 'pulse_action' in guess_pulse_params):
             guess_pulse_params['pulse_action'] = guess_pulse_action
-         
+
     return optimize_pulse_unitary(
         H_d, H_c, U_0, U_targ,
         num_tslots=num_tslots, evo_time=evo_time, tau=tau,
@@ -1396,11 +1401,12 @@ def opt_pulse_crab_unitary(
         phase_option=phase_option,
         dyn_params=dyn_params, prop_params=prop_params, fid_params=fid_params,
         tslot_type=tslot_type, tslot_params=tslot_params,
-        init_pulse_type=guess_pulse_type, 
+        init_pulse_type=guess_pulse_type,
         init_pulse_params=guess_pulse_params,
-        ramping_pulse_type=ramping_pulse_type, 
+        ramping_pulse_type=ramping_pulse_type,
         ramping_pulse_params=ramping_pulse_params,
         log_level=log_level, out_file_ext=out_file_ext, gen_stats=gen_stats)
+
 
 def create_pulse_optimizer(
         drift, ctrls, initial, target,
@@ -1421,7 +1427,6 @@ def create_pulse_optimizer(
         pulse_scaling=1.0, pulse_offset=0.0,
         ramping_pulse_type=None, ramping_pulse_params=None,
         log_level=logging.NOTSET, gen_stats=False):
-
     """
     Generate the objects of the appropriate subclasses
     required for the pulse optmisation based on the parameters given
@@ -1488,7 +1493,7 @@ def create_pulse_optimizer(
 
     max_wall_time : float
         Maximum allowed elapsed time for the optimisation algorithm
-        
+
     alg : string
         Algorithm to use in pulse optimisation.
         Options are:
@@ -1497,14 +1502,14 @@ def create_pulse_optimizer(
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
-        
+
     optim_params : Dictionary
         The key value pairs are the attribute name and value
         used to set attribute values
         Note: attributes are created if they do not exist already,
         and are overwritten if they do.
         Note: method_params are applied afterwards and so may override these
-        
+
     optim_method : string
         a scipy.optimize.minimize method that will be used to optimise
         the pulse for minimum fidelity error
@@ -1515,7 +1520,7 @@ def create_pulse_optimizer(
         Supplying DEF will given alg dependent result:
             - GRAPE - Default optim_method is FMIN_L_BFGS_B
             - CRAB - Default optim_method is Nelder-Mead
-        
+
     method_params : dict
         Parameters for the optim_method. 
         Note that where there is an attribute of the
@@ -1523,7 +1528,7 @@ def create_pulse_optimizer(
         that attribute. Otherwise, and in some case also, 
         they are assumed to be method_options
         for the scipy.optimize.minimize method.        
-        
+
     optim_alg : string
         Deprecated. Use optim_method.
 
@@ -1537,7 +1542,7 @@ def create_pulse_optimizer(
         Dynamics type, i.e. the type of matrix used to describe
         the dynamics. Options are UNIT, GEN_MAT, SYMPL
         (see Dynamics classes for details)
-        
+
     dyn_params : dict
         Parameters for the Dynamics object
         The key value pairs are assumed to be attribute name value pairs
@@ -1554,7 +1559,7 @@ def create_pulse_optimizer(
         Parameters for the PropagatorComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     fid_type : string
         Fidelity error (and fidelity error gradient) computation method
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX
@@ -1565,7 +1570,7 @@ def create_pulse_optimizer(
         Parameters for the FidelityComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     phase_option : string
         Deprecated. Pass in fid_params instead.
 
@@ -1578,23 +1583,23 @@ def create_pulse_optimizer(
         Options: DEF, UPDATE_ALL, DYNAMIC
         UPDATE_ALL is the only one that currently works
         (See TimeslotComputer classes for details)
-        
+
     tslot_params : dict
         Parameters for the TimeslotComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     amp_update_mode : string
         Deprecated. Use tslot_type instead.
-        
+
     init_pulse_type : string
         type / shape of pulse(s) used to initialise the
         the control amplitudes. 
         Options (GRAPE) include:
-            
+
             RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW
             DEF is RND
-        
+
         (see PulseGen classes for details)
         For the CRAB the this the guess_pulse_type. 
 
@@ -1611,19 +1616,19 @@ def create_pulse_optimizer(
     pulse_offset : float
         Linear offset for the pulse. That is this value will be added
         to any initial / guess pulses generated.
-        
+
     ramping_pulse_type : string
         Type of pulse used to modulate the control pulse.
         It's intended use for a ramping modulation, which is often required in 
         experimental setups.
         This is only currently implemented in CRAB.
         GAUSSIAN_EDGE was added for this purpose.
-        
+
     ramping_pulse_params : dict
         Parameters for the ramping pulse generator object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-    
+
     log_level : integer
         level of messaging output from the logger.
         Options are attributes of qutip.logging_utils,
@@ -1648,7 +1653,7 @@ def create_pulse_optimizer(
         The PropagatorComputer, FidelityComputer and TimeslotComputer objects
         can be accessed as attributes of the Dynamics object, e.g. optimizer.dynamics.fid_computer
         The optimisation can be run through the optimizer.run_optimization
-    
+
     """
 
     # check parameters
@@ -1660,56 +1665,56 @@ def create_pulse_optimizer(
 
     if not isinstance(target, Qobj):
         raise TypeError("target must be a Qobj")
-        
+
     # Deprecated parameter management
     if not optim_alg is None:
         optim_method = optim_alg
         _param_deprecation(
             "The 'optim_alg' parameter is deprecated. "
             "Use 'optim_method' instead")
-            
+
     if not max_metric_corr is None:
         if isinstance(method_params, dict):
             if not 'max_metric_corr' in method_params:
-                 method_params['max_metric_corr'] = max_metric_corr
+                method_params['max_metric_corr'] = max_metric_corr
         else:
-            method_params = {'max_metric_corr':max_metric_corr}
+            method_params = {'max_metric_corr': max_metric_corr}
         _param_deprecation(
             "The 'max_metric_corr' parameter is deprecated. "
             "Use 'max_metric_corr' in method_params instead")
-            
+
     if not accuracy_factor is None:
         if isinstance(method_params, dict):
             if not 'accuracy_factor' in method_params:
-                 method_params['accuracy_factor'] = accuracy_factor
+                method_params['accuracy_factor'] = accuracy_factor
         else:
-            method_params = {'accuracy_factor':accuracy_factor}
+            method_params = {'accuracy_factor': accuracy_factor}
         _param_deprecation(
             "The 'accuracy_factor' parameter is deprecated. "
             "Use 'accuracy_factor' in method_params instead")
-    
+
     # phase_option
     if not phase_option is None:
         if isinstance(fid_params, dict):
             if not 'phase_option' in fid_params:
-                 fid_params['phase_option'] = phase_option
+                fid_params['phase_option'] = phase_option
         else:
-            fid_params = {'phase_option':phase_option}
+            fid_params = {'phase_option': phase_option}
         _param_deprecation(
             "The 'phase_option' parameter is deprecated. "
             "Use 'phase_option' in fid_params instead")
-            
+
     # fid_err_scale_factor
     if not fid_err_scale_factor is None:
         if isinstance(fid_params, dict):
             if not 'fid_err_scale_factor' in fid_params:
-                 fid_params['scale_factor'] = fid_err_scale_factor
+                fid_params['scale_factor'] = fid_err_scale_factor
         else:
-            fid_params = {'scale_factor':fid_err_scale_factor}
+            fid_params = {'scale_factor': fid_err_scale_factor}
         _param_deprecation(
             "The 'fid_err_scale_factor' parameter is deprecated. "
             "Use 'scale_factor' in fid_params instead")
-            
+
     # amp_update_mode
     if not amp_update_mode is None:
         amp_update_mode_up = _upper_safe(amp_update_mode)
@@ -1720,7 +1725,7 @@ def create_pulse_optimizer(
         _param_deprecation(
             "The 'amp_update_mode' parameter is deprecated. "
             "Use 'tslot_type' instead")
-            
+
     # set algorithm defaults
     alg_up = _upper_safe(alg)
     if alg is None:
@@ -1768,7 +1773,7 @@ def create_pulse_optimizer(
     dyn.apply_params(dyn_params)
     dyn._drift_dyn_gen_checked = True
     dyn._ctrl_dyn_gen_checked = True
-    
+
     # Create the PropagatorComputer instance
     # The default will be typically be the best option
     if prop_type == 'DEF' or prop_type is None or prop_type == '':
@@ -1810,11 +1815,11 @@ def create_pulse_optimizer(
     else:
         raise errors.UsageError("No option for fid_type: " + fid_type)
     dyn.fid_computer.apply_params(fid_params)
-    
-    # Currently the only working option for tslot computer is 
+
+    # Currently the only working option for tslot computer is
     # TSlotCompUpdateAll.
     # so just apply the parameters
-    dyn.tslot_computer.apply_params(tslot_params)    
+    dyn.tslot_computer.apply_params(tslot_params)
 
     # Create the Optimiser instance
     optim_method_up = _upper_safe(optim_method)
@@ -1831,22 +1836,22 @@ def create_pulse_optimizer(
         else:
             raise errors.UsageError(
                 "Invalid optim_method '{}' for '{}' algorthim".format(
-                                    optim_method, alg))
+                    optim_method, alg))
     else:
         # Assume that the optim_method is a valid
-        #scipy.optimize.minimize method
+        # scipy.optimize.minimize method
         # Choose an optimiser based on the algorithm
         if alg_up == 'CRAB':
             optim = optimizer.OptimizerCrab(cfg, dyn)
         else:
             optim = optimizer.Optimizer(cfg, dyn)
-    
+
     optim.alg = alg
     optim.method = optim_method
     optim.amp_lbound = amp_lbound
     optim.amp_ubound = amp_ubound
     optim.apply_params(optim_params)
-    
+
     # Create the TerminationConditions instance
     tc = termcond.TerminationConditions()
     tc.fid_err_targ = fid_err_targ
@@ -1854,7 +1859,7 @@ def create_pulse_optimizer(
     tc.max_iterations = max_iter
     tc.max_wall_time = max_wall_time
     optim.termination_conditions = tc
-    
+
     optim.apply_method_params(method_params)
 
     if gen_stats:
@@ -1897,8 +1902,8 @@ def create_pulse_optimizer(
     ramping_pgen = None
     if ramping_pulse_type:
         ramping_pgen = pulsegen.create_pulse_gen(
-                            pulse_type=ramping_pulse_type, dyn=dyn, 
-                            pulse_params=ramping_pulse_params)
+            pulse_type=ramping_pulse_type, dyn=dyn,
+            pulse_params=ramping_pulse_params)
     if alg_up == 'CRAB':
         # Create a pulse generator for each ctrl
         crab_pulse_params = None
@@ -1909,12 +1914,12 @@ def create_pulse_optimizer(
             init_coeff_scaling = alg_params.get('init_coeff_scaling')
             if 'crab_pulse_params' in alg_params:
                 crab_pulse_params = alg_params.get('crab_pulse_params')
-            
+
         guess_pulse_type = init_pulse_type
         if guess_pulse_type:
             guess_pulse_action = None
             guess_pgen = pulsegen.create_pulse_gen(
-                                pulse_type=guess_pulse_type, dyn=dyn)
+                pulse_type=guess_pulse_type, dyn=dyn)
             guess_pgen.scaling = pulse_scaling
             guess_pgen.offset = pulse_offset
             if init_pulse_params is not None:
@@ -1924,12 +1929,12 @@ def create_pulse_optimizer(
         optim.pulse_generator = []
         for j in range(n_ctrls):
             crab_pgen = pulsegen.PulseGenCrabFourier(
-                                dyn=dyn, num_coeffs=num_coeffs)
+                dyn=dyn, num_coeffs=num_coeffs)
             if init_coeff_scaling is not None:
                 crab_pgen.scaling = init_coeff_scaling
             if isinstance(crab_pulse_params, dict):
                 crab_pgen.apply_params(crab_pulse_params)
-                
+
             lb = None
             if amp_lbound:
                 if isinstance(amp_lbound, list):
@@ -1950,25 +1955,25 @@ def create_pulse_optimizer(
                     ub = amp_ubound
             crab_pgen.lbound = lb
             crab_pgen.ubound = ub
-            
+
             if guess_pulse_type:
                 guess_pgen.lbound = lb
                 guess_pgen.ubound = ub
                 crab_pgen.guess_pulse = guess_pgen.gen_pulse()
                 if guess_pulse_action:
                     crab_pgen.guess_pulse_action = guess_pulse_action
-                
+
             if ramping_pgen:
                 crab_pgen.ramping_pulse = ramping_pgen.gen_pulse()
 
             optim.pulse_generator.append(crab_pgen)
-        #This is just for the debug message now
+        # This is just for the debug message now
         pgen = optim.pulse_generator[0]
-            
+
     else:
         # Create a pulse generator of the type specified
         pgen = pulsegen.create_pulse_gen(pulse_type=init_pulse_type, dyn=dyn,
-                                        pulse_params=init_pulse_params)
+                                         pulse_params=init_pulse_params)
         pgen.scaling = pulse_scaling
         pgen.offset = pulse_offset
         pgen.lbound = amp_lbound
@@ -1988,5 +1993,3 @@ def create_pulse_optimizer(
             "\n    pulsegen: " + pgen.__class__.__name__)
 
     return optim
-
-

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -465,7 +465,7 @@ def optimize_pulse(
     dyn.init_timeslots()
     # Generate initial pulses for each control
     init_amps = np.zeros([dyn.num_tslots, dyn.num_ctrls])
-
+    
     if alg == 'CRAB':
         for j in range(dyn.num_ctrls):
             pgen = optim.pulse_generator[j]
@@ -475,7 +475,7 @@ def optimize_pulse(
         pgen = optim.pulse_generator
         for j in range(dyn.num_ctrls):
             init_amps[:, j] = pgen.gen_pulse()
-    
+        
     # Initialise the starting amplitudes
     dyn.initialize_controls(init_amps)
     
@@ -821,8 +821,8 @@ def optimize_pulse_unitary(
             optim_method=optim_method, method_params=method_params,
             dyn_type='UNIT', dyn_params=dyn_params,
             prop_params=prop_params, fid_params=fid_params,
-            pulse_scaling=pulse_scaling, pulse_offset=pulse_offset,
-            init_pulse_type=init_pulse_type, init_pulse_params=init_pulse_params,
+        init_pulse_type=init_pulse_type, init_pulse_params=init_pulse_params,
+        pulse_scaling=pulse_scaling, pulse_offset=pulse_offset,
             ramping_pulse_type=ramping_pulse_type, 
             ramping_pulse_params=ramping_pulse_params,
             log_level=log_level, out_file_ext=out_file_ext,

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -465,7 +465,7 @@ def optimize_pulse(
     dyn.init_timeslots()
     # Generate initial pulses for each control
     init_amps = np.zeros([dyn.num_tslots, dyn.num_ctrls])
-    
+
     if alg == 'CRAB':
         for j in range(dyn.num_ctrls):
             pgen = optim.pulse_generator[j]
@@ -475,7 +475,7 @@ def optimize_pulse(
         pgen = optim.pulse_generator
         for j in range(dyn.num_ctrls):
             init_amps[:, j] = pgen.gen_pulse()
-        
+    
     # Initialise the starting amplitudes
     dyn.initialize_controls(init_amps)
     
@@ -821,8 +821,8 @@ def optimize_pulse_unitary(
             optim_method=optim_method, method_params=method_params,
             dyn_type='UNIT', dyn_params=dyn_params,
             prop_params=prop_params, fid_params=fid_params,
-            init_pulse_type=init_pulse_type, init_pulse_params=init_pulse_params,
             pulse_scaling=pulse_scaling, pulse_offset=pulse_offset,
+            init_pulse_type=init_pulse_type, init_pulse_params=init_pulse_params,
             ramping_pulse_type=ramping_pulse_type, 
             ramping_pulse_params=ramping_pulse_params,
             log_level=log_level, out_file_ext=out_file_ext,


### PR DESCRIPTION
**Description**
Added the possibility of providing a custom initial pulse in qutip.control functions. The user can now use the following syntax:
```
init_pulse_params = {}
init_pulse_params['init_custom_pulse'] = my_init_pulse_array

# Run optimization
result = optimize_pulse_unitary(H_drift, H_control, uni_ini, uni_targ,
    num_tslots, gate_time, 
    init_pulse_type='CUSTOM', init_pulse_params=init_pulse_params)
```
when calling functions such as optimize_pulse_unitary() or optimize_pulse(). The custom array should be passed in the init_pulse_params dictionnary, and should be of size (n_tslots x n_ctrls).

**Changelog**
Added the possibility of providing a custom initial pulse in qutip.control functions.
