### PR TITLE
Core update for solver in v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,15 @@ qutip/cy/*.c
 *.dat
 qutip/core/*.h
 
+qutip/core/*/*.html
+qutip/solve/*.html
+qutip/solver/*.html
+qutip/solver/nonmarkov/*.html
+qutip/solve/nonmarkov/*.html
+qutip/solver/ode/*.html
+qutip/solver/ode/*.c
+
+
 *.qo
 
 benchmark/benchmark_data.js

--- a/.gitignore
+++ b/.gitignore
@@ -30,12 +30,8 @@ qutip/cy/*.c
 *.dat
 qutip/core/*.h
 
-qutip/core/*/*.html
-qutip/solve/*.html
-qutip/solver/*.html
-qutip/solver/nonmarkov/*.html
-qutip/solve/nonmarkov/*.html
-qutip/solver/ode/*.html
+
+qutip/**/*.html
 qutip/solver/ode/*.c
 
 

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -35,6 +35,8 @@ cdef class Coefficient:
         return ""
 
     def __add__(left, right):
+        if (isinstance(left, InterCoefficient) and isinstance(right, InterCoefficient)):
+            return add_inter(left, right)
         if isinstance(left, Coefficient) and isinstance(right, Coefficient):
             return SumCoefficient(left.copy(), right.copy())
         return NotImplemented
@@ -209,6 +211,17 @@ cdef class InterCoefficient(Coefficient):
     def array(self):
         # Fro QIP tests
         return self.coeff_np
+
+
+cdef Coefficient add_inter(InterCoefficient left, InterCoefficient right):
+    if np.array_equal(left.tlist_np, right.tlist_np):
+        return InterCoefficient(left.coeff_np + right.coeff_np,
+                                left.tlist_np,
+                                left.second_np + right.second_np,
+                                left.cte
+                               )
+    else:
+        return SumCoefficient(left.copy(), right.copy())
 
 
 cdef class StepCoefficient(Coefficient):

--- a/qutip/core/cy/cqobjevo.pxd
+++ b/qutip/core/cy/cqobjevo.pxd
@@ -37,15 +37,23 @@ cimport numpy as cnp
 from qutip.core.data.base cimport idxint
 from qutip.core.data cimport CSR, Dense, Data
 
+
+cpdef enum LTYPE:
+    MIXED_TYPE   = 0
+    CSR_TYPE     = 1
+    Dense_TYPE   = 2
+
+
 cdef class CQobjEvo:
     cdef readonly (idxint, idxint) shape
-    cdef object dims
+    cdef readonly object dims
     cdef str type
+    cdef LTYPE layer_type
     cdef str superrep
-    cdef bint issuper
+    cdef readonly bint issuper
     cdef size_t n_ops
 
-    cdef CSR constant
+    cdef Data constant
     cdef list ops
     cdef list coeff
     cdef object coefficients
@@ -56,7 +64,8 @@ cdef class CQobjEvo:
     cdef list dynamic_arguments
     cdef dict args
     cdef object op
-    cpdef dyn_args(self, double t, Data matrix)
 
-    cpdef Dense matmul(self, double t, Dense matrix, Dense out=*)
+    cpdef Data matmul(self, double t, Data matrix)
+    cpdef Dense matmul_dense(self, double t, Dense matrix, Dense out=*)
     cpdef double complex expect(self, double t, Data matrix) except *
+    cpdef double complex expect_dense(self, double t, Dense matrix) except *

--- a/qutip/core/cy/cqobjevo.pxd
+++ b/qutip/core/cy/cqobjevo.pxd
@@ -37,18 +37,10 @@ cimport numpy as cnp
 from qutip.core.data.base cimport idxint
 from qutip.core.data cimport CSR, Dense, Data
 
-
-cpdef enum LTYPE:
-    MIXED_TYPE   = 0
-    CSR_TYPE     = 1
-    Dense_TYPE   = 2
-
-
 cdef class CQobjEvo:
     cdef readonly (idxint, idxint) shape
     cdef readonly object dims
     cdef str type
-    cdef LTYPE layer_type
     cdef str superrep
     cdef readonly bint issuper
     cdef size_t n_ops

--- a/qutip/core/cy/cqobjevo.pyx
+++ b/qutip/core/cy/cqobjevo.pyx
@@ -48,10 +48,8 @@ from qutip.core.data cimport CSR, Dense, Data
 from qutip.core.data.add cimport add_csr, iadd_dense
 from qutip.core.data.matmul cimport (matmul_csr, matmul_csr_dense_dense,
                                      matmul_dense)
-# TODO: handle dispatch properly.  We import rather than cimport because we
-# have to call with Python semantics.
 from qutip.core.data.expect cimport (
-    expect_csr, expect_super_csr, expect_csr_dense, expect_super_csr_dense,
+    expect_csr_dense, expect_super_csr_dense,
     expect_dense_dense, expect_super_dense_dense,
 )
 from qutip.core.data.reshape cimport (column_stack_dense, column_unstack_dense)

--- a/qutip/core/cy/cqobjevo.pyx
+++ b/qutip/core/cy/cqobjevo.pyx
@@ -54,8 +54,7 @@ from qutip.core.data.expect cimport (
     expect_csr, expect_super_csr, expect_csr_dense, expect_super_csr_dense,
     expect_dense_dense, expect_super_dense_dense,
 )
-from qutip.core.data.reshape cimport (column_stack_csr, column_stack_dense,
-                                      column_unstack_dense)
+from qutip.core.data.reshape cimport (column_stack_dense, column_unstack_dense)
 from qutip.core.cy.coefficient cimport Coefficient
 
 

--- a/qutip/core/cy/cqobjevo.pyx
+++ b/qutip/core/cy/cqobjevo.pyx
@@ -45,79 +45,17 @@ from ..qobj import Qobj
 from .. import data as _data
 
 from qutip.core.data cimport CSR, Dense, Data
-from qutip.core.data.add cimport add_csr, iadd_dense
-from qutip.core.data.matmul cimport (matmul_csr, matmul_csr_dense_dense,
-                                     matmul_dense)
-from qutip.core.data.expect cimport (
-    expect_csr_dense, expect_super_csr_dense,
-    expect_dense_dense, expect_super_dense_dense,
-)
+from qutip.core.data.add cimport iadd_dense
+from qutip.core.data.matmul cimport *
+#(matmul_csr, matmul_csr_dense_dense, matmul_dense, matmul_data_dense, imatmul_dense_dense)
+from qutip.core.data.expect cimport *
+#(expect_csr_dense, expect_super_csr_dense, expect_dense, expect_super_dense, expect_data_dense, expect_super_data_dense)
 from qutip.core.data.reshape cimport (column_stack_dense, column_unstack_dense)
 from qutip.core.cy.coefficient cimport Coefficient
 
 
 cdef extern from "<complex>" namespace "std" nogil:
     double complex conj(double complex x)
-
-
-cdef Dense cy_matmul(Data left, Dense right, LTYPE layer_type):
-    cdef Dense out
-    if layer_type == CSR_TYPE:
-        out = matmul_csr_dense_dense(left, right)
-    elif layer_type == Dense_TYPE:
-        out = matmul_dense(left, right)
-    else:
-        out = _data.matmul(left, right)
-    return out
-
-
-cdef void cy_matmul_inplace(Data left, Dense right, LTYPE layer_type,
-                            double complex scale, Dense out):
-    if layer_type == CSR_TYPE:
-        matmul_csr_dense_dense(left, right, scale, out)
-    elif layer_type == Dense_TYPE:
-        matmul_dense(left, right, scale, out)
-    else:
-        iadd_dense(out, _data.matmul[type(left), Dense, Dense](left, right, scale))
-
-
-cdef double complex cy_expect(Data left, Dense right, LTYPE layer_type):
-    cdef double complex out
-    if layer_type == CSR_TYPE:
-        out = expect_csr_dense(left, right)
-    elif layer_type == Dense_TYPE:
-        out = expect_dense_dense(left, right)
-    else:
-        out = _data.expect(left, right)
-    return out
-
-
-cdef double complex cy_expect_super(Data left, Dense right, LTYPE layer_type):
-    cdef double complex out
-    if layer_type == CSR_TYPE:
-        out = expect_super_csr_dense(left, right)
-    elif layer_type == Dense_TYPE:
-        out = expect_super_dense_dense(left, right)
-    else:
-        out = _data.expect_super(left, right)
-    return out
-
-
-def count_types(data_obj, types):
-    if isinstance(data_obj, CSR):
-        types[0] += 1
-    elif isinstance(data_obj, Dense):
-        types[1] += 1
-
-
-def set_types(types):
-    if types[1] == 0 and types[2] == 0:
-        layer_type = CSR_TYPE
-    elif types[0] == 0 and types[2] == 0:
-        layer_type = Dense_TYPE
-    else:
-        layer_type = MIXED_TYPE
-    return layer_type
 
 
 cdef class CQobjEvo:
@@ -151,8 +89,6 @@ cdef class CQobjEvo:
         self.coefficients = cnp.PyArray_EMPTY(1, [self.n_ops],
                                               cnp.NPY_COMPLEX128, False)
         self.coeff = [None] * self.n_ops
-        types = [0, 0, 0]
-        count_types(self.constant, types)
         for i in range(self.n_ops):
             vary = ops[i]
             qobj = vary.qobj
@@ -164,8 +100,7 @@ cdef class CQobjEvo:
                 raise ValueError("not all inputs have the same structure")
             self.ops[i] = qobj.data
             self.coeff[i] = vary.coeff
-            count_types(qobj.data, types)
-        self.layer_type = set_types(types)
+
 
     def call(self, double t, object coefficients=None, bint data=False):
         cdef Data out = self.constant.copy()
@@ -211,12 +146,12 @@ cdef class CQobjEvo:
         cdef size_t i
         self._factor(t)
         if out is None:
-            out = cy_matmul(self.constant, matrix, self.layer_type)
+            out = matmul_data_dense(self.constant, matrix)
         else:
-            cy_matmul_inplace(self.constant, matrix, self.layer_type, 1, out)
+            imatmul_data_dense(self.constant, matrix, 1, out)
         for i in range(self.n_ops):
-            cy_matmul_inplace(<Data> self.ops[i], matrix, self.layer_type,
-                                    self.coefficients[i], out)
+            imatmul_data_dense(<Data> self.ops[i], matrix,
+                               self.coefficients[i], out)
         return out
 
     cpdef double complex expect(self, double t, Data matrix) except *:
@@ -255,15 +190,15 @@ cdef class CQobjEvo:
         if self.issuper:
             if matrix.shape[1] != 1:
                 matrix = column_stack_dense(matrix, inplace=matrix.fortran)
-            out = cy_expect_super(self.constant, matrix, self.layer_type)
+            out = expect_super_data_dense(self.constant, matrix)
             for i in range(self.n_ops):
-                out += self.coefficients[i] * cy_expect_super(<Data> self.ops[i], matrix, self.layer_type)
+                out += self.coefficients[i] * expect_super_data_dense(<Data> self.ops[i], matrix)
             if matrix.fortran:
                 column_unstack_dense(matrix, nrow, inplace=matrix.fortran)
         else:
-            out = cy_expect(self.constant, matrix, self.layer_type)
+            out = expect_data_dense(self.constant, matrix)
             for i in range(self.n_ops):
-                out += self.coefficients[i] * cy_expect(<Data> self.ops[i], matrix, self.layer_type)
+                out += self.coefficients[i] * expect_data_dense(<Data> self.ops[i], matrix)
         return out
 
 
@@ -287,11 +222,13 @@ cdef class CQobjFunc(CQobjEvo):
         return out
 
     cpdef Dense matmul_dense(self, double t, Dense matrix, Dense out=None):
-        cdef Data objdata = self.base(t, data=True)
+        cdef Data objdata = self.base(t).data
         if out is None:
-            out = _data.matmul(objdata, matrix)
+            # out = _data.matmul(objdata, matrix)
+            out = matmul_data_dense(objdata, matrix)
         else:
-            iadd_dense(out, _data.matmul[type(objdata), Dense, Dense](objdata, matrix, 1))
+            imatmul_data_dense(objdata, matrix, 1, out)
+            #iadd_dense(out, _data.matmul[type(objdata), Dense, Dense](objdata, matrix, 1))
         return out
 
     cpdef double complex expect(self, double t, Data matrix) except *:

--- a/qutip/core/data/add.pxd
+++ b/qutip/core/data/add.pxd
@@ -3,8 +3,10 @@
 from qutip.core.data.csr cimport CSR
 from qutip.core.data.dense cimport Dense
 
+cdef void add_dense_eq_order_inplace(Dense left, Dense right, double complex scale)
 cpdef CSR add_csr(CSR left, CSR right, double complex scale=*)
 cpdef Dense add_dense(Dense left, Dense right, double complex scale=*)
+cpdef Dense iadd_dense(Dense left, Dense right, double complex scale=*)
 
 cpdef CSR sub_csr(CSR left, CSR right)
 cpdef Dense sub_dense(Dense left, Dense right)

--- a/qutip/core/data/add.pyx
+++ b/qutip/core/data/add.pyx
@@ -4,12 +4,13 @@
 cimport cython
 import numpy as np
 cimport numpy as cnp
-
 from scipy.linalg cimport cython_blas as blas
 
 from qutip.core.data.base cimport idxint, Data
 from qutip.core.data.dense cimport Dense
-from qutip.core.data.csr cimport CSR
+from qutip.core.data.csr cimport (
+    CSR, Accumulator, acc_alloc, acc_free, acc_scatter, acc_gather, acc_reset,
+)
 from qutip.core.data cimport csr, dense
 
 cnp.import_array()
@@ -19,12 +20,15 @@ cdef extern from *:
     void *PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
     void PyDataMem_FREE(void *ptr)
 
+
 __all__ = [
     'add', 'add_csr', 'add_dense', 'iadd_dense',
     'sub', 'sub_csr', 'sub_dense',
 ]
 
+
 cdef int _ONE=1
+
 
 cdef void _check_shape(Data left, Data right) nogil except *:
     if left.shape[0] != right.shape[0] or left.shape[1] != right.shape[1]:
@@ -35,7 +39,8 @@ cdef void _check_shape(Data left, Data right) nogil except *:
             + str(right.shape)
         )
 
-cdef idxint _add_csr(CSR a, CSR b, CSR c) nogil:
+
+cdef idxint _add_csr(Accumulator *acc, CSR a, CSR b, CSR c) nogil:
     """
     Perform the operation
         c := a + b
@@ -44,43 +49,40 @@ cdef idxint _add_csr(CSR a, CSR b, CSR c) nogil:
 
     Return the true value of nnz(c).
     """
-    cdef:
-        idxint nrows=c.shape[0], ncols=c.shape[1]
-        idxint row, col_a, col_b
-        double complex tmp
-        # These all refer to "pointers" into the col_index or data arrays.
-        idxint ptr_a, ptr_b, ptr_c=0, max_ptr_a, max_ptr_b
-    c.row_index[0] = 0
-    for row in range(nrows):
-        ptr_a = a.row_index[row]
-        ptr_b = b.row_index[row]
-        max_ptr_a = a.row_index[row+1]
-        max_ptr_b = b.row_index[row+1]
-        while ptr_a < max_ptr_a or ptr_b < max_ptr_b:
-            col_a = a.col_index[ptr_a] if ptr_a < max_ptr_a else ncols + 1
-            col_b = b.col_index[ptr_b] if ptr_b < max_ptr_b else ncols + 1
+    cdef idxint row, ptr_a, ptr_b, ptr_a_max, ptr_b_max, nnz=0, col_a, col_b
+    cdef idxint ncols = a.shape[1]
+    c.row_index[0] = nnz
+    ptr_a_max = ptr_b_max = 0
+    for row in range(a.shape[0]):
+        ptr_a = ptr_a_max
+        ptr_a_max = a.row_index[row + 1]
+        ptr_b = ptr_b_max
+        ptr_b_max = b.row_index[row + 1]
+        col_a = a.col_index[ptr_a] if ptr_a < ptr_a_max else ncols + 1
+        col_b = b.col_index[ptr_b] if ptr_b < ptr_b_max else ncols + 1
+        # We use this method of going through the row to give the Accumulator
+        # the best chance of receiving the scatters in a sorted order.  We
+        # could also safely iterate through a completely then b, which would be
+        # more cache efficient, but would quite often require a sort within the
+        # gather, making the algorithimic complexity worse.
+        while ptr_a < ptr_a_max or ptr_b < ptr_b_max:
             if col_a < col_b:
-                c.data[ptr_c] = a.data[ptr_a]
-                c.col_index[ptr_c] = col_a
+                acc_scatter(acc, a.data[ptr_a], col_a)
                 ptr_a += 1
-                ptr_c += 1
-            elif col_b < col_a:
-                c.data[ptr_c] = b.data[ptr_b]
-                c.col_index[ptr_c] = col_b
+                col_a = a.col_index[ptr_a] if ptr_a < ptr_a_max else ncols + 1
+            else:
+                acc_scatter(acc, b.data[ptr_b], col_b)
                 ptr_b += 1
-                ptr_c += 1
-            else:  # equal
-                tmp = a.data[ptr_a] + b.data[ptr_b]
-                if tmp != 0:
-                    c.data[ptr_c] = tmp
-                    c.col_index[ptr_c] = col_a
-                    ptr_c += 1
-                ptr_a += 1
-                ptr_b += 1
-        c.row_index[row+1] = ptr_c
-    return ptr_c
+                col_b = b.col_index[ptr_b] if ptr_b < ptr_b_max else ncols + 1
+            # There's no need to test col_a == col_b because the Accumulator
+            # already tests that in all scatters anyway.
+        nnz += acc_gather(acc, c.data + nnz, c.col_index + nnz)
+        acc_reset(acc)
+        c.row_index[row + 1] = nnz
+    return nnz
 
-cdef idxint _add_csr_scale(CSR a, CSR b, CSR c, double complex scale) nogil:
+
+cdef idxint _add_csr_scale(Accumulator *acc, CSR a, CSR b, CSR c, double complex scale) nogil:
     """
     Perform the operation
         c := a + scale*b
@@ -89,41 +91,30 @@ cdef idxint _add_csr_scale(CSR a, CSR b, CSR c, double complex scale) nogil:
 
     Return the true value of nnz(c).
     """
-    cdef:
-        idxint nrows=c.shape[0], ncols=c.shape[1]
-        idxint row, col_a, col_b
-        double complex tmp
-        # These all refer to "pointers" into the col_index or data arrays.
-        idxint ptr_a, ptr_b, ptr_c=0, max_ptr_a, max_ptr_b
-    c.row_index[0] = 0
-    for row in range(nrows):
-        ptr_a = a.row_index[row]
-        ptr_b = b.row_index[row]
-        max_ptr_a = a.row_index[row+1]
-        max_ptr_b = b.row_index[row+1]
-        while ptr_a < max_ptr_a or ptr_b < max_ptr_b:
-            col_a = a.col_index[ptr_a] if ptr_a < max_ptr_a else ncols + 1
-            col_b = b.col_index[ptr_b] if ptr_b < max_ptr_b else ncols + 1
+    cdef idxint row, ptr_a, ptr_b, ptr_a_max, ptr_b_max, nnz=0, col_a, col_b
+    cdef idxint ncols = a.shape[1]
+    c.row_index[0] = nnz
+    ptr_a_max = ptr_b_max = 0
+    for row in range(a.shape[0]):
+        ptr_a = ptr_a_max
+        ptr_a_max = a.row_index[row + 1]
+        ptr_b = ptr_b_max
+        ptr_b_max = b.row_index[row + 1]
+        col_a = a.col_index[ptr_a] if ptr_a < ptr_a_max else ncols + 1
+        col_b = b.col_index[ptr_b] if ptr_b < ptr_b_max else ncols + 1
+        while ptr_a < ptr_a_max or ptr_b < ptr_b_max:
             if col_a < col_b:
-                c.data[ptr_c] = a.data[ptr_a]
-                c.col_index[ptr_c] = col_a
+                acc_scatter(acc, a.data[ptr_a], col_a)
                 ptr_a += 1
-                ptr_c += 1
-            elif col_b < col_a:
-                c.data[ptr_c] = scale * b.data[ptr_b]
-                c.col_index[ptr_c] = col_b
+                col_a = a.col_index[ptr_a] if ptr_a < ptr_a_max else ncols + 1
+            else:
+                acc_scatter(acc, scale * b.data[ptr_b], col_b)
                 ptr_b += 1
-                ptr_c += 1
-            else:  # equal
-                tmp = a.data[ptr_a] + scale*b.data[ptr_b]
-                if tmp != 0:
-                    c.data[ptr_c] = tmp
-                    c.col_index[ptr_c] = col_a
-                    ptr_c += 1
-                ptr_a += 1
-                ptr_b += 1
-        c.row_index[row+1] = ptr_c
-    return ptr_c
+                col_b = b.col_index[ptr_b] if ptr_b < ptr_b_max else ncols + 1
+        nnz += acc_gather(acc, c.data + nnz, c.col_index + nnz)
+        acc_reset(acc)
+        c.row_index[row + 1] = nnz
+    return nnz
 
 
 cpdef CSR add_csr(CSR left, CSR right, double complex scale=1):
@@ -154,6 +145,7 @@ cpdef CSR add_csr(CSR left, CSR right, double complex scale=1):
     cdef idxint worst_nnz = left_nnz + right_nnz
     cdef idxint i
     cdef CSR out
+    cdef Accumulator acc
     # Fast paths for zero matrices.
     if right_nnz == 0 or scale == 0:
         return left.copy()
@@ -166,12 +158,12 @@ cpdef CSR add_csr(CSR left, CSR right, double complex scale=1):
         return out
     # Main path.
     out = csr.empty(left.shape[0], left.shape[1], worst_nnz)
-    left.sort_indices()
-    right.sort_indices()
+    acc = acc_alloc(left.shape[1])
     if scale == 1:
-        _add_csr(left, right, out)
+        _add_csr(&acc, left, right, out)
     else:
-        _add_csr_scale(left, right, out, scale)
+        _add_csr_scale(&acc, left, right, out, scale)
+    acc_free(&acc)
     return out
 
 
@@ -188,6 +180,7 @@ cdef Dense _add_dense_eq_order(Dense left, Dense right, double complex scale):
         blas.zaxpy(&size, &scale, right.data, &_ONE, out.data, &_ONE)
     return out
 
+
 cpdef Dense add_dense(Dense left, Dense right, double complex scale=1):
     _check_shape(left, right)
     if not (left.fortran ^ right.fortran):
@@ -201,6 +194,7 @@ cpdef Dense add_dense(Dense left, Dense right, double complex scale=1):
         for idx in range(dim2):
             blas.zaxpy(&dim1, &scale, right.data + idx, &dim2, out.data + idx*dim1, &_ONE)
     return out
+
 
 cpdef Dense iadd_dense(Dense left, Dense right, double complex scale=1):
     _check_shape(left, right)
@@ -217,11 +211,14 @@ cpdef Dense iadd_dense(Dense left, Dense right, double complex scale=1):
                            left.data + idx*dim1, &_ONE)
     return left
 
+
 cpdef CSR sub_csr(CSR left, CSR right):
     return add_csr(left, right, -1)
 
+
 cpdef Dense sub_dense(Dense left, Dense right):
     return add_dense(left, right, -1)
+
 
 from .dispatch import Dispatcher as _Dispatcher
 import inspect as _inspect

--- a/qutip/core/data/add.pyx
+++ b/qutip/core/data/add.pyx
@@ -9,9 +9,7 @@ from scipy.linalg cimport cython_blas as blas
 
 from qutip.core.data.base cimport idxint, Data
 from qutip.core.data.dense cimport Dense
-from qutip.core.data.csr cimport (
-    CSR, Accumulator, acc_alloc, acc_free, acc_scatter, acc_gather, acc_reset,
-)
+from qutip.core.data.csr cimport CSR
 from qutip.core.data cimport csr, dense
 
 cnp.import_array()
@@ -22,7 +20,7 @@ cdef extern from *:
     void PyDataMem_FREE(void *ptr)
 
 __all__ = [
-    'add', 'add_csr', 'add_dense',
+    'add', 'add_csr', 'add_dense', 'iadd_dense',
     'sub', 'sub_csr', 'sub_dense',
 ]
 
@@ -37,7 +35,7 @@ cdef void _check_shape(Data left, Data right) nogil except *:
             + str(right.shape)
         )
 
-cdef idxint _add_csr(Accumulator *acc, CSR a, CSR b, CSR c) nogil:
+cdef idxint _add_csr(CSR a, CSR b, CSR c) nogil:
     """
     Perform the operation
         c := a + b
@@ -46,39 +44,43 @@ cdef idxint _add_csr(Accumulator *acc, CSR a, CSR b, CSR c) nogil:
 
     Return the true value of nnz(c).
     """
-    cdef idxint row, ptr_a, ptr_b, ptr_a_max, ptr_b_max, nnz=0, col_a, col_b
-    cdef idxint ncols = a.shape[1]
-    c.row_index[0] = nnz
-    ptr_a_max = ptr_b_max = 0
-    for row in range(a.shape[0]):
-        ptr_a = ptr_a_max
-        ptr_a_max = a.row_index[row + 1]
-        ptr_b = ptr_b_max
-        ptr_b_max = b.row_index[row + 1]
-        col_a = a.col_index[ptr_a] if ptr_a < ptr_a_max else ncols + 1
-        col_b = b.col_index[ptr_b] if ptr_b < ptr_b_max else ncols + 1
-        # We use this method of going through the row to give the Accumulator
-        # the best chance of receiving the scatters in a sorted order.  We
-        # could also safely iterate through a completely then b, which would be
-        # more cache efficient, but would quite often require a sort within the
-        # gather, making the algorithimic complexity worse.
-        while ptr_a < ptr_a_max or ptr_b < ptr_b_max:
+    cdef:
+        idxint nrows=c.shape[0], ncols=c.shape[1]
+        idxint row, col_a, col_b
+        double complex tmp
+        # These all refer to "pointers" into the col_index or data arrays.
+        idxint ptr_a, ptr_b, ptr_c=0, max_ptr_a, max_ptr_b
+    c.row_index[0] = 0
+    for row in range(nrows):
+        ptr_a = a.row_index[row]
+        ptr_b = b.row_index[row]
+        max_ptr_a = a.row_index[row+1]
+        max_ptr_b = b.row_index[row+1]
+        while ptr_a < max_ptr_a or ptr_b < max_ptr_b:
+            col_a = a.col_index[ptr_a] if ptr_a < max_ptr_a else ncols + 1
+            col_b = b.col_index[ptr_b] if ptr_b < max_ptr_b else ncols + 1
             if col_a < col_b:
-                acc_scatter(acc, a.data[ptr_a], col_a)
+                c.data[ptr_c] = a.data[ptr_a]
+                c.col_index[ptr_c] = col_a
                 ptr_a += 1
-                col_a = a.col_index[ptr_a] if ptr_a < ptr_a_max else ncols + 1
-            else:
-                acc_scatter(acc, b.data[ptr_b], col_b)
+                ptr_c += 1
+            elif col_b < col_a:
+                c.data[ptr_c] = b.data[ptr_b]
+                c.col_index[ptr_c] = col_b
                 ptr_b += 1
-                col_b = b.col_index[ptr_b] if ptr_b < ptr_b_max else ncols + 1
-            # There's no need to test col_a == col_b because the Accumulator
-            # already tests that in all scatters anyway.
-        nnz += acc_gather(acc, c.data + nnz, c.col_index + nnz)
-        acc_reset(acc)
-        c.row_index[row + 1] = nnz
-    return nnz
+                ptr_c += 1
+            else:  # equal
+                tmp = a.data[ptr_a] + b.data[ptr_b]
+                if tmp != 0:
+                    c.data[ptr_c] = tmp
+                    c.col_index[ptr_c] = col_a
+                    ptr_c += 1
+                ptr_a += 1
+                ptr_b += 1
+        c.row_index[row+1] = ptr_c
+    return ptr_c
 
-cdef idxint _add_csr_scale(Accumulator *acc, CSR a, CSR b, CSR c, double complex scale) nogil:
+cdef idxint _add_csr_scale(CSR a, CSR b, CSR c, double complex scale) nogil:
     """
     Perform the operation
         c := a + scale*b
@@ -87,30 +89,42 @@ cdef idxint _add_csr_scale(Accumulator *acc, CSR a, CSR b, CSR c, double complex
 
     Return the true value of nnz(c).
     """
-    cdef idxint row, ptr_a, ptr_b, ptr_a_max, ptr_b_max, nnz=0, col_a, col_b
-    cdef idxint ncols = a.shape[1]
-    c.row_index[0] = nnz
-    ptr_a_max = ptr_b_max = 0
-    for row in range(a.shape[0]):
-        ptr_a = ptr_a_max
-        ptr_a_max = a.row_index[row + 1]
-        ptr_b = ptr_b_max
-        ptr_b_max = b.row_index[row + 1]
-        col_a = a.col_index[ptr_a] if ptr_a < ptr_a_max else ncols + 1
-        col_b = b.col_index[ptr_b] if ptr_b < ptr_b_max else ncols + 1
-        while ptr_a < ptr_a_max or ptr_b < ptr_b_max:
+    cdef:
+        idxint nrows=c.shape[0], ncols=c.shape[1]
+        idxint row, col_a, col_b
+        double complex tmp
+        # These all refer to "pointers" into the col_index or data arrays.
+        idxint ptr_a, ptr_b, ptr_c=0, max_ptr_a, max_ptr_b
+    c.row_index[0] = 0
+    for row in range(nrows):
+        ptr_a = a.row_index[row]
+        ptr_b = b.row_index[row]
+        max_ptr_a = a.row_index[row+1]
+        max_ptr_b = b.row_index[row+1]
+        while ptr_a < max_ptr_a or ptr_b < max_ptr_b:
+            col_a = a.col_index[ptr_a] if ptr_a < max_ptr_a else ncols + 1
+            col_b = b.col_index[ptr_b] if ptr_b < max_ptr_b else ncols + 1
             if col_a < col_b:
-                acc_scatter(acc, a.data[ptr_a], col_a)
+                c.data[ptr_c] = a.data[ptr_a]
+                c.col_index[ptr_c] = col_a
                 ptr_a += 1
-                col_a = a.col_index[ptr_a] if ptr_a < ptr_a_max else ncols + 1
-            else:
-                acc_scatter(acc, scale * b.data[ptr_b], col_b)
+                ptr_c += 1
+            elif col_b < col_a:
+                c.data[ptr_c] = scale * b.data[ptr_b]
+                c.col_index[ptr_c] = col_b
                 ptr_b += 1
-                col_b = b.col_index[ptr_b] if ptr_b < ptr_b_max else ncols + 1
-        nnz += acc_gather(acc, c.data + nnz, c.col_index + nnz)
-        acc_reset(acc)
-        c.row_index[row + 1] = nnz
-    return nnz
+                ptr_c += 1
+            else:  # equal
+                tmp = a.data[ptr_a] + scale*b.data[ptr_b]
+                if tmp != 0:
+                    c.data[ptr_c] = tmp
+                    c.col_index[ptr_c] = col_a
+                    ptr_c += 1
+                ptr_a += 1
+                ptr_b += 1
+        c.row_index[row+1] = ptr_c
+    return ptr_c
+
 
 cpdef CSR add_csr(CSR left, CSR right, double complex scale=1):
     """
@@ -140,7 +154,6 @@ cpdef CSR add_csr(CSR left, CSR right, double complex scale=1):
     cdef idxint worst_nnz = left_nnz + right_nnz
     cdef idxint i
     cdef CSR out
-    cdef Accumulator acc
     # Fast paths for zero matrices.
     if right_nnz == 0 or scale == 0:
         return left.copy()
@@ -153,13 +166,20 @@ cpdef CSR add_csr(CSR left, CSR right, double complex scale=1):
         return out
     # Main path.
     out = csr.empty(left.shape[0], left.shape[1], worst_nnz)
-    acc = acc_alloc(left.shape[1])
+    left.sort_indices()
+    right.sort_indices()
     if scale == 1:
-        _add_csr(&acc, left, right, out)
+        _add_csr(left, right, out)
     else:
-        _add_csr_scale(&acc, left, right, out, scale)
-    acc_free(&acc)
+        _add_csr_scale(left, right, out, scale)
     return out
+
+
+cdef void add_dense_eq_order_inplace(Dense left, Dense right, double complex scale):
+    cdef int size = left.shape[0] * left.shape[1]
+    with nogil:
+        blas.zaxpy(&size, &scale, right.data, &_ONE, left.data, &_ONE)
+
 
 cdef Dense _add_dense_eq_order(Dense left, Dense right, double complex scale):
     cdef Dense out = left.copy()
@@ -182,12 +202,26 @@ cpdef Dense add_dense(Dense left, Dense right, double complex scale=1):
             blas.zaxpy(&dim1, &scale, right.data + idx, &dim2, out.data + idx*dim1, &_ONE)
     return out
 
+cpdef Dense iadd_dense(Dense left, Dense right, double complex scale=1):
+    _check_shape(left, right)
+    cdef int size = left.shape[0] * left.shape[1]
+    cdef int dim1, dim2
+    cdef size_t nrows=left.shape[0], ncols=left.shape[1], idx
+    dim1, dim2 = (nrows, ncols) if left.fortran else (ncols, nrows)
+    with nogil:
+        if not (left.fortran ^ right.fortran):
+            blas.zaxpy(&size, &scale, right.data, &_ONE, left.data, &_ONE)
+        else:
+            for idx in range(dim2):
+                blas.zaxpy(&dim1, &scale, right.data + idx, &dim2,
+                           left.data + idx*dim1, &_ONE)
+    return left
+
 cpdef CSR sub_csr(CSR left, CSR right):
     return add_csr(left, right, -1)
 
 cpdef Dense sub_dense(Dense left, Dense right):
     return add_dense(left, right, -1)
-
 
 from .dispatch import Dispatcher as _Dispatcher
 import inspect as _inspect

--- a/qutip/core/data/expect.pxd
+++ b/qutip/core/data/expect.pxd
@@ -8,3 +8,6 @@ cpdef double complex expect_super_csr(CSR op, CSR state) nogil except *
 
 cpdef double complex expect_csr_dense(CSR op, Dense state) nogil except *
 cpdef double complex expect_super_csr_dense(CSR op, Dense state) nogil except *
+
+cpdef double complex expect_dense_dense(Dense op, Dense state) nogil except *
+cpdef double complex expect_super_dense_dense(Dense op, Dense state) nogil except *

--- a/qutip/core/data/expect.pxd
+++ b/qutip/core/data/expect.pxd
@@ -1,7 +1,7 @@
 #cython: language_level=3
 #cython: boundscheck=False, wraparound=False, initializedcheck=False
 
-from qutip.core.data cimport CSR, Dense
+from qutip.core.data cimport CSR, Dense, Data
 
 cpdef double complex expect_csr(CSR op, CSR state) nogil except *
 cpdef double complex expect_super_csr(CSR op, CSR state) nogil except *
@@ -9,5 +9,8 @@ cpdef double complex expect_super_csr(CSR op, CSR state) nogil except *
 cpdef double complex expect_csr_dense(CSR op, Dense state) nogil except *
 cpdef double complex expect_super_csr_dense(CSR op, Dense state) nogil except *
 
-cpdef double complex expect_dense_dense(Dense op, Dense state) nogil except *
-cpdef double complex expect_super_dense_dense(Dense op, Dense state) nogil except *
+cpdef double complex expect_dense(Dense op, Dense state) nogil except *
+cpdef double complex expect_super_dense(Dense op, Dense state) nogil except *
+
+cdef double complex expect_data_dense(Data op, Dense state)
+cdef double complex expect_super_data_dense(Data op, Dense state)

--- a/qutip/core/data/expect.pyx
+++ b/qutip/core/data/expect.pyx
@@ -15,8 +15,9 @@ from qutip.core.data.base cimport idxint, Data
 from qutip.core.data cimport csr, CSR, Dense
 
 __all__ = [
-    'expect', 'expect_csr', 'expect_csr_dense',
-    'expect_super', 'expect_super_csr', 'expect_super_csr_dense',
+    'expect', 'expect_csr', 'expect_csr_dense', 'expect_dense_dense',
+    'expect_super', 'expect_super_csr',
+    'expect_super_csr_dense', 'expect_super_dense_dense',
 ]
 
 cdef void _check_shape_ket(Data op, Data state) nogil except *:
@@ -110,7 +111,6 @@ cpdef double complex expect_csr(CSR op, CSR state) nogil except *:
         return _expect_csr_ket(op, state)
     return _expect_csr_dm(op, state)
 
-
 cdef double complex _expect_csr_dense_ket(CSR op, Dense state) nogil except *:
     _check_shape_ket(op, state)
     cdef double complex out=0, sum
@@ -139,6 +139,38 @@ cdef double complex _expect_csr_dense_dm(CSR op, Dense state) nogil except *:
     return out
 
 
+cdef double complex _expect_dense_dense_ket(Dense op, Dense state) nogil except *:
+    _check_shape_ket(op, state)
+    cdef double complex out=0, sum
+    cdef size_t row, col, op_row_stride, op_col_stride
+    op_row_stride = 1 if op.fortran else op.shape[1]
+    op_col_stride = op.shape[0] if op.fortran else 1
+
+    for row in range(op.shape[0]):
+        sum = 0
+        for col in range(op.shape[0]):
+            sum += (op.data[row * op_row_stride + col * op_col_stride] *
+                    state.data[col])
+        out += sum * conj(state.data[row])
+    return out
+
+cdef double complex _expect_dense_dense_dm(Dense op, Dense state) nogil except *:
+    _check_shape_dm(op, state)
+    cdef double complex out=0
+    cdef size_t row, col, op_row_stride, op_col_stride
+    cdef size_t state_row_stride, state_col_stride
+    state_row_stride = 1 if state.fortran else state.shape[1]
+    state_col_stride = state.shape[0] if state.fortran else 1
+    op_row_stride = 1 if op.fortran else op.shape[1]
+    op_col_stride = op.shape[0] if op.fortran else 1
+
+    for row in range(op.shape[0]):
+        for col in range(op.shape[1]):
+            out += op.data[row * op_row_stride + col * op_col_stride] * \
+                   state.data[col * state_row_stride + row * state_col_stride]
+    return out
+
+
 cpdef double complex expect_csr_dense(CSR op, Dense state) nogil except *:
     """
     Get the expectation value of the operator `op` over the state `state`.  The
@@ -154,6 +186,21 @@ cpdef double complex expect_csr_dense(CSR op, Dense state) nogil except *:
     return _expect_csr_dense_dm(op, state)
 
 
+cpdef double complex expect_dense_dense(Dense op, Dense state) nogil except *:
+    """
+    Get the expectation value of the operator `op` over the state `state`.  The
+    state can be either a ket or a density matrix.
+
+    The expectation of a state is defined as the operation:
+        state.adjoint() @ op @ state
+    and of a density matrix:
+        tr(op @ state)
+    """
+    if state.shape[1] == 1:
+        return _expect_dense_dense_ket(op, state)
+    return _expect_dense_dense_dm(op, state)
+
+
 cpdef double complex expect_super_csr_dense(CSR op, Dense state) nogil except *:
     """
     Perform the operation `tr(op @ state)` where `op` is supplied as a
@@ -166,6 +213,27 @@ cpdef double complex expect_super_csr_dense(CSR op, Dense state) nogil except *:
     for _ in range(n):
         for ptr in range(op.row_index[row], op.row_index[row + 1]):
             out += op.data[ptr] * state.data[op.col_index[ptr]]
+        row += n + 1
+    return out
+
+
+cpdef double complex expect_super_dense_dense(Dense op, Dense state) nogil except *:
+    """
+    Perform the operation `tr(op @ state)` where `op` is supplied as a
+    superoperator, and `state` is a column-stacked operator.
+    """
+    _check_shape_super(op, state)
+    cdef double complex out=0
+    cdef size_t row=0, col, N = state.shape[0]
+    cdef size_t n = <size_t> sqrt(state.shape[0])
+    cdef size_t op_row_stride, op_col_stride
+    op_row_stride = 1 if op.fortran else op.shape[1]
+    op_col_stride = op.shape[0] if op.fortran else 1
+
+    for _ in range(n):
+        for col in range(N):
+            out += op.data[row * op_row_stride + col * op_col_stride] * \
+                   state.data[col]
         row += n + 1
     return out
 
@@ -196,6 +264,7 @@ expect.__doc__ =\
 expect.add_specialisations([
     (CSR, CSR, expect_csr),
     (CSR, Dense, expect_csr_dense),
+    (Dense, Dense, expect_dense_dense),
 ], _defer=True)
 
 expect_super = _Dispatcher(
@@ -217,6 +286,7 @@ expect_super.__doc__ =\
 expect_super.add_specialisations([
     (CSR, CSR, expect_super_csr),
     (CSR, Dense, expect_super_csr_dense),
+    (Dense, Dense, expect_super_dense_dense),
 ], _defer=True)
 
 del _inspect, _Dispatcher

--- a/qutip/core/data/matmul.pxd
+++ b/qutip/core/data/matmul.pxd
@@ -2,7 +2,10 @@
 
 from qutip.core.data.csr cimport CSR
 from qutip.core.data.dense cimport Dense
+from qutip.core.data.base cimport Data
 
 cpdef CSR matmul_csr(CSR left, CSR right, double complex scale=*, CSR out=*)
 cpdef Dense matmul_dense(Dense left, Dense right, double complex scale=*, Dense out=*)
 cpdef Dense matmul_csr_dense_dense(CSR left, Dense right, double complex scale=*, Dense out=*)
+cdef Dense matmul_data_dense(Data left, Dense right)
+cdef void imatmul_data_dense(Data left, Dense right, double complex scale, Dense out)

--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -17,6 +17,7 @@ from qutip.core.data.base cimport idxint, Data
 from qutip.core.data.dense cimport Dense
 from qutip.core.data.csr cimport CSR
 from qutip.core.data cimport csr, dense
+from qutip.core.data.add cimport iadd_dense
 
 cnp.import_array()
 
@@ -328,3 +329,23 @@ matmul.add_specialisations([
 ], _defer=True)
 
 del _inspect, _Dispatcher
+
+
+cdef Dense matmul_data_dense(Data left, Dense right):
+    cdef Dense out
+    if type(left) is CSR:
+        out = matmul_csr_dense_dense(left, right)
+    elif type(left) is Dense:
+        out = matmul_dense(left, right)
+    else:
+        out = matmul(left, right)
+    return out
+
+
+cdef void imatmul_data_dense(Data left, Dense right, double complex scale, Dense out):
+    if type(left) is CSR:
+        matmul_csr_dense_dense(left, right, scale, out)
+    elif type(left) is Dense:
+        matmul_dense(left, right, scale, out)
+    else:
+        iadd_dense(out, matmul(left, right), scale)

--- a/qutip/core/data/mul.pxd
+++ b/qutip/core/data/mul.pxd
@@ -2,8 +2,10 @@
 
 from qutip.core.data cimport CSR, Dense
 
+cpdef void mul_csr_inplace(CSR matrix, double complex value)
 cpdef CSR mul_csr(CSR matrix, double complex value)
 cpdef CSR neg_csr(CSR matrix)
 
+cpdef void mul_dense_inplace(Dense matrix, double complex value)
 cpdef Dense mul_dense(Dense matrix, double complex value)
 cpdef Dense neg_dense(Dense matrix)

--- a/qutip/core/data/mul.pxd
+++ b/qutip/core/data/mul.pxd
@@ -2,10 +2,10 @@
 
 from qutip.core.data cimport CSR, Dense
 
-cpdef void mul_csr_inplace(CSR matrix, double complex value)
+cpdef CSR mul_csr_inplace(CSR matrix, double complex value)
 cpdef CSR mul_csr(CSR matrix, double complex value)
 cpdef CSR neg_csr(CSR matrix)
 
-cpdef void mul_dense_inplace(Dense matrix, double complex value)
+cpdef Dense mul_dense_inplace(Dense matrix, double complex value)
 cpdef Dense mul_dense(Dense matrix, double complex value)
 cpdef Dense neg_dense(Dense matrix)

--- a/qutip/core/data/mul.pxd
+++ b/qutip/core/data/mul.pxd
@@ -2,10 +2,10 @@
 
 from qutip.core.data cimport CSR, Dense
 
-cpdef CSR mul_csr_inplace(CSR matrix, double complex value)
+cpdef CSR imul_csr(CSR matrix, double complex value)
 cpdef CSR mul_csr(CSR matrix, double complex value)
 cpdef CSR neg_csr(CSR matrix)
 
-cpdef Dense mul_dense_inplace(Dense matrix, double complex value)
+cpdef Dense imul_dense(Dense matrix, double complex value)
 cpdef Dense mul_dense(Dense matrix, double complex value)
 cpdef Dense neg_dense(Dense matrix)

--- a/qutip/core/data/mul.pyx
+++ b/qutip/core/data/mul.pyx
@@ -5,6 +5,7 @@ from qutip.core.data cimport idxint, csr, CSR, dense, Dense
 
 __all__ = [
     'mul', 'mul_csr', 'mul_dense',
+    'imul', 'imul_csr', 'imul_dense',
     'neg', 'neg_csr', 'neg_dense',
 ]
 
@@ -17,7 +18,6 @@ cpdef CSR imul_csr(CSR matrix, double complex value):
             matrix.data[ptr] *= value
     return matrix
 
-
 cpdef CSR mul_csr(CSR matrix, double complex value):
     """Multiply this CSR `matrix` by a complex scalar `value`."""
     if value == 0:
@@ -28,7 +28,6 @@ cpdef CSR mul_csr(CSR matrix, double complex value):
         for ptr in range(csr.nnz(matrix)):
             out.data[ptr] = value * matrix.data[ptr]
     return out
-
 
 cpdef CSR neg_csr(CSR matrix):
     """Unary negation of this CSR `matrix`.  Return a new object."""
@@ -48,7 +47,6 @@ cpdef Dense imul_dense(Dense matrix, double complex value):
             matrix.data[ptr] *= value
     return matrix
 
-
 cpdef Dense mul_dense(Dense matrix, double complex value):
     """Multiply this Dense `matrix` by a complex scalar `value`."""
     cdef Dense out = dense.empty_like(matrix)
@@ -57,7 +55,6 @@ cpdef Dense mul_dense(Dense matrix, double complex value):
         for ptr in range(matrix.shape[0]*matrix.shape[1]):
             out.data[ptr] = value * matrix.data[ptr]
     return out
-
 
 cpdef Dense neg_dense(Dense matrix):
     """Unary negation of this CSR `matrix`.  Return a new object."""
@@ -89,22 +86,22 @@ mul.add_specialisations([
     (Dense, Dense, mul_dense),
 ], _defer=True)
 
-mul_inplace = _Dispatcher(
+imul = _Dispatcher(
     # Will not be inplce if specialisation does not exist but should still
     # give expected results if used as:
-    # mat = mul_inplace(mat, x)
+    # mat = imul(mat, x)
     _inspect.Signature([
         _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
         _inspect.Parameter('value', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
     ]),
-    name='mul_inplace',
+    name='imul',
     module=__name__,
     inputs=('matrix',),
     out=True,
 )
-mul_inplace.__doc__ =\
+imul.__doc__ =\
     """Multiply inplace a matrix element-wise by a scalar."""
-mul_inplace.add_specialisations([
+imul.add_specialisations([
     (CSR, CSR, imul_csr),
     (Dense, Dense, imul_dense),
 ], _defer=True)

--- a/qutip/core/data/mul.pyx
+++ b/qutip/core/data/mul.pyx
@@ -9,7 +9,7 @@ __all__ = [
 ]
 
 
-cpdef CSR mul_csr_inplace(CSR matrix, double complex value):
+cpdef CSR imul_csr(CSR matrix, double complex value):
     """Multiply this CSR `matrix` by a complex scalar `value`."""
     cdef idxint ptr
     with nogil:
@@ -40,7 +40,7 @@ cpdef CSR neg_csr(CSR matrix):
     return out
 
 
-cpdef Dense mul_dense_inplace(Dense matrix, double complex value):
+cpdef Dense imul_dense(Dense matrix, double complex value):
     """Multiply this Dense `matrix` by a complex scalar `value`."""
     cdef size_t ptr
     with nogil:
@@ -105,8 +105,8 @@ mul_inplace = _Dispatcher(
 mul_inplace.__doc__ =\
     """Multiply inplace a matrix element-wise by a scalar."""
 mul_inplace.add_specialisations([
-    (CSR, CSR, mul_csr_inplace),
-    (Dense, Dense, mul_dense_inplace),
+    (CSR, CSR, imul_csr),
+    (Dense, Dense, imul_dense),
 ], _defer=True)
 
 neg = _Dispatcher(

--- a/qutip/core/data/project.pyx
+++ b/qutip/core/data/project.pyx
@@ -96,7 +96,7 @@ cpdef Dense project_dense(Dense state):
     function will be identical is passed `state` or `adjoint(state)`.
     """
     cdef Dense out
-    cdef size_t size, i, h
+    cdef size_t size, i
     cdef bint fortran
     if state.shape[1] == 1:
         size = state.shape[0]

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -666,7 +666,7 @@ class Qobj:
             cols += list(range(n_cols - half_length, n_cols))
         # Make the data array.
         data = r'\begin{equation*}\left(\begin{array}{*{11}c}'
-        data += r"\\".join(_latex_row(row, cols, self.data.as_scipy())
+        data += r"\\".join(_latex_row(row, cols, self.data.to_array())
                            for row in rows)
         data += r'\end{array}\right)\end{equation*}'
         return self._str_header() + data

--- a/qutip/core/qobjevo.py
+++ b/qutip/core/qobjevo.py
@@ -739,7 +739,7 @@ class QobjEvo(QobjEvoBase):
     # function to linear_map custom transformations
     def linear_map(self, op_mapping):
         """
-        Apply function to each Qobj contribution.
+        Apply mapping to each Qobj contribution.
 
         Example:
         `QobjEvo([sigmax(), coeff]).linear_map(spre)`

--- a/qutip/core/qobjevo.py
+++ b/qutip/core/qobjevo.py
@@ -77,10 +77,10 @@ class QobjEvoBase:
             raise TypeError("time needs to be a real scalar")
         if isinstance(state, Qobj):
             state = state.data
-        elif isinstance(state, np.ndarray):
-            state = _data.dense.fast_from_numpy(state)
         elif isinstance(state, _data.Data):
             pass
+        elif isinstance(state, np.ndarray):
+            state = _data.dense.fast_from_numpy(state)
         else:
             raise TypeError("The vector must be an array or Qobj")
 
@@ -110,25 +110,29 @@ class QobjEvoBase:
         was_data = False
         if not isinstance(t, (int, float)):
             raise TypeError("the time need to be a real scalar")
+
         if isinstance(mat, Qobj):
             if self.dims[1] != mat.dims[0]:
                 raise Exception("Dimensions do not fit")
             was_Qobj = True
-            dims = mat.dims
+            dims = [self.dims[0], mat.dims[1]]
             mat = mat.data
+
+        elif isinstance(mat, _data.Data):
+            was_data = True
+
         elif isinstance(mat, np.ndarray):
             if mat.ndim == 1:
-                # TODO: do this properly.
                 mat = _data.dense.fast_from_numpy(mat)
                 was_vec = True
             elif mat.ndim == 2:
                 mat = _data.dense.fast_from_numpy(mat)
             else:
                 raise Exception("The matrice must be 1d or 2d")
-        elif isinstance(mat, _data.Data):
-            was_data = True
+
         else:
             raise TypeError("The vector must be an array or Qobj")
+
         if mat.shape[0] != self.shape[1]:
             raise Exception("The length do not match")
 
@@ -136,10 +140,10 @@ class QobjEvoBase:
 
         if was_Qobj:
             return Qobj(out, dims=dims)
-        elif was_vec:
-            return out.as_ndarray()[:, 0]
         elif was_data:
             return out
+        elif was_vec:
+            return out.as_ndarray()[:, 0]
         else:
             return out.as_ndarray()
 
@@ -340,6 +344,7 @@ class QobjEvo(QobjEvoBase):
         if isinstance(Q_object, Qobj):
             self.cte = Q_object
             self.const = True
+
         elif isinstance(Q_object, list):
             use_step_func = self.args.get("_step_func_coeff", 0)
             for op in Q_object:

--- a/qutip/core/qobjevofunc.py
+++ b/qutip/core/qobjevofunc.py
@@ -1,0 +1,581 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+"""Time-dependent Quantum Object (QobjEvo) wrapper class
+for function returning Qobj.
+"""
+__all__ = ['QobjEvoFunc']
+
+from .qobj import Qobj
+from .qobjevo import QobjEvo, QobjEvoBase
+import numpy as np
+from .cy.cqobjevo import CQobjFunc
+from .superoperator import *
+
+
+class QobjEvoFunc(QobjEvoBase):
+    """A class for representing time-dependent quantum objects,
+    such as quantum operators and states from a function or callable.
+
+    The QobjEvoFunc class is a representation of time-dependent Qutip quantum
+    objects (Qobj). This class implements math operations :
+        +,- : QobjEvo[Func], Qobj
+        * : QobjEvo[Func], Qobj, Complex-number
+        / : Complex-number
+    and some common linear operator/state operations. The QobjEvoFunc is
+    constructed from a function that return a Qobj from time and extra
+    arguments.
+
+    The signature of the function must be
+    - f(t, args) -> Qobj
+
+    args is a dict of (key: object). The keys must be a valid variables string.
+
+    Parameters
+    ----------
+    QobjEvoFunc(Q_object=[], args={}, copy=True)
+
+    Q_object : callable
+        Function/method that return the Qobj at time t.
+
+    args : dictionary that contain the arguments for function.
+
+    copy : bool
+        If Q_object is already a QobjEvoFunc, return a copy.
+
+    Attributes
+    ----------
+    func : callable
+        Funtion wrapped to a Qobj.
+
+    cte : Qobj
+        Value at time 0. (To obtain the dimensions, etc.)
+
+    args : map
+        arguments of the coefficients
+
+    compiled_qobjevo : cy_qobj
+        Cython version of the QobjEvo
+
+    const : bool
+        Indicates if quantum object is Constant
+
+    operation_stack : list of _Block_transform
+        List of operation that are done on the Qobj.
+        ex. func -> liouvillian -> + Qobj
+
+    Methods
+    -------
+    copy() :
+        Create copy of QobjEvoFunc
+
+    arguments(new_args):
+        Update the args and set the dynamics_args
+
+    Math:
+        +/- QobjEvo, Qobj, scalar:
+            Addition is possible between QobjEvo and with Qobj or scalar
+        -
+            Negation operator
+        * Qobj, scalar:
+            Product is possible with Qobj or scalar
+        / scalar:
+            It is possible to divide by scalar only
+
+    conj()
+        Return the conjugate of quantum object.
+
+    dag()
+        Return the adjoint (dagger) of quantum object.
+
+    trans()
+        Return the transpose of quantum object.
+
+    norm()
+        Return self.dag() * self.
+        Only possible if num_obj == 1
+
+    permute(order)
+        Returns composite qobj with indices reordered.
+
+    &
+        tensor between Quantum Object
+
+    apply(f, *args, **kw_args)
+        Apply a transformation function to the Quantum Object
+
+    __call__(t, args={}, data=False):
+        Return the Qobj at time t.
+
+    mul(t, mat):
+        Product of this at t time with a Qobj or np.ndarray.
+
+    expect(t, psi, herm=False):
+        Calculates the expectation value for the quantum object (if operator,
+            no check) and state psi.
+        Return only the real part if `herm` is True.
+    """
+    def __init__(self, Q_object=[], args={}, copy=True):
+        if isinstance(Q_object, QobjEvoFunc):
+            if copy:
+                self.cte = Q_object.cte.copy()
+                self.args = Q_object.args.copy()
+                self.operation_stack = [oper.copy()
+                                        for oper in Q_object.operation_stack]
+                self._shifted = Q_object._shifted
+                self.func = Q_object.func
+                self.const = False
+                self.compiled_qobjevo = CQobjFunc(self)
+            else:
+                self.__dict__ = Q_object.__dict__
+            if args:
+                self.arguments(args, state, e_ops)
+            return
+
+        if not callable(Q_object):
+            raise TypeError("expected a function")
+        self.func = Q_object
+        self.cte = self.func(0, args)
+        if not isinstance(self.cte, Qobj):
+            raise TypeError("QobjEvoFunc require a "
+                            "function returning a Qobj")
+
+        self.args = args.copy() if copy else args
+
+        self.compiled_qobjevo = CQobjFunc(self)
+        self.operation_stack = []
+        self._shifted = False
+        self.const = False
+
+    def __call__(self, t, args={}, data=False):
+        try:
+            t = float(t)
+        except Exception as e:
+            raise TypeError("t should be a real scalar.") from e
+        out = self._get_qobj(t, args)
+        if data:
+            out = out.data
+        return out
+
+    def _get_qobj(self, t, args={}):
+        if args:
+            if not isinstance(args, dict):
+                raise TypeError("The new args must be in a dict")
+            now_args = self.args.copy()
+            now_args.update(args)
+        else:
+            now_args = self.args
+        if self._shifted:
+            t += now_args["_t0"]
+        qobj = self.func(t, now_args)
+        for transform in self.operation_stack:
+            qobj = transform(qobj, t, now_args)
+        return qobj
+
+    def copy(self):
+        new = QobjEvoFunc.__new__(QobjEvoFunc)
+        new.__dict__ = self.__dict__.copy()
+        new.compiled_qobjevo = CQobjFunc(new)
+        new.args = self.args.copy()
+        new.cte = self.cte.copy()
+        new.operation_stack = [oper.copy() for oper in self.operation_stack]
+        return new
+
+    def arguments(self, new_args, state=None, e_ops=[]):
+        if not isinstance(new_args, dict):
+            raise TypeError("The new args must be in a dict")
+        self.args.update(new_args)
+
+    # Math function
+    def __add__(self, other):
+        res = self.copy()
+        res += other
+        return res
+
+    def __radd__(self, other):
+        res = self.copy()
+        res += other
+        return res
+
+    def __iadd__(self, other):
+        if isinstance(other, (QobjEvo, QobjEvoFunc)):
+            self.operation_stack.append(_Block_Sum_Qoe(other))
+        elif isinstance(other, Qobj):
+            self.operation_stack.append(_Block_Sum(other))
+        else:
+            self.operation_stack.append(_Block_Sum(other))
+        if not self._check_validity():
+            self.operation_stack = self.operation_stack[:-1]
+            return NotImplemented
+        return self
+
+    def __sub__(self, other):
+        res = self.copy()
+        res -= other
+        return res
+
+    def __rsub__(self, other):
+        res = -self.copy()
+        res += other
+        return res
+
+    def __isub__(self, other):
+        self += (-other)
+        return self
+
+    def __mul__(self, other):
+        res = self.copy()
+        res *= other
+        return res
+
+    def __rmul__(self, other):
+        res = self.copy()
+        if isinstance(other, (QobjEvo, QobjEvoFunc)):
+            res.operation_stack.append(_Block_rmul_Qoe(other))
+        else:
+            res.operation_stack.append(_Block_rmul(other))
+        if not self._check_validity():
+            self.operation_stack = self.operation_stack[:-1]
+            raise Exception
+        return res
+
+    def __imul__(self, other):
+        if isinstance(other, (QobjEvo, QobjEvoFunc)):
+            self.operation_stack.append(_Block_mul_Qoe(other))
+        else:
+            self.operation_stack.append(_Block_mul(other))
+        if not self._check_validity():
+            self.operation_stack = self.operation_stack[:-1]
+            raise Exception
+        return self
+
+    def __matmul__(self, other):
+        res = self.copy()
+        res *= other
+        return res
+
+    def __rmatmul__(self, other):
+        res = self.copy()
+        if isinstance(other, (QobjEvo, QobjEvoFunc)):
+            res.operation_stack.append(_Block_rmul_Qoe(other))
+        else:
+            res.operation_stack.append(_Block_rmul(other))
+        if not self._check_validity():
+            self.operation_stack = self.operation_stack[:-1]
+            raise Exception
+        return res
+
+
+    def __imatmul__(self, other):
+        if isinstance(other, (QobjEvo, QobjEvoFunc)):
+            self.operation_stack.append(_Block_mul_Qoe(other))
+        else:
+            self.operation_stack.append(_Block_mul(other))
+        if not self._check_validity():
+            self.operation_stack = self.operation_stack[:-1]
+            raise Exception
+        return self
+
+
+    def __div__(self, other):
+        if isinstance(other, (int, float, complex,
+                              np.integer, np.floating, np.complexfloating)):
+            res = self.copy()
+            res *= other**(-1)
+            return res
+        else:
+            raise TypeError('Incompatible object for division')
+
+    def __idiv__(self, other):
+        if isinstance(other, (int, float, complex,
+                              np.integer, np.floating, np.complexfloating)):
+            self *= other**(-1)
+        else:
+            raise TypeError('Incompatible object for division')
+        return self
+
+    def __truediv__(self, other):
+        return self.__div__(other)
+
+    def __neg__(self):
+        res = self.copy()
+        res.operation_stack.append(_Block_neg())
+        return res
+
+    def __and__(self, other):
+        """
+        Syntax shortcut for tensor:
+        A & B ==> tensor(A, B)
+        """
+        return self._tensor(other)
+
+    # Transformations
+    def trans(self):
+        res = self.copy()
+        res.operation_stack.append(_Block_trans())
+        return res
+
+    def conj(self):
+        res = self.copy()
+        res.operation_stack.append(_Block_conj())
+        return res
+
+    def dag(self):
+        res = self.copy()
+        res.operation_stack.append(_Block_dag())
+        return res
+
+    def _cdc(self):
+        """return a.dag * a """
+        res = self.copy()
+        res.operation_stack.append(_Block_cdc())
+        return res
+
+    def _tensor(self, other):
+        res = self.copy()
+        res.operation_stack.append(_Block_tensor_l(other))
+        res._check_validity()
+        return res
+
+    def _tensor_left(self, other):
+        res = self.copy()
+        res.operation_stack.append(_Block_tensor_r(other))
+        res._check_validity()
+        return res
+
+    def _spre(self):
+        res = self.copy()
+        res.operation_stack.append(_Block_pre())
+        res._check_validity()
+        return res
+
+    def _spost(self):
+        res = self.copy()
+        res.operation_stack.append(_Block_post())
+        res._check_validity()
+        return res
+
+    def _lindblad_dissipator(self, chi=0):
+        res = self.copy()
+        chi = 0 if chi is None else chi
+        res.operation_stack.append(_Block_lindblad_dissipator(chi))
+        res._check_validity()
+        return res
+
+    def _prespostdag(self):
+        """return spre(a) * spost(a.dag()) """
+        res = self.copy()
+        res.operation_stack.append(_Block_prespostdag())
+        res._check_validity()
+        return res
+
+    def _liouvillian_h(self):
+        """return 1j * (spre(a) - spost(a)) """
+        res = self.copy()
+        res.operation_stack.append(_Block_liouvillian_H())
+        res._check_validity()
+        return res
+
+    def _shift(self):
+        """shift t by args("_t0") """
+        res = self.copy()
+        res._shifted = True
+        res.args["_t0"] = 0
+        return res
+
+    # Unitary function of Qobj
+    def tidyup(self, atol=1e-12):
+        for transform in self.operation_stack:
+            transform.tidyup(atol)
+        return self
+
+    def compress(self):
+        pass
+
+    def permute(self, order):
+        """
+        Permute tensor subspaces of the quantum object
+        """
+        res = self.copy()
+        res.operation_stack.append(_Block_permute(order))
+        return res
+
+    def _check_validity(self):
+        try:
+            self.cte = self.__call__(0)
+            self.compiled_qobjevo.reset_shape()
+        except Exception:
+            return False
+        return True
+
+    # function to apply custom transformations
+    def apply(self, function, *args, **kw_args):
+        """
+        Apply function to each Qobj contribution.
+        """
+        if function is spre:
+            return self._spre
+        if function is spost:
+            return self._spost
+
+        res = self.copy()
+        res.operation_stack.append(_Block_apply(function, args, kw_args))
+        res._check_validity()
+        return res
+
+
+class _Block_transform:
+    def __init__(self, other=None):
+        self.other = other
+
+    def tidyup(self, atol):
+        pass
+
+    def copy(self):
+        return self.__class__(self.other)
+
+    def __call__(self, obj, t, args={}):
+        return obj
+
+
+class _Block_neg(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return -obj
+
+
+class _Block_Sum(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return obj + self.other
+
+
+class _Block_mul(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return obj * self.other
+
+
+class _Block_rmul(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return self.other * obj
+
+
+class _Block_Sum_Qoe(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return obj + self.other(t, args=args)
+
+
+class _Block_mul_Qoe(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return obj * self.other(t, args=args)
+
+
+class _Block_rmul_Qoe(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return self.other(t, args=args) * obj
+
+
+class _Block_tensor_l(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        if isinstance(self.other, (QobjEvo, QobjEvoFunc)):
+            return tensor(obj, self.other(t, args))
+        return tensor(obj, self.other)
+
+
+class _Block_tensor_r(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        if isinstance(self.other, (QobjEvo, QobjEvoFunc)):
+            return tensor(self.other(t, args), obj)
+        return tensor(self.other, obj)
+
+
+class _Block_trans(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return obj.trans()
+
+
+class _Block_conj(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return obj.conj()
+
+
+class _Block_dag(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return obj.dag()
+
+
+class _Block_cdc(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return obj.dag() * obj
+
+
+class _Block_prespostdag(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return spre(obj) * spost(obj.dag())
+
+
+class _Block_permute(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return obj.permute(self.other)
+
+
+class _Block_pre(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return spre(obj)
+
+
+class _Block_post(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return spost(obj)
+
+
+class _Block_liouvillian_H(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return -1.0j * (spre(obj) - spost(obj))
+
+
+class _Block_lindblad_dissipator(_Block_transform):
+    def __call__(self, obj, t, args={}):
+        return lindblad_dissipator(obj, chi=self.other)
+
+
+class _Block_apply(_Block_transform):
+    def __init__(self, func, args, kwargs):
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def copy(self):
+        return _Block_apply(self.func, self.args, self.kwargs.copy())
+
+    def __call__(self, obj, t, args={}):
+        return self.func(obj, *self.args, **self.kwargs)
+
+from .tensor import tensor

--- a/qutip/core/superoperator.py
+++ b/qutip/core/superoperator.py
@@ -52,8 +52,8 @@ def _map_over_compound_operators(f):
     """
     @functools.wraps(f)
     def out(qobj):
-        if isinstance(qobj, (QobjEvo, QobjEvoFunc)):
-            return qobj.apply(f)
+        if isinstance(qobj, QobjEvoBase):
+            return qobj.linear_map(f)
         if not isinstance(qobj, Qobj):
             raise TypeError("expected a quantum object")
         return f(qobj)
@@ -80,14 +80,14 @@ def liouvillian(H, c_ops=[], data_only=False, chi=None):
         Liouvillian superoperator.
 
     """
-    if isinstance(c_ops, (Qobj, QobjEvo, QobjEvoFunc)):
+    if isinstance(c_ops, (Qobj, QobjEvoBase)):
         c_ops = [c_ops]
     if chi and len(chi) != len(c_ops):
         raise ValueError('chi must be a list with same length as c_ops')
 
     h = None
     if H is not None:
-        if isinstance(H, (QobjEvo, QobjEvoFunc)):
+        if isinstance(H, QobjEvoBase):
             h = H.cte
         else:
             h = H
@@ -158,7 +158,7 @@ def liouvillian(H, c_ops=[], data_only=False, chi=None):
     td_c_ops = []
 
     for idx, c_op in enumerate(c_ops):
-        if isinstance(c_op, (QobjEvo, QobjEvoFunc)):
+        if isinstance(c_op, QobjEvoBase):
             td = True
             if c_op.const:
                 c_ = c_op.cte
@@ -424,8 +424,8 @@ def sprepost(A, B):
         Superoperator formed from input quantum objects.
     """
     if (
-        isinstance(A, (QobjEvo, QobjEvoFunc)) or
-        isinstance(B, (QobjEvo, QobjEvoFunc))
+        isinstance(A, QobjEvoBase) or
+        isinstance(B, QobjEvoBase)
     ):
         return spre(A) * spost(B)
     dims = [[_drop_projected_dims(A.dims[0]),
@@ -465,5 +465,5 @@ def reshuffle(q_oper):
     return q_oper.permute(list(perm_idxs))
 
 
-from .qobjevo import QobjEvo
+from .qobjevo import QobjEvo, QobjEvoBase
 from .qobjevofunc import QobjEvoFunc

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -42,7 +42,7 @@ import numpy as np
 from functools import partial
 from .operators import qeye
 from .qobj import Qobj
-from .qobjevo import QobjEvo
+from .qobjevo import QobjEvo, QobjEvoBase
 from .qobjevofunc import QobjEvoFunc
 from .superoperator import operator_to_vector, reshuffle
 from .dimensions import (
@@ -80,16 +80,16 @@ shape = [4, 4], type = oper, isHerm = True
     """
     if not args:
         raise TypeError("Requires at least one input argument")
-    if len(args) == 1 and isinstance(args[0], (Qobj, QobjEvo, QobjEvoFunc)):
+    if len(args) == 1 and isinstance(args[0], (Qobj, QobjEvoBase)):
         return args[0].copy()
     if len(args) == 1:
         try:
             args = tuple(args[0])
         except TypeError:
             raise TypeError("requires Qobj or QobjEvo operands") from None
-    if not all(isinstance(q, (Qobj, QobjEvo, QobjEvoFunc)) for q in args):
+    if not all(isinstance(q, (Qobj, QobjEvoBase)) for q in args):
         raise TypeError("requires Qobj or QobjEvo operands")
-    if any(isinstance(q, (QobjEvo, QobjEvoFunc)) for q in args):
+    if any(isinstance(q, QobjEvoBase) for q in args):
         # First make tensor from pairs only
         if len(args) >= 3:
             return tensor(args[0], tensor(args[1:]))
@@ -102,13 +102,13 @@ shape = [4, 4], type = oper, isHerm = True
         left = args[0]
         right = args[1]
         if isinstance(left, Qobj):
-            return right.apply(partial(tensor, left))
+            return right.linear_map(partial(tensor, left))
         if isinstance(right, Qobj):
-            return left.apply(tensor, right)
+            return left.linear_map(lambda op: tensor(op, right))
         id_like_left = qeye(left.dims[0])
         id_like_right = qeye(right.dims[0])
-        left = left.apply(tensor, id_like_right)
-        right = right.apply(partial(tensor, id_like_left))
+        left = left.linear_map(lambda op: tensor(op, id_like_right))
+        right = right.linear_map(partial(tensor, id_like_left))
         return left * right
     if not all(q.superrep == args[0].superrep for q in args[1:]):
         raise TypeError("".join([

--- a/qutip/optionsclass.py
+++ b/qutip/optionsclass.py
@@ -216,12 +216,7 @@ def _load(self, file="qutiprc", _recursive=False):
 
 
 def _contains(self, key):
-    # Let the dict catch the KeyError
-    if key in self.read_only_options:
-        return True
-    if key in self.options:
-        return True
-    return False
+    return key in self.read_only_options or key in self.options
 
 
 def _getitem(self, key):

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -785,6 +785,10 @@ class TestProject(UnaryOpMixin):
         (pytest.param((1, 100), id="bra"),),
         (pytest.param((100, 1), id="ket"),),
     ]
+    bad_shapes = [
+        (pytest.param((10, 10), id="square"),),
+        (pytest.param((2, 10), id="nonsquare"),),
+    ]
 
     specialisations = [
         pytest.param(data.project_csr, CSR, CSR),

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -750,6 +750,7 @@ class TestTrace(UnaryOpMixin):
     ]
     specialisations = [
         pytest.param(data.trace_csr, CSR, complex),
+        pytest.param(data.trace_dense, Dense, complex),
     ]
 
     # Trace actually does have bad shape, so we put that in too.
@@ -769,4 +770,23 @@ class TestTranspose(UnaryOpMixin):
     specialisations = [
         pytest.param(data.transpose_csr, CSR, CSR),
         pytest.param(data.transpose_dense, Dense, Dense),
+    ]
+
+
+class TestProject(UnaryOpMixin):
+    def op_numpy(self, matrix):
+        if matrix.shape[0] == 1:
+            return np.outer(np.conj(matrix), matrix)
+        else:
+            return np.outer(matrix, np.conj(matrix))
+
+    shapes = [
+        (pytest.param((1, 1), id="scalar"),),
+        (pytest.param((1, 100), id="bra"),),
+        (pytest.param((100, 1), id="ket"),),
+    ]
+
+    specialisations = [
+        pytest.param(data.project_csr, CSR, CSR),
+        pytest.param(data.project_dense, Dense, Dense),
     ]

--- a/qutip/tests/core/test_expect.py
+++ b/qutip/tests/core/test_expect.py
@@ -36,6 +36,7 @@ import collections
 import functools
 import numpy as np
 import qutip
+from qutip.core.data import CSR, Dense
 
 # We want to test the broadcasting rules for `qutip.expect` for a whole bunch
 # of different systems, without having to repeatedly specify the systems over
@@ -146,12 +147,14 @@ class TestKnownExpectation:
             assert list(part) == list(expected_part)
 
 
-@pytest.mark.repeat(20)
+@pytest.mark.repeat(5)
 @pytest.mark.parametrize("hermitian", [False, True], ids=['complex', 'real'])
-def test_equivalent_to_matrix_element(hermitian):
+@pytest.mark.parametrize("op_type", [CSR, Dense], ids=['csr', 'dense'])
+@pytest.mark.parametrize("state_type", [CSR, Dense], ids=['csr', 'dense'])
+def test_equivalent_to_matrix_element(hermitian, op_type, state_type):
     dimension = 20
-    state = qutip.rand_ket(dimension, 0.3)
-    op = qutip.rand_herm(dimension, 0.2)
+    state = qutip.rand_ket(dimension, 0.3).to(op_type)
+    op = qutip.rand_herm(dimension, 0.2).to(state_type)
     if not hermitian:
         op = op + 1j*qutip.rand_herm(dimension, 0.1)
     expected = state.dag() * op * state

--- a/qutip/tests/core/test_expect.py
+++ b/qutip/tests/core/test_expect.py
@@ -156,7 +156,7 @@ def test_equivalent_to_matrix_element(hermitian, op_type, state_type):
     state = qutip.rand_ket(dimension, 0.3).to(op_type)
     op = qutip.rand_herm(dimension, 0.2).to(state_type)
     if not hermitian:
-        op = op + 1j*qutip.rand_herm(dimension, 0.1)
+        op = op + 1j*qutip.rand_herm(dimension, 0.1).to(state_type)
     expected = state.dag() * op * state
     assert abs(qutip.expect(op, state) - expected) < 1e-14
 

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -37,10 +37,10 @@ from numpy.testing import assert_allclose
 from functools import partial
 from types import FunctionType, BuiltinFunctionType
 from qutip import Cubic_Spline
-from qutip.core.cy.cqobjevo import CQobjEvo
+from qutip.core.cy.cqobjevo import CQobjEvo, CQobjFunc
 
 from qutip.core import data as _data
-
+from qutip.core.qobjevofunc import QobjEvoFunc
 
 class Base_coeff:
     def __init__(self, func, string):
@@ -75,6 +75,7 @@ def _cplx(t, args):
     pytest.param("with_args", id="with_args"),
     pytest.param("no_args", id="no_args"),
     pytest.param("mixed_tlist", id="mixed_tlist"),
+    pytest.param("qobjevofunc", id="qobjevofunc"),
 ])
 def form(request):
     return request.param
@@ -84,6 +85,7 @@ def form(request):
     pytest.param("func", id="func"),
     pytest.param("string", id="string"),
     pytest.param("with_args", id="with_args"),
+    pytest.param("qobjevofunc", id="qobjevofunc"),
 ])
 def args_form(request):
     return request.param
@@ -99,6 +101,7 @@ def args_form(request):
     pytest.param("with_args", id="with_args"),
     pytest.param("no_args", id="no_args"),
     pytest.param("mixed_tlist", id="mixed_tlist"),
+    pytest.param("qobjevofunc", id="qobjevofunc"),
 ])
 def extra_form(request):
     return request.param
@@ -160,13 +163,16 @@ class TestQobjevo:
     tlistlog = np.logspace(-3, 1, 10001)
     args = {'w1': 1, "w2": 2}
     cte_qobj = rand_herm(N)
-    real_qobj = Qobj(np.random.rand(N, N))
-    cplx_qobj = rand_herm(N)
+    real_qobj = Qobj(np.random.rand(N, N)).to(_data.Dense)
+    cplx_qobj = rand_herm(N).to(_data.CSR)
     real_coeff = Base_coeff(_real, "sin(t*w1)")
     cplx_coeff = Base_coeff(_cplx, "exp(1j*t*w2)")
-    qobjevos = {"qobj": rand_herm(N), "scalar":np.random.rand()}
+    qobjevos = {"qobj": rand_herm(N), "scalar": np.random.rand()}
     cplx_forms = ['func', 'string', 'spline', 'array', 'array_log']
     mixed_forms = ['with_args', 'no_args', 'mixed_tlist']
+
+    def _func(self, t, args):
+        return self.cte_qobj + self.cplx_qobj * self.cplx_coeff.func(t, args)
 
     def _rand_t(self):
         return np.random.rand() * 0.9 + 0.05
@@ -216,6 +222,11 @@ class TestQobjevo:
         self.qobjevos[form] = obj
         assert isinstance(obj.compiled_qobjevo, CQobjEvo)
 
+    def test_creation_qobjevofunc(self):
+        obj = QobjEvoFunc(self._func, args=self.args)
+        self.qobjevos['qobjevofunc'] = obj
+        assert isinstance(obj.compiled_qobjevo, CQobjFunc)
+
     def test_call(self, form):
         t = self._rand_t()
         assert isinstance(self.qobjevos[form](t), Qobj)
@@ -253,9 +264,9 @@ class TestQobjevo:
         assert copy is not self.qobjevos[form]
         t = self._rand_t()
         before = self.qobjevos[form](t)
-        copy.cte *= 2
-        for op in copy.ops:
-            op.coeff = coefficient("0")
+        copy *= 2
+        copy += rand_herm(self.N)
+        copy *= rand_herm(self.N)
         after = self.qobjevos[form](t)
         _assert_qobj_almost_eq(before, after)
 
@@ -433,19 +444,26 @@ class TestQobjevo:
         N = self.N
         mat = np.random.rand(N, N) + 1 + 1j * np.random.rand(N, N)
         matF = np.asfortranarray(mat)
+        matDense = Qobj(mat).to(_data.Dense)
+        matCSR = Qobj(mat).to(_data.CSR)
         op = self.qobjevos[form]
         Qo1 = op(t)
         assert_allclose(Qo1.full() @ mat, op.mul(t, mat), atol=1e-14)
         assert_allclose(Qo1.full() @ matF, op.mul(t, matF), atol=1e-14)
+        assert_allclose(Qo1.full() @ mat, op.mul(t, matDense).full(), atol=1e-14)
+        assert_allclose(Qo1.full() @ mat, op.mul(t, matCSR).full(), atol=1e-14)
 
     def test_expect_psi(self, form):
         "QobjEvo expect psi"
         t = self._rand_t()
         N = self.N
         vec = _data.dense.fast_from_numpy(np.arange(N)*.5 + .5j)
+        csr = _data.to(_data.CSR, vec)
         op = self.qobjevos[form]
         Qo1 = op(t)
         assert_allclose(_data.expect(Qo1.data, vec), op.expect(t, vec),
+                        atol=1e-14)
+        assert_allclose(_data.expect(Qo1.data, csr), op.expect(t, vec),
                         atol=1e-14)
 
     def test_expect_rho(self, form):
@@ -508,83 +526,3 @@ def test_QobjEvo_step_coeff():
     assert qobjevo.ops[1].coeff(6.7) == coeff2[4]
     assert qobjevo.ops[1].coeff(7.9999) == coeff2[4]
     assert qobjevo.ops[1].coeff(3.9999) == coeff2[1]
-
-
-@pytest.mark.skipif(True, reason="Now returning Coefficient, to adapt/remove")
-def test_QobjEvo_to_list():
-    "QobjEvo to_list"
-    td_as_list_1 = _random_QobjEvo((5,5), [0,2,3], tlist=np.linspace(0,1,100))
-    td_as_list_2 = _random_QobjEvo((5,5), [1,0,0], tlist=np.linspace(0,1,100))
-    args={"w1":1, "w2":2}
-    td_obj_1 = QobjEvo(td_as_list_1, args=args, tlist=np.linspace(0,1,100))
-    td_obj_2 = QobjEvo(td_as_list_2, args=args, tlist=np.linspace(0,1,100))
-    td_as_list_back = (td_obj_1 + td_obj_2).to_list()
-
-    for part in td_as_list_back:
-        if isinstance(part, Qobj):
-            assert td_as_list_1[0] + td_as_list_2[0] == part
-        elif isinstance(part[1], (FunctionType, BuiltinFunctionType, partial)):
-            assert td_as_list_2[1][1] == part[1]
-            assert td_as_list_2[1][0] == part[0]
-        elif isinstance(part[1], str):
-            assert td_as_list_1[1][1] == part[1]
-            assert td_as_list_1[1][0] == part[0]
-        elif isinstance(part[1], np.ndarray):
-            assert (td_as_list_1[2][1] == part[1]).all()
-            assert td_as_list_1[2][0] == part[0]
-        else:
-            assert False
-
-
-# TODO remove when with state moved to solvers
-def test_QobjEvo_with_state():
-    "QobjEvo dynamics_args"
-    def coeff_state(t, args):
-        return np.mean(args["state_vec"]) * args["w"] * args["expect_op_0"]
-    N = 5
-    vec = np.arange(N)*.5+.5j
-    t = np.random.random()
-    data1 = np.random.random((N, N))
-    data2 = np.random.random((N, N))
-    q1 = Qobj(data1)
-    q2 = Qobj(data2)
-    args = {"w": 5, "state_vec": None, "expect_op_0": 2*qeye(N)}
-
-    td_data = QobjEvo([q1, [q2, coeff_state]], args=args, e_ops=[2*qeye(N)])
-    q_at_t = q1 + np.mean(vec) * args["w"] * expect(2*qeye(N), Qobj(vec.T)) * q2
-    # Check that the with_state call
-    assert_allclose(td_data.mul(t, vec), (q_at_t * vec).full()[:, 0],
-                    atol=1e-14)
-    # Check that the with_state call compiled
-    assert_allclose(td_data.mul(t, vec), (q_at_t * vec).full()[:, 0],
-                    atol=1e-14)
-
-    td_data = QobjEvo([q1, [q2, "state_vec[0] * cos(w*expect_op_0*t)"]],
-                      args=args, e_ops=[2*qeye(N)])
-    data_at_t = q1 + q2*vec[0]*np.cos(10 * t * expect(qeye(N), Qobj(vec.T)))
-    # Check that the with_state call for str format
-    assert_allclose(td_data.mul(t, vec), (data_at_t * vec).full()[:, 0],
-                    atol=1e-14)
-    # Check that the with_state call for str format and compiled
-    assert_allclose(td_data.mul(t, vec), (data_at_t * vec).full()[:, 0],
-                    atol=1e-14)
-
-    args = {"state_mat": None, "state_vec": None, "state_qobj": None}
-    mat = np.arange(N*N).reshape((N, N))
-
-    def check_dyn_args(t, args):
-        assert isinstance(args["state_qobj"], Qobj)
-        assert isinstance(args["state_vec"], np.ndarray)
-        assert isinstance(args["state_mat"], np.ndarray)
-
-        assert len(args["state_vec"].shape) == 1
-        assert len(args["state_mat"].shape) == 2
-
-        assert (np.all(args["state_vec"]
-                == args["state_qobj"].full().ravel("F")))
-        assert np.all(args["state_vec"] == args["state_mat"].ravel("F"))
-        assert np.all(args["state_mat"] == mat)
-        return 1
-
-    td_data = QobjEvo([q1, check_dyn_args], args=args)
-    td_data.mul(0, mat)

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -427,7 +427,7 @@ class TestQobjevo:
     def test_QobjEvo_apply(self):
         "QobjEvo apply"
         obj = self.qobjevos["no_args"]
-        transposed = obj.apply(_trans)
+        transposed = obj.linear_map(_trans)
         _assert_qobjevo_equivalent(transposed, obj.trans())
 
     def test_mul_vec(self, form):

--- a/qutip/tests/solve/test_mesolve.py
+++ b/qutip/tests/solve/test_mesolve.py
@@ -843,30 +843,5 @@ class TestMESolveStepFuncCoeff:
         assert_allclose(
             fidelity(result.states[-1], sigmax()*rho0), 1, rtol=1.e-7)
 
-    def test_dynamic_args(self):
-        "sesolve: state feedback"
-        tol = 1e-3
-        def f(t, args):
-            return np.sqrt(args["state_vec"][3])
-
-        H = [qeye(2), [destroy(2)+create(2), f]]
-        res = mesolve(H, basis(2, 1), tlist=np.linspace(0, 10, 11),
-                      c_ops=[qeye(2)],
-                      e_ops=[num(2)],
-                      args={"state_vec": basis(2, 1)})
-        assert_(max(abs(res.expect[0][5:])) < tol,
-            msg="evolution with feedback not proceding as expected")
-
-        def f(t, args):
-            return np.sqrt(args["expect_op_0"])
-
-        H = [qeye(2), [destroy(2)+create(2), f]]
-        res = mesolve(H, basis(2, 1), tlist=np.linspace(0, 10, 11),
-                      c_ops=[qeye(2)],
-                      e_ops=[num(2)], args={"expect_op_0":num(2)})
-        assert_(max(abs(res.expect[0][5:])) < tol,
-            msg="evolution with feedback not proceding as expected")
-
-
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/solve/test_sesolve.py
+++ b/qutip/tests/solve/test_sesolve.py
@@ -352,26 +352,7 @@ class TestSESolve:
         self.compare_evolution(H, psi0, tlist,
                         normalize=True, td_args=td_args, tol=5e-5)
 
-    def test_07_1_dynamic_args(self):
-        "sesolve: state feedback"
-        tol = 1e-3
-        def f(t, args):
-            return np.abs(args["state_vec"][1])
 
-        H = [qeye(2), [destroy(2)+create(2), f]]
-        res = sesolve(H, basis(2,1), tlist=np.linspace(0,10,11),
-                      e_ops=[num(2)], args={"state_vec":basis(2,1)})
-        assert_(max(abs(res.expect[0][5:])) < tol,
-                msg="evolution with feedback not proceding as expected")
-
-        def f(t, args):
-            return np.sqrt(args["expect_op_0"])
-
-        H = [qeye(2), [destroy(2)+create(2), f]]
-        res = sesolve(H, basis(2,1), tlist=np.linspace(0,10,11),
-                      e_ops=[num(2)], args={"expect_op_0":num(2)})
-        assert_(max(abs(res.expect[0][5:])) < tol,
-                msg="evolution with feedback not proceding as expected")
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
**Description**
First part of rework of solver for dev.major. It allows QobjEvo to support any data types for both itself and the state. And reuse the QobjEvoFunc of #1123 so function can be used in any solver. 

- Update `cQobjEvo` to use `Data` object instead of `CSR` matrices only.
- Split `cQobjEvo.matmul` and `expect`: used to accept only `Dense` state, now accept any data type and use Jake's dispatcher. But added `matmul_dense` and `expect_dense` to do operation inplace when possible. Dispatche on `inplace` out parameter is not possible and such operation are mostly limited to `Dense`.
- Compiling string coefficients will now create the build directory in `.qutip` folder instead of current active directory.
- array coefficients addition will add array when possible.
- `scipy.special` had a cython interface... added it to string coefficient's cimport as `cython_special`.
- Added an inplace addition for `Dense` object and inplace multiplication with a scalar for both `Dense` and `CSR`.
- Added `Dense` specialization for `expect`.
- Added `project_dense`.
- Added `QobjEvoFunc`, a wrapper for function `f(t: float, args: dict) -> Qobj` to be used like `QobjEvo` in solver.
- Added the method `to` to QobjEvo to control data types.

