### PR TITLE
Add type choice in Qobj creation function.

### DIFF
--- a/qutip/core/cy/cqobjevo.pyx
+++ b/qutip/core/cy/cqobjevo.pyx
@@ -35,28 +35,17 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-from libc.math cimport sqrt, NAN
-from cpython.exc cimport PyErr_CheckSignals
-
 cimport numpy as cnp
 cnp.import_array()
 
 from ..qobj import Qobj
 from .. import data as _data
 
-from qutip.core.data cimport CSR, Dense, Data
-from qutip.core.data.add cimport iadd_dense
-from qutip.core.data.matmul cimport *
-#(matmul_csr, matmul_csr_dense_dense, matmul_dense, matmul_data_dense, imatmul_dense_dense)
-from qutip.core.data.expect cimport *
-#(expect_csr_dense, expect_super_csr_dense, expect_dense, expect_super_dense, expect_data_dense, expect_super_data_dense)
-from qutip.core.data.reshape cimport (column_stack_dense, column_unstack_dense)
+from qutip.core.data cimport Dense, dense
+from qutip.core.data.reshape cimport column_stack_dense, column_unstack_dense
+from qutip.core.data.expect cimport expect_super_data_dense, expect_data_dense
+from qutip.core.data.matmul cimport matmul_data_dense, imatmul_data_dense
 from qutip.core.cy.coefficient cimport Coefficient
-
-
-cdef extern from "<complex>" namespace "std" nogil:
-    double complex conj(double complex x)
-
 
 cdef class CQobjEvo:
     """

--- a/qutip/core/data/__init__.py
+++ b/qutip/core/data/__init__.py
@@ -14,6 +14,7 @@ from .expm import *
 from .inner import *
 from .kron import *
 from .matmul import *
+from .make import *
 from .mul import *
 from .pow import *
 from .project import *

--- a/qutip/core/data/__init__.py
+++ b/qutip/core/data/__init__.py
@@ -34,5 +34,20 @@ to.add_conversions([
     (Dense, CSR, dense.from_csr, 1),
     (CSR, Dense, csr.from_dense, 1.4),
 ])
+to.register_aliases(['csr', 'CSR'], CSR)
+to.register_aliases(['Dense', 'dense'], Dense)
+
+
+from . import _creator_utils
+import numpy as np
+create.add_creators([
+    (_creator_utils.is_data, _creator_utils.data_copy, 100),
+    (_creator_utils.isspmatrix_csr, CSR, 80),
+    (_creator_utils.is_nparray, Dense, 80),
+    (_creator_utils.issparse, CSR, 20),
+    (_creator_utils.true, Dense, -np.inf),
+])
+del _creator_utils
+del np
 
 from .dispatch import Dispatcher

--- a/qutip/core/data/_creator_utils.py
+++ b/qutip/core/data/_creator_utils.py
@@ -1,0 +1,27 @@
+"""
+Define functions to use as Data creator for `create` in `convert.py`.
+"""
+
+from scipy.sparse import isspmatrix_csr, issparse
+import numpy as np
+from .csr import CSR
+from .base import Data
+from .dense import Dense
+
+__all__ = ['is_data', 'is_nparray', 'data_copy', 'isspmatrix_csr', 'issparse']
+
+
+def is_data(arg):
+    return isinstance(arg, Data)
+
+
+def is_nparray(arg):
+    return isinstance(arg, np.ndarray)
+
+
+def true(arg):
+    return True
+
+
+def data_copy(arg, shape, copy=True):
+    return arg.copy() if copy else arg

--- a/qutip/core/data/_creator_utils.py
+++ b/qutip/core/data/_creator_utils.py
@@ -24,4 +24,8 @@ def true(arg):
 
 
 def data_copy(arg, shape, copy=True):
+    if shape is not None and shape != arg.shape:
+        raise ValueError("".join([
+            "shapes do not match: ", str(shape), " and ", str(arg.shape),
+        ]))
     return arg.copy() if copy else arg

--- a/qutip/core/data/convert.pyx
+++ b/qutip/core/data/convert.pyx
@@ -265,23 +265,41 @@ cdef class _to:
             self._str2type[dtype.__name__.lower()] = dtype
 
     def parse(self, dtype):
-        """Convert case-insensitive string name of the data-layer to the type
-        itself.
+        """
+        Return a data-layer type object given its name or the type itself.
 
         Parameters
         ----------
         dtype : type, str
-            string to read or type itself.
+            Either the (case-insensitive) name of a data-layer type or a type
+            itself.
+
+        Returns
+        -------
+        type
+            A data-layer type.
+
+        Raises
+        ------
+        TypeError
+            If ``dtype`` is neither a string nor a type.
+        ValueError
+            If ``dtype`` is a name, but no data-layer type of that name is
+            registered, or if ``dtype`` is a type, but not a known data-layer
+            type.
         """
         if type(dtype) is type:
             if dtype not in self.dtypes:
-                raise TypeError("Unsupported data type: " + dtype)
+                raise ValueError(
+                    "Type is not a data-layer type: " + repr(dtype))
             return dtype
         elif type(dtype) is str:
             if dtype.lower() not in self._str2type:
-                raise TypeError("Type name is not known: " + dtype)
+                raise ValueError(
+                    "Type name is not known to the data-layer: " + repr(dtype))
             return self._str2type[dtype.lower()]
-        raise TypeError("Invalid data-layer type: " + dtype)
+        raise TypeError(
+            "Invalid dtype is neither a type nor a type name: " + repr(dtype))
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/qutip/core/data/convert.pyx
+++ b/qutip/core/data/convert.pyx
@@ -334,34 +334,47 @@ cdef class _create:
     def add_creators(self, creators):
         """
         Add creation functions to make a data-layer object from an arbitrary
-        python object.
+        Python object.
 
         Parameters
         ----------
         creators : iterable of (condition, creator, [priority])
-            An iterable of 2- or 3-tuples describing all the new data layer
-            creation function.
+            An iterable of 2- or 3-tuples describing the new data layer
+            creation functions.
             Each element can individually be a 2- or 3-tuple; they do not need
             to be all one or the other.
 
             Elements
             ........
             condition : callable (object) -> Data
-                function determining if that object can be made to a data layer
-                using this creator.
+                function determining if the given object can be converted to a
+                data-layer type using this creator.
 
             creator function: callable (object, shape) -> Data
-                The creator function.  This should take an object and a shape
-                and output a data-layer object. The object can be anything that
-                The condition function returned `True` when tested.
+                The creator function. It should take an object and a shape
+                and return a data-layer type instance. The object may be
+                any object for which the condition function returned ``True``
+                when tested.
 
             priority : positive real, optional (1)
-                The priority associated with this creation. Higher priority
+                The priority associated with this creator. Higher priority
                 conditions will be tested first and the first valid creator
-                (condition(object) == True) will handle the creation.
-                Priority 100 is used for already data-layer entry.
-                80 for object that have a direct data-layer equivalent
-                (scipy.sparse.csr_matrix, numpy.ndarray)
+                (i.e. for which ``condition(object) == True``) will handle
+                the creation.
+
+        Notes
+        -----
+            Default creators are added with the following priorities:
+
+                * Objects that are instances of data-layer types are
+                  converted using ``.copy`` with priority ``100``.
+                * Objects that are ``numpy.ndarray`` instances or for
+                  which ``scipy.sparse.isspmatrix_csr`` is ``True`` are
+                  converted using an internal CSR converter with
+                  priority ``80``.
+                * Objects for which ``scipy.sparse.issparse`` is ``True``
+                  are converted using an internal CSR converter with
+                  priority ``10``.
         """
         _creators = []
         for creator in creators:

