### PR TITLE
Correctly set num_collapse in mesolve output

### DIFF
--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -265,6 +265,7 @@ def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None,
 
     res = _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, options,
                              progress_bar, dims=rho0.dims)
+    res.num_collapse = len(c_ops)
 
     if e_ops_dict:
         res.expect = {e: res.expect[n]

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -722,7 +722,6 @@ class TestMESolverMisc:
     """
     A test class for the misc mesolve features.
     """
-
     def testMEFinalState(self):
         "mesolve: final_state has correct dims"
 
@@ -757,6 +756,19 @@ class TestMESolverMisc:
                          options=opts)
         assert_(psi0.dims == result.final_state.dims)
 
+    def test_num_collapse_set(self):
+        H = sigmaz()
+        psi = (basis(2, 0) + basis(2, 1)).unit()
+        ts = [0, 1]
+        for c_ops in (
+            sigmax(),
+            [sigmax()],
+            [sigmay(), sigmax()],
+        ):
+            res = qutip.mesolve(H, psi, ts, c_ops=c_ops)
+            if not isinstance(c_ops, list):
+                c_ops = [c_ops]
+            assert res.num_collapse == len(c_ops)
 
 class TestMESolveStepFuncCoeff:
     """


### PR DESCRIPTION
In the result from `qutip.mesolve(..., c_ops=[...])`, the attribute `num_collapse` would always be 0 no matter how many `c_ops` were actually passed.  This was correct in `mcsolve`, but missing in `mesolve`.  This is likely because the result is mostly created within `_generic_ode_solve()`, but at this point the `c_ops` list has already been consumed in the creation of the Liouvillian.  There is no need to set `col_times` and `col_which` (compare mcsolve) because mesolve tracks the full density matrix, rather than following the quantum trajectory approach.

Noticed by @nathanshammah during @quantshah's talk on Twitch.

@Ericgig: to check - I assume this wasn't by design?