### PR TITLE
Remove use of deprecated numpy type aliases

### DIFF
--- a/qutip/_mkl/spmv.py
+++ b/qutip/_mkl/spmv.py
@@ -49,9 +49,9 @@ def mkl_spmv(A, x):
 
      # Allocate output, using same conventions as input
      if x.ndim == 1:
-        y = np.empty(m,dtype=np.complex,order='C')
+        y = np.empty(m,dtype=np.complex128,order='C')
      elif x.ndim==2 and x.shape[1]==1:
-        y = np.empty((m,1),dtype=np.complex,order='C')
+        y = np.empty((m,1),dtype=np.complex128,order='C')
      else:
         raise Exception('Input vector must be 1D row or 2D column vector')
      

--- a/qutip/lattice.py
+++ b/qutip/lattice.py
@@ -685,7 +685,8 @@ class Lattice1d():
                         data = np.append(data, [op[k, l]])
 
         m = nx_units*ny_units*nS
-        op_H = csr_matrix((data, (row_ind, col_ind)), [m, m], dtype=np.complex)
+        op_H = csr_matrix((data, (row_ind, col_ind)), [m, m],
+                          dtype=np.complex128)
         dim_op = [self.lattice_tensor_config, self.lattice_tensor_config]
         return Qobj(op_H, dims=dim_op)
 

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -893,7 +893,7 @@ def enr_destroy(dims, excitations):
 
     nstates, state2idx, idx2state = enr_state_dictionaries(dims, excitations)
 
-    a_ops = [sp.lil_matrix((nstates, nstates), dtype=np.complex)
+    a_ops = [sp.lil_matrix((nstates, nstates), dtype=np.complex128)
              for _ in range(len(dims))]
 
     for n1, state1 in idx2state.items():
@@ -936,7 +936,7 @@ def enr_identity(dims, excitations):
     from qutip.states import enr_state_dictionaries
 
     nstates, _, _ = enr_state_dictionaries(dims, excitations)
-    data = sp.eye(nstates, nstates, dtype=np.complex)
+    data = sp.eye(nstates, nstates, dtype=np.complex128)
     return Qobj(data, dims=[dims, dims])
 
 

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -910,9 +910,9 @@ def jspin(N, op=None, basis="dicke"):
 
     nds = num_dicke_states(N)
     num_ladders = num_dicke_ladders(N)
-    jz_operator = dok_matrix((nds, nds), dtype=np.complex)
-    jp_operator = dok_matrix((nds, nds), dtype=np.complex)
-    jm_operator = dok_matrix((nds, nds), dtype=np.complex)
+    jz_operator = dok_matrix((nds, nds), dtype=np.complex128)
+    jp_operator = dok_matrix((nds, nds), dtype=np.complex128)
+    jm_operator = dok_matrix((nds, nds), dtype=np.complex128)
     s = 0
 
     for k in range(0, num_ladders):
@@ -1386,7 +1386,7 @@ def css(
         return _uncoupled_css(N, a, b)
     nds = num_dicke_states(N)
     num_ladders = num_dicke_ladders(N)
-    rho = dok_matrix((nds, nds), dtype=np.complex)
+    rho = dok_matrix((nds, nds), dtype=np.complex128)
 
     # loop in the allowed matrix elements
     jmm1_dict = jmm1_dictionary(N)[1]
@@ -1435,7 +1435,7 @@ def ghz(N, basis="dicke"):
     if basis == "uncoupled":
         return _uncoupled_ghz(N)
     nds = _num_dicke_states(N)
-    rho = dok_matrix((nds, nds), dtype=np.complex)
+    rho = dok_matrix((nds, nds), dtype=np.complex128)
     rho[0, 0] = 1 / 2
     rho[N, N] = 1 / 2
     rho[N, 0] = 1 / 2
@@ -1468,7 +1468,7 @@ def ground(N, basis="dicke"):
         state = _uncoupled_ground(N)
         return state
     nds = _num_dicke_states(N)
-    rho = dok_matrix((nds, nds), dtype=np.complex)
+    rho = dok_matrix((nds, nds), dtype=np.complex128)
     rho[N, N] = 1
     return Qobj(rho)
 

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -33,6 +33,7 @@
 
 from collections.abc import Iterable
 from itertools import product
+import numbers
 
 import warnings
 import inspect
@@ -142,7 +143,7 @@ class Gate:
         for ind_list in [self.targets, self.controls, self.classical_controls]:
             if isinstance(ind_list, Iterable):
                 all_integer = all(
-                    [isinstance(ind, np.int) for ind in ind_list])
+                    [isinstance(ind, numbers.Integral) for ind in ind_list])
                 if not all_integer:
                     raise ValueError("Index of a qubit must be an integer")
 
@@ -312,7 +313,7 @@ class Measurement:
         for ind_list in [self.targets]:
             if isinstance(ind_list, Iterable):
                 all_integer = all(
-                    [isinstance(ind, np.int) for ind in ind_list])
+                    [isinstance(ind, numbers.Integral) for ind in ind_list])
                 if not all_integer:
                     raise ValueError("Index of a qubit must be an integer")
 

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -430,7 +430,7 @@ class Processor(object):
         coeffs = np.array(self.get_full_coeffs())
         if inctime:
             shp = coeffs.T.shape