--- a/qutip/core/data/convert.pyx
+++ b/qutip/core/data/convert.pyx
@@ -319,9 +319,7 @@ cdef class _to:
 
     def __call__(self, to_type, data):
         to_type = self.parse(to_type)
-        from_type = type(data)
-        if from_type not in self.dtypes:
-            raise TypeError("unknown input type: " + from_type.__name__)
+        from_type = self.parse(type(data))
         if to_type == from_type:
             return data
         return self._convert[to_type, from_type](data)

--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -75,7 +75,7 @@ cdef class CSR(base.Data):
         # single flag that is set as soon as the pointers are assigned.
         self._deallocate = True
 
-    def __init__(self, arg=None, shape=None, bint copy=False):
+    def __init__(self, arg=None, shape=None, bint copy=True):
         # This is the Python __init__ method, so we do not care that it is not
         # super-fast C access.  Typically Cython code will not call this, but
         # will use a factory method in this module or at worst, call

--- a/qutip/core/data/dense.pyx
+++ b/qutip/core/data/dense.pyx
@@ -44,8 +44,8 @@ class OrderEfficiencyWarning(EfficiencyWarning):
 cdef class Dense(base.Data):
     def __init__(self, data, shape=None, copy=True):
         base = np.array(data, dtype=np.complex128, order='K', copy=copy)
-        # Ensure that the array is continuous.
-        # Non continuous array with copy=False would otherwise slip through
+        # Ensure that the array is contiguous.
+        # Non contiguous array with copy=False would otherwise slip through
         if not (cnp.PyArray_IS_C_CONTIGUOUS(base) or
                 cnp.PyArray_IS_F_CONTIGUOUS(base)):
             base = base.copy()

--- a/qutip/core/data/dense.pyx
+++ b/qutip/core/data/dense.pyx
@@ -44,8 +44,15 @@ class OrderEfficiencyWarning(EfficiencyWarning):
 cdef class Dense(base.Data):
     def __init__(self, data, shape=None, copy=True):
         base = np.array(data, dtype=np.complex128, order='K', copy=copy)
+        # Ensure that the array is continuous.
+        # Non continuous array with copy=False would otherwise slip through
+        if not (cnp.PyArray_IS_C_CONTIGUOUS(base) or
+                cnp.PyArray_IS_F_CONTIGUOUS(base)):
+            base = base.copy()
         if shape is None:
             shape = base.shape
+            if len(shape) == 0:
+                shape = (1, 1)
             # Promote to a ket by default if passed 1D data.
             if len(shape) == 1:
                 shape = (shape[0], 1)
@@ -345,4 +352,110 @@ cpdef Dense from_csr(CSR matrix, bint fortran=False):
         for ptr_in in range(matrix.row_index[row], matrix.row_index[row + 1]):
             out.data[ptr_out + matrix.col_index[ptr_in]*col_stride] = matrix.data[ptr_in]
         ptr_out += row_stride
+    return out
+
+
+cdef inline base.idxint _diagonal_length(
+    base.idxint offset, base.idxint n_rows, base.idxint n_cols,
+) nogil:
+    if offset > 0:
+        return n_rows if offset <= n_cols - n_rows else n_cols - offset
+    return n_cols if offset > n_cols - n_rows else n_rows + offset
+
+
+@cython.wraparound(True)
+def diags(diagonals, offsets=None, shape=None):
+    """
+    Construct a matrix from diagonals and their offsets.  Using this
+    function in single-argument form produces a square matrix with the given
+    values on the main diagonal.
+    With lists of diagonals and offsets, the matrix will be the smallest
+    possible square matrix if shape is not given, but in all cases the
+    diagonals must fit exactly with no extra or missing elements. Duplicated
+    diagonals will be summed together in the output.
+
+    Parameters
+    ----------
+    diagonals : sequence of array_like of complex or array_like of complex
+        The entries (including zeros) that should be placed on the diagonals in
+        the output matrix.  Each entry must have enough entries in it to fill
+        the relevant diagonal and no more.
+    offsets : sequence of integer or integer, optional
+        The indices of the diagonals.  `offsets[i]` is the location of the
+        values `diagonals[i]`.  An offset of 0 is the main diagonal, positive
+        values are above the main diagonal and negative ones are below the main
+        diagonal.
+    shape : tuple, optional
+        The shape of the output as (``rows``, ``columns``).  The result does
+        not need to be square, but the diagonals must be of the correct length
+        to fit in exactly.
+    """
+    cdef base.idxint n_rows, n_cols, offset
+    try:
+        diagonals = list(diagonals)
+        if diagonals and np.isscalar(diagonals[0]):
+            # Catch the case where we're being called as (for example)
+            #   diags([1, 2, 3], 0)
+            # with a single diagonal and offset.
+            diagonals = [diagonals]
+    except TypeError:
+        raise TypeError("diagonals must be a list of arrays of complex") from None
+    if offsets is None:
+        if len(diagonals) == 0:
+            offsets = []
+        elif len(diagonals) == 1:
+            offsets = [0]
+        else:
+            raise TypeError("offsets must be supplied if passing more than one diagonal")
+    offsets = np.atleast_1d(offsets)
+    if offsets.ndim > 1:
+        raise ValueError("offsets must be a 1D array of integers")
+    if len(diagonals) != len(offsets):
+        raise ValueError("number of diagonals does not match number of offsets")
+    if len(diagonals) == 0:
+        if shape is None:
+            raise ValueError("cannot construct matrix with no diagonals without a shape")
+        else:
+            n_rows, n_cols = shape
+        return zeros(n_rows, n_cols)
+    order = np.argsort(offsets)
+    diagonals_ = []
+    offsets_ = []
+    prev, cur = None, None
+    for i in order:
+        cur = offsets[i]
+        if cur == prev:
+            diagonals_[-1] += np.asarray(diagonals[i], dtype=np.complex128)
+        else:
+            offsets_.append(cur)
+            diagonals_.append(np.asarray(diagonals[i], dtype=np.complex128))
+        prev = cur
+    if shape is None:
+        n_rows = n_cols = abs(offsets_[0]) + len(diagonals_[0])
+    else:
+        try:
+            n_rows, n_cols = shape
+        except (TypeError, ValueError):
+            raise TypeError("shape must be a 2-tuple of positive integers")
+        if n_rows < 0 or n_cols < 0:
+            raise ValueError("shape must be a 2-tuple of positive integers")
+    for i in range(len(diagonals_)):
+        offset = offsets_[i]
+        if len(diagonals_[i]) != _diagonal_length(offset, n_rows, n_cols):
+            raise ValueError("given diagonals do not have the correct lengths")
+    if n_rows == 0 and n_cols == 0:
+        raise ValueError("can't produce a 0x0 matrix")
+
+    out = zeros(n_rows, n_cols, fortran=True)
+
+    cdef size_t diag_idx, idx, n_diagonals = len(diagonals_)
+
+    for diag_idx in range(n_diagonals):
+        offset = offsets_[diag_idx]
+        if offset <= 0:
+            for idx in range(_diagonal_length(offset, n_rows, n_cols)):
+                out.data[idx*(n_rows+1) - offset] = diagonals_[diag_idx][idx]
+        else:
+            for idx in range(_diagonal_length(offset, n_rows, n_cols)):
+                out.data[idx*(n_rows+1) + offset*n_rows] = diagonals_[diag_idx][idx]
     return out

