### PR TITLE
Fix memory leak in Dense.copy()

### DIFF
--- a/qutip/core/data/dense.pyx
+++ b/qutip/core/data/dense.pyx
@@ -120,6 +120,7 @@ cdef class Dense(base.Data):
         out.shape = self.shape
         out.data = ptr
         out.fortran = self.fortran
+        out._deallocate = True
         return out
 
     cdef void _fix_flags(self, object array, bint make_owner=False):


### PR DESCRIPTION
Add missing flag `Dense._deallocate = True` in `Dense.copy()`; the copy operation invariably owns its own data (otherwise what's the point of a copy!).  I imagine I probably just missed this when the `_deallocate` flag was born in the midst of segfault and exception handling woes.

Fix #1415