### PR TITLE
Fix consumable iterator in test parametrisation

### DIFF
--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -137,7 +137,8 @@ class TestExplicitForm:
         assert _infidelity(swapped, swap*start) < 1e-12
         assert _infidelity(start, swap*swap*start) < 1e-12
 
-    @pytest.mark.parametrize('permutation', itertools.permutations([0, 1, 2]),
+    @pytest.mark.parametrize('permutation',
+                             tuple(itertools.permutations([0, 1, 2])),
                              ids=_permutation_id)
     def test_toffoli(self, permutation):
         test = gates.toffoli(N=3,
@@ -296,8 +297,9 @@ class Test_expand_operator:
     # surrounding code, but the surrounding code wasn't updated.
     @pytest.mark.parametrize(
         'permutation',
-        itertools.chain(*[itertools.permutations(range(k))
-                          for k in [2, 3, 4]]),
+        tuple(itertools.chain(*[
+            itertools.permutations(range(k)) for k in [2, 3, 4]
+        ])),
         ids=_permutation_id)
     def test_permutation_without_expansion(self, permutation):
         base = qutip.tensor([qutip.rand_unitary(2) for _ in permutation])


### PR DESCRIPTION
If
```python
    qutip.testing.run()
```
was called twice in the same Python session, then cases where a consumable iterator (such as `itertools.permutations` or `itertools.chain`) was used in the test parametrisation would fail on subsequent runs.  This is because the iterator is consumed when the module is loaded, and cannot be re-run after.

This was not caught in CI because naturally CI only runs the testing suite once in a session.