--- a/qutip/core/data/dispatch.pyx
+++ b/qutip/core/data/dispatch.pyx
@@ -552,8 +552,9 @@ cdef class Dispatcher:
         callable object which requires that the dispatched arguments match
         those specified in `types`.
         """
-        if isinstance(types, type):
+        if type(types) is not tuple:
             types = (types,)
+        types = tuple(_to.parse(arg) for arg in types)
         try:
             return self._lookup[types]
         except KeyError:
@@ -572,6 +573,7 @@ cdef class Dispatcher:
         args_, kwargs_ = self._parameters.bind(args, kwargs)
         dispatch = self._parameters.dispatch_types(args_, kwargs_)
         if self.output and dtype is not None:
+            dtype = _to.parse(dtype)
             dispatch.append(dtype)
         cdef _constructed_specialisation function
         try:

--- a/qutip/core/data/make.py
+++ b/qutip/core/data/make.py
@@ -1,0 +1,101 @@
+from .dispatch import Dispatcher as _Dispatcher
+from . import csr, dense, CSR, Dense
+
+__all__ = ['diag', 'one_element_csr', 'one_element_dense', 'one_element']
+
+
+def _diag_signature(diagonals, offsets=0, shape=None):
+    """
+    Construct a matrix from diagonals and their offsets.  Using this
+    function in single-argument form produces a square matrix with the given
+    values on the main diagonal.
+    With lists of diagonals and offsets, the matrix will be the smallest
+    possible square matrix if shape is not given, but in all cases the
+    diagonals must fit exactly with no extra or missing elements. Duplicated
+    diagonals will be summed together in the output.
+
+    Parameters
+    ----------
+    diagonals : sequence of array_like of complex or array_like of complex
+        The entries (including zeros) that should be placed on the diagonals in
+        the output matrix.  Each entry must have enough entries in it to fill
+        the relevant diagonal and no more.
+    offsets : sequence of integer or integer, optional
+        The indices of the diagonals.  `offsets[i]` is the location of the
+        values `diagonals[i]`.  An offset of 0 is the main diagonal, positive
+        values are above the main diagonal and negative ones are below the main
+        diagonal.
+    shape : tuple, optional
+        The shape of the output as (``rows``, ``columns``).  The result does
+        not need to be square, but the diagonals must be of the correct length
+        to fit in exactly.
+    """
+    pass
+
+
+diag = _Dispatcher(_diag_signature, name='diag', inputs=(), out=True)
+diag.add_specialisations([
+    (CSR, csr.diags),
+    (Dense, dense.diags),
+], _defer=True)
+
+del _diag_signature
+
+
+def one_element_csr(shape, position, value=1.0):
+    """
+    Create a matrix with only one non-null elements.
+
+    Parameters
+    ----------
+    shape : tuple
+        The shape of the output as (``rows``, ``columns``).
+
+    position : tuple
+        The position of the non zero in the matrix as (``rows``, ``columns``).
+
+    value : complex, optional
+        The value of the non-null element.
+    """
+    if not (0 <= position[0] < shape[0] and 0 <= position[1] < shape[1]):
+        raise ValueError("Position of the elements out of bound: " +
+                         str(position) + " in " + str(shape))
+    data = csr.empty(*shape, 1)
+    sci = data.as_scipy(full=True)
+    sci.data[0] = value
+    sci.indices[0] = position[1]
+    sci.indptr[:position[0]+1] = 0
+    sci.indptr[position[0]+1:] = 1
+    return data
+
+
+def one_element_dense(shape, position, value=1.0):
+    """
+    Create a matrix with only one non-null elements.
+
+    Parameters
+    ----------
+    shape : tuple
+        The shape of the output as (``rows``, ``columns``).
+
+    position : tuple
+        The position of the non zero in the matrix as (``rows``, ``columns``).
+
+    value : complex, optional
+        The value of the non-null element.
+    """
+    if not (0 <= position[0] < shape[0] and 0 <= position[1] < shape[1]):
+        raise ValueError("Position of the elements out of bound: " +
+                         str(position) + " in " + str(shape))
+    data = dense.zeros(*shape, 1)
+    nda = data.as_ndarray()
+    nda[position] = value
+    return data
+
+
+one_element = _Dispatcher(one_element_dense, name='one_element',
+                          inputs=(), out=True)
+one_element.add_specialisations([
+    (CSR, one_element_csr),
+    (Dense, one_element_dense),
+], _defer=True)

--- a/qutip/core/data/make.py
+++ b/qutip/core/data/make.py
@@ -44,7 +44,7 @@ del _diag_signature
 
 def one_element_csr(shape, position, value=1.0):
     """
-    Create a matrix with only one non-null elements.
+    Create a matrix with only one nonzero element.
 
     Parameters
     ----------
