### PR TITLE
Fix setting of Python version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ os: linux
 dist: xenial
 language: python
 
-# We use our own "_PYTHON_VERSION" variable because Travis jobs on macOS don't
-# have a "language: python" available, so don't define the variable.
-env: _CONDA_SUFFIX="Linux-x86_64" _PYTHON_VERSION="$TRAVIS_PYTHON_VERSION"
+# This is overriden by the Mac versions, which also directly set
+# _PYTHON_VERSION.  We cannot set _PYTHON_VERSION to TRAVIS_PYTHON_VERSION here
+# because the latter is not defined until after this environment setup takes
+# place.
+env: _CONDA_SUFFIX="Linux-x86_64"
 
 # Set up conda with the correct version of conda.
 before_install:
@@ -19,6 +21,10 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda info -a
+  # We have to use the older [[ -z "$x" ]] syntax rather than the more robust
+  #   [[ ! -v _PYTHON_VERSION ]]
+  # because the macOS machines on Travis only have bash 3.2 (released 2006)!
+  - if [[ -z "$_PYTHON_VERSION" ]]; then export _PYTHON_VERSION="$TRAVIS_PYTHON_VERSION"; fi
   - conda create -q -n test-environment python="$_PYTHON_VERSION"
   - source activate test-environment
   - QUTIP_DOWNLOAD=$(pwd -P)


### PR DESCRIPTION
#1347 changed the setup of the tests, but it went unnoticed (sorry!) that the Python version wasn't set correctly; we've been silently testing everything against python-latest since then.  That wasn't an issue as long as Python 3.8 was the latest, but the release of Python 3.9 (and the fact we haven't rebuilt a binary distribution of QuTiP for 3.9) caused all Linux builds to break.  Mac builds were unaffected because they set `$_PYTHON_VERSION` to a string literal.

The Linux Python version was not set correctly because it attempted to set it to the definition of `$TRAVIS_PYTHON_VERSION` _as defined during the `env` stage of the Travis build_.  Unfortunately, this environment variable isn't defined until after that stage, which caused us to pass an empty constraint on the Python version to conda, resulting in us getting the latest version.

This moves this part of the environment setup into the pre-install phase so `TRAVIS_PYTHON_VERSION` is now set, and guards it with a conditional so the mac builds can still neatly override the standard setup.

**Changelog**
Fix Python version setting in CI tests.