-            data = np.empty((shp[0], shp[1] + 1), dtype=np.float)
+            data = np.empty((shp[0], shp[1] + 1), dtype=np.float64)
             data[:, 0] = self.get_full_tlist()
             data[:, 1:] = coeffs.T
         else:

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -80,10 +80,10 @@ def rand_jacobi_rotation(A, seed=None):
     angle = 2*np.random.random()*np.pi
     a = 1.0/np.sqrt(2)*np.exp(-1j*angle)
     b = 1.0/np.sqrt(2)*np.exp(1j*angle)
-    i = np.int(np.floor(np.random.random()*n))
+    i = int(np.floor(np.random.random()*n))
     j = i
     while (i == j):
-        j = np.int(np.floor(np.random.random()*n))
+        j = int(np.floor(np.random.random()*n))
     data = np.hstack((np.array([a,-b,a,b], dtype=complex),
                       np.ones(n-2, dtype=complex)))
     diag = np.delete(np.arange(n), [i,j])
@@ -181,7 +181,7 @@ def _rand_herm_sparse(N, density, pos_def):
     target = (1-(1-density)**0.5)
     num_elems = (N**2 - 0.666 * N) * target + 0.666 * N * density
     num_elems = max([num_elems, 1])
-    num_elems = np.int(num_elems)
+    num_elems = int(num_elems)
     data = (2 * np.random.rand(num_elems) - 1) + \
            (2 * np.random.rand(num_elems) - 1) * 1j
     row_idx, col_idx = zip(*[divmod(index, N) for index
@@ -204,7 +204,7 @@ def _rand_herm_dense(N, density, pos_def):
     target = (1-(density)**0.5)
     num_remove = N * (N - 0.666) * target + 0.666 * N * (1 - density)
     num_remove = max([num_remove, 1])
-    num_remove = np.int(num_remove)
+    num_remove = int(num_remove)
     for row, col in [divmod(index, N)
                      for index in np.random.choice(N*N,
                                                    num_remove,
@@ -678,7 +678,7 @@ def rand_stochastic(N, density=0.75, kind='left', dims=None, seed=None):
         np.random.seed(seed=seed)
     if dims:
         _check_dims(dims, N, N)
-    num_elems = max([np.int(np.ceil(N*(N+1)*density)/2), N])
+    num_elems = max([int(np.ceil(N*(N+1)*density)/2), N])
     data = np.random.rand(num_elems)
     # Ensure an element on every row and column
     row_idx = np.hstack([np.random.permutation(N),

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -979,7 +979,7 @@ def enr_fock(dims, excitations, state):
     """
     nstates, state2idx, idx2state = enr_state_dictionaries(dims, excitations)
 
-    data = sp.lil_matrix((nstates, 1), dtype=np.complex)
+    data = sp.lil_matrix((nstates, 1), dtype=np.complex128)
 
     try:
         data[state2idx[tuple(state)], 0] = 1

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -993,7 +993,7 @@ class TestDicke:
 
         PIQS: Test for N = 2 in the 'dicke' and in the 'uncoupled' basis.
         """
-        zeros = np.zeros((4, 4), dtype=np.complex)
+        zeros = np.zeros((4, 4), dtype=np.complex128)
         gdicke = zeros.copy()
         guncoupled = zeros.copy()
         gdicke[2, 2] = 1
@@ -1017,7 +1017,7 @@ class TestDicke:
         test_identity = identity_uncoupled(4)
         assert_equal(test_identity.dims, [[2, 2, 2, 2], [2, 2, 2, 2]])
         assert_array_equal(
-            np.diag(test_identity.full()), np.ones(16, np.complex)
+            np.diag(test_identity.full()), np.ones(16, np.complex128)
         )
 
     def test_css(self):
@@ -1026,7 +1026,7 @@ class TestDicke:
         """
         test_css_uncoupled = css(2, basis="uncoupled")
         test_css_dicke = css(2)
-        css_uncoupled = 0.25 * np.ones((4, 4), dtype=np.complex)
+        css_uncoupled = 0.25 * np.ones((4, 4), dtype=np.complex128)
         css_dicke = np.array(
             [
                 [

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -457,7 +457,7 @@ class TestQubitCircuit:
         User defined gate for QubitCircuit
         """
         def customer_gate1(arg_values):
-            mat = np.zeros((4, 4), dtype=np.complex)
+            mat = np.zeros((4, 4), dtype=np.complex128)
             mat[0, 0] = mat[1, 1] = 1.
             mat[2:4, 2:4] = gates.rx(arg_values)
             return Qobj(mat, dims=[[2, 2], [2, 2]])


### PR DESCRIPTION
Numpy 1.20 officially deprecated use of `np.int` and other things like `np.complex`.  These were just thin aliases to Python types anyway, so that replacement is safe.  Swap `float` and `complex` to `np.float64` and `np.complex128`; these still match Python precision (and standard double-precision floats), but more importantly we assume at all points in Cython code that we're dealing with double-precision arithmetic.  Anything else would be a larger problem for us.

In cases where `np.int` was used as a type check, we actually care more about checking for Integral typing, rather than specifically the int class; super weird constructs like
```python
isinstance(np.int64(1), int) == False
```
so taking indices out of an ndarry may lead to incorrect results when this sort of test is used.  Better to use the abstract
```python
isinstance(..., numbers.Integral)
```

See: https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated