### PR TITLE
Fix QuTiP interaction with numpy 1.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython", "numpy", "scipy"]
+requires = [
+    "setuptools",
+    "wheel",
+    "cython>=0.29.20",
+    "numpy>=1.16.6,<1.20",
+    "scipy>=1.0",
+]

--- a/qutip/continuous_variables.py
+++ b/qutip/continuous_variables.py
@@ -69,15 +69,16 @@ def correlation_matrix(basis, rho=None):
 
 
     """
-
     if rho is None:
         # return array of operators
-        return np.array([[op1 * op2 for op1 in basis]
-                         for op2 in basis], dtype=object)
+        out = np.empty((len(basis), len(basis)), dtype=object)
+        for i, op2 in enumerate(basis):
+            out[i, :] = [op1 * op2 for op1 in basis]
+        return out
     else:
         # return array of expectation values
         return np.array([[expect(op1 * op2, rho)
-                          for op1 in basis] for op2 in basis], dtype=object)
+                          for op1 in basis] for op2 in basis])
 
 
 def covariance_matrix(basis, rho, symmetrized=True):
@@ -116,11 +117,11 @@ def covariance_matrix(basis, rho, symmetrized=True):
     if symmetrized:
         return np.array([[0.5 * expect(op1 * op2 + op2 * op1, rho) -
                           expect(op1, rho) * expect(op2, rho)
-                          for op1 in basis] for op2 in basis], dtype=object)
+                          for op1 in basis] for op2 in basis])
     else:
         return np.array([[expect(op1 * op2, rho) -
                           expect(op1, rho) * expect(op2, rho)
-                          for op1 in basis] for op2 in basis], dtype=object)
+                          for op1 in basis] for op2 in basis])
 
 
 def correlation_matrix_field(a1, a2, rho=None):
@@ -145,9 +146,7 @@ def correlation_matrix_field(a1, a2, rho=None):
         A 2-dimensional *array* of covariance values, or, if rho=0, a matrix
         of operators.
     """
-
     basis = [a1, a1.dag(), a2, a2.dag()]
-
     return correlation_matrix(basis, rho)
 
 
@@ -183,9 +182,7 @@ def correlation_matrix_quadrature(a1, a2, rho=None, g=np.sqrt(2)):
     p1 = -1j * (a1 - a1.dag()) / g
     x2 = (a2 + a2.dag()) / g
     p2 = -1j * (a2 - a2.dag()) / g
-
     basis = [x1, p1, x2, p2]
-
     return correlation_matrix(basis, rho)
 
 
@@ -232,18 +229,15 @@ def wigner_covariance_matrix(a1=None, a2=None, R=None, rho=None, g=np.sqrt(2)):
 
     """
     if R is not None:
-
         if rho is None:
             return np.array([[0.5 * np.real(R[i, j] + R[j, i])
                               for i in range(4)]
-                             for j in range(4)], dtype=object)
+                             for j in range(4)], dtype=np.float64)
         else:
             return np.array([[0.5 * np.real(expect(R[i, j] + R[j, i], rho))
                               for i in range(4)]
-                             for j in range(4)], dtype=object)
-
+                             for j in range(4)], dtype=np.float64)
     elif a1 is not None and a2 is not None:
-
         if rho is not None:
             x1 = (a1 + a1.dag()) / g
             p1 = -1j * (a1 - a1.dag()) / g
@@ -253,7 +247,6 @@ def wigner_covariance_matrix(a1=None, a2=None, R=None, rho=None, g=np.sqrt(2)):
         else:
             raise ValueError("Must give rho if using field operators " +
                              "(a1 and a2)")
-
     else:
         raise ValueError("Must give either field operators (a1 and a2) " +
                          "or a precomputed correlation matrix (R)")
@@ -286,11 +279,9 @@ def logarithmic_negativity(V, g=np.sqrt(2)):
         that is described by the the Wigner covariance matrix V.
 
     """
-
     A = 0.5 * V[0:2, 0:2] * g ** 2
     B = 0.5 * V[2:4, 2:4] * g ** 2
     C = 0.5 * V[0:2, 2:4] * g ** 2
-
     sigma = np.linalg.det(A) + np.linalg.det(B) - 2 * np.linalg.det(C)
     nu_ = sigma / 2 - np.sqrt(sigma ** 2 - 4 * np.linalg.det(V)) / 2
     if nu_ < 0.0:
@@ -298,5 +289,4 @@ def logarithmic_negativity(V, g=np.sqrt(2)):
     nu = np.sqrt(nu_)
     lognu = -np.log(2 * nu)
     logneg = max(0, lognu)
-
     return logneg

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -104,7 +104,10 @@ def _check_ctrls_container(ctrls):
         # Check to see if list of lists
         try:
             if isinstance(ctrls[0], (list, tuple)):
-                ctrls = np.array(ctrls, dtype=object)
+                ctrls_ = np.empty((len(ctrls), len(ctrls[0])), dtype=object)
+                for i, ctrl in enumerate(ctrls):
+                    ctrls_[i, :] = ctrl
+                ctrls = ctrls_
         except:
             pass
 

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -65,26 +65,26 @@ CRAB
 ----
 The CRAB [3][4] algorithm was developed at the University of Ulm.
 In full it is the Chopped RAndom Basis algorithm.
-The main difference is that it reduces the number of optimisation variables 
-by defining the control pulses by expansions of basis functions, 
-where the variables are the coefficients. Typically a Fourier series is chosen, 
-i.e. the variables are the Fourier coefficients. 
-Therefore it does not need to compute an explicit gradient. 
-By default it uses the Nelder-Mead method for fidelity error minimisation. 
+The main difference is that it reduces the number of optimisation variables
+by defining the control pulses by expansions of basis functions,
+where the variables are the coefficients. Typically a Fourier series is chosen,
+i.e. the variables are the Fourier coefficients.
+Therefore it does not need to compute an explicit gradient.
+By default it uses the Nelder-Mead method for fidelity error minimisation.
 
 References
 ----------
-1.  N Khaneja et. al. 
-    Optimal control of coupled spin dynamics: Design of NMR pulse sequences 
+1.  N Khaneja et. al.
+    Optimal control of coupled spin dynamics: Design of NMR pulse sequences
     by gradient ascent algorithms. J. Magn. Reson. 172, 296–305 (2005).
 2.  Shai Machnes et.al
     DYNAMO - Dynamic Framework for Quantum Optimal Control
     arXiv.1011.4874
-3.  Doria, P., Calarco, T. & Montangero, S. 
-    Optimal Control Technique for Many-Body Quantum Dynamics. 
+3.  Doria, P., Calarco, T. & Montangero, S.
+    Optimal Control Technique for Many-Body Quantum Dynamics.
     Phys. Rev. Lett. 106, 1–4 (2011).
-4.  Caneva, T., Calarco, T. & Montangero, S. 
-    Chopped random-basis quantum optimization. 
+4.  Caneva, T., Calarco, T. & Montangero, S.
+    Chopped random-basis quantum optimization.
     Phys. Rev. A - At. Mol. Opt. Phys. 84, (2011).
 
 """
@@ -107,7 +107,7 @@ import qutip.control.propcomp as propcomp
 import qutip.control.pulsegen as pulsegen
 #import qutip.control.pulsegencrab as pulsegencrab
 
-warnings.simplefilter('always', DeprecationWarning) #turn off filter 
+warnings.simplefilter('always', DeprecationWarning) #turn off filter
 def _param_deprecation(message, stacklevel=3):
     """
     Issue deprecation warning
