### PR TITLE
Fixed invalid string literals and unclosed files

### DIFF
--- a/qutip/_mkl/utilities.py
+++ b/qutip/_mkl/utilities.py
@@ -53,7 +53,7 @@ def _set_mkl():
         if plat == 'darwin':
             lib = '/libmkl_rt.dylib'
         elif plat == 'win32':
-            lib = '\\mkl_rt.dll'
+            lib = r'\mkl_rt.dll'
         elif plat in ['linux2', 'linux']:
             lib = '/libmkl_rt.so'
         else:
@@ -62,7 +62,7 @@ def _set_mkl():
         if plat in ['darwin','linux2', 'linux']:
             lib_dir = '/lib'
         else:
-            lib_dir = '\Library\\bin'
+            lib_dir = r'\Library\bin'
         
         # Try in default Anaconda location first
         try:
@@ -76,7 +76,7 @@ def _set_mkl():
             if plat in ['darwin','linux2', 'linux']:
                 lib_dir = '/ext/lib'
             else:
-                lib_dir = '\ext\\lib'
+                lib_dir = r'\ext\lib'
             try:
                 qset.mkl_lib = cdll.LoadLibrary(python_dir+lib_dir+lib)
                 qset.has_mkl = True

--- a/qutip/continuous_variables.py
+++ b/qutip/continuous_variables.py
@@ -45,13 +45,13 @@ import numpy as np
 
 
 def correlation_matrix(basis, rho=None):
-    """
-    Given a basis set of operators :math:`\\{a\\}_n`, calculate the correlation
+    r"""
+    Given a basis set of operators :math:`\{a\}_n`, calculate the correlation
     matrix:
 
     .. math::
 
-        C_{mn} = \\langle a_m a_n \\rangle
+        C_{mn} = \langle a_m a_n \rangle
 
     Parameters
     ----------
@@ -81,21 +81,21 @@ def correlation_matrix(basis, rho=None):
 
 
 def covariance_matrix(basis, rho, symmetrized=True):
-    """
+    r"""
     Given a basis set of operators :math:`\{a\}_n`, calculate the covariance
     matrix:
 
     .. math::
 
-        V_{mn} = \\frac{1}{2}\\langle a_m a_n + a_n a_m \\rangle -
-        \\langle a_m \\rangle \\langle a_n\\rangle
+        V_{mn} = \frac{1}{2}\langle a_m a_n + a_n a_m \rangle -
+        \langle a_m \rangle \langle a_n\rangle
 
     or, if of the optional argument `symmetrized=False`,
 
     .. math::
 
-        V_{mn} = \\langle a_m a_n\\rangle -
-        \\langle a_m \\rangle \\langle a_n\\rangle
+        V_{mn} = \langle a_m a_n\rangle -
+        \langle a_m \rangle \langle a_n\rangle
 
     Parameters
     ----------
@@ -190,12 +190,12 @@ def correlation_matrix_quadrature(a1, a2, rho=None, g=np.sqrt(2)):
 
 
 def wigner_covariance_matrix(a1=None, a2=None, R=None, rho=None, g=np.sqrt(2)):
-    """
+    r"""
     Calculates the Wigner covariance matrix
-    :math:`V_{ij} = \\frac{1}{2}(R_{ij} + R_{ji})`, given
+    :math:`V_{ij} = \frac{1}{2}(R_{ij} + R_{ji})`, given
     the quadrature correlation matrix
-    :math:`R_{ij} = \\langle R_{i} R_{j}\\rangle -
-    \\langle R_{i}\\rangle \\langle R_{j}\\rangle`, where
+    :math:`R_{ij} = \langle R_{i} R_{j}\rangle -
+    \langle R_{i}\rangle \langle R_{j}\rangle`, where
     :math:`R = (q_1, p_1, q_2, p_2)^T` is the vector with quadrature operators
     for the two modes.
 

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -1791,7 +1791,7 @@ class DynamicsSymplectic(Dynamics):
 
     @property
     def dyn_gen_phase(self):
-        """
+        r"""
         The phasing operator for the symplectic group generators
         usually refered to as \Omega
         By default this is applied as 'postop' dyn_gen*-\Omega

--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -74,9 +74,9 @@ if debug:
 def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
                        solver="me", reverse=False, args={},
                        options=Options(ntraj=[20, 100])):
