### PR TITLE
Fast qdiags

### DIFF
--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -386,16 +386,8 @@ def destroy(N, offset=0):
     """
     if not isinstance(N, (int, np.integer)):  # raise error if N not integer
         raise ValueError("Hilbert space dimension must be integer value")
-    data = np.sqrt(np.arange(offset+1, N+offset, dtype=complex))
-    ind = np.arange(1, N, dtype=np.int32)
-    ptr = np.arange(N+1, dtype=np.int32)
-    ptr[-1] = N-1
-    return Qobj(_data.csr.CSR((data, ind, ptr), shape=(N, N)),
-                dims=[[N], [N]],
-                type='oper',
-                isherm=False,
-                isunitary=False,
-                copy=False)
+    data = np.sqrt(np.arange(offset+1, N+offset)).astype(np.complex128)
+    return qdiags([data], [1])
 
 
 def create(N, offset=0):
@@ -426,7 +418,10 @@ def create(N, offset=0):
      [ 0.00000000+0.j  1.41421356+0.j  0.00000000+0.j  0.00000000+0.j]
      [ 0.00000000+0.j  0.00000000+0.j  1.73205081+0.j  0.00000000+0.j]]
     """
-    return destroy(N, offset=offset).dag()
+    if not isinstance(N, (int, np.integer)):  # raise error if N not integer
+        raise ValueError("Hilbert space dimension must be integer value")
+    data = np.sqrt(np.arange(offset+1, N+offset)).astype(np.complex128)
+    return qdiags([data], [-1])
 
 
 def _implicit_tensor_dimensions(dimensions):
@@ -601,22 +596,7 @@ def num(N, offset=0):
      [0 0 2 0]
      [0 0 0 3]]
     """
-    if offset == 0:
-        data = np.arange(1, N, dtype=complex)
-        ind = np.arange(1, N, dtype=np.int32)
-        ptr = np.arange(-1, N, dtype=np.int32)
-        ptr[0] = 0
-    else:
-        data = np.arange(offset, offset + N, dtype=complex)
-        ind = np.arange(N, dtype=np.int32)
-        ptr = np.arange(N+1, dtype=np.int32)
-
-    return Qobj(_data.CSR((data, ind, ptr), shape=(N, N)),
-                dims=[[N], [N]],
-                type='oper',
-                isherm=True,
-                isunitary=False,
-                copy=False)
+    return qdiags([np.arange(offset, offset+N, dtype=np.complex128)], [0])
 
 
 def squeeze(N, z, offset=0):
@@ -801,8 +781,7 @@ shape = [4, 4], type = oper, isherm = False
      [ 0.          0.          0.          0.        ]]
 
     """
-    data = scipy.sparse.diags(diagonals, offsets, shape,
-                              format='csr', dtype=np.complex128)
+    data = _data.csr.diags(diagonals, offsets, shape)
     return Qobj(data, dims=dims, type='oper', copy=False)
 
 

--- a/qutip/tests/core/data/test_csr.py
+++ b/qutip/tests/core/data/test_csr.py
@@ -269,3 +269,40 @@ class TestFactoryMethods:
         assert base.shape == (dimension, dimension)
         assert sci.nnz == dimension
         assert (sci - scipy_test).nnz == 0
+
+    @pytest.mark.parametrize(['diagonals', 'offsets', 'shape'], [
+        pytest.param([2j, 3, 5, 9], None, None, id='main diagonal'),
+        pytest.param([1], None, None, id='1x1'),
+        pytest.param([[0.2j, 0.3]], None, None, id='main diagonal list'),
+        pytest.param([0.2j, 0.3], 2, None, id='superdiagonal'),
+        pytest.param([0.2j, 0.3], -2, None, id='subdiagonal'),
+        pytest.param([[0.2, 0.3, 0.4], [0.1, 0.9]], [-2, 3], None,
+                     id='two diagonals'),
+        pytest.param([1, 2, 3], 0, (3, 5), id='main wide'),
+        pytest.param([1, 2, 3], 0, (5, 3), id='main tall'),
+        pytest.param([[1, 2, 3], [4, 5]], [-1, -2], (4, 8), id='two wide sub'),
+        pytest.param([[1, 2, 3, 4], [4, 5, 4j, 1j]], [1, 2], (4, 8),
+                     id='two wide super'),
+        pytest.param([[1, 2, 3], [4, 5]], [1, 2], (8, 4), id='two tall super'),
+        pytest.param([[1, 2, 3, 4], [4, 5, 4j, 1j]], [-1, -2], (8, 4),
+                     id='two tall sub'),
+        pytest.param([[1, 2, 3], [4, 5, 6], [1, 2]], [1, -1, -2], (4, 4),
+                     id='out of order'),
+        pytest.param([[1, 2, 3], [4, 5, 6], [1, 2]], [1, 1, -2], (4, 4),
+                     id='sum duplicates'),
+    ])
+    def test_diags(self, diagonals, offsets, shape):
+        base = csr.diags(diagonals, offsets, shape)
+        # Build numpy version test.
+        if not isinstance(diagonals[0], list):
+            diagonals = [diagonals]
+        offsets = np.atleast_1d(offsets if offsets is not None else [0])
+        if shape is None:
+            size = len(diagonals[0]) + abs(offsets[0])
+            shape = (size, size)
+        test = np.zeros(shape, dtype=np.complex128)
+        for diagonal, offset in zip(diagonals, offsets):
+            test[np.where(np.eye(*shape, k=offset) == 1)] += diagonal
+        assert isinstance(base, data.CSR)
+        assert base.shape == shape
+        np.testing.assert_allclose(base.to_array(), test, rtol=1e-10)


### PR DESCRIPTION
Adds custom `csr.diags` and swaps `qdiags` over to use it to avoid using the `scipy` version with its large overhead.  Constructing a tridiagonal matrix of dimension 100 gets approximately a 7x speed up (320µs to 45µs on my machine) and it's better for small dimensions - the `scipy` overhead has a constant component something around 280µs compared to a constant ~20µs in the new `csr` one.  Not a big deal since it's hardly ever going to be a bottleneck, but it's just part of my work speeding up general QuTiP operations.