@@ -115,14 +115,14 @@ def _param_deprecation(message, stacklevel=3):
     calling with the deprecated parameter,
     """
     warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
-    
+
 def _upper_safe(s):
     try:
         s = s.upper()
     except:
         pass
     return s
-            
+
 def optimize_pulse(
         drift, ctrls, initial, target,
         num_tslots=None, evo_time=None, tau=None,
@@ -215,39 +215,39 @@ def optimize_pulse(
     alg : string
         Algorithm to use in pulse optimisation.
         Options are:
-            
+
             'GRAPE' (default) - GRadient Ascent Pulse Engineering
             'CRAB' - Chopped RAndom Basis
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
-        
+
     optim_params : Dictionary
         The key value pairs are the attribute name and value
         used to set attribute values
         Note: attributes are created if they do not exist already,
         and are overwritten if they do.
         Note: method_params are applied afterwards and so may override these
-        
+
     optim_method : string
         a scipy.optimize.minimize method that will be used to optimise
         the pulse for minimum fidelity error
         Note that FMIN, FMIN_BFGS & FMIN_L_BFGS_B will all result
         in calling these specific scipy.optimize methods
-        Note the LBFGSB is equivalent to FMIN_L_BFGS_B for backwards 
+        Note the LBFGSB is equivalent to FMIN_L_BFGS_B for backwards
         capatibility reasons.
         Supplying DEF will given alg dependent result:
             GRAPE - Default optim_method is FMIN_L_BFGS_B
             CRAB - Default optim_method is FMIN
-        
+
     method_params : dict
-        Parameters for the optim_method. 
+        Parameters for the optim_method.
         Note that where there is an attribute of the
-        Optimizer object or the termination_conditions matching the key 
-        that attribute. Otherwise, and in some case also, 
+        Optimizer object or the termination_conditions matching the key
+        that attribute. Otherwise, and in some case also,
         they are assumed to be method_options
-        for the scipy.optimize.minimize method.        
-        
+        for the scipy.optimize.minimize method.
+
     optim_alg : string
         Deprecated. Use optim_method.
 
@@ -261,7 +261,7 @@ def optimize_pulse(
         Dynamics type, i.e. the type of matrix used to describe
         the dynamics. Options are UNIT, GEN_MAT, SYMPL
         (see Dynamics classes for details)
-        
+
     dyn_params : dict
         Parameters for the Dynamics object
         The key value pairs are assumed to be attribute name value pairs
@@ -278,7 +278,7 @@ def optimize_pulse(
         Parameters for the PropagatorComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     fid_type : string
         Fidelity error (and fidelity error gradient) computation method
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX
@@ -289,7 +289,7 @@ def optimize_pulse(
         Parameters for the FidelityComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     phase_option : string
         Deprecated. Pass in fid_params instead.
 
@@ -297,28 +297,28 @@ def optimize_pulse(
         Deprecated. Use scale_factor key in fid_params instead.
 
     tslot_type : string
-        Method for computing the dynamics generators, propagators and 
+        Method for computing the dynamics generators, propagators and
         evolution in the timeslots.
         Options: DEF, UPDATE_ALL, DYNAMIC
         UPDATE_ALL is the only one that currently works
         (See TimeslotComputer classes for details)
-        
+
     tslot_params : dict
         Parameters for the TimeslotComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     amp_update_mode : string
         Deprecated. Use tslot_type instead.
-        
+
     init_pulse_type : string
         type / shape of pulse(s) used to initialise the
-        the control amplitudes. 
+        the control amplitudes.
         Options (GRAPE) include:
             RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW
         DEF is RND
         (see PulseGen classes for details)
-        For the CRAB the this the guess_pulse_type. 
+        For the CRAB the this the guess_pulse_type.
 
     init_pulse_params : dict
         Parameters for the initial / guess pulse generator object
@@ -333,14 +333,14 @@ def optimize_pulse(
     pulse_offset : float
         Linear offset for the pulse. That is this value will be added
         to any initial / guess pulses generated.
-        
+
     ramping_pulse_type : string
         Type of pulse used to modulate the control pulse.
-        It's intended use for a ramping modulation, which is often required in 
+        It's intended use for a ramping modulation, which is often required in
         experimental setups.
         This is only currently implemented in CRAB.
         GAUSSIAN_EDGE was added for this purpose.
-        
+
     ramping_pulse_params : dict
         Parameters for the ramping pulse generator object
         The key value pairs are assumed to be attribute name value pairs
@@ -369,17 +369,17 @@ def optimize_pulse(
 
     Returns
     -------
-    opt : OptimResult     
+    opt : OptimResult
         Returns instance of OptimResult, which has attributes giving the
         reason for termination, final fidelity error, final evolution
         final amplitudes, statistics etc
-    
+
     """
     if log_level == logging.NOTSET:
         log_level = logger.getEffectiveLevel()
     else:
         logger.setLevel(log_level)
-        
+
     # The parameters types are checked in create_pulse_optimizer
     # so no need to do so here
     # However, the deprecation management is repeated here