-    """
+    r"""
     Calculate the two-operator two-time correlation function:
-    :math:`\left<A(t+\\tau)B(t)\\right>`
+    :math:`\left<A(t+\tau)B(t)\right>`
     along one time axis using the quantum regression theorem and the evolution
     solver indicated by the `solver` parameter.
 
@@ -87,12 +87,12 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
         system Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     state0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+        Initial state density matrix :math:`\rho(t_0)` or state vector
+        :math:`\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        list of times for :math:`\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
         list of collapse operators, may be time-dependent for solver choice of
@@ -102,8 +102,8 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
     b_op : Qobj
         operator B.
     reverse : bool {False, True}
-        If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
-        :math:`\left<A(t+\\tau)B(t)\\right>`.
+        If `True`, calculate :math:`\left<A(t)B(t+\tau)\right>` instead of
+        :math:`\left<A(t+\tau)B(t)\right>`.
     solver : str {'me', 'mc', 'es'}
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
@@ -143,9 +143,9 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
 def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
                        solver="me", reverse=False, args={},
                        options=Options(ntraj=[20, 100])):
-    """
+    r"""
     Calculate the two-operator two-time correlation function:
-    :math:`\left<A(t+\\tau)B(t)\\right>`
+    :math:`\left<A(t+\tau)B(t)\right>`
     along two time axes using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
@@ -155,17 +155,17 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
         system Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     state0 : Qobj
-        Initial state density matrix :math:`\\rho_0` or state vector
-        :math:`\\psi_0`. If 'state0' is 'None', then the steady state will
+        Initial state density matrix :math:`\rho_0` or state vector
+        :math:`\psi_0`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     tlist : array_like
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
+        value is necessary, i.e. when :math:`t \rightarrow \infty`; here
         tlist is automatically set, ignoring user input.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        list of times for :math:`\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
         list of collapse operators, may be time-dependent for solver choice of
@@ -175,8 +175,8 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
     b_op : Qobj
         operator B.
     reverse : bool {False, True}
-        If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
-        :math:`\left<A(t+\\tau)B(t)\\right>`.
+        If `True`, calculate :math:`\left<A(t)B(t+\tau)\right>` instead of
+        :math:`\left<A(t+\tau)B(t)\right>`.
     solver : str
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
         `es` for exponential series).
@@ -225,14 +225,14 @@ def correlation_2op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op,
 def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
                        solver="me", args={},
                        options=Options(ntraj=[20, 100])):
-    """
+    r"""
     Calculate the three-operator two-time correlation function:
-    :math:`\left<A(t)B(t+\\tau)C(t)\\right>`
+    :math:`\left<A(t)B(t+\tau)C(t)\right>`
     along one time axis using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
     Note: it is not possibly to calculate a physically meaningful correlation
-    of this form where :math:`\\tau<0`.
+    of this form where :math:`\tau<0`.
 
     Parameters
     ----------
@@ -240,12 +240,12 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
         system Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     rho0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+        Initial state density matrix :math:`\rho(t_0)` or state vector
+        :math:`\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        list of times for :math:`\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
         list of collapse operators, may be time-dependent for solver choice of
@@ -286,14 +286,14 @@ def correlation_3op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op,
 def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
                        solver="me", args={},
                        options=Options(ntraj=[20, 100])):
-    """
+    r"""
     Calculate the three-operator two-time correlation function:
-    :math:`\left<A(t)B(t+\\tau)C(t)\\right>`
+    :math:`\left<A(t)B(t+\tau)C(t)\right>`
     along two time axes using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
     Note: it is not possibly to calculate a physically meaningful correlation
-    of this form where :math:`\\tau<0`.
+    of this form where :math:`\tau<0`.
 
     Parameters
     ----------
@@ -301,17 +301,17 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
         system Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     rho0 : Qobj
-        Initial state density matrix :math:`\\rho_0` or state vector
-        :math:`\\psi_0`. If 'state0' is 'None', then the steady state will
+        Initial state density matrix :math:`\rho_0` or state vector
+        :math:`\psi_0`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     tlist : array_like
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
+        value is necessary, i.e. when :math:`t \rightarrow \infty`; here
         tlist is automatically set, ignoring user input.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        list of times for :math:`\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
         list of collapse operators, may be time-dependent for solver choice of
@@ -362,15 +362,15 @@ def correlation_3op_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
 
 def coherence_function_g1(H, state0, taulist, c_ops, a_op, solver="me",
                           args={}, options=Options(ntraj=[20, 100])):
-    """
+    r"""
     Calculate the normalized first-order quantum coherence function:
 
     .. math::
 
-        g^{(1)}(\\tau) =
-        \\frac{\\langle A^\\dagger(\\tau)A(0)\\rangle}
-        {\\sqrt{\\langle A^\\dagger(\\tau)A(\\tau)\\rangle
-                \\langle A^\\dagger(0)A(0)\\rangle}}
+        g^{(1)}(\tau) =
+        \frac{\langle A^\dagger(\tau)A(0)\rangle}
+        {\sqrt{\langle A^\dagger(\tau)A(\tau)\rangle
+                \langle A^\dagger(0)A(0)\rangle}}
 
     using the quantum regression theorem and the evolution solver indicated by
     the `solver` parameter.
@@ -381,12 +381,12 @@ def coherence_function_g1(H, state0, taulist, c_ops, a_op, solver="me",
         system Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     state0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+        Initial state density matrix :math:`\rho(t_0)` or state vector
+        :math:`\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        list of times for :math:`\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
         list of collapse operators, may be time-dependent for solver choice of
@@ -427,15 +427,15 @@ def coherence_function_g1(H, state0, taulist, c_ops, a_op, solver="me",
 
 def coherence_function_g2(H, state0, taulist, c_ops, a_op, solver="me", args={},
                           options=Options(ntraj=[20, 100])):
-    """
+    r"""
     Calculate the normalized second-order quantum coherence function:
 
     .. math::
 
-         g^{(2)}(\\tau) =
-        \\frac{\\langle A^\\dagger(0)A^\\dagger(\\tau)A(\\tau)A(0)\\rangle}
-        {\\langle A^\\dagger(\\tau)A(\\tau)\\rangle
-         \\langle A^\\dagger(0)A(0)\\rangle}
+         g^{(2)}(\tau) =
+        \frac{\langle A^\dagger(0)A^\dagger(\tau)A(\tau)A(0)\rangle}
+        {\langle A^\dagger(\tau)A(\tau)\rangle
+         \langle A^\dagger(0)A(0)\rangle}
 
     using the quantum regression theorem and the evolution solver indicated by
     the `solver` parameter.
@@ -446,12 +446,12 @@ def coherence_function_g2(H, state0, taulist, c_ops, a_op, solver="me", args={},
         system Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     state0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+        Initial state density matrix :math:`\rho(t_0)` or state vector
+        :math:`\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        list of times for :math:`\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
         list of collapse operators, may be time-dependent for solver choice of
@@ -495,16 +495,16 @@ def coherence_function_g2(H, state0, taulist, c_ops, a_op, solver="me", args={},
 # spectrum
 
 def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
-    """
+    r"""
     Calculate the spectrum of the correlation function
-    :math:`\lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>`,
+    :math:`\lim_{t \to \infty} \left<A(t+\tau)B(t)\right>`,
     i.e., the Fourier transform of the correlation function:
 
     .. math::
 
         S(\omega) = \int_{-\infty}^{\infty}
-        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
-        e^{-i\omega\\tau} d\\tau.
+        \lim_{t \to \infty} \left<A(t+\tau)B(t)\right>
+        e^{-i\omega\tau} d\tau.
 
     using the solver indicated by the `solver` parameter. Note: this spectrum
     is only defined for stationary statistics (uses steady state rho0)
@@ -514,7 +514,7 @@ def spectrum(H, wlist, c_ops, a_op, b_op, solver="es", use_pinv=False):
     H : :class:`qutip.qobj`
         system Hamiltonian.
     wlist : array_like
-        list of frequencies for :math:`\\omega`.
+        list of frequencies for :math:`\omega`.
     c_ops : list
         list of collapse operators.
     a_op : Qobj
@@ -603,12 +603,12 @@ def spectrum_correlation_fft(tlist, y, inverse=False):
 def correlation_ss(H, taulist, c_ops, a_op, b_op,
                    solver="me", reverse=False, args={},
                    options=Options(ntraj=[20, 100])):
-    """
+    r"""
     Calculate the two-operator two-time correlation function:
 
     .. math::
 
-        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
+        \lim_{t \to \infty} \left<A(t+\tau)B(t)\right>
 
     along one time axis (given steady-state initial conditions) using the
     quantum regression theorem and the evolution solver indicated by the
@@ -621,7 +621,7 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
         system Hamiltonian.
 
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        list of times for :math:`\tau`. taulist must be positive and contain
         the element `0`.
 
     c_ops : list
@@ -635,8 +635,8 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
 
     reverse : *bool*
         If `True`, calculate
-        :math:`\lim_{t \\to \\infty} \left<A(t)B(t+\\tau)\\right>` instead of
-        :math:`\lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>`.
+        :math:`\lim_{t \to \infty} \left<A(t)B(t+\tau)\right>` instead of
+        :math:`\lim_{t \to \infty} \left<A(t+\tau)B(t)\right>`.
 
     solver : str
         choice of solver (`me` for master-equation and
@@ -675,9 +675,9 @@ def correlation_ss(H, taulist, c_ops, a_op, b_op,
 def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
                 solver="me", reverse=False, args={},
                 options=Options(ntraj=[20, 100])):
-    """
+    r"""
     Calculate the two-operator two-time correlation function:
-    :math:`\left<A(t+\\tau)B(t)\\right>`
+    :math:`\left<A(t+\tau)B(t)\right>`
     along two time axes using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
@@ -689,19 +689,19 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
         `mc`.
 
     state0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+        Initial state density matrix :math:`\rho(t_0)` or state vector
+        :math:`\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
     tlist : array_like
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
+        value is necessary, i.e. when :math:`t \rightarrow \infty`; here
         tlist is automatically set, ignoring user input.
 
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        list of times for :math:`\tau`. taulist must be positive and contain
         the element `0`.
 
     c_ops : list
@@ -715,8 +715,8 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
         operator B.
 
     reverse : *bool*
-        If `True`, calculate :math:`\left<A(t)B(t+\\tau)\\right>` instead of
-        :math:`\left<A(t+\\tau)B(t)\\right>`.
+        If `True`, calculate :math:`\left<A(t)B(t+\tau)\right>` instead of
+        :math:`\left<A(t+\tau)B(t)\right>`.
 
     solver : str
         choice of solver (`me` for master-equation, `mc` for Monte Carlo, and
@@ -758,14 +758,14 @@ def correlation(H, state0, tlist, taulist, c_ops, a_op, b_op,
 def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
                        solver="me", args={},
                        options=Options(ntraj=[20, 100])):
-    """
+    r"""
     Calculate the four-operator two-time correlation function:
-    :math:`\left<A(t)B(t+\\tau)C(t+\\tau)D(t)\\right>`
+    :math:`\left<A(t)B(t+\tau)C(t+\tau)D(t)\right>`
     along one time axis using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
     Note: it is not possibly to calculate a physically meaningful correlation
-    of this form where :math:`\\tau<0`.
+    of this form where :math:`\tau<0`.
 
     Parameters
     ----------
@@ -773,12 +773,12 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
         system Hamiltonian, may be time-dependent for solver choice of `me` or
         `mc`.
     rho0 : Qobj
-        Initial state density matrix :math:`\\rho(t_0)` or state vector
-        :math:`\\psi(t_0)`. If 'state0' is 'None', then the steady state will
+        Initial state density matrix :math:`\rho(t_0)` or state vector
+        :math:`\psi(t_0)`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        list of times for :math:`\tau`. taulist must be positive and contain
         the element `0`.
     c_ops : list
         list of collapse operators, may be time-dependent for solver choice of
@@ -836,14 +836,14 @@ def correlation_4op_1t(H, state0, taulist, c_ops, a_op, b_op, c_op, d_op,
 def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
                        a_op, b_op, c_op, d_op, solver="me", args={},
                        options=Options(ntraj=[20, 100])):
-    """
+    r"""
     Calculate the four-operator two-time correlation function:
-    :math:`\left<A(t)B(t+\\tau)C(t+\\tau)D(t)\\right>`
+    :math:`\left<A(t)B(t+\tau)C(t+\tau)D(t)\right>`
     along two time axes using the quantum regression theorem and the
     evolution solver indicated by the `solver` parameter.
 
     Note: it is not possibly to calculate a physically meaningful correlation
-    of this form where :math:`\\tau<0`.
+    of this form where :math:`\tau<0`.
 
     Parameters
     ----------
@@ -853,19 +853,19 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
         `mc`.
 
     rho0 : Qobj
-        Initial state density matrix :math:`\\rho_0` or state vector
-        :math:`\\psi_0`. If 'state0' is 'None', then the steady state will
+        Initial state density matrix :math:`\rho_0` or state vector
+        :math:`\psi_0`. If 'state0' is 'None', then the steady state will
         be used as the initial state. The 'steady-state' is only implemented
         for the `me` and `es` solvers.
 
     tlist : array_like
         list of times for :math:`t`. tlist must be positive and contain the
         element `0`. When taking steady-steady correlations only one tlist
-        value is necessary, i.e. when :math:`t \\rightarrow \\infty`; here
+        value is necessary, i.e. when :math:`t \rightarrow \infty`; here
         tlist is automatically set, ignoring user input.
 
     taulist : array_like
-        list of times for :math:`\\tau`. taulist must be positive and contain
+        list of times for :math:`\tau`. taulist must be positive and contain
         the element `0`.
 
     c_ops : list
@@ -926,16 +926,16 @@ def correlation_4op_2t(H, state0, tlist, taulist, c_ops,
 # spectrum
 
 def spectrum_ss(H, wlist, c_ops, a_op, b_op):
-    """
+    r"""
     Calculate the spectrum of the correlation function
-    :math:`\lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>`,
+    :math:`\lim_{t \to \infty} \left<A(t+\tau)B(t)\right>`,
     i.e., the Fourier transform of the correlation function:
 
     .. math::
 
         S(\omega) = \int_{-\infty}^{\infty}
-        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
-        e^{-i\omega\\tau} d\\tau.
+        \lim_{t \to \infty} \left<A(t+\tau)B(t)\right>
+        e^{-i\omega\tau} d\tau.
 
     using an eseries based solver Note: this spectrum is only defined for
     stationary statistics (uses steady state rho0).
@@ -947,7 +947,7 @@ def spectrum_ss(H, wlist, c_ops, a_op, b_op):
         system Hamiltonian.
 
     wlist : array_like
-        list of frequencies for :math:`\\omega`.
+        list of frequencies for :math:`\omega`.
 
     c_ops : *list* of :class:`qutip.qobj`
         list of collapse operators.
@@ -976,16 +976,16 @@ def spectrum_ss(H, wlist, c_ops, a_op, b_op):
 
 
 def spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
-    """
+    r"""
     Calculate the spectrum of the correlation function
-    :math:`\lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>`,
+    :math:`\lim_{t \to \infty} \left<A(t+\tau)B(t)\right>`,
     i.e., the Fourier transform of the correlation function:
 
     .. math::
 
         S(\omega) = \int_{-\infty}^{\infty}
-        \lim_{t \\to \\infty} \left<A(t+\\tau)B(t)\\right>
-        e^{-i\omega\\tau} d\\tau.
+        \lim_{t \to \infty} \left<A(t+\tau)B(t)\right>
+        e^{-i\omega\tau} d\tau.
 
     using a psuedo-inverse method. Note: this spectrum is only defined for
     stationary statistics (uses steady state rho0)
@@ -997,7 +997,7 @@ def spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
         system Hamiltonian.
 
     wlist : array_like
-        list of frequencies for :math:`\\omega`.
+        list of frequencies for :math:`\omega`.
 
     c_ops : *list* of :class:`qutip.qobj`
         list of collapse operators.
@@ -1164,9 +1164,9 @@ def _correlation_es_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op):
 
 
 def _spectrum_es(H, wlist, c_ops, a_op, b_op):
-    """
+    r"""
     Internal function for calculating the spectrum of the correlation function
-    :math:`\left<A(\\tau)B(0)\\right>`.
+    :math:`\left<A(\tau)B(0)\right>`.
     """
     if debug:
         print(inspect.stack()[0][3])
@@ -1305,9 +1305,9 @@ def _correlation_mc_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
 
 # pseudo-inverse solvers
 def _spectrum_pi(H, wlist, c_ops, a_op, b_op, use_pinv=False):
-    """
+    r"""
     Internal function for calculating the spectrum of the correlation function
-    :math:`\left<A(\\tau)B(0)\\right>`.
+    :math:`\left<A(\tau)B(0)\right>`.
     """
 
     L = H if issuper(H) else liouvillian(H, c_ops)

--- a/qutip/floquet.py
+++ b/qutip/floquet.py
@@ -409,9 +409,9 @@ def floquet_wavefunction_t(f_modes_0, f_energies, f_coeff, t, H, T, args=None):
                 for i in np.arange(len(f_energies))])
 
 def floquet_state_decomposition(f_states, f_energies, psi):
-    """
+    r"""
     Decompose the wavefunction `psi` (typically an initial state) in terms of
-    the Floquet states, :math:`\psi = \sum_\\alpha c_\\alpha \psi_\\alpha(0)`.
+    the Floquet states, :math:`\psi = \sum_\alpha c_\alpha \psi_\alpha(0)`.
 
     Parameters
     ----------
@@ -430,7 +430,7 @@ def floquet_state_decomposition(f_states, f_energies, psi):
 
     output : array
 
-        The coefficients :math:`c_\\alpha` in the Floquet state decomposition.
+        The coefficients :math:`c_\alpha` in the Floquet state decomposition.
 
     """
     # [:1,:1][0, 0] patch around scipy 1.3.0 bug

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -59,18 +59,20 @@ def _linux_hardware_info():
     sockets = 0
     cores_per_socket = 0
     frequency = 0.0
-    for l in [l.split(':') for l in open("/proc/cpuinfo").readlines()]:
-        if (l[0].strip() == "physical id"):
-            sockets = np.maximum(sockets,int(l[1].strip())+1)
-        if (l[0].strip() == "cpu cores"):
-            cores_per_socket = int(l[1].strip())
-        if (l[0].strip() == "cpu MHz"):
-            frequency = float(l[1].strip()) / 1000.
+    with open("/proc/cpuinfo") as f:
+        for l in [l.split(':') for l in f.readlines()]:
+            if (l[0].strip() == "physical id"):
+                sockets = np.maximum(sockets,int(l[1].strip())+1)
+            if (l[0].strip() == "cpu cores"):
+                cores_per_socket = int(l[1].strip())
+            if (l[0].strip() == "cpu MHz"):
+                frequency = float(l[1].strip()) / 1000.
     results.update({'cpus': sockets * cores_per_socket})
     # get cpu frequency directly (bypasses freq scaling)
     try:
-        file = "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"
-        line = open(file).readlines()[0]
+        with open(
+                "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq") as f:
+            line = f.readlines()[0]
         frequency = float(line.strip('\n')) / 1000000.
     except:
         pass
@@ -78,8 +80,9 @@ def _linux_hardware_info():
 
     # get total amount of memory
     mem_info = dict()
-    for l in [l.split(':') for l in open("/proc/meminfo").readlines()]:
-        mem_info[l[0]] = l[1].strip('.\n ').strip('kB')
+    with open("/proc/meminfo") as f:
+        for l in [l.split(':') for l in f.readlines()]:
+            mem_info[l[0]] = l[1].strip('.\n ').strip('kB')
     results.update({'memsize': int(mem_info['MemTotal']) / 1024})
     # add OS information
     results.update({'os': 'Linux'})

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -99,7 +99,7 @@ def _freebsd_hardware_info():
 def _win_hardware_info():
     try:
         from comtypes.client import CoGetObject
-        winmgmts_root = CoGetObject("winmgmts:root\cimv2")
+        winmgmts_root = CoGetObject(r"winmgmts:root\cimv2")
         cpus = winmgmts_root.ExecQuery("Select * from Win32_Processor")
         ncpus = 0
         for cpu in cpus:

--- a/qutip/lattice.py
+++ b/qutip/lattice.py
@@ -765,7 +765,7 @@ class Lattice1d():
             else:
                 ax.plot(knxA/np.pi, val_kns[g, :], 'ro')
         ax.set_ylabel('Energy')
-        ax.set_xlabel('$k_x(\pi/a)$')
+        ax.set_xlabel(r'$k_x(\pi/a)$')
         plt.show(fig)
         fig.savefig('./Dispersion.pdf')
 
@@ -826,7 +826,7 @@ class Lattice1d():
         return (knxA, val_kns)
 
     def bloch_wave_functions(self):
-        """
+        r"""
         Returns eigenvectors ($\psi_n(k)$) of the Hamiltonian in a
         numpy.ndarray for translationally symmetric lattices with periodic
         boundary condition.
@@ -862,7 +862,7 @@ class Lattice1d():
         return eigen_states
 
     def cell_periodic_parts(self):
-        """
+        r"""
         Returns eigenvectors of the bulk Hamiltonian, i.e. the cell periodic
         part($u_n(k)$) of the Bloch wavefunctios in a numpy.ndarray for
         translationally symmetric lattices with periodic boundary condition.
@@ -1186,7 +1186,7 @@ class Lattice1d():
         return Hcell
 
     def display_lattice(self):
-        """
+        r"""
         Produces a graphic portraying the lattice symbolically with a unit cell
         marked in it.
 

--- a/qutip/mcsolve.py
+++ b/qutip/mcsolve.py
@@ -78,7 +78,7 @@ class qutip_zvode(zvode):
 def mcsolve(H, psi0, tlist, c_ops=[], e_ops=[], ntraj=0,
             args={}, options=None, progress_bar=True,
             map_func=parallel_map, map_kwargs={}, _safe_mode=True):
-    """Monte Carlo evolution of a state vector :math:`|\psi \\rangle` for a
+    r"""Monte Carlo evolution of a state vector :math:`|\psi \rangle` for a
     given Hamiltonian and sets of collapse operators, and possibly, operators
     for calculating expectation values. Options for the underlying ODE solver
     are given by the Options class.

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -981,7 +981,7 @@ def charge(Nmax, Nmin=None, frac = 1):
 def tunneling(N, m=1):
     """
     Tunneling operator with elements of the form
-    :math:`\sum |N><N+m| + |N+m><N|`.
+    :math:`\\sum |N><N+m| + |N+m><N|`.
 
     Parameters
     ----------

--- a/qutip/orbital.py
+++ b/qutip/orbital.py
@@ -38,7 +38,7 @@ from scipy.special import factorial
 
 
 def orbital(theta, phi, *args):
-    """Calculates an angular wave function on a sphere.
+    r"""Calculates an angular wave function on a sphere.
     ``psi = orbital(theta,phi,ket1,ket2,...)`` calculates
     the angular wave function on a sphere at the mesh of points
     defined by theta and phi which is

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -58,11 +58,11 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                unitary_mode='batch', parallel=False,
                progress_bar=None, _safe_mode=True,
                **kwargs):
-    """
+    r"""
     Calculate the propagator U(t) for the density matrix or wave function such
     that :math:`\psi(t) = U(t)\psi(0)` or
-    :math:`\\rho_{\mathrm vec}(t) = U(t) \\rho_{\mathrm vec}(0)`
-    where :math:`\\rho_{\mathrm vec}` is the vector representation of the
+    :math:`\rho_{\mathrm vec}(t) = U(t) \rho_{\mathrm vec}(0)`
+    where :math:`\rho_{\mathrm vec}` is the vector representation of the
     density matrix.
 
     Parameters

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -218,7 +218,7 @@ def _rand_herm_dense(N, density, pos_def):
 
 
 def rand_unitary(N, density=0.75, dims=None, seed=None):
-    """Creates a random NxN sparse unitary quantum object.
+    r"""Creates a random NxN sparse unitary quantum object.
 
     Uses :math:`\exp(-iH)` where H is a randomly generated
     Hermitian operator.
@@ -375,7 +375,7 @@ def rand_ket_haar(N=2, dims=None, seed=None):
 
 
 def rand_dm(N, density=0.75, pure=False, dims=None, seed=None):
-    """Creates a random NxN density matrix.
+    r"""Creates a random NxN density matrix.
 
     Parameters
     ----------
@@ -396,7 +396,7 @@ def rand_dm(N, density=0.75, pure=False, dims=None, seed=None):
     Notes
     -----
     For small density matrices., choosing a low density will result in an error
-    as no diagonal elements will be generated such that :math:`Tr(\\rho)=1`.
+    as no diagonal elements will be generated such that :math:`Tr(\rho)=1`.
 
     """
     if isinstance(N, (np.ndarray, list)):

--- a/qutip/three_level_atom.py
+++ b/qutip/three_level_atom.py
@@ -30,7 +30,7 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-'''
+r'''
 This module provides functions that are useful for simulating the
 three level atom with QuTiP.  A three level atom (qutrit) has three states,
 which are linked by dipole transitions so that 1 <-> 2 <-> 3.

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -291,12 +291,12 @@ def wigner(psi, xvec, yvec, method='clenshaw', g=sqrt(2),
 
 
 def _wigner_iterative(rho, xvec, yvec, g=sqrt(2)):
-    """
+    r"""
     Using an iterative method to evaluate the wigner functions for the Fock
     state :math:`|m><n|`.
 
     The Wigner function is calculated as
-    :math:`W = \sum_{mn} \\rho_{mn} W_{mn}` where :math:`W_{mn}` is the Wigner
+    :math:`W = \sum_{mn} \rho_{mn} W_{mn}` where :math:`W_{mn}` is the Wigner
     function for the density matrix :math:`|m><n|`.
 
     In this implementation, for each row m, Wlist contains the Wigner functions
@@ -337,10 +337,10 @@ def _wigner_iterative(rho, xvec, yvec, g=sqrt(2)):
 
 
 def _wigner_laguerre(rho, xvec, yvec, g, parallel):
-    """
+    r"""
     Using Laguerre polynomials from scipy to evaluate the Wigner function for
     the density matrices :math:`|m><n|`, :math:`W_{mn}`. The total Wigner
-    function is calculated as :math:`W = \sum_{mn} \\rho_{mn} W_{mn}`.
+    function is calculated as :math:`W = \sum_{mn} \rho_{mn} W_{mn}`.
     """
 
     M = np.prod(rho.shape[0])
@@ -479,14 +479,14 @@ def _osc_eigen(N, pnts):
 
 
 def _wigner_clenshaw(rho, xvec, yvec, g=sqrt(2), sparse=False):
-    """
+    r"""
     Using Clenshaw summation - numerically stable and efficient
     iterative algorithm to evaluate polynomial series.
 
     The Wigner function is calculated as
-    :math:`W = e^(-0.5*x^2)/pi * \sum_{L} c_L (2x)^L / sqrt(L!)` where
-    :math:`c_L = \sum_n \\rho_{n,L+n} LL_n^L` where
-    :math:`LL_n^L = (-1)^n sqrt(L!n!/(L+n)!) LaguerreL[n,L,x]`
+    :math:`W = e^(-0.5*x^2)/pi * \sum_{L} c_L (2x)^L / \sqrt(L!)` where
+    :math:`c_L = \sum_n \rho_{n,L+n} LL_n^L` where
+    :math:`LL_n^L = (-1)^n \sqrt(L!n!/(L+n)!) LaguerreL[n,L,x]`
 
     """
 
@@ -499,7 +499,7 @@ def _wigner_clenshaw(rho, xvec, yvec, g=sqrt(2), sparse=False):
     B *= B
     w0 = (2*rho.data[0,-1])*np.ones_like(A2)
     L = M-1
-    #calculation of \sum_{L} c_L (2x)^L / sqrt(L!)
+    #calculation of \sum_{L} c_L (2x)^L / \sqrt(L!)
     #using Horner's method
     if not sparse:
         rho = rho.full() * (2*np.ones((M,M)) - np.diag(np.ones(M)))
@@ -521,12 +521,12 @@ def _wigner_clenshaw(rho, xvec, yvec, g=sqrt(2), sparse=False):
 
 
 def _wig_laguerre_val(L, x, c):
-    """
+    r"""
     this is evaluation of polynomial series inspired by hermval from numpy.
     Returns polynomial series
     \sum_n b_n LL_n^L,
     where
-    LL_n^L = (-1)^n sqrt(L!n!/(L+n)!) LaguerreL[n,L,x]
+    LL_n^L = (-1)^n \sqrt(L!n!/(L+n)!) LaguerreL[n,L,x]
     The evaluation uses Clenshaw recursion
     """
 


### PR DESCRIPTION
**Description**
Minor changes to correct invalid string literals and close files opened by `hardware_info.py`.

This removes warnings that currently appear when importing quTiP with non-standard warnings settings (for instance when testing a code that import quTiP).

**Changelog**
Give a short description of the PR in a few words. This will be shown in the QuTiP change log after the PR gets merged.
For example: 
Fixed invalid string literals and proporly close opened files.