### PR TITLE
Catch integer overflow segfault in zcsr_kron

### DIFF
--- a/qutip/cy/brtools.pxd
+++ b/qutip/cy/brtools.pxd
@@ -62,7 +62,7 @@ cdef void cop_super_mult(complex[::1,:] cop, complex[::1,:] evecs,  double compl
                     double complex alpha,
                     double complex * out,
                     unsigned int nrows,
-                    double atol)
+                    double atol) except *
 
 cdef void vec2mat_index(int nrows, int index, int[2] out) nogil
 

--- a/qutip/cy/openmp/br_omp.pxd
+++ b/qutip/cy/openmp/br_omp.pxd
@@ -33,8 +33,7 @@
 ###############################################################################
 cimport numpy as cnp
 
-#Spectral function with signature (w,t)
-ctypedef complex (*spec_func)(double, double)
+from qutip.cy.brtools cimport spec_func
 
 
 cdef void cop_super_mult_openmp(complex[::1,:] cop, complex[::1,:] evecs,  double complex * vec,

--- a/qutip/cy/openmp/br_omp.pxd
+++ b/qutip/cy/openmp/br_omp.pxd
@@ -42,7 +42,7 @@ cdef void cop_super_mult_openmp(complex[::1,:] cop, complex[::1,:] evecs,  doubl
                     unsigned int nrows,
                     unsigned int omp_thresh,
                     unsigned int nthr,
-                    double atol)
+                    double atol) except *
 
 
 cdef void br_term_mult_openmp(double t, complex[::1,:] A, complex[::1,:] evecs,
@@ -52,4 +52,4 @@ cdef void br_term_mult_openmp(double t, complex[::1,:] A, complex[::1,:] evecs,
                 double sec_cutoff,
                 unsigned int omp_thresh,
                 unsigned int nthr,
-                double atol)
+                double atol) except *

--- a/qutip/cy/spmath.pxd
+++ b/qutip/cy/spmath.pxd
@@ -34,6 +34,8 @@
 
 from qutip.cy.sparse_structs cimport CSR_Matrix
 
+cdef int _safe_multiply(int a, int b) except? -1
+
 cdef void _zcsr_add(CSR_Matrix * A, CSR_Matrix * B,
                     CSR_Matrix * C, double complex alpha)
 
@@ -46,7 +48,7 @@ cdef int _zcsr_add_core(double complex * Adata, int * Aind, int * Aptr,
 cdef void _zcsr_mult(CSR_Matrix * A, CSR_Matrix * B, CSR_Matrix * C)
 
 
-cdef void _zcsr_kron(CSR_Matrix * A, CSR_Matrix * B, CSR_Matrix * C)
+cdef void _zcsr_kron(CSR_Matrix * A, CSR_Matrix * B, CSR_Matrix * C) except *
 
 cdef void _zcsr_kron_core(double complex * dataA, int * indsA, int * indptrA,
                           double complex * dataB, int * indsB, int * indptrB,


### PR DESCRIPTION
The function _safe_multiply was meant to raise a Python exception if the
integer arithmetic overflowed.  However, neither it nor several of its
call sites had the full exception-handling mechanisms enabled.

In addition, extremely large tensor products such as
    tensor([basis(2, 0) for _ in [None]*31])
would segfault when using 32-bit integer arithmetic, because the size
calculation was not checked with _safe_multiply.

Fix #1406: turns the segfault into an exception.