@@ -389,7 +389,7 @@ def optimize_pulse(
         _param_deprecation(
             "The 'optim_alg' parameter is deprecated. "
             "Use 'optim_method' instead")
-            
+
     if not max_metric_corr is None:
         if isinstance(method_params, dict):
             if not 'max_metric_corr' in method_params:
@@ -399,7 +399,7 @@ def optimize_pulse(
         _param_deprecation(
             "The 'max_metric_corr' parameter is deprecated. "
             "Use 'max_metric_corr' in method_params instead")
-            
+
     if not accuracy_factor is None:
         if isinstance(method_params, dict):
             if not 'accuracy_factor' in method_params:
@@ -409,7 +409,7 @@ def optimize_pulse(
         _param_deprecation(
             "The 'accuracy_factor' parameter is deprecated. "
             "Use 'accuracy_factor' in method_params instead")
-    
+
     # phase_option
     if not phase_option is None:
         if isinstance(fid_params, dict):
@@ -420,7 +420,7 @@ def optimize_pulse(
         _param_deprecation(
             "The 'phase_option' parameter is deprecated. "
             "Use 'phase_option' in fid_params instead")
-            
+
     # fid_err_scale_factor
     if not fid_err_scale_factor is None:
         if isinstance(fid_params, dict):
@@ -431,7 +431,7 @@ def optimize_pulse(
         _param_deprecation(
             "The 'fid_err_scale_factor' parameter is deprecated. "
             "Use 'scale_factor' in fid_params instead")
-            
+
     # amp_update_mode
     if not amp_update_mode is None:
         amp_update_mode_up = _upper_safe(amp_update_mode)
@@ -451,12 +451,12 @@ def optimize_pulse(
         max_iter=max_iter, max_wall_time=max_wall_time,
         alg=alg, alg_params=alg_params, optim_params=optim_params,
         optim_method=optim_method, method_params=method_params,
-        dyn_type=dyn_type, dyn_params=dyn_params, 
+        dyn_type=dyn_type, dyn_params=dyn_params,
         prop_type=prop_type, prop_params=prop_params,
         fid_type=fid_type, fid_params=fid_params,
         init_pulse_type=init_pulse_type, init_pulse_params=init_pulse_params,
         pulse_scaling=pulse_scaling, pulse_offset=pulse_offset,
-        ramping_pulse_type=ramping_pulse_type, 
+        ramping_pulse_type=ramping_pulse_type,
         ramping_pulse_params=ramping_pulse_params,
         log_level=log_level, gen_stats=gen_stats)
 
@@ -465,7 +465,7 @@ def optimize_pulse(
     dyn.init_timeslots()
     # Generate initial pulses for each control
     init_amps = np.zeros([dyn.num_tslots, dyn.num_ctrls])
-    
+
     if alg == 'CRAB':
         for j in range(dyn.num_ctrls):
             pgen = optim.pulse_generator[j]
@@ -475,10 +475,10 @@ def optimize_pulse(
         pgen = optim.pulse_generator
         for j in range(dyn.num_ctrls):
             init_amps[:, j] = pgen.gen_pulse()
-        
+
     # Initialise the starting amplitudes
     dyn.initialize_controls(init_amps)
-    
+
     if log_level <= logging.INFO:
         msg = "System configuration:\n"
         dg_name = "dynamics generator"
@@ -527,7 +527,7 @@ def optimize_pulse_unitary(
         alg='GRAPE', alg_params=None,
         optim_params=None, optim_method='DEF', method_params=None,
         optim_alg=None, max_metric_corr=None, accuracy_factor=None,
-        phase_option='PSU', 
+        phase_option='PSU',
         dyn_params=None, prop_params=None, fid_params=None,
         tslot_type='DEF', tslot_params=None,
         amp_update_mode=None,
@@ -558,7 +558,7 @@ def optimize_pulse_unitary(
     H_d : Qobj or list of Qobj
         Drift (aka system) the underlying Hamiltonian of the system
         can provide list (of length num_tslots) for time dependent drift
-        
+
     H_c : List of Qobj or array like [num_tslots, evo_time]
         a list of control Hamiltonians. These are scaled by
         the amplitudes to alter the overall dynamics
@@ -619,34 +619,34 @@ def optimize_pulse_unitary(
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
-        
+
     optim_params : Dictionary
         The key value pairs are the attribute name and value
         used to set attribute values
         Note: attributes are created if they do not exist already,
         and are overwritten if they do.
         Note: method_params are applied afterwards and so may override these
-        
+
     optim_method : string
         a scipy.optimize.minimize method that will be used to optimise
         the pulse for minimum fidelity error
         Note that FMIN, FMIN_BFGS & FMIN_L_BFGS_B will all result
         in calling these specific scipy.optimize methods
-        Note the LBFGSB is equivalent to FMIN_L_BFGS_B for backwards 
+        Note the LBFGSB is equivalent to FMIN_L_BFGS_B for backwards
         capatibility reasons.
         Supplying DEF will given alg dependent result:
-            
+
             GRAPE - Default optim_method is FMIN_L_BFGS_B
             CRAB - Default optim_method is FMIN
-        
+
     method_params : dict
-        Parameters for the optim_method. 
+        Parameters for the optim_method.
         Note that where there is an attribute of the
-        Optimizer object or the termination_conditions matching the key 
-        that attribute. Otherwise, and in some case also, 
+        Optimizer object or the termination_conditions matching the key
+        that attribute. Otherwise, and in some case also,
         they are assumed to be method_options
-        for the scipy.optimize.minimize method.        
-        
+        for the scipy.optimize.minimize method.
+
     optim_alg : string
         Deprecated. Use optim_method.
 
@@ -659,7 +659,7 @@ def optimize_pulse_unitary(
     phase_option : string
         determines how global phase is treated in fidelity
         calculations (fid_type='UNIT' only). Options:
-            
+
             PSU - global phase ignored
             SU - global phase included
 
@@ -677,32 +677,32 @@ def optimize_pulse_unitary(
         Parameters for the FidelityComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     tslot_type : string
-        Method for computing the dynamics generators, propagators and 
+        Method for computing the dynamics generators, propagators and
         evolution in the timeslots.
         Options: DEF, UPDATE_ALL, DYNAMIC
         UPDATE_ALL is the only one that currently works
         (See TimeslotComputer classes for details)
-        
+
     tslot_params : dict
         Parameters for the TimeslotComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     amp_update_mode : string
         Deprecated. Use tslot_type instead.
-        
+
     init_pulse_type : string
         type / shape of pulse(s) used to initialise the
-        the control amplitudes. 
+        the control amplitudes.
         Options (GRAPE) include:
-            
+
             RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW
             DEF is RND
-        
+
         (see PulseGen classes for details)
-        For the CRAB the this the guess_pulse_type. 
+        For the CRAB the this the guess_pulse_type.
 
     init_pulse_params : dict
         Parameters for the initial / guess pulse generator object
@@ -717,14 +717,14 @@ def optimize_pulse_unitary(
     pulse_offset : float
         Linear offset for the pulse. That is this value will be added
         to any initial / guess pulses generated.
-        
+
     ramping_pulse_type : string
         Type of pulse used to modulate the control pulse.
-        It's intended use for a ramping modulation, which is often required in 
+        It's intended use for a ramping modulation, which is often required in
         experimental setups.
         This is only currently implemented in CRAB.
         GAUSSIAN_EDGE was added for this purpose.
-        
+
     ramping_pulse_params : dict
         Parameters for the ramping pulse generator object
         The key value pairs are assumed to be attribute name value pairs
@@ -757,11 +757,11 @@ def optimize_pulse_unitary(
         Returns instance of OptimResult, which has attributes giving the
         reason for termination, final fidelity error, final evolution
         final amplitudes, statistics etc
-    
+
     """
 
     # parameters are checked in create pulse optimiser
-        
+
     # The deprecation management is repeated here
     # so that the stack level is correct
     if not optim_alg is None:
@@ -769,7 +769,7 @@ def optimize_pulse_unitary(
         _param_deprecation(
             "The 'optim_alg' parameter is deprecated. "
             "Use 'optim_method' instead")
-            
+
     if not max_metric_corr is None:
         if isinstance(method_params, dict):
             if not 'max_metric_corr' in method_params:
@@ -779,7 +779,7 @@ def optimize_pulse_unitary(
         _param_deprecation(
             "The 'max_metric_corr' parameter is deprecated. "
             "Use 'max_metric_corr' in method_params instead")
-            
+
     if not accuracy_factor is None:
         if isinstance(method_params, dict):
             if not 'accuracy_factor' in method_params:
@@ -789,7 +789,7 @@ def optimize_pulse_unitary(
         _param_deprecation(
             "The 'accuracy_factor' parameter is deprecated. "
             "Use 'accuracy_factor' in method_params instead")
-            
+
     # amp_update_mode
     if not amp_update_mode is None:
         amp_update_mode_up = _upper_safe(amp_update_mode)
@@ -800,7 +800,7 @@ def optimize_pulse_unitary(
         _param_deprecation(
             "The 'amp_update_mode' parameter is deprecated. "
             "Use 'tslot_type' instead")
-            
+
     # phase_option is still valid for this method
     # pass it via the fid_params
     if not phase_option is None:
@@ -809,8 +809,8 @@ def optimize_pulse_unitary(
         else:
             if not 'phase_option' in fid_params:
                 fid_params['phase_option'] = phase_option
-            
-            
+
+
     return optimize_pulse(
             drift=H_d, ctrls=H_c, initial=U_0, target=U_targ,
             num_tslots=num_tslots, evo_time=evo_time, tau=tau,
@@ -823,11 +823,11 @@ def optimize_pulse_unitary(
             prop_params=prop_params, fid_params=fid_params,
             init_pulse_type=init_pulse_type, init_pulse_params=init_pulse_params,
             pulse_scaling=pulse_scaling, pulse_offset=pulse_offset,
-            ramping_pulse_type=ramping_pulse_type, 
+            ramping_pulse_type=ramping_pulse_type,
             ramping_pulse_params=ramping_pulse_params,
             log_level=log_level, out_file_ext=out_file_ext,
             gen_stats=gen_stats)
-            
+
 def opt_pulse_crab(
         drift, ctrls, initial, target,
         num_tslots=None, evo_time=None, tau=None,
@@ -835,7 +835,7 @@ def opt_pulse_crab(
         fid_err_targ=1e-5,
         max_iter=500, max_wall_time=180,
         alg_params=None,
-        num_coeffs=None, init_coeff_scaling=1.0, 
+        num_coeffs=None, init_coeff_scaling=1.0,
         optim_params=None, optim_method='fmin', method_params=None,
         dyn_type='GEN_MAT', dyn_params=None,
         prop_type='DEF', prop_params=None,
@@ -843,7 +843,7 @@ def opt_pulse_crab(
         tslot_type='DEF', tslot_params=None,
         guess_pulse_type=None, guess_pulse_params=None,
         guess_pulse_scaling=1.0, guess_pulse_offset=0.0,
-        guess_pulse_action='MODULATE', 
+        guess_pulse_action='MODULATE',
         ramping_pulse_type=None, ramping_pulse_params=None,
         log_level=logging.NOTSET, out_file_ext=None, gen_stats=False):
     """
@@ -914,7 +914,7 @@ def opt_pulse_crab(
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
-        
+
     optim_params : Dictionary
         The key value pairs are the attribute name and value
         used to set attribute values
@@ -926,37 +926,37 @@ def opt_pulse_crab(
         Linear scale factor for the random basis coefficients
         By default these range from -1.0 to 1.0
         Note this is overridden by alg_params (if given there)
-        
+
     num_coeffs : integer
         Number of coefficients used for each basis function
         Note this is calculated automatically based on the dimension of the
-        dynamics if not given. It is crucial to the performane of the 
+        dynamics if not given. It is crucial to the performane of the
         algorithm that it is set as low as possible, while still giving
         high enough frequencies.
         Note this is overridden by alg_params (if given there)
-        
+
     optim_method : string
         Multi-variable optimisation method
         The only tested options are 'fmin' and 'Nelder-mead'
-        In theory any non-gradient method implemented in 
+        In theory any non-gradient method implemented in
         scipy.optimize.mininize could be used.
 
     method_params : dict
-        Parameters for the optim_method. 
+        Parameters for the optim_method.
         Note that where there is an attribute of the
-        Optimizer object or the termination_conditions matching the key 
-        that attribute. Otherwise, and in some case also, 
+        Optimizer object or the termination_conditions matching the key
+        that attribute. Otherwise, and in some case also,
         they are assumed to be method_options
         for the scipy.optimize.minimize method.
         The commonly used parameter are:
             xtol - limit on variable change for convergence
             ftol - limit on fidelity error change for convergence
-            
+
     dyn_type : string
         Dynamics type, i.e. the type of matrix used to describe
         the dynamics. Options are UNIT, GEN_MAT, SYMPL
         (see Dynamics classes for details)
-        
+
     dyn_params : dict
         Parameters for the Dynamics object
         The key value pairs are assumed to be attribute name value pairs
@@ -973,7 +973,7 @@ def opt_pulse_crab(
         Parameters for the PropagatorComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     fid_type : string
         Fidelity error (and fidelity error gradient) computation method
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX
@@ -984,34 +984,34 @@ def opt_pulse_crab(
         Parameters for the FidelityComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     tslot_type : string
-        Method for computing the dynamics generators, propagators and 
+        Method for computing the dynamics generators, propagators and
         evolution in the timeslots.
         Options: DEF, UPDATE_ALL, DYNAMIC
         UPDATE_ALL is the only one that currently works
         (See TimeslotComputer classes for details)
-        
+
     tslot_params : dict
         Parameters for the TimeslotComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     guess_pulse_type : string
-        type / shape of pulse(s) used modulate the control amplitudes. 
+        type / shape of pulse(s) used modulate the control amplitudes.
         Options include:
             RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW, GAUSSIAN
         Default is None
-        
+
     guess_pulse_params : dict
         Parameters for the guess pulse generator object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     guess_pulse_action : string
         Determines how the guess pulse is applied to the pulse generated
         by the basis expansion.
-        Options are: MODULATE, ADD 
+        Options are: MODULATE, ADD
         Default is MODULATE
 
     pulse_scaling : float
@@ -1022,14 +1022,14 @@ def opt_pulse_crab(
     pulse_offset : float
         Linear offset for the pulse. That is this value will be added
         to any guess pulses generated.
-        
+
     ramping_pulse_type : string
         Type of pulse used to modulate the control pulse.
-        It's intended use for a ramping modulation, which is often required in 
+        It's intended use for a ramping modulation, which is often required in
         experimental setups.
         This is only currently implemented in CRAB.
         GAUSSIAN_EDGE was added for this purpose.
-        
+
     ramping_pulse_params : dict
         Parameters for the ramping pulse generator object
         The key value pairs are assumed to be attribute name value pairs
@@ -1058,11 +1058,11 @@ def opt_pulse_crab(
 
     Returns
     -------
-    opt : OptimResult    
+    opt : OptimResult
         Returns instance of OptimResult, which has attributes giving the
         reason for termination, final fidelity error, final evolution
         final amplitudes, statistics etc
-    
+
     """
 
     # The parameters are checked in create_pulse_optimizer
@@ -1074,33 +1074,33 @@ def opt_pulse_crab(
         logger.setLevel(log_level)
 
     # build the algorithm options
-    if not isinstance(alg_params, dict): 
-        alg_params = {'num_coeffs':num_coeffs, 
+    if not isinstance(alg_params, dict):
+        alg_params = {'num_coeffs':num_coeffs,
                        'init_coeff_scaling':init_coeff_scaling}
     else:
-        if (num_coeffs is not None and 
+        if (num_coeffs is not None and
             not 'num_coeffs' in alg_params):
             alg_params['num_coeffs'] = num_coeffs
-        if (init_coeff_scaling is not None and 
+        if (init_coeff_scaling is not None and
             not 'init_coeff_scaling' in alg_params):
             alg_params['init_coeff_scaling'] = init_coeff_scaling
-            
+
     # Build the guess pulse options
     # Any options passed in the guess_pulse_params take precedence
     # over the parameter values.
-    if guess_pulse_type: 
+    if guess_pulse_type:
         if not isinstance(guess_pulse_params, dict):
             guess_pulse_params = {}
-        if (guess_pulse_scaling is not None and 
+        if (guess_pulse_scaling is not None and
             not 'scaling' in guess_pulse_params):
             guess_pulse_params['scaling'] = guess_pulse_scaling
-        if (guess_pulse_offset is not None and 
+        if (guess_pulse_offset is not None and
             not 'offset' in guess_pulse_params):
             guess_pulse_params['offset'] = guess_pulse_offset
-        if (guess_pulse_action is not None and 
+        if (guess_pulse_action is not None and
             not 'pulse_action' in guess_pulse_params):
             guess_pulse_params['pulse_action'] = guess_pulse_action
-         
+
     return optimize_pulse(
         drift, ctrls, initial, target,
         num_tslots=num_tslots, evo_time=evo_time, tau=tau,
@@ -1109,16 +1109,16 @@ def opt_pulse_crab(
         max_iter=max_iter, max_wall_time=max_wall_time,
         alg='CRAB', alg_params=alg_params, optim_params=optim_params,
         optim_method=optim_method, method_params=method_params,
-        dyn_type=dyn_type, dyn_params=dyn_params, 
+        dyn_type=dyn_type, dyn_params=dyn_params,
         prop_type=prop_type, prop_params=prop_params,
         fid_type=fid_type, fid_params=fid_params,
         tslot_type=tslot_type, tslot_params=tslot_params,
-        init_pulse_type=guess_pulse_type, 
+        init_pulse_type=guess_pulse_type,
         init_pulse_params=guess_pulse_params,
-        ramping_pulse_type=ramping_pulse_type, 
+        ramping_pulse_type=ramping_pulse_type,
         ramping_pulse_params=ramping_pulse_params,
         log_level=log_level, out_file_ext=out_file_ext, gen_stats=gen_stats)
-          
+
 def opt_pulse_crab_unitary(
         H_d, H_c, U_0, U_targ,
         num_tslots=None, evo_time=None, tau=None,
@@ -1126,14 +1126,14 @@ def opt_pulse_crab_unitary(
         fid_err_targ=1e-5,
         max_iter=500, max_wall_time=180,
         alg_params=None,
-        num_coeffs=None, init_coeff_scaling=1.0, 
+        num_coeffs=None, init_coeff_scaling=1.0,
         optim_params=None, optim_method='fmin', method_params=None,
-        phase_option='PSU', 
+        phase_option='PSU',
         dyn_params=None, prop_params=None, fid_params=None,
         tslot_type='DEF', tslot_params=None,
         guess_pulse_type=None, guess_pulse_params=None,
         guess_pulse_scaling=1.0, guess_pulse_offset=0.0,
-        guess_pulse_action='MODULATE', 
+        guess_pulse_action='MODULATE',
         ramping_pulse_type=None, ramping_pulse_params=None,
         log_level=logging.NOTSET, out_file_ext=None, gen_stats=False):
     """
@@ -1146,7 +1146,7 @@ def opt_pulse_crab_unitary(
     by the combined Hamiltonian,
     i.e. the sum of the H_d + ctrl_amp[j]*H_c[j]
     The control pulse is an [n_ts, n_ctrls] array of piecewise amplitudes
-    
+
     The CRAB algorithm uses basis function coefficents as the variables to
     optimise. It does NOT use any gradient function.
     A multivariable optimisation algorithm attempts to determines the
@@ -1210,7 +1210,7 @@ def opt_pulse_crab_unitary(
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
-        
+
     optim_params : Dictionary
         The key value pairs are the attribute name and value
         used to set attribute values
@@ -1222,26 +1222,26 @@ def opt_pulse_crab_unitary(
         Linear scale factor for the random basis coefficients
         By default these range from -1.0 to 1.0
         Note this is overridden by alg_params (if given there)
-        
+
     num_coeffs : integer
         Number of coefficients used for each basis function
         Note this is calculated automatically based on the dimension of the
-        dynamics if not given. It is crucial to the performane of the 
+        dynamics if not given. It is crucial to the performane of the
         algorithm that it is set as low as possible, while still giving
         high enough frequencies.
         Note this is overridden by alg_params (if given there)
-        
+
     optim_method : string
         Multi-variable optimisation method
         The only tested options are 'fmin' and 'Nelder-mead'
-        In theory any non-gradient method implemented in 
+        In theory any non-gradient method implemented in
         scipy.optimize.mininize could be used.
 
     method_params : dict
-        Parameters for the optim_method. 
+        Parameters for the optim_method.
         Note that where there is an attribute of the
-        Optimizer object or the termination_conditions matching the key 
-        that attribute. Otherwise, and in some case also, 
+        Optimizer object or the termination_conditions matching the key
+        that attribute. Otherwise, and in some case also,
         they are assumed to be method_options
         for the scipy.optimize.minimize method.
         The commonly used parameter are:
@@ -1268,34 +1268,34 @@ def opt_pulse_crab_unitary(
         Parameters for the FidelityComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     tslot_type : string
-        Method for computing the dynamics generators, propagators and 
+        Method for computing the dynamics generators, propagators and
         evolution in the timeslots.
         Options: DEF, UPDATE_ALL, DYNAMIC
         UPDATE_ALL is the only one that currently works
         (See TimeslotComputer classes for details)
-        
+
     tslot_params : dict
         Parameters for the TimeslotComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     guess_pulse_type : string
-        type / shape of pulse(s) used modulate the control amplitudes. 
+        type / shape of pulse(s) used modulate the control amplitudes.
         Options include:
             RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW, GAUSSIAN
         Default is None
-        
+
     guess_pulse_params : dict
         Parameters for the guess pulse generator object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     guess_pulse_action : string
         Determines how the guess pulse is applied to the pulse generated
         by the basis expansion.
-        Options are: MODULATE, ADD 
+        Options are: MODULATE, ADD
         Default is MODULATE
 
     pulse_scaling : float
@@ -1306,14 +1306,14 @@ def opt_pulse_crab_unitary(
     pulse_offset : float
         Linear offset for the pulse. That is this value will be added
         to any guess pulses generated.
-        
+
     ramping_pulse_type : string
         Type of pulse used to modulate the control pulse.
-        It's intended use for a ramping modulation, which is often required in 
+        It's intended use for a ramping modulation, which is often required in
         experimental setups.
         This is only currently implemented in CRAB.
         GAUSSIAN_EDGE was added for this purpose.
-        
+
     ramping_pulse_params : dict
         Parameters for the ramping pulse generator object
         The key value pairs are assumed to be attribute name value pairs
@@ -1342,11 +1342,11 @@ def opt_pulse_crab_unitary(
 
     Returns
     -------
-    opt : OptimResult    
+    opt : OptimResult
         Returns instance of OptimResult, which has attributes giving the
         reason for termination, final fidelity error, final evolution
         final amplitudes, statistics etc
-    
+
     """
 
     # The parameters are checked in create_pulse_optimizer
@@ -1358,33 +1358,33 @@ def opt_pulse_crab_unitary(
         logger.setLevel(log_level)
 
     # build the algorithm options
-    if not isinstance(alg_params, dict): 
-        alg_params = {'num_coeffs':num_coeffs, 
+    if not isinstance(alg_params, dict):
+        alg_params = {'num_coeffs':num_coeffs,
                        'init_coeff_scaling':init_coeff_scaling}
     else:
-        if (num_coeffs is not None and 
+        if (num_coeffs is not None and
             not 'num_coeffs' in alg_params):
             alg_params['num_coeffs'] = num_coeffs
-        if (init_coeff_scaling is not None and 
+        if (init_coeff_scaling is not None and
             not 'init_coeff_scaling' in alg_params):
             alg_params['init_coeff_scaling'] = init_coeff_scaling
-            
+
     # Build the guess pulse options
     # Any options passed in the guess_pulse_params take precedence
     # over the parameter values.
-    if guess_pulse_type: 
+    if guess_pulse_type:
         if not isinstance(guess_pulse_params, dict):
             guess_pulse_params = {}
-        if (guess_pulse_scaling is not None and 
+        if (guess_pulse_scaling is not None and
             not 'scaling' in guess_pulse_params):
             guess_pulse_params['scaling'] = guess_pulse_scaling
-        if (guess_pulse_offset is not None and 
+        if (guess_pulse_offset is not None and
             not 'offset' in guess_pulse_params):
             guess_pulse_params['offset'] = guess_pulse_offset
-        if (guess_pulse_action is not None and 
+        if (guess_pulse_action is not None and
             not 'pulse_action' in guess_pulse_params):
             guess_pulse_params['pulse_action'] = guess_pulse_action
-         
+
     return optimize_pulse_unitary(
         H_d, H_c, U_0, U_targ,
         num_tslots=num_tslots, evo_time=evo_time, tau=tau,
@@ -1396,9 +1396,9 @@ def opt_pulse_crab_unitary(
         phase_option=phase_option,
         dyn_params=dyn_params, prop_params=prop_params, fid_params=fid_params,
         tslot_type=tslot_type, tslot_params=tslot_params,
-        init_pulse_type=guess_pulse_type, 
+        init_pulse_type=guess_pulse_type,
         init_pulse_params=guess_pulse_params,
-        ramping_pulse_type=ramping_pulse_type, 
+        ramping_pulse_type=ramping_pulse_type,
         ramping_pulse_params=ramping_pulse_params,
         log_level=log_level, out_file_ext=out_file_ext, gen_stats=gen_stats)
 
@@ -1488,7 +1488,7 @@ def create_pulse_optimizer(
 
     max_wall_time : float
         Maximum allowed elapsed time for the optimisation algorithm
-        
+
     alg : string
         Algorithm to use in pulse optimisation.
         Options are:
@@ -1497,33 +1497,33 @@ def create_pulse_optimizer(
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
-        
+
     optim_params : Dictionary
         The key value pairs are the attribute name and value
         used to set attribute values
         Note: attributes are created if they do not exist already,
         and are overwritten if they do.
         Note: method_params are applied afterwards and so may override these
-        
+
     optim_method : string
         a scipy.optimize.minimize method that will be used to optimise
         the pulse for minimum fidelity error
         Note that FMIN, FMIN_BFGS & FMIN_L_BFGS_B will all result
         in calling these specific scipy.optimize methods
-        Note the LBFGSB is equivalent to FMIN_L_BFGS_B for backwards 
+        Note the LBFGSB is equivalent to FMIN_L_BFGS_B for backwards
         capatibility reasons.
         Supplying DEF will given alg dependent result:
             - GRAPE - Default optim_method is FMIN_L_BFGS_B
             - CRAB - Default optim_method is Nelder-Mead
-        
+
     method_params : dict
-        Parameters for the optim_method. 
+        Parameters for the optim_method.
         Note that where there is an attribute of the
-        Optimizer object or the termination_conditions matching the key 
-        that attribute. Otherwise, and in some case also, 
+        Optimizer object or the termination_conditions matching the key
+        that attribute. Otherwise, and in some case also,
         they are assumed to be method_options
-        for the scipy.optimize.minimize method.        
-        
+        for the scipy.optimize.minimize method.
+
     optim_alg : string
         Deprecated. Use optim_method.
 
@@ -1537,7 +1537,7 @@ def create_pulse_optimizer(
         Dynamics type, i.e. the type of matrix used to describe
         the dynamics. Options are UNIT, GEN_MAT, SYMPL
         (see Dynamics classes for details)
-        
+
     dyn_params : dict
         Parameters for the Dynamics object
         The key value pairs are assumed to be attribute name value pairs
@@ -1554,7 +1554,7 @@ def create_pulse_optimizer(
         Parameters for the PropagatorComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     fid_type : string
         Fidelity error (and fidelity error gradient) computation method
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX
@@ -1565,7 +1565,7 @@ def create_pulse_optimizer(
         Parameters for the FidelityComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     phase_option : string
         Deprecated. Pass in fid_params instead.
 
@@ -1573,30 +1573,30 @@ def create_pulse_optimizer(
         Deprecated. Use scale_factor key in fid_params instead.
 
     tslot_type : string
-        Method for computing the dynamics generators, propagators and 
+        Method for computing the dynamics generators, propagators and
         evolution in the timeslots.
         Options: DEF, UPDATE_ALL, DYNAMIC
         UPDATE_ALL is the only one that currently works
         (See TimeslotComputer classes for details)
-        
+
     tslot_params : dict
         Parameters for the TimeslotComputer object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-        
+
     amp_update_mode : string
         Deprecated. Use tslot_type instead.
-        
+
     init_pulse_type : string
         type / shape of pulse(s) used to initialise the
-        the control amplitudes. 
+        the control amplitudes.
         Options (GRAPE) include:
-            
+
             RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW
             DEF is RND
-        
+
         (see PulseGen classes for details)
-        For the CRAB the this the guess_pulse_type. 
+        For the CRAB the this the guess_pulse_type.
 
     init_pulse_params : dict
         Parameters for the initial / guess pulse generator object
@@ -1611,19 +1611,19 @@ def create_pulse_optimizer(
     pulse_offset : float
         Linear offset for the pulse. That is this value will be added
         to any initial / guess pulses generated.
-        
+
     ramping_pulse_type : string
         Type of pulse used to modulate the control pulse.
-        It's intended use for a ramping modulation, which is often required in 
+        It's intended use for a ramping modulation, which is often required in
         experimental setups.
         This is only currently implemented in CRAB.
         GAUSSIAN_EDGE was added for this purpose.
-        
+
     ramping_pulse_params : dict
         Parameters for the ramping pulse generator object
         The key value pairs are assumed to be attribute name value pairs
         They applied after the object is created
-    
+
     log_level : integer
         level of messaging output from the logger.
         Options are attributes of qutip.logging_utils,
@@ -1641,14 +1641,14 @@ def create_pulse_optimizer(
 
     Returns
     -------
-    opt : Optimizer    
+    opt : Optimizer
         Instance of an Optimizer, through which the
         Config, Dynamics, PulseGen, and TerminationConditions objects
         can be accessed as attributes.
         The PropagatorComputer, FidelityComputer and TimeslotComputer objects
         can be accessed as attributes of the Dynamics object, e.g. optimizer.dynamics.fid_computer
         The optimisation can be run through the optimizer.run_optimization
-    
+
     """
 
     # check parameters
@@ -1660,14 +1660,14 @@ def create_pulse_optimizer(
 
     if not isinstance(target, Qobj):
         raise TypeError("target must be a Qobj")
-        
+
     # Deprecated parameter management
     if not optim_alg is None:
         optim_method = optim_alg
         _param_deprecation(
             "The 'optim_alg' parameter is deprecated. "
             "Use 'optim_method' instead")
-            
+
     if not max_metric_corr is None:
         if isinstance(method_params, dict):
             if not 'max_metric_corr' in method_params:
@@ -1677,7 +1677,7 @@ def create_pulse_optimizer(
         _param_deprecation(
             "The 'max_metric_corr' parameter is deprecated. "
             "Use 'max_metric_corr' in method_params instead")
-            
+
     if not accuracy_factor is None:
         if isinstance(method_params, dict):
             if not 'accuracy_factor' in method_params:
@@ -1687,7 +1687,7 @@ def create_pulse_optimizer(
         _param_deprecation(
             "The 'accuracy_factor' parameter is deprecated. "
             "Use 'accuracy_factor' in method_params instead")
-    
+
     # phase_option
     if not phase_option is None:
         if isinstance(fid_params, dict):
@@ -1698,7 +1698,7 @@ def create_pulse_optimizer(
         _param_deprecation(
             "The 'phase_option' parameter is deprecated. "
             "Use 'phase_option' in fid_params instead")
-            
+
     # fid_err_scale_factor
     if not fid_err_scale_factor is None:
         if isinstance(fid_params, dict):
@@ -1709,7 +1709,7 @@ def create_pulse_optimizer(
         _param_deprecation(
             "The 'fid_err_scale_factor' parameter is deprecated. "
             "Use 'scale_factor' in fid_params instead")
-            
+
     # amp_update_mode
     if not amp_update_mode is None:
         amp_update_mode_up = _upper_safe(amp_update_mode)
@@ -1720,7 +1720,7 @@ def create_pulse_optimizer(
         _param_deprecation(
             "The 'amp_update_mode' parameter is deprecated. "
             "Use 'tslot_type' instead")
-            
+
     # set algorithm defaults
     alg_up = _upper_safe(alg)
     if alg is None:
@@ -1768,7 +1768,7 @@ def create_pulse_optimizer(
     dyn.apply_params(dyn_params)
     dyn._drift_dyn_gen_checked = True
     dyn._ctrl_dyn_gen_checked = True
-    
+
     # Create the PropagatorComputer instance
     # The default will be typically be the best option
     if prop_type == 'DEF' or prop_type is None or prop_type == '':
@@ -1810,11 +1810,11 @@ def create_pulse_optimizer(
     else:
         raise errors.UsageError("No option for fid_type: " + fid_type)
     dyn.fid_computer.apply_params(fid_params)
-    
-    # Currently the only working option for tslot computer is 
+
+    # Currently the only working option for tslot computer is
     # TSlotCompUpdateAll.
     # so just apply the parameters
-    dyn.tslot_computer.apply_params(tslot_params)    
+    dyn.tslot_computer.apply_params(tslot_params)
 
     # Create the Optimiser instance
     optim_method_up = _upper_safe(optim_method)
@@ -1840,13 +1840,13 @@ def create_pulse_optimizer(
             optim = optimizer.OptimizerCrab(cfg, dyn)
         else:
             optim = optimizer.Optimizer(cfg, dyn)
-    
+
     optim.alg = alg
     optim.method = optim_method
     optim.amp_lbound = amp_lbound
     optim.amp_ubound = amp_ubound
     optim.apply_params(optim_params)
-    
+
     # Create the TerminationConditions instance
     tc = termcond.TerminationConditions()
     tc.fid_err_targ = fid_err_targ
@@ -1854,7 +1854,7 @@ def create_pulse_optimizer(
     tc.max_iterations = max_iter
     tc.max_wall_time = max_wall_time
     optim.termination_conditions = tc
-    
+
     optim.apply_method_params(method_params)
 
     if gen_stats:
@@ -1897,7 +1897,7 @@ def create_pulse_optimizer(
     ramping_pgen = None
     if ramping_pulse_type:
         ramping_pgen = pulsegen.create_pulse_gen(
-                            pulse_type=ramping_pulse_type, dyn=dyn, 
+                            pulse_type=ramping_pulse_type, dyn=dyn,
                             pulse_params=ramping_pulse_params)
     if alg_up == 'CRAB':
         # Create a pulse generator for each ctrl
@@ -1909,7 +1909,7 @@ def create_pulse_optimizer(
             init_coeff_scaling = alg_params.get('init_coeff_scaling')
             if 'crab_pulse_params' in alg_params:
                 crab_pulse_params = alg_params.get('crab_pulse_params')
-            
+
         guess_pulse_type = init_pulse_type
         if guess_pulse_type:
             guess_pulse_action = None
@@ -1929,7 +1929,7 @@ def create_pulse_optimizer(
                 crab_pgen.scaling = init_coeff_scaling
             if isinstance(crab_pulse_params, dict):
                 crab_pgen.apply_params(crab_pulse_params)
-                
+
             lb = None
             if amp_lbound:
                 if isinstance(amp_lbound, list):
@@ -1950,21 +1950,21 @@ def create_pulse_optimizer(
                     ub = amp_ubound
             crab_pgen.lbound = lb
             crab_pgen.ubound = ub
-            
+
             if guess_pulse_type:
                 guess_pgen.lbound = lb
                 guess_pgen.ubound = ub
                 crab_pgen.guess_pulse = guess_pgen.gen_pulse()
                 if guess_pulse_action:
                     crab_pgen.guess_pulse_action = guess_pulse_action
-                
+
             if ramping_pgen:
                 crab_pgen.ramping_pulse = ramping_pgen.gen_pulse()
 
             optim.pulse_generator.append(crab_pgen)
         #This is just for the debug message now
         pgen = optim.pulse_generator[0]
-            
+
     else:
         # Create a pulse generator of the type specified
         pgen = pulsegen.create_pulse_gen(pulse_type=init_pulse_type, dyn=dyn,
@@ -1986,7 +1986,4 @@ def create_pulse_optimizer(
             "\n    fidcomp: " + dyn.fid_computer.__class__.__name__ +
             "\n    propcomp: " + dyn.prop_computer.__class__.__name__ +
             "\n    pulsegen: " + pgen.__class__.__name__)
-
     return optim
-
-

--- a/qutip/eseries.py
+++ b/qutip/eseries.py
@@ -84,13 +84,12 @@ class eseries():
                 self.dims = q.dims
                 self.shape = q.shape
             elif isinstance(q, (np.ndarray, list)):
-                ind = np.shape(q)
-                num = ind[0]  # number of elements in q
+                num = len(q)  # number of elements in q
                 if any([Qobj(x).shape != Qobj(q[0]).shape for x in q]):
                     raise TypeError('All amplitudes must have same dimension.')
-                self.ampl = np.empty(ind, dtype=object)
+                self.ampl = np.empty((num,), dtype=object)
                 self.ampl[:] = q
-                self.rates = np.zeros(ind)
+                self.rates = np.zeros((num,))
                 self.dims = self.ampl[0].dims
                 self.shape = self.ampl[0].shape
             elif isinstance(q, Qobj):
@@ -108,11 +107,10 @@ class eseries():
 
         elif len(s) != 0:
             if isinstance(q, (np.ndarray, list)):
-                ind = np.shape(q)
-                num = ind[0]
+                num = len(q)
                 if any([Qobj(x).shape != Qobj(q[0]).shape for x in q]):
                     raise TypeError('All amplitudes must have same dimension.')
-                self.ampl = np.empty((len(q),), dtype=object)
+                self.ampl = np.empty((num,), dtype=object)
                 self.ampl[:] = [Qobj(qq) for qq in q]
                 self.dims = self.ampl[0].dims
                 self.shape = self.ampl[0].shape

--- a/qutip/eseries.py
+++ b/qutip/eseries.py
@@ -84,18 +84,19 @@ class eseries():
                 self.dims = q.dims
                 self.shape = q.shape
             elif isinstance(q, (np.ndarray, list)):
-                q = np.asarray(q, dtype=object)
                 ind = np.shape(q)
                 num = ind[0]  # number of elements in q
                 if any([Qobj(x).shape != Qobj(q[0]).shape for x in q]):
                     raise TypeError('All amplitudes must have same dimension.')
-                self.ampl = np.array([x for x in q], dtype=object)
+                self.ampl = np.empty(ind, dtype=object)
+                self.ampl[:] = q
                 self.rates = np.zeros(ind)
                 self.dims = self.ampl[0].dims
                 self.shape = self.ampl[0].shape
             elif isinstance(q, Qobj):
                 qo = Qobj(q)
-                self.ampl = np.array([qo], dtype=object)
+                self.ampl = np.empty((1,), dtype=object)
+                self.ampl[0] = qo
                 self.rates = np.array([0])
                 self.dims = qo.dims
                 self.shape = qo.shape
@@ -107,18 +108,18 @@ class eseries():
 
         elif len(s) != 0:
             if isinstance(q, (np.ndarray, list)):
-                q = np.asarray(q, dtype=object)
                 ind = np.shape(q)
                 num = ind[0]
                 if any([Qobj(x).shape != Qobj(q[0]).shape for x in q]):
                     raise TypeError('All amplitudes must have same dimension.')
-                self.ampl = np.array([Qobj(q[x]) for x in range(0, num)],
-                                     dtype=object)
+                self.ampl = np.empty((len(q),), dtype=object)
+                self.ampl[:] = [Qobj(qq) for qq in q]
                 self.dims = self.ampl[0].dims
                 self.shape = self.ampl[0].shape
             else:
                 num = 1
-                self.ampl = np.array([Qobj(q)], dtype=object)
+                self.ampl = np.empty((num,), dtype=object)
+                self.ampl[0] = Qobj(q)
                 self.dims = self.ampl[0].dims
                 self.shape = self.ampl[0].shape
 
@@ -134,13 +135,9 @@ class eseries():
                 self.rates = np.array(s)
 
         if len(self.ampl) != 0:
-            # combine arrays so that they can be sorted together
-            zipped = list(zip(self.rates, self.ampl))
-            zipped.sort()  # sort rates from lowest to highest
-            rates, ampl = list(zip(*zipped))  # get back rates and ampl
-            self.ampl = np.array(ampl, dtype=object)
-            self.rates = np.array(rates)
-
+            # Sort rates from lowest to highest.
+            order = np.argsort(self.rates)
+            self.ampl, self.rates = self.ampl[order], self.rates[order]
 
     def __str__(self):  # string of ESERIES information
         self.tidyup()
@@ -255,22 +252,17 @@ class eseries():
 
         if isinstance(self.ampl[0], Qobj):
             # amplitude vector contains quantum objects
-            val_list = []
+            val_list = np.empty((len(tlist),), dtype=object)
 
             for j in range(len(tlist)):
                 exp_factors = np.exp(np.array(self.rates) * tlist[j])
-
                 val = 0
                 for i in range(len(self.ampl)):
                     val += self.ampl[i] * exp_factors[i]
-
-                val_list.append(val)
-
-            val_list = np.array(val_list, dtype=object)
+                val_list[j] = val
         else:
             # the amplitude vector contains c numbers
             val_list = np.zeros(np.size(tlist), dtype=complex)
-
             for j in range(len(tlist)):
                 exp_factors = np.exp(np.array(self.rates) * tlist[j])
                 val_list[j] = np.sum(np.dot(self.ampl, exp_factors))
@@ -320,14 +312,12 @@ class eseries():
         ur_len = 0
 
         for r_idx in range(len(self.rates)):
-
             # look for a matching rate in the list of unique rates
             idx = -1
             for ur_key in unique_rates.keys():
                 if abs(self.rates[r_idx] - unique_rates[ur_key]) < rate_tol:
                     idx = ur_key
                     break
-
             if idx == -1:
                 # no matching rate, add it
                 unique_rates[ur_len] = self.rates[r_idx]
@@ -339,23 +329,21 @@ class eseries():
 
         # create new amplitude and rate list with only unique rates, and
         # nonzero amplitudes
-        self.rates = np.array([])
-        self.ampl = np.array([])
+        rates, ampl = [], []
         for ur_key in unique_rates.keys():
-            total_ampl = np.sum(np.asarray(ampl_dict[ur_key], dtype=object))
-
+            total_ampl = sum(ampl_dict[ur_key])
             if (isinstance(total_ampl, float) or
                     isinstance(total_ampl, complex)):
                 if abs(total_ampl) > ampl_tol:
-                    self.rates = np.append(self.rates, unique_rates[ur_key])
-                    self.ampl = np.append(self.ampl, total_ampl)
+                    rates.append(unique_rates[ur_key])
+                    ampl.append(total_ampl)
             else:
                 if abs(total_ampl.full()).max() > ampl_tol:
-                    self.rates = np.append(self.rates, unique_rates[ur_key])
-                    self.ampl = np.append(self.ampl,
-                                          np.asarray([total_ampl],
-                                                     dtype=object))
-
+                    rates.append(unique_rates[ur_key])
+                    ampl.append(total_ampl)
+        self.rates = np.array(rates)
+        self.ampl = np.empty((len(ampl),), dtype=object)
+        self.ampl[:] = ampl
         return self
 
 

--- a/qutip/essolve.py
+++ b/qutip/essolve.py
@@ -137,19 +137,15 @@ def ode2es(L, rho0):
         ``eseries`` represention of the system dynamics.
 
     """
-
     if issuper(L):
-
         # check initial state
         if isket(rho0):
             # Got a wave function as initial state: convert to density matrix.
             rho0 = rho0 * rho0.dag()
-
         # check if state is below error threshold
         if abs(rho0.full()).sum() < 1e-10 + 1e-24:
             # enforce zero operator
             return eseries(qzero(rho0.dims[0]))
-
         w, v = L.eigenstates()
         v = np.hstack([ket.full() for ket in v])
         # w[i]   = eigenvalue i

--- a/qutip/lattice.py
+++ b/qutip/lattice.py
@@ -376,7 +376,7 @@ class Lattice1d():
                 raise Exception("Hamiltonian_of_cell does not have a shape \
                             consistent with cell_num_site and cell_site_dof.")
             self._H_intra = Qobj(Hamiltonian_of_cell, dims=dim_ih, type='oper')
-        is_real = np.isreal(self._H_intra).all()
+        is_real = np.isreal(self._H_intra.full()).all()
         if not isherm(self._H_intra):
             raise Exception("Hamiltonian_of_cell is required to be Hermitian.")
 
@@ -396,7 +396,7 @@ class Lattice1d():
                 else:    # inter_hop[i] has the right shape, now confirmed,
                     inter_hop[i] = Qobj(inter_hop[i], dims=dim_ih)
                     inter_hop_sum = inter_hop_sum + inter_hop[i]
-                    is_real = is_real and np.isreal(inter_hop[i]).all()
+                    is_real = is_real and np.isreal(inter_hop[i].full()).all()
             self._H_inter_list = inter_hop    # The user input list was correct
             # we store it in _H_inter_list
             self._H_inter = Qobj(inter_hop_sum, dims=dim_ih, type='oper')
@@ -410,7 +410,7 @@ class Lattice1d():
                 inter_hop = Qobj(inter_hop, dims=dim_ih, type='oper')
             self._H_inter_list = [inter_hop]
             self._H_inter = inter_hop
-            is_real = is_real and np.isreal(inter_hop).all()
+            is_real = is_real and np.isreal(inter_hop.full()).all()
 
         elif inter_hop is None:      # inter_hop is the default None)
             # So, we set self._H_inter_list from cell_num_site and
@@ -668,7 +668,7 @@ class Lattice1d():
             raise Exception("op in operstor_at_cells() is required to \
                             be dimensionaly the same as Hamiltonian_of_cell.")
 
-        (xx, yy) = np.shape(op)
+        (xx, yy) = op.shape
         row_ind = np.array([])
         col_ind = np.array([])
         data = np.array([])
@@ -1030,7 +1030,7 @@ class Lattice1d():
         chiral_op = self.distribute_operator(sigmaz())
         Hamt = self.Hamiltonian()
         anti_commutator_chi_H = chiral_op * Hamt + Hamt * chiral_op
-        is_null = (np.abs(anti_commutator_chi_H) < 1E-10).all()
+        is_null = (np.abs(anti_commutator_chi_H.full()) < 1E-10).all()
 
         if not is_null:
             raise Exception("The Hamiltonian does not have chiral symmetry!")
@@ -1077,9 +1077,9 @@ class Lattice1d():
                     ddk_Phi_m_k[knpoints//2:knpoints])
             winding_number = intg_over_k/(2*np.pi)
 
-            X_lim = 1.125 * np.abs(self._H_intra[1, 0])
+            X_lim = 1.125 * np.abs(self._H_intra.full()[1, 0])
             for i in range(len(self._H_inter_list)):
-                X_lim = X_lim + np.abs(self._H_inter_list[i][1, 0])
+                X_lim = X_lim + np.abs(self._H_inter_list[i].full()[1, 0])
             plt.figure(figsize=(3*X_lim, 3*X_lim))
             plt.plot(mx_k, my_k)
             plt.plot(0, 0, 'ro')

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -758,16 +758,15 @@ def qutrit_ops():
 
     """
     from qutip.states import qutrit_basis
-
+    out = np.empty((6,), dtype=object)
     one, two, three = qutrit_basis()
-    sig11 = one * one.dag()
-    sig22 = two * two.dag()
-    sig33 = three * three.dag()
-    sig12 = one * two.dag()
-    sig23 = two * three.dag()
-    sig31 = three * one.dag()
-    return np.array([sig11, sig22, sig33, sig12, sig23, sig31],
-                    dtype=object)
+    out[0] = one * one.dag()
+    out[1] = two * two.dag()
+    out[2] = three * three.dag()
+    out[3] = one * two.dag()
+    out[4] = two * three.dag()
+    out[5] = three * one.dag()
+    return out
 
 
 def qdiags(diagonals, offsets, dims=None, shape=None):

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -811,11 +811,7 @@ shape = [4, 4], type = oper, isherm = False
 
     """
     data = sp.diags(diagonals, offsets, shape, format='csr', dtype=complex)
-    if not dims:
-        dims = [[], []]
-    if not shape:
-        shape = []
-    return Qobj(data, dims, list(shape))
+    return Qobj(data, dims, shape)
 
 
 def phase(N, phi0=0):

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -258,11 +258,13 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
             return Qobj(u[:, :, 1], dims=dims)
     else:
         if unitary_mode == 'batch':
-            return np.array([Qobj(u[k], dims=dims)
-                             for k in range(len(tlist))], dtype=object)
+            out = np.empty((len(tlist),), dtype=object)
+            out[:] = [Qobj(u[k], dims=dims) for k in range(len(tlist))]
+            return out
         else:
-            return np.array([Qobj(u[:, :, k], dims=dims)
-                             for k in range(len(tlist))], dtype=object)
+            out = np.empty((len(tlist),), dtype=object)
+            out[:] = [Qobj(u[:, :, k], dims=dims) for k in range(len(tlist))]
+            return out
 
 
 def _get_min_and_index(lst):

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -133,7 +133,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
     if isinstance(H, (types.FunctionType, types.BuiltinFunctionType,
                       functools.partial)):
         H0 = H(0.0, args)
-        if unitary_mode =='batch':
+        if unitary_mode == 'batch':
             # batch don't work with function Hamiltonian
             unitary_mode = 'single'
     elif isinstance(H, list):
@@ -165,7 +165,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                 else:
                     return output.states
 
-            elif unitary_mode =='batch':
+            elif unitary_mode == 'batch':
                 u = np.zeros(len(tlist), dtype=object)
                 _rows = np.array([(N+1)*m for m in range(N)])
                 _cols = np.zeros_like(_rows)
@@ -192,7 +192,6 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
             else:
                 raise Exception('Invalid unitary mode.')
 
-
     elif len(c_op_list) == 0 and H0.issuper:
         # calculate the propagator for the vector representation of the
         # density matrix (a superoperator propagator)
@@ -204,7 +203,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
         u = np.zeros([N, N, len(tlist)], dtype=complex)
 
         if parallel:
-            output = parallel_map(_parallel_mesolve,range(N * N),
+            output = parallel_map(_parallel_mesolve, range(N * N),
                                   task_args=(
                                       sqrt_N, H, tlist, c_op_list, args,
                                       options),
@@ -213,7 +212,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                 for k, t in enumerate(tlist):
                     u[:, n, k] = mat2vec(output[n].states[k].full()).T
         else:
-            rho0 = qeye(N,N)
+            rho0 = qeye(N, N)
             rho0.dims = [[sqrt_N, sqrt_N], [sqrt_N, sqrt_N]]
             output = mesolve(H, psi0, tlist, [], args, options,
                              _safe_mode=False)
@@ -245,7 +244,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                 progress_bar.update(n)
                 col_idx, row_idx = np.unravel_index(n, (N, N))
                 rho0 = Qobj(sp.csr_matrix(([1], ([row_idx], [col_idx])),
-                                          shape=(N,N), dtype=complex))
+                                          shape=(N, N), dtype=complex))
                 output = mesolve(H, rho0, tlist, c_op_list, [], args, options,
                                  _safe_mode=False)
                 for k, t in enumerate(tlist):
@@ -311,10 +310,11 @@ def _parallel_sesolve(n, N, H, tlist, args, options):
     output = sesolve(H, psi0, tlist, [], args, options, _safe_mode=False)
     return output
 
+
 def _parallel_mesolve(n, N, H, tlist, c_op_list, args, options):
     col_idx, row_idx = np.unravel_index(n, (N, N))
     rho0 = Qobj(sp.csr_matrix(([1], ([row_idx], [col_idx])),
-                              shape=(N,N), dtype=complex))
+                              shape=(N, N), dtype=complex))
     output = mesolve(H, rho0, tlist, c_op_list, [], args, options,
                      _safe_mode=False)
     return output

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -218,7 +218,7 @@ class Qobj(object):
     # define __array__.
     __array_ufunc__ = None
 
-    def __init__(self, inpt=None, dims=[[], []], shape=[],
+    def __init__(self, inpt=None, dims=None, shape=None,
                  type=None, isherm=None, copy=True,
                  fast=False, superrep=None, isunitary=None):
         """
@@ -251,7 +251,7 @@ class Qobj(object):
                 shape=inpt.shape, copy=copy,
             )
 
-            if not np.any(dims):
+            if dims is None:
                 # Dimensions of quantum object used for keeping track of tensor
                 # components
                 self.dims = inpt.dims
@@ -264,11 +264,11 @@ class Qobj(object):
         elif inpt is None:
             # initialize an empty Qobj with correct dimensions and shape
 
-            if any(dims):
+            if dims is not None:
                 N, M = np.prod(dims[0]), np.prod(dims[1])
                 self.dims = dims
 
-            elif shape:
+            elif shape is not None:
                 N, M = shape
                 self.dims = [[N], [M]]
 
@@ -290,7 +290,7 @@ class Qobj(object):
                 (_tmp.data, _tmp.indices, _tmp.indptr),
                 shape=_tmp.shape,
             )
-            if not np.any(dims):
+            if dims is None:
                 self.dims = [[int(data.shape[0])], [int(data.shape[1])]]
             else:
                 self.dims = dims
@@ -313,7 +313,7 @@ class Qobj(object):
                 copy=do_copy,
             )
 
-            if not np.any(dims):
+            if dims is None:
                 self.dims = [[int(inpt.shape[0])], [int(inpt.shape[1])]]
             else:
                 self.dims = dims
@@ -326,7 +326,7 @@ class Qobj(object):
                 (_tmp.data, _tmp.indices, _tmp.indptr),
                 shape=_tmp.shape,
             )
-            if not np.any(dims):
+            if dims is None:
                 self.dims = [[1], [1]]
             else:
                 self.dims = dims
@@ -345,7 +345,7 @@ class Qobj(object):
         if type == 'super':
             # Type is not super, i.e. dims not explicitly passed, but oper-like
             # shape.
-            if dims == [[], []] and self.shape[0] == self.shape[1]:
+            if dims is None and self.shape[0] == self.shape[1]:
                 sub_shape = np.sqrt(self.shape[0])
                 # check if root of shape is int
                 if (sub_shape % 1) != 0:

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -209,6 +209,9 @@ class Qobj(object):
 
     """
     __array_priority__ = 100  # sets Qobj priority above numpy arrays
+    # Disable ufuncs and other numpy interface functions from acting directly
+    # on Qobj. This is necessary because we define __array__.
+    __array_ufunc__ = __array_function__ = None
 
     def __init__(self, inpt=None, dims=[[], []], shape=[],
                  type=None, isherm=None, copy=True,

--- a/qutip/simdiag.py
+++ b/qutip/simdiag.py
@@ -97,15 +97,15 @@ def simdiag(ops, evals=True):
         inds = np.array(abs(ds - ds[k]) < max(tol, tol * abs(ds[k])))
         inds = rng[inds]
         if len(inds) > 1:  # if at least 2 eigvals are degenerate
-            eigvecs_array[inds] = degen(
-                tol, eigvecs_array[inds],
-                np.array([ops[kk] for kk in range(1, num_ops)], dtype=object))
+            eigvecs_array[inds] = degen(tol, eigvecs_array[inds], ops[1:])
         k = max(inds) + 1
-    eigvals_out = np.zeros((num_ops, len(ds)), dtype=float)
-    kets_out = np.array([Qobj(eigvecs_array[j] / la.norm(eigvecs_array[j]),
-                              dims=[ops[0].dims[0], [1]],
-                              shape=[ops[0].shape[0], 1])
-                         for j in range(len(ds))], dtype=object)
+    eigvals_out = np.zeros((num_ops, len(ds)), dtype=np.float64)
+    kets_out = np.empty((len(ds),), dtype=object)
+    kets_out[:] = [
+        Qobj(eigvecs_array[j] / la.norm(eigvecs_array[j]),
+             dims=[ops[0].dims[0], [1]], shape=[ops[0].shape[0], 1])
+        for j in range(len(ds))
+    ]
     if not evals:
         return kets_out
     else:
@@ -147,8 +147,6 @@ def degen(tol, in_vecs, ops):
             tol, tol * abs(ds[k])))  # get indicies of degenerate eigvals
         inds = rng[inds]
         if len(inds) > 1:  # if at least 2 eigvals are degenerate
-            vecs_out[inds] = degen(tol, vecs_out[inds],
-                                   np.array([ops[jj] for jj in range(1, n)],
-                                            dtype=object))
+            vecs_out[inds] = degen(tol, vecs_out[inds], ops[1:n])
         k = max(inds) + 1
     return vecs_out

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -163,7 +163,9 @@ def qutrit_basis():
         Array of qutrit basis vectors
 
     """
-    return np.array([basis(3, 0), basis(3, 1), basis(3, 2)], dtype=object)
+    out = np.empty((3,), dtype=object)
+    out[:] = [basis(3, 0), basis(3, 1), basis(3, 2)]
+    return out
 
 
 def coherent(N, alpha, offset=0, method='operator'):

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -224,16 +224,15 @@ def coherent(N, alpha, offset=0, method='operator'):
         return D * x
 
     elif method == "analytic" or offset > 0:
-
         sqrtn = np.sqrt(np.arange(offset, offset+N, dtype=complex))
-        sqrtn[0] = 1 # Get rid of divide by zero warning
+        sqrtn[0] = 1  # Get rid of divide by zero warning
         data = alpha/sqrtn
         if offset == 0:
             data[0] = np.exp(-abs(alpha)**2 / 2.0)
         else:
-            s = np.prod(np.sqrt(np.arange(1, offset + 1))) # sqrt factorial
+            s = np.prod(np.sqrt(np.arange(1, offset + 1)))  # sqrt factorial
             data[0] = np.exp(-abs(alpha)**2 / 2.0) * alpha**(offset) / s
-        np.cumprod(data, out=sqrtn) # Reuse sqrtn array
+        np.cumprod(data, out=sqrtn)  # Reuse sqrtn array
         return Qobj(sqrtn)
 
     else:

--- a/qutip/tests/test_three_level.py
+++ b/qutip/tests/test_three_level.py
@@ -38,7 +38,8 @@ from qutip.three_level_atom import *
 
 
 three_states = three_level_basis()
-three_check = np.array([basis(3), basis(3, 1), basis(3, 2)], dtype=object)
+three_check = np.empty((3,), dtype=object)
+three_check[:] = [basis(3, 0), basis(3, 1), basis(3, 2)]
 three_ops = three_level_ops()
 
 

--- a/qutip/three_level_atom.py
+++ b/qutip/three_level_atom.py
@@ -66,8 +66,8 @@ Contributed by Markus Baden, Oct. 07, 2011
 
 __all__ = ['three_level_basis', 'three_level_ops']
 
+import numpy as np
 from qutip.states import qutrit_basis
-from numpy import array
 
 
 def three_level_basis():
@@ -93,14 +93,15 @@ def three_level_ops():
         `array` of three level operators.
 
     '''
+    out = np.empty((5,), dtype=object)
     one, two, three = qutrit_basis()
     # Note that the three level operators are different
     # from the qutrit operators. A three level atom only
     # has transitions 1 <-> 2 <-> 3, so we define the
     # operators seperately from the qutrit code
-    sig11 = one * one.dag()
-    sig22 = two * two.dag()
-    sig33 = three * three.dag()
-    sig12 = one * two.dag()
-    sig32 = three * two.dag()
-    return array([sig11, sig22, sig33, sig12, sig32], dtype=object)
+    out[0] = one * one.dag()
+    out[1] = two * two.dag()
+    out[2] = three * three.dag()
+    out[3] = one * two.dag()
+    out[4] = three * two.dag()
+    return out


### PR DESCRIPTION
Fix #1433, see further discussion of points there.

- sets `Qobj.__array_ufunc__ = None` to prevent implicit usage with ufuncs
- change use of `np.array(dtype=object)` with `Qobj` into either raw Python lists (when only used internally), or sets `out = np.empty(shape, dtype=object); out[:] = ...` to force object-array creation
- fix version of numpy build version to `1.16.6 <= x < 1.20` to prevent cross-version ABI incompatibility (see also comments in #1429)
- change default of `dims` and `shape` in `Qobj` constructor to `None`, rather than dangerous lists (also helps avoid numpy calls on ragged sequences)