@@ -71,7 +71,7 @@ def one_element_csr(shape, position, value=1.0):
 
 def one_element_dense(shape, position, value=1.0):
     """
-    Create a matrix with only one non-null elements.
+    Create a matrix with only one nonzero element.
 
     Parameters
     ----------

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -37,12 +37,10 @@ of commonly occuring quantum operators.
 
 __all__ = ['jmat', 'spin_Jx', 'spin_Jy', 'spin_Jz', 'spin_Jm', 'spin_Jp',
            'spin_J_set', 'sigmap', 'sigmam', 'sigmax', 'sigmay', 'sigmaz',
-           'destroy', 'create',  'qeye', 'identity', 'num', 'charge',
-           'position', 'momentum', 'tunneling',
-           'qzero', 'squeeze', 'displace', 'phase',
-           'squeezing', 'commutator', 'qdiags',
-           'qutrit_ops', 'enr_destroy', 'enr_identity',
-          ]
+           'destroy', 'create', 'qeye', 'identity', 'position', 'momentum',
+           'num', 'squeeze', 'squeezing', 'displace', 'commutator',
+           'qutrit_ops', 'qdiags', 'phase', 'qzero', 'enr_destroy',
+           'enr_identity', 'charge', 'tunneling']
 
 import numbers
 
@@ -78,14 +76,6 @@ def qdiags(diagonals, offsets, dims=None, shape=None, *, dtype=_data.CSR):
     dtype : type or str
         Storage representation. Any data-layer known to `qutip.data.to` is
         accepted.
-
-    See Also
-    --------
-    scipy.sparse.diags : for usage information.
-
-    Notes
-    -----
-    This function requires SciPy 0.11+.
 
     Examples
     --------

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -428,11 +428,13 @@ class Qobj:
             A new `Qobj` if a type conversion took place with the data stored
             in the requested format, or `self` if not.
         """
-        if data_type not in _data.to.dtypes:
+        try:
+            converter = _data.to[data_type]
+        except (KeyError, TypeError):
             raise ValueError("Unknown conversion type: " + str(data_type))
         if type(self.data) is data_type:
             return self
-        return Qobj(_data.to(data_type, self._data),
+        return Qobj(converter(self._data),
                     dims=self.dims,
                     type=self.type,
                     superrep=self.superrep,

--- a/qutip/core/qobjevo.py
+++ b/qutip/core/qobjevo.py
@@ -724,6 +724,7 @@ class QobjEvo(QobjEvoBase):
         self.cte = self.cte.tidyup(atol)
         for op in self.ops:
             op.qobj = op.qobj.tidyup(atol)
+        self._compile()
         return self
 
     def permute(self, order):
@@ -768,7 +769,6 @@ class QobjEvo(QobjEvoBase):
         return res
 
     def _compile(self):
-        self.tidyup()
         self.compiled_qobjevo = CQobjEvo(self.cte, self.ops)
 
     def _compress_make_set(self):

--- a/qutip/core/superop_reps.py
+++ b/qutip/core/superop_reps.py
@@ -51,6 +51,7 @@ import numpy as np
 import scipy.linalg
 
 from . import data as _data
+from .data import matmul
 from .superoperator import stack_columns, unstack_columns, sprepost
 from .tensor import tensor
 from .dimensions import flatten
@@ -232,7 +233,7 @@ def _choi_to_chi(q_oper):
     """
     nq = _nq(q_oper.dims)
     B = _superpauli_basis(nq).data
-    return Qobj(B.adjoint() @ q_oper.data @ B,
+    return Qobj(matmul(matmul(B.adjoint(), q_oper.data), B),
                 dims=q_oper.dims,
                 type='super',
                 superrep='chi',
@@ -250,7 +251,7 @@ def _chi_to_choi(q_oper):
     B = _superpauli_basis(nq).data
     # The Chi matrix has tr(chi) == d², so we need to divide out
     # by that to get back to the Choi form.
-    return Qobj((B @ q_oper.data @ B.adjoint()) / q_oper.shape[0],
+    return Qobj(matmul(matmul(B, q_oper.data), B.adjoint()) / q_oper.shape[0],
                 dims=q_oper.dims,
                 type='super',
                 superrep='choi',

--- a/qutip/tests/core/data/test_convert.py
+++ b/qutip/tests/core/data/test_convert.py
@@ -5,8 +5,8 @@ from qutip.core.data import to, create, CSR, Dense, dense, csr
 
 
 @pytest.mark.parametrize(['base', 'dtype'], [
-    pytest.param(dense.zeros(2,2), Dense, id='data.Dense'),
-    pytest.param(csr.zeros(2,2), CSR, id='data.CSR'),
+    pytest.param(dense.zeros(2, 2), Dense, id='data.Dense'),
+    pytest.param(csr.zeros(2, 2), CSR, id='data.CSR'),
     pytest.param(np.zeros((10, 10), dtype=np.complex128), Dense, id='array'),
     pytest.param(sparse.eye(10, dtype=np.complex128, format='csr'), CSR,
                  id='sparse'),
@@ -21,12 +21,12 @@ def test_create(base, dtype):
 
 
 @pytest.mark.parametrize(['from_', 'base'], [
-    pytest.param('dense', dense.zeros(2,2), id='from Dense str'),
-    pytest.param('Dense', dense.zeros(2,2), id='from Dense STR'),
-    pytest.param(Dense, dense.zeros(2,2), id='from Dense type'),
-    pytest.param('csr', csr.zeros(2,2), id='from CSR str'),
-    pytest.param('CSR', csr.zeros(2,2), id='from CSR STR'),
-    pytest.param(CSR, csr.zeros(2,2), id='from CSR type'),
+    pytest.param('dense', dense.zeros(2, 2), id='from Dense str'),
+    pytest.param('Dense', dense.zeros(2, 2), id='from Dense STR'),
+    pytest.param(Dense, dense.zeros(2, 2), id='from Dense type'),
+    pytest.param('csr', csr.zeros(2, 2), id='from CSR str'),
+    pytest.param('CSR', csr.zeros(2, 2), id='from CSR STR'),
+    pytest.param(CSR, csr.zeros(2, 2), id='from CSR type'),
 ])
 @pytest.mark.parametrize(['to_', 'dtype'], [
     pytest.param('dense', Dense, id='to Dense str'),

--- a/qutip/tests/core/data/test_convert.py
+++ b/qutip/tests/core/data/test_convert.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pytest
+from scipy import sparse
+from qutip.core.data import to, create, CSR, Dense, dense, csr
+
+
+@pytest.mark.parametrize(['base', 'dtype'], [
+    pytest.param(dense.zeros(2,2), Dense, id='data.Dense'),
+    pytest.param(csr.zeros(2,2), CSR, id='data.CSR'),
+    pytest.param(np.zeros((10, 10), dtype=np.complex128), Dense, id='array'),
+    pytest.param(sparse.eye(10, dtype=np.complex128, format='csr'), CSR,
+                 id='sparse'),
+    pytest.param(np.zeros((10, 10), dtype=np.int32), Dense, id='array'),
+    pytest.param(sparse.eye(10, dtype=np.float, format='csr'), CSR,
+                 id='sparse'),
+])
+def test_create(base, dtype):
+    # The test of exactitude is done in test_csr, test_dense.
+    created = create(base)
+    assert isinstance(created, dtype)
+
+
+@pytest.mark.parametrize(['from_', 'base'], [
+    pytest.param('dense', dense.zeros(2,2), id='from Dense str'),
+    pytest.param('Dense', dense.zeros(2,2), id='from Dense STR'),
+    pytest.param(Dense, dense.zeros(2,2), id='from Dense type'),
+    pytest.param('csr', csr.zeros(2,2), id='from CSR str'),
+    pytest.param('CSR', csr.zeros(2,2), id='from CSR STR'),
+    pytest.param(CSR, csr.zeros(2,2), id='from CSR type'),
+])
+@pytest.mark.parametrize(['to_', 'dtype'], [
+    pytest.param('dense', Dense, id='to Dense str'),
+    pytest.param('Dense', Dense, id='to Dense STR'),
+    pytest.param(Dense, Dense, id='to Dense type'),
+    pytest.param('csr', CSR, id='to CSR str'),
+    pytest.param('CSR', CSR, id='to CSR STR'),
+    pytest.param(CSR, CSR, id='to CSR type'),
+])
+def test_converters(from_, base, to_, dtype):
+    converter = to[to_, from_]
+    assert isinstance(converter(base), dtype)
+    converter = to[to_]
+    assert isinstance(converter(base), dtype)
+    assert isinstance(to(to_, base), dtype)
+
+
+def test_parse():
+    assert to.parse("dense") is Dense
+    assert to.parse("Dense") is Dense
+    assert to.parse("DeNsE") is Dense
+
+    assert to.parse("csr") is CSR
+    assert to.parse("CSR") is CSR
+    assert to.parse("cSr") is CSR
+
+    with pytest.raises(TypeError) as exc:
+        to.parse(5)
+    assert str(exc.value) == (
+        "Invalid dtype is neither a type nor a type name: 5"
+    )
+
+    with pytest.raises(ValueError) as exc:
+        to.parse("__this_is_not_a_known_type_name__")
+    assert str(exc.value) == (
+        "Type name is not known to the data-layer: "
+        "'__this_is_not_a_known_type_name__'"
+    )
+
+    with pytest.raises(ValueError) as exc:
+        to.parse(object)
+    assert str(exc.value) == "Type is not a data-layer type: <class 'object'>"

--- a/qutip/tests/core/data/test_convert.py
+++ b/qutip/tests/core/data/test_convert.py
@@ -1,71 +1,71 @@
 import numpy as np
 import pytest
 from scipy import sparse
-from qutip.core.data import to, create, CSR, Dense, dense, csr
+from qutip import data
 
 
 @pytest.mark.parametrize(['base', 'dtype'], [
-    pytest.param(dense.zeros(2, 2), Dense, id='data.Dense'),
-    pytest.param(csr.zeros(2, 2), CSR, id='data.CSR'),
-    pytest.param(np.zeros((10, 10), dtype=np.complex128), Dense, id='array'),
-    pytest.param(sparse.eye(10, dtype=np.complex128, format='csr'), CSR,
+    pytest.param(data.dense.zeros(2, 2), data.Dense, id='data.Dense'),
+    pytest.param(data.csr.zeros(2, 2), data.CSR, id='data.CSR'),
+    pytest.param(np.zeros((10, 10), dtype=np.complex128), data.Dense,
+                 id='array'),
+    pytest.param(sparse.eye(10, dtype=np.complex128, format='csr'), data.CSR,
                  id='sparse'),
-    pytest.param(np.zeros((10, 10), dtype=np.int32), Dense, id='array'),
-    pytest.param(sparse.eye(10, dtype=np.float, format='csr'), CSR,
+    pytest.param(np.zeros((10, 10), dtype=np.int32), data.Dense, id='array'),
+    pytest.param(sparse.eye(10, dtype=float, format='csr'), data.CSR,
                  id='sparse'),
 ])
 def test_create(base, dtype):
     # The test of exactitude is done in test_csr, test_dense.
-    created = create(base)
+    created = data.create(base)
     assert isinstance(created, dtype)
 
 
 @pytest.mark.parametrize(['from_', 'base'], [
-    pytest.param('dense', dense.zeros(2, 2), id='from Dense str'),
-    pytest.param('Dense', dense.zeros(2, 2), id='from Dense STR'),
-    pytest.param(Dense, dense.zeros(2, 2), id='from Dense type'),
-    pytest.param('csr', csr.zeros(2, 2), id='from CSR str'),
-    pytest.param('CSR', csr.zeros(2, 2), id='from CSR STR'),
-    pytest.param(CSR, csr.zeros(2, 2), id='from CSR type'),
+    pytest.param('dense', data.dense.zeros(2, 2), id='from Dense str'),
+    pytest.param('Dense', data.dense.zeros(2, 2), id='from Dense STR'),
+    pytest.param(data.Dense, data.dense.zeros(2, 2), id='from Dense type'),
+    pytest.param('csr', data.csr.zeros(2, 2), id='from CSR str'),
+    pytest.param('CSR', data.csr.zeros(2, 2), id='from CSR STR'),
+    pytest.param(data.CSR, data.csr.zeros(2, 2), id='from CSR type'),
 ])
 @pytest.mark.parametrize(['to_', 'dtype'], [
-    pytest.param('dense', Dense, id='to Dense str'),
-    pytest.param('Dense', Dense, id='to Dense STR'),
-    pytest.param(Dense, Dense, id='to Dense type'),
-    pytest.param('csr', CSR, id='to CSR str'),
-    pytest.param('CSR', CSR, id='to CSR STR'),
-    pytest.param(CSR, CSR, id='to CSR type'),
+    pytest.param('dense', data.Dense, id='to Dense str'),
+    pytest.param('Dense', data.Dense, id='to Dense STR'),
+    pytest.param(data.Dense, data.Dense, id='to Dense type'),
+    pytest.param('csr', data.CSR, id='to CSR str'),
+    pytest.param('CSR', data.CSR, id='to CSR STR'),
+    pytest.param(data.CSR, data.CSR, id='to CSR type'),
 ])
 def test_converters(from_, base, to_, dtype):
-    converter = to[to_, from_]
+    converter = data.to[to_, from_]
     assert isinstance(converter(base), dtype)
-    converter = to[to_]
+    converter = data.to[to_]
     assert isinstance(converter(base), dtype)
-    assert isinstance(to(to_, base), dtype)
+    assert isinstance(data.to(to_, base), dtype)
 
 
-def test_parse():
-    assert to.parse("dense") is Dense
-    assert to.parse("Dense") is Dense
-    assert to.parse("DeNsE") is Dense
+dtype_names = list(data.to._str2type.keys()) + list(data.to.dtypes)
+dtype_types = list(data.to._str2type.values()) + list(data.to.dtypes)
+@pytest.mark.parametrize(['input', 'type_'], zip(dtype_names, dtype_types),
+                         ids=[str(dtype) for dtype in dtype_names])
+def test_parse_error(input, type_):
+    assert data.to.parse(input) is type_
 
-    assert to.parse("csr") is CSR
-    assert to.parse("CSR") is CSR
-    assert to.parse("cSr") is CSR
 
-    with pytest.raises(TypeError) as exc:
-        to.parse(5)
-    assert str(exc.value) == (
-        "Invalid dtype is neither a type nor a type name: 5"
-    )
-
-    with pytest.raises(ValueError) as exc:
-        to.parse("__this_is_not_a_known_type_name__")
-    assert str(exc.value) == (
-        "Type name is not known to the data-layer: "
-        "'__this_is_not_a_known_type_name__'"
-    )
-
-    with pytest.raises(ValueError) as exc:
-        to.parse(object)
-    assert str(exc.value) == "Type is not a data-layer type: <class 'object'>"
+@pytest.mark.parametrize(['input', 'error', 'msg'], [
+    pytest.param(5, TypeError,
+                  "Invalid dtype is neither a type nor a type name: 5",
+                 id="wrong type"),
+    pytest.param("__this_is_not_a_known_type_name__", ValueError,
+                  "Type name is not known to the data-layer: "
+                  "'__this_is_not_a_known_type_name__'",
+                 id="not alias"),
+    pytest.param(object, ValueError,
+                  "Type is not a data-layer type: <class 'object'>",
+                 id="not Data"),
+])
+def test_parse_error(input, error, msg):
+    with pytest.raises(error) as exc:
+        data.to.parse(input)
+    assert str(exc.value) == msg

--- a/qutip/tests/core/data/test_csr.py
+++ b/qutip/tests/core/data/test_csr.py
@@ -306,3 +306,37 @@ class TestFactoryMethods:
         assert isinstance(base, data.CSR)
         assert base.shape == shape
         np.testing.assert_allclose(base.to_array(), test, rtol=1e-10)
+
+    @pytest.mark.parametrize(['shape', 'position', 'value'], [
+        pytest.param((1, 1), (0, 0), None, id='minimal'),
+        pytest.param((10, 10), (5, 5), 1.j, id='on diagonal'),
+        pytest.param((10, 10), (1, 5), 1., id='upper'),
+        pytest.param((10, 10), (5, 1), 2., id='lower'),
+        pytest.param((10, 1), (5, 0), None, id='column'),
+        pytest.param((1, 10), (0, 5), -5j, id='row'),
+        pytest.param((10, 2), (5, 1), 1+2j, id='tall'),
+        pytest.param((2, 10), (1, 5), 10, id='wide'),
+    ])
+    def test_one_element(self, shape, position, value):
+        test = np.zeros(shape, dtype=np.complex128)
+        if value is None:
+            base = data.one_element_csr(shape, position)
+            test[position] = 1.0+0.0j
+        else:
+            base = data.one_element_csr(shape, position, value)
+            test[position] = value
+        assert isinstance(base, data.CSR)
+        assert base.shape == shape
+        np.testing.assert_allclose(base.to_array(), test, atol=1e-10)
+
+    @pytest.mark.parametrize(['shape', 'position', 'value'], [
+        pytest.param((0, 0), (0, 0), None, id='zero shape'),
+        pytest.param((10, -2), (5, 0), 1.j, id='neg shape'),
+        pytest.param((10, 10), (10, 5), 1., id='outside'),
+        pytest.param((10, 10), (5, -1), 2., id='outside neg'),
+    ])
+    def test_one_element_error(self, shape, position, value):
+        with pytest.raises(ValueError) as exc:
+            base = data.one_element_csr(shape, position, value)
+        assert str(exc.value).startswith("Position of the elements"
+                                         " out of bound: ")

--- a/qutip/tests/core/data/test_dense.py
+++ b/qutip/tests/core/data/test_dense.py
@@ -215,3 +215,74 @@ class TestFactoryMethods:
         assert isinstance(base, data.Dense)
         assert base.shape == (dimension, dimension)
         assert np.count_nonzero(nd - numpy_test) == 0
+
+    @pytest.mark.parametrize(['diagonals', 'offsets', 'shape'], [
+        pytest.param([2j, 3, 5, 9], None, None, id='main diagonal'),
+        pytest.param([1], None, None, id='1x1'),
+        pytest.param([[0.2j, 0.3]], None, None, id='main diagonal list'),
+        pytest.param([0.2j, 0.3], 2, None, id='superdiagonal'),
+        pytest.param([0.2j, 0.3], -2, None, id='subdiagonal'),
+        pytest.param([[0.2, 0.3, 0.4], [0.1, 0.9]], [-2, 3], None,
+                     id='two diagonals'),
+        pytest.param([1, 2, 3], 0, (3, 5), id='main wide'),
+        pytest.param([1, 2, 3], 0, (5, 3), id='main tall'),
+        pytest.param([[1, 2, 3], [4, 5]], [-1, -2], (4, 8), id='two wide sub'),
+        pytest.param([[1, 2, 3, 4], [4, 5, 4j, 1j]], [1, 2], (4, 8),
+                     id='two wide super'),
+        pytest.param([[1, 2, 3], [4, 5]], [1, 2], (8, 4), id='two tall super'),
+        pytest.param([[1, 2, 3, 4], [4, 5, 4j, 1j]], [-1, -2], (8, 4),
+                     id='two tall sub'),
+        pytest.param([[1, 2, 3], [4, 5, 6], [1, 2]], [1, -1, -2], (4, 4),
+                     id='out of order'),
+        pytest.param([[1, 2, 3], [4, 5, 6], [1, 2]], [1, 1, -2], (4, 4),
+                     id='sum duplicates'),
+    ])
+    def test_diags(self, diagonals, offsets, shape):
+        base = dense.diags(diagonals, offsets, shape)
+        # Build numpy version test.
+        if not isinstance(diagonals[0], list):
+            diagonals = [diagonals]
+        offsets = np.atleast_1d(offsets if offsets is not None else [0])
+        if shape is None:
+            size = len(diagonals[0]) + abs(offsets[0])
+            shape = (size, size)
+        test = np.zeros(shape, dtype=np.complex128)
+        for diagonal, offset in zip(diagonals, offsets):
+            test[np.where(np.eye(*shape, k=offset) == 1)] += diagonal
+        assert isinstance(base, data.Dense)
+        assert base.shape == shape
+        np.testing.assert_allclose(base.to_array(), test, rtol=1e-10)
+
+    @pytest.mark.parametrize(['shape', 'position', 'value'], [
+        pytest.param((1, 1), (0, 0), None, id='minimal'),
+        pytest.param((10, 10), (5, 5), 1.j, id='on diagonal'),
+        pytest.param((10, 10), (1, 5), 1., id='upper'),
+        pytest.param((10, 10), (5, 1), 2., id='lower'),
+        pytest.param((10, 1), (5, 0), None, id='column'),
+        pytest.param((1, 10), (0, 5), -5.j, id='row'),
+        pytest.param((10, 2), (5, 1), 1+2j, id='tall'),
+        pytest.param((2, 10), (1, 5), 10, id='wide'),
+    ])
+    def test_one_element(self, shape, position, value):
+        test = np.zeros(shape, dtype=np.complex128)
+        if value is None:
+            base = data.one_element_dense(shape, position)
+            test[position] = 1.0+0.0j
+        else:
+            base = data.one_element_dense(shape, position, value)
+            test[position] = value
+        assert isinstance(base, data.Dense)
+        assert base.shape == shape
+        assert np.allclose(base.to_array(), test, atol=1e-10)
+
+    @pytest.mark.parametrize(['shape', 'position', 'value'], [
+        pytest.param((0, 0), (0, 0), None, id='zero shape'),
+        pytest.param((10, -2), (5, 0), 1.j, id='neg shape'),
+        pytest.param((10, 10), (10, 5), 1., id='outside'),
+        pytest.param((10, 10), (5, -1), 2., id='outside neg'),
+    ])
+    def test_one_element_error(self, shape, position, value):
+        with pytest.raises(ValueError) as exc:
+            base = data.one_element_dense(shape, position, value)
+        assert str(exc.value).startswith("Position of the elements"
+                                         " out of bound: ")

--- a/qutip/tests/core/test_operators.py
+++ b/qutip/tests/core/test_operators.py
@@ -214,8 +214,8 @@ def test_tunneling():
     N = 5
     tn = tunneling(2*N+1)
     tn_matrix = np.diag(np.ones(2*N),k=-1) + np.diag(np.ones(2*N),k=1)
-    assert_equal(np.allclose(tn.full(), tn_matrix), True) 
-    
+    assert_equal(np.allclose(tn.full(), tn_matrix), True)
+
     tn = tunneling(2*N+1,2)
     tn_matrix = np.diag(np.ones(2*N-1),k=-2) + np.diag(np.ones(2*N-1),k=2)
     assert_equal(np.allclose(tn.full(), tn_matrix), True)
@@ -223,3 +223,47 @@ def test_tunneling():
 
 if __name__ == "__main__":
     run_module_suite()
+
+
+def _id_func(val):
+    "ids generated from the function only"
+    if isinstance(val, tuple):
+        return ""
+
+
+# random object accept `str` and base.Data
+# Obtain all valid dtype from `to`
+dtype_names = list(qutip.data.to._str2type.keys()) + list(qutip.data.to.dtypes)
+dtype_types = list(qutip.data.to._str2type.values()) + list(qutip.data.to.dtypes)
+@pytest.mark.parametrize(['alias', 'dtype'], zip(dtype_names, dtype_types),
+                         ids=[str(dtype) for dtype in dtype_names])
+@pytest.mark.parametrize(['func', 'args'], [
+    (qutip.qdiags, ([0, 1, 2], 1)),
+    (qutip.jmat, (1,)),
+    (qutip.spin_Jx, (1,)),
+    (qutip.spin_Jy, (1,)),
+    (qutip.spin_Jz, (1,)),
+    (qutip.spin_Jp, (1,)),
+    (qutip.destroy, (5,)),
+    (qutip.create, (5,)),
+    (qutip.qzero, (5,)),
+    (qutip.qeye, (5,)),
+    (qutip.position, (5,)),
+    (qutip.momentum, (5,)),
+    (qutip.num, (5,)),
+    (qutip.squeeze, (5, 0.5)),
+    (qutip.displace, (5, 1.0)),
+    (qutip.qutrit_ops, ()),
+    (qutip.phase, (5,)),
+    (qutip.charge, (5,)),
+    (qutip.tunneling, (5,)),
+    (qutip.enr_destroy, ([3, 3, 3], 4)),
+    (qutip.enr_identity, ([3, 3, 3], 4)),
+], ids=_id_func)
+def test_operator_type(func, args, alias, dtype):
+    object = func(*args, dtype=alias)
+    if isinstance(object, qutip.Qobj):
+        assert isinstance(object.data, dtype)
+    else:
+        for obj in object:
+            assert isinstance(obj.data, dtype)

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -369,7 +369,7 @@ class TestQobjevo:
     def test_tidyup(self):
         "QobjEvo tidyup"
         obj = self.qobjevos["no_args"]
-        obj *= 1e-10 * np.random.random()
+        obj = obj * 1e-10 * np.random.random()
         obj.tidyup(atol=1e-8)
         t = self._rand_t()
         # check that the Qobj are cleaned

--- a/qutip/tests/core/test_states.py
+++ b/qutip/tests/core/test_states.py
@@ -126,3 +126,50 @@ class TestStates:
 
 if __name__ == "__main__":
     run_module_suite()
+
+
+def _id_func(val):
+    "ids generated from the function only"
+    if isinstance(val, tuple):
+        return ""
+
+
+# random object accept `str` and base.Data
+# Obtain all valid dtype from `to`
+dtype_names = list(qutip.data.to._str2type.keys()) + list(qutip.data.to.dtypes)
+dtype_types = list(qutip.data.to._str2type.values()) + list(qutip.data.to.dtypes)
+@pytest.mark.parametrize(['alias', 'dtype'], zip(dtype_names, dtype_types),
+                         ids=[str(dtype) for dtype in dtype_names])
+@pytest.mark.parametrize(['func', 'args'], [
+    (qutip.basis, (5, 1)),
+    (qutip.fock, (5, 1)),
+    (qutip.fock_dm, (5, 1)),
+    (qutip.coherent, (5, 1)),
+    (qutip.coherent_dm, (5, 1)),
+    (qutip.thermal_dm, (5, 1)),
+    (qutip.maximally_mixed_dm, (5,)),
+    (qutip.phase_basis, (5, 1)),
+    (qutip.zero_ket, (5,)),
+    (qutip.spin_state, (5, 1)),
+    (qutip.spin_coherent, (5, 1, 0.5)),
+    (qutip.projection, (5, 1, 2)),
+    (qutip.ket, ("001",)),
+    (qutip.bra, ('010',)),
+    (qutip.qstate, ("uud",)),
+    (qutip.state_number_qobj, ([2, 2, 2], [1, 0, 1])),
+    (qutip.w_state, (5,)),
+    (qutip.ghz_state, (5,)),
+    (qutip.qutrit_basis, ()),
+    (qutip.triplet_states, ()),
+    (qutip.singlet_state, ()),
+    (qutip.bell_state, ('10',)),
+    (qutip.enr_fock, ([3, 3, 3], 4, [1, 1, 0])),
+    (qutip.enr_thermal_dm, ([3, 3, 3], 4, 2)),
+], ids=_id_func)
+def test_state_type(func, args, alias, dtype):
+    object = func(*args, dtype=alias)
+    if isinstance(object, qutip.Qobj):
+        assert isinstance(object.data, dtype)
+    else:
+        for obj in object:
+            assert isinstance(obj.data, dtype)

--- a/qutip/tests/core/test_superoper.py
+++ b/qutip/tests/core/test_superoper.py
@@ -65,7 +65,7 @@ class TestMatVec:
         N = 3
         rho1 = qutip.rand_dm(N)
         rho2 = qutip.vector_to_operator(qutip.operator_to_vector(rho1))
-        assert (rho1 - rho2).norm('max') < 1e-8
+        np.testing.assert_allclose(rho1.full(), rho2.full(), 1e-8)
 
     def testOperatorVectorTensor(self):
         """
@@ -77,7 +77,7 @@ class TestMatVec:
         rhob = qutip.rand_dm(Nb)
         rho1 = qutip.tensor(rhoa, rhob)
         rho2 = qutip.vector_to_operator(qutip.operator_to_vector(rho1))
-        assert (rho1 - rho2).norm('max') < 1e-8
+        np.testing.assert_allclose(rho1.full(), rho2.full(), 1e-8)
 
     def testOperatorVectorNotSquare(self):
         """
@@ -85,7 +85,7 @@ class TestMatVec:
         """
         op1 = qutip.Qobj(np.random.rand(6).reshape((3, 2)))
         op2 = qutip.vector_to_operator(qutip.operator_to_vector(op1))
-        assert (op1 - op2).norm('max') < 1e-8
+        np.testing.assert_allclose(op1.full(), op2.full(), 1e-8)
 
     def testOperatorSpreAppl(self):
         """
@@ -97,7 +97,7 @@ class TestMatVec:
         rho1 = U * rho
         rho2_vec = qutip.spre(U) * qutip.operator_to_vector(rho)
         rho2 = qutip.vector_to_operator(rho2_vec)
-        assert (rho1 - rho2).norm('max') < 1e-8
+        np.testing.assert_allclose(rho1.full(), rho2.full(), 1e-8)
 
     def testOperatorSpostAppl(self):
         """
@@ -109,7 +109,7 @@ class TestMatVec:
         rho1 = rho * U
         rho2_vec = qutip.spost(U) * qutip.operator_to_vector(rho)
         rho2 = qutip.vector_to_operator(rho2_vec)
-        assert (rho1 - rho2).norm('max') < 1e-8
+        np.testing.assert_allclose(rho1.full(), rho2.full(), 1e-8)
 
     def testOperatorUnitaryTransform(self):
         """
@@ -121,7 +121,7 @@ class TestMatVec:
         rho1 = U * rho * U.dag()
         rho2_vec = qutip.sprepost(U, U.dag()) * qutip.operator_to_vector(rho)
         rho2 = qutip.vector_to_operator(rho2_vec)
-        assert (rho1 - rho2).norm('max') < 1e-8
+        np.testing.assert_allclose(rho1.full(), rho2.full(), 1e-8)
 
     def testMatrixVecMat(self):
         """
@@ -130,7 +130,7 @@ class TestMatVec:
         M = _data.create(np.random.rand(10, 10))
         V = qutip.stack_columns(M)
         M2 = qutip.unstack_columns(V)
-        assert _data.csr.nnz(M - M2) == 0
+        np.testing.assert_allclose(M.to_array(), M2.to_array(), 1e-8)
 
     def testVecMatVec(self):
         """
@@ -139,7 +139,7 @@ class TestMatVec:
         V = _data.create(np.random.rand(100, 1))
         M = qutip.unstack_columns(V)
         V2 = qutip.stack_columns(M)
-        assert _data.csr.nnz(V - V2) == 0
+        np.testing.assert_allclose(V.to_array(), V2.to_array(), 1e-8)
 
     def testVecMatIndexConversion(self):
         """
@@ -195,7 +195,7 @@ class TestMatVec:
         c_ops = [np.sqrt(0.01) * a1, np.sqrt(0.025) * a2, np.sqrt(0.05) * a3]
         L1 = qutip.liouvillian(H, c_ops)
         L2 = liouvillian_ref(H, c_ops)
-        assert (L1 - L2).norm('max') < 1e-8
+        np.testing.assert_allclose(L1.full(), L2.full(), 1e-8)
 
 
 class TestSuper_td:

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -31,14 +31,16 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+import pytest
 import scipy.sparse as sp
 import scipy.linalg as la
 import numpy as np
 from numpy.testing import assert_equal, assert_, run_module_suite
 
 from qutip import qeye
+from qutip import data as _data
 from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
-                                  rand_ket_haar, rand_dm_hs,
+                                  rand_ket_haar, rand_dm_hs, rand_stochastic,
                                   rand_super, rand_unitary_haar, rand_dm_ginibre,
                                   rand_super_bcsz)
 
@@ -93,3 +95,18 @@ def test_rand_super_dims():
 
 if __name__ == "__main__":
     run_module_suite()
+
+# random object accept `str` and base.Data
+# Obtain all valid dtype from `to`
+dtype_names = list(_data.to._str2type.keys()) + list(_data.to.dtypes)
+dtype_types = list(_data.to._str2type.values()) + list(_data.to.dtypes)
+@pytest.mark.parametrize(['alias', 'dtype'], zip(dtype_names, dtype_types),
+                         ids=[str(dtype) for dtype in dtype_names])
+@pytest.mark.parametrize('func', [
+    rand_dm, rand_dm_hs, rand_dm_ginibre,
+    rand_ket, rand_ket_haar, rand_herm, rand_unitary,
+    rand_super, rand_unitary_haar, rand_super_bcsz, rand_stochastic
+])
+def test_random_type(func, alias, dtype):
+    rand_qobj = func(5, dtype=alias)
+    assert isinstance(rand_qobj.data, dtype)


### PR DESCRIPTION
**Description**
Qobj support Dense representation, but there are still no easy way to create dense matrix. So this add a keyword only `dtype` options to most function of qutip.states, qutip.operators and qutip.random_object.

To make them, I made 2 new dispatched function: `diag` and `one_element`. `diag` has the same use than @jakelishman #1419 function, but I fall back on scipy quickly... So I will switch to his version as soon as it is merged. 

To make the `dtype` more user friendly than seeking the type in `qutip.core.data`, I changed `to` to accept the string representation of the name (case insensitive). Only `to` accept string, `dispatch` is not really user facing so there is no reason to touch it.

I also updated the `create` to use `add_creators` and make `Dense` out of `numpy array`. Jake, I am not sure of what were your plans for this. So if I am messing your plans, please tell me. 

Tests are not all created yet and it will create a conflict with #1419 and #1407.

**Related issues or PRs**
#1419 
