### PR TITLE
fix parsing hardware information problem for Macbook Pro (M1 CPU/Big Sur)

### DIFF
--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -45,8 +45,9 @@ def _mac_hardware_info():
         info[l[0].strip(' "').replace(' ', '_').lower().strip('hw.')] = \
             l[1].strip('.\n ')
     results.update({'cpus': int(info['physicalcpu'])})
-    results.update({'cpu_freq': int(float(os.popen('sysctl -n machdep.cpu.brand_string')
-                                          .readlines()[0].split('@')[1].split(' ')[1].replace('GHz', '')) * 1000)})
+    results.update({'cpu_freq': int(float(os.popen('sysctl -n machdep.cpu.brand_string'
+                    ).readlines()[0].split('@')[1].split(' '
+                    )[1].replace('GHz', '')) * 1000)})
     results.update({'memsize': int(int(info['memsize']) / (1024 ** 2))})
     # add OS information
     results.update({'os': 'Mac OSX'})

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -33,10 +33,12 @@
 
 __all__ = ['hardware_info']
 
+import multiprocessing
 import os
 import sys
-import multiprocessing
+
 import numpy as np
+
 
 def _mac_hardware_info():
     info = dict()
@@ -46,8 +48,9 @@ def _mac_hardware_info():
             l[1].strip('.\n ')
     results.update({'cpus': int(info['physicalcpu'])})
     results.update({'cpu_freq': int(float(os.popen('sysctl -n machdep.cpu.brand_string'
-                    ).readlines()[0].split('@')[1].split(' '
-                    )[1].replace('GHz', '')) * 1000)})
+                                                   ).readlines()[0].split('@')[1].split(' '
+                                                                                        )[1].replace('GHz',
+                                                                                                     '')) * 1000)})
     results.update({'memsize': int(int(info['memsize']) / (1024 ** 2))})
     # add OS information
     results.update({'os': 'Mac OSX'})

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -47,12 +47,9 @@ def _mac_hardware_info():
         info[l[0].strip(' "').replace(' ', '_').lower().strip('hw.')] = \
             l[1].strip('.\n ')
     results.update({'cpus': int(info['physicalcpu'])})
-    results.update(
-        {'cpu_freq': int(float(os.popen('sysctl -n machdep.cpu.brand_string'
-                                        ).readlines()[0].split('@')[1].split(
-            ' '
-        )[1].replace('GHz',
-                     '')) * 1000)})
+    results.update({'cpu_freq': int(float(os.popen('sysctl hw.cpufrequency')
+                                          .readlines()[0].split(':')[
+                                              1]) / 1000000)})
     results.update({'memsize': int(int(info['memsize']) / (1024 ** 2))})
     # add OS information
     results.update({'os': 'Mac OSX'})
@@ -94,13 +91,17 @@ def _linux_hardware_info():
     results.update({'os': 'Linux'})
     return results
 
+
 def _freebsd_hardware_info():
     results = {}
     results.update({'cpus': int(os.popen('sysctl -n hw.ncpu').readlines()[0])})
-    results.update({'cpu_freq': int(os.popen('sysctl -n dev.cpu.0.freq').readlines()[0])})
-    results.update({'memsize': int(os.popen('sysctl -n hw.realmem').readlines()[0]) / 1024})
+    results.update(
+        {'cpu_freq': int(os.popen('sysctl -n dev.cpu.0.freq').readlines()[0])})
+    results.update({'memsize': int(
+        os.popen('sysctl -n hw.realmem').readlines()[0]) / 1024})
     results.update({'os': 'FreeBSD'})
     return results
+
 
 def _win_hardware_info():
     try:
@@ -139,6 +140,7 @@ def hardware_info():
     else:
         out = {}
     return out
+
 
 if __name__ == '__main__':
     print(hardware_info())

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -46,7 +46,7 @@ def _mac_hardware_info():
             l[1].strip('.\n ')
     results.update({'cpus': int(info['physicalcpu'])})
     results.update({'cpu_freq': int(float(os.popen('sysctl -n machdep.cpu.brand_string')
-                                .readlines()[0].split('@')[1][:-4])*1000)})
+                                          .readlines()[0].split('@')[1].split(' ')[1].replace('GHz', '')) * 1000)})
     results.update({'memsize': int(int(info['memsize']) / (1024 ** 2))})
     # add OS information
     results.update({'os': 'Mac OSX'})

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -47,10 +47,12 @@ def _mac_hardware_info():
         info[l[0].strip(' "').replace(' ', '_').lower().strip('hw.')] = \
             l[1].strip('.\n ')
     results.update({'cpus': int(info['physicalcpu'])})
-    results.update({'cpu_freq': int(float(os.popen('sysctl -n machdep.cpu.brand_string'
-                                                   ).readlines()[0].split('@')[1].split(' '
-                                                                                        )[1].replace('GHz',
-                                                                                                     '')) * 1000)})
+    results.update(
+        {'cpu_freq': int(float(os.popen('sysctl -n machdep.cpu.brand_string'
+                                        ).readlines()[0].split('@')[1].split(
+            ' '
+        )[1].replace('GHz',
+                     '')) * 1000)})
     results.update({'memsize': int(int(info['memsize']) / (1024 ** 2))})
     # add OS information
     results.update({'os': 'Mac OSX'})


### PR DESCRIPTION
 and compatible with previous syntax

**Description**
Operating System: MacOS Big Sur 11.0.1
CPU: Apple M1

The syntax of output of command 
```
sysctl -n machdep.cpu.brand_string
``` 
has been changed.

The output for previous MacOS: 
```
$ sysctl -n machdep.cpu.brand_string
Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz\n
```

The updated output
```
$ sysctl -n machdep.cpu.brand_string
VirtualApple @ 2.50GHz processor\n
```

Therefore, the function [`_mac_hardware_info`](https://github.com/qutip/qutip/blob/cb201690a2ca3a9c904bc642ef6600f2ef54f763/qutip/hardware_info.py#L48)  of file `hardware_info.py` cannot parse the frequency of CPU correctly.

The popped error information is attached below.

```
ValueError: could not convert string to float: ' 2.50GHz proces'
```

This pull request fix this problem and compatible with both syntax of hardware information. 

Since the unit tests of file or function are not found, I do not add test files for this change. I attach python code below to prove the correctness of the implementation.

```python
# before change
old_str = 'Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz\n'
new_str = 'VirtualApple @ 2.50GHz processor\n'
# parse old hardware message
int(float(old_str.split('@')[1].split(' ')[1].replace('GHz', ''))*1000)
# parse new hardware message
int(float(new_str.split('@')[1].split(' ')[1].replace('GHz', ''))*1000)
```

**Related issues or PRs**
No related issue.

**Changelog**
Fixed error parsing hardware information for MacOS Big Sur (Apple M1 chip)
