### PR TITLE
Integrate scheduler into the compiler

### DIFF
--- a/qutip/qip/compiler/cavityqedcompiler.py
+++ b/qutip/qip/compiler/cavityqedcompiler.py
@@ -79,18 +79,18 @@ class CavityQEDCompiler(GateCompiler):
     num_ops: int
         Number of control Hamiltonians in the processor.
 
-    gate_decomps: dict
+    gate_compiler: dict
         The Python dictionary in the form of {gate_name: decompose_function}.
         It saves the decomposition scheme for each gate.
     """
     def __init__(self, N, params, global_phase, num_ops):
         super(CavityQEDCompiler, self).__init__(
             N=N, params=params, num_ops=num_ops)
-        self.gate_decomps = {"ISWAP": self.iswap_dec,
-                             "SQRTISWAP": self.sqrtiswap_dec,
-                             "RZ": self.rz_dec,
-                             "RX": self.rx_dec,
-                             "GLOBALPHASE": self.globalphase_dec
+        self.gate_compiler = {"ISWAP": self.iswap_compiler,
+                             "SQRTISWAP": self.sqrtiswap_compiler,
+                             "RZ": self.rz_compiler,
+                             "RX": self.rx_compiler,
+                             "GLOBALPHASE": self.globalphase_compiler
                              }
         self._sx_ind = list(range(0, N))
         self._sz_ind = list(range(N, 2*N))
@@ -103,7 +103,7 @@ class CavityQEDCompiler(GateCompiler):
         tlist, coeffs = super(CavityQEDCompiler, self).compile(gates, schedule_mode=schedule_mode)
         return tlist, coeffs, self.global_phase
 
-    def rz_dec(self, gate):
+    def rz_compiler(self, gate):
         """
         Compiler for the RZ gate
         """
@@ -115,7 +115,7 @@ class CavityQEDCompiler(GateCompiler):
         pulse_coeffs = [(pulse_ind, coeff)]
         return [_PulseInstruction(gate, tlist, pulse_coeffs)]
 
-    def rx_dec(self, gate):
+    def rx_compiler(self, gate):
         """
         Compiler for the RX gate
         """
@@ -127,13 +127,13 @@ class CavityQEDCompiler(GateCompiler):
         pulse_coeffs = [(pulse_ind, coeff)]
         return [_PulseInstruction(gate, tlist, pulse_coeffs)]
 
-    def sqrtiswap_dec(self, gate):
+    def sqrtiswap_compiler(self, gate):
         """
         Compiler for the SQRTISWAP gate
 
         Notes
         -----
-        This version of sqrtiswap_dec has very low fidelity, please use
+        This version of sqrtiswap_compiler has very low fidelity, please use
         iswap
         """
         # FIXME This decomposition has poor behaviour
@@ -159,16 +159,16 @@ class CavityQEDCompiler(GateCompiler):
 
         # corrections
         gate1 = Gate("RZ", [q1], None, arg_value=-np.pi/4) 
-        compiled_gate1 = self.rz_dec(gate1)
+        compiled_gate1 = self.rz_compiler(gate1)
         instruction_list += compiled_gate1
         gate2 = Gate("RZ", [q2], None, arg_value=-np.pi/4)
-        compiled_gate2 = self.rz_dec(gate2)
+        compiled_gate2 = self.rz_compiler(gate2)
         instruction_list += compiled_gate2
         gate3 = Gate("GLOBALPHASE", None, None, arg_value=-np.pi/4)
-        self.globalphase_dec(gate3)
+        self.globalphase_compiler(gate3)
         return instruction_list
 
-    def iswap_dec(self, gate):
+    def iswap_compiler(self, gate):
         """
         Compiler for the ISWAP gate
         """
@@ -194,16 +194,16 @@ class CavityQEDCompiler(GateCompiler):
 
         # corrections
         gate1 = Gate("RZ", [q1], None, arg_value=-np.pi/2.)
-        compiled_gate1 = self.rz_dec(gate1)
+        compiled_gate1 = self.rz_compiler(gate1)
         instruction_list += compiled_gate1
         gate2 = Gate("RZ", [q2], None, arg_value=-np.pi/2)
-        compiled_gate2 = self.rz_dec(gate2)
+        compiled_gate2 = self.rz_compiler(gate2)
         instruction_list += compiled_gate2
         gate3 = Gate("GLOBALPHASE", None, None, arg_value=-np.pi/2)
-        self.globalphase_dec(gate3)
+        self.globalphase_compiler(gate3)
         return instruction_list
 
-    def globalphase_dec(self, gate):
+    def globalphase_compiler(self, gate):
         """
         Compiler for the GLOBALPHASE gate
         """

--- a/qutip/qip/compiler/cavityqedcompiler.py
+++ b/qutip/qip/compiler/cavityqedcompiler.py
@@ -33,7 +33,7 @@
 import numpy as np
 
 from qutip.qip.circuit import QubitCircuit, Gate
-from qutip.qip.compiler.gatecompiler import GateCompiler, _PulseInstruction
+from qutip.qip.compiler.gatecompiler import GateCompiler, Instruction
 
 
 __all__ = ['CavityQEDCompiler']
@@ -108,8 +108,8 @@ class CavityQEDCompiler(GateCompiler):
         g = self.params["sz"][targets[0]]
         coeff = np.array([np.sign(gate.arg_value) * g])
         tlist = np.array([abs(gate.arg_value) / (2 * g)])
-        pulse_coeffs = [("sz" + str(targets[0]), coeff)]
-        return [_PulseInstruction(gate, tlist, pulse_coeffs)]
+        pulse_info = [("sz" + str(targets[0]), coeff)]
+        return [Instruction(gate, tlist, pulse_info)]
 
     def rx_compiler(self, gate):
         """
@@ -119,8 +119,8 @@ class CavityQEDCompiler(GateCompiler):
         g = self.params["sx"][targets[0]]
         coeff = np.array([np.sign(gate.arg_value) * g])
         tlist = np.array([abs(gate.arg_value) / (2 * g)])
-        pulse_coeffs = [("sx" + str(targets[0]), coeff)]
-        return [_PulseInstruction(gate, tlist, pulse_coeffs)]
+        pulse_info = [("sx" + str(targets[0]), coeff)]
+        return [Instruction(gate, tlist, pulse_info)]
 
     def sqrtiswap_compiler(self, gate):
         """
@@ -133,24 +133,24 @@ class CavityQEDCompiler(GateCompiler):
         """
         # FIXME This decomposition has poor behaviour
         q1, q2 = gate.targets
-        pulse_coeffs = []
+        pulse_info = []
         pulse_name = "sz" + str(q1)
         coeff = np.array([self.wq[q1] - self.params["w0"]])
-        pulse_coeffs += [(pulse_name, coeff)]
+        pulse_info += [(pulse_name, coeff)]
         pulse_name = "sz" + str(q1)
         coeff = np.array([self.wq[q2] - self.params["w0"]])
-        pulse_coeffs += [(pulse_name, coeff)]
+        pulse_info += [(pulse_name, coeff)]
         pulse_name = "g" + str(q1)
         coeff = np.array([self.params["g"][q1]])
-        pulse_coeffs += [(pulse_name, coeff)]
+        pulse_info += [(pulse_name, coeff)]
         pulse_name = "g" + str(q2)
         coeff = np.array([self.params["g"][q2]])
-        pulse_coeffs += [(pulse_name, coeff)]
+        pulse_info += [(pulse_name, coeff)]
 
         J = self.params["g"][q1] * self.params["g"][q2] * (
             1 / self.Delta[q1] + 1 / self.Delta[q2]) / 2
         tlist = np.array([(4 * np.pi / abs(J)) / 8])
-        instruction_list = [_PulseInstruction(gate, tlist, pulse_coeffs)]
+        instruction_list = [Instruction(gate, tlist, pulse_info)]
 
         # corrections
         gate1 = Gate("RZ", [q1], None, arg_value=-np.pi/4) 
@@ -168,24 +168,24 @@ class CavityQEDCompiler(GateCompiler):
         Compiler for the ISWAP gate
         """
         q1, q2 = gate.targets
-        pulse_coeffs = []
+        pulse_info = []
         pulse_name = "sz" + str(q1)
         coeff = np.array([self.wq[q1] - self.params["w0"]])
-        pulse_coeffs += [(pulse_name, coeff)]
+        pulse_info += [(pulse_name, coeff)]
         pulse_name = "sz" + str(q2)
         coeff = np.array([self.wq[q2] - self.params["w0"]])
-        pulse_coeffs += [(pulse_name, coeff)]
+        pulse_info += [(pulse_name, coeff)]
         pulse_name = "g" + str(q1)
         coeff = np.array([self.params["g"][q1]])
-        pulse_coeffs += [(pulse_name, coeff)]
+        pulse_info += [(pulse_name, coeff)]
         pulse_name = "g" + str(q2)
         coeff = np.array([self.params["g"][q2]])
-        pulse_coeffs += [(pulse_name, coeff)]
+        pulse_info += [(pulse_name, coeff)]
 
         J = self.params["g"][q1] * self.params["g"][q2] * (
             1 / self.Delta[q1] + 1 / self.Delta[q2]) / 2
         tlist = np.array([(4 * np.pi / abs(J)) / 4])
-        instruction_list = [_PulseInstruction(gate, tlist, pulse_coeffs)]
+        instruction_list = [Instruction(gate, tlist, pulse_info)]
 
         # corrections
         gate1 = Gate("RZ", [q1], None, arg_value=-np.pi/2.)

--- a/qutip/qip/compiler/cavityqedcompiler.py
+++ b/qutip/qip/compiler/cavityqedcompiler.py
@@ -53,19 +53,15 @@ class CavityQEDCompiler(GateCompiler):
         A Python dictionary contains the name and the value of the parameters,
         such as laser frequency, detuning etc.
 
-    wq: list of float
-        The frequency of the qubits calculated from
-        eps and delta for each qubit.
-
-    Delta: list of float
-        The detuning with respect to w0 calculated
-        from wq and w0 for each qubit.
-
-    global_phase: bool
+    global_phase: float, optional
         Record of the global phase change and will be returned.
 
-    pulse_dict: int
-        Dictionary of pulse indices.
+    pulse_dict: dict, optional
+        A map between the pulse label and its index in the pulse list.
+        If given, the compiled pulse can be identified with
+        ``(pulse_label, coeff)``, instead of ``(pulse_index, coeff)``.
+        The number of key-value pairs should match the number of pulses
+        in the processor.
 
     Attributes
     ----------
@@ -76,8 +72,8 @@ class CavityQEDCompiler(GateCompiler):
         A Python dictionary contains the name and the value of the parameters,
         such as laser frequency, detuning etc.
 
-    pulse_dict: int
-        Dictionary of pulse indices.
+    pulse_dict: dict
+        A map between the pulse label and its index in the pulse list.
 
     gate_compiler: dict
         The Python dictionary in the form of {gate_name: decompose_function}.

--- a/qutip/qip/compiler/cavityqedcompiler.py
+++ b/qutip/qip/compiler/cavityqedcompiler.py
@@ -62,6 +62,8 @@ class CavityQEDCompiler(GateCompiler):
         ``(pulse_label, coeff)``, instead of ``(pulse_index, coeff)``.
         The number of key-value pairs should match the number of pulses
         in the processor.
+        If it is empty, an integer ``pulse_index`` needs to be used
+        in the compiling routine saved under the attributes ``gate_compiler``.
 
     Attributes
     ----------

--- a/qutip/qip/compiler/cavityqedcompiler.py
+++ b/qutip/qip/compiler/cavityqedcompiler.py
@@ -33,7 +33,7 @@
 import numpy as np
 
 from qutip.qip.circuit import QubitCircuit, Gate
-from qutip.qip.compiler.gatecompiler import GateCompiler, Instruction
+from qutip.qip.compiler import GateCompiler, Instruction
 
 
 __all__ = ['CavityQEDCompiler']
@@ -142,7 +142,7 @@ class CavityQEDCompiler(GateCompiler):
 
         J = self.params["g"][q1] * self.params["g"][q2] * (
             1 / self.Delta[q1] + 1 / self.Delta[q2]) / 2
-        tlist = 0., (4 * np.pi / abs(J)) / 8
+        tlist = (4 * np.pi / abs(J)) / 8
         instruction_list = [Instruction(gate, tlist, pulse_info)]
 
         # corrections

--- a/qutip/qip/compiler/cavityqedcompiler.py
+++ b/qutip/qip/compiler/cavityqedcompiler.py
@@ -50,8 +50,8 @@ class CavityQEDCompiler(GateCompiler):
         The number of qubits in the system.
 
     params: dict
-        A Python dictionary contains the name and the value of the parameters,
-        such as laser frequency, detuning etc.
+        A Python dictionary contains the name and the value of the parameters.
+        See :meth:`.DispersiveCavityQED.set_up_params` for the definition.
 
     global_phase: float, optional
         Record of the global phase change and will be returned.

--- a/qutip/qip/compiler/cavityqedcompiler.py
+++ b/qutip/qip/compiler/cavityqedcompiler.py
@@ -83,22 +83,18 @@ class CavityQEDCompiler(GateCompiler):
         The Python dictionary in the form of {gate_name: decompose_function}.
         It saves the decomposition scheme for each gate.
     """
-    def __init__(self, N, params, global_phase, pulse_dict):
+    def __init__(self, N, params, pulse_dict, global_phase=0.):
         super(CavityQEDCompiler, self).__init__(
             N=N, params=params, pulse_dict=pulse_dict)
-        self.gate_compiler = {"ISWAP": self.iswap_compiler,
+        self.gate_compiler.update({"ISWAP": self.iswap_compiler,
                              "SQRTISWAP": self.sqrtiswap_compiler,
                              "RZ": self.rz_compiler,
                              "RX": self.rx_compiler,
                              "GLOBALPHASE": self.globalphase_compiler
-                             }
+                             })
         self.wq = np.sqrt(self.params["eps"]**2 + self.params["delta"]**2)
         self.Delta = self.wq - self.params["w0"]
         self.global_phase = global_phase
-
-    def compile(self, gates, schedule_mode=None):
-        tlist, coeffs = super(CavityQEDCompiler, self).compile(gates, schedule_mode=schedule_mode)
-        return tlist, coeffs, self.global_phase
 
     def rz_compiler(self, gate):
         """

--- a/qutip/qip/compiler/cavityqedcompiler.py
+++ b/qutip/qip/compiler/cavityqedcompiler.py
@@ -41,7 +41,7 @@ __all__ = ['CavityQEDCompiler']
 
 class CavityQEDCompiler(GateCompiler):
     """
-    Decompose a :class:`qutip.QubitCircuit` into
+    Decompose a :class:`.QubitCircuit` into
     the pulse sequence for the processor.
 
     Parameters

--- a/qutip/qip/compiler/cavityqedcompiler.py
+++ b/qutip/qip/compiler/cavityqedcompiler.py
@@ -58,7 +58,7 @@ class CavityQEDCompiler(GateCompiler):
         eps and delta for each qubit.
 
     Delta: list of float
-        The detuning with repect to w0 calculated
+        The detuning with respect to w0 calculated
         from wq and w0 for each qubit.
 
     global_phase: bool
@@ -99,8 +99,8 @@ class CavityQEDCompiler(GateCompiler):
         self.Delta = self.wq - self.params["w0"]
         self.global_phase = global_phase
 
-    def decompose(self, gates):
-        tlist, coeffs = super(CavityQEDCompiler, self).decompose(gates)
+    def compile(self, gates, schedule_mode=None):
+        tlist, coeffs = super(CavityQEDCompiler, self).compile(gates, schedule_mode=schedule_mode)
         return tlist, coeffs, self.global_phase
 
     def rz_dec(self, gate):

--- a/qutip/qip/compiler/gatecompiler.py
+++ b/qutip/qip/compiler/gatecompiler.py
@@ -79,12 +79,12 @@ class GateCompiler(object):
     num_ops: int
         Number of control Hamiltonians in the processor.
 
-    gate_decomps: dict
+    gate_compiler: dict
         The Python dictionary in the form of {gate_name: decompose_function}.
         It saves the decomposition scheme for each gate.
     """
     def __init__(self, N, params, num_ops):
-        self.gate_decomps = {}
+        self.gate_compiler = {}
         self.N = N
         self.params = params
         self.num_ops = num_ops
@@ -98,7 +98,7 @@ class GateCompiler(object):
         ----------
         gates: list
             A list of elementary gates that can be implemented in this
-            model. The gate names have to be in `gate_decomps`.
+            model. The gate names have to be in `gate_compiler`.
 
         Returns
         -------
@@ -115,9 +115,9 @@ class GateCompiler(object):
         """
         instruction_list = []
         for gate in gates:
-            if gate.name not in self.gate_decomps:
+            if gate.name not in self.gate_compiler:
                 raise ValueError("Unsupported gate %s" % gate.name)
-            compilered_gate = self.gate_decomps[gate.name](gate)
+            compilered_gate = self.gate_compiler[gate.name](gate)
             if compilered_gate is None:
                 continue  # neglecting global phase gate
             instruction_list += compilered_gate

--- a/qutip/qip/compiler/gatecompiler.py
+++ b/qutip/qip/compiler/gatecompiler.py
@@ -77,7 +77,13 @@ class GateCompiler(object):
         self.N = N
         self.params = params
         self.pulse_dict = pulse_dict
-        self.gate_compiler = {}
+        self.gate_compiler = {"GLOBALPHASE": self.globalphase_compiler}
+
+    def globalphase_compiler(self, gate):
+        """
+        Compiler for the GLOBALPHASE gate
+        """
+        pass
 
     def compile(self, circuit, schedule_mode=None):
         """
@@ -103,9 +109,6 @@ class GateCompiler(object):
             A 2d NumPy array of the shape ``(len(ctrls), len(tlist))``. Each
             row corresponds to the control pulse sequence for
             one Hamiltonian.
-
-        global_phase: bool
-            Recorded change of global phase.
         """
         if isinstance(circuit, QubitCircuit):
             gates = circuit.gates
@@ -149,7 +152,7 @@ class GateCompiler(object):
             start_time = scheduled_start_time[ind]
             for pulse_name, coeff in instruction.pulse_info:
                 pulse_ind = self.pulse_dict[pulse_name]
-                if np.abs(start_time - tlist[pulse_ind][-1]) > instruction.tlist * 1.0e-6:
+                if np.abs(start_time - tlist[pulse_ind][-1]) > instruction.tlist[-1] * 1.0e-6:
                     tlist[pulse_ind].append([start_time])
                     coeffs[pulse_ind].append([0.])
                 tlist[pulse_ind].append(instruction.tlist + start_time)

--- a/qutip/qip/compiler/gatecompiler.py
+++ b/qutip/qip/compiler/gatecompiler.py
@@ -178,7 +178,10 @@ class GateCompiler(object):
         for instruction, start_time in \
                 zip(instruction_list, scheduled_start_time):
             for pulse_name, coeff in instruction.pulse_info:
-                pulse_ind = self.pulse_dict[pulse_name]
+                if self.pulse_dict is not None:
+                    pulse_ind = self.pulse_dict[pulse_name]
+                else:
+                    pulse_ind = pulse_name
                 pulse_instructions[pulse_ind].append(
                     (start_time, instruction.tlist, coeff))
 

--- a/qutip/qip/compiler/gatecompiler.py
+++ b/qutip/qip/compiler/gatecompiler.py
@@ -144,13 +144,13 @@ class GateCompiler(object):
         if not instruction_list:
             return None, None
         if self.pulse_dict is not None:
-            num_pulses = len(self.pulse_dict)
+            num_controls = len(self.pulse_dict)
         else:  # if pulse_dict is not given, compute the number of pulses
-            num_pulses = 0
+            num_controls = 0
             for instruction in instruction_list:
-                for pulse_index in instruction_list.pulse_info:
-                    num_pulses = max(num_pulses, pulse_index)
-            num_pulses += 1
+                for pulse_index, _ in instruction.pulse_info:
+                    num_controls = max(num_controls, pulse_index)
+            num_controls += 1
 
         # schedule
         # scheduled_start_time:
@@ -174,7 +174,7 @@ class GateCompiler(object):
         # compile
         # An instruction can be composed from several different pulse elements.
         # We separate them an assign them to each pulse index.
-        pulse_instructions = [[] for tmp in range(num_pulses)]
+        pulse_instructions = [[] for tmp in range(num_controls)]
         for instruction, start_time in \
                 zip(instruction_list, scheduled_start_time):
             for pulse_name, coeff in instruction.pulse_info:
@@ -185,9 +185,9 @@ class GateCompiler(object):
                 pulse_instructions[pulse_ind].append(
                     (start_time, instruction.tlist, coeff))
 
-        compiled_tlist = [[[0.]] for tmp in range(num_pulses)]
-        compiled_coeffs = [[] for tmp in range(num_pulses)]
-        for pulse_ind in range(num_pulses):
+        compiled_tlist = [[[0.]] for tmp in range(num_controls)]
+        compiled_coeffs = [[] for tmp in range(num_controls)]
+        for pulse_ind in range(num_controls):
             for start_time, tlist, coeff in pulse_instructions[pulse_ind]:
                 if np.isscalar(tlist):
                     # a single constant rectanglar pulse, where
@@ -252,7 +252,7 @@ class GateCompiler(object):
                 compiled_tlist[pulse_ind].append(temp_tlist + start_time)
                 compiled_coeffs[pulse_ind].append(coeff)
 
-        for i in range(num_pulses):
+        for i in range(num_controls):
             if not compiled_coeffs[i]:
                 compiled_tlist[i] = None
                 compiled_coeffs[i] = None

--- a/qutip/qip/compiler/gatecompiler.py
+++ b/qutip/qip/compiler/gatecompiler.py
@@ -41,7 +41,7 @@ __all__ = ['GateCompiler']
 
 class GateCompiler(object):
     """
-    Base class. It compiles a :class:`qutip.QubitCircuit` into
+    Base class. It compiles a :class:`.QubitCircuit` into
     the pulse sequence for the processor. The core member function
     `compile` calls compiling method from the sub-class and concatenate
     the compiled pulses.
@@ -98,8 +98,8 @@ class GateCompiler(object):
 
         Parameters
         ----------
-        circuit: :class:`qutip.qip.circuit.QubitCircuit` or list of
-            :class:`qutip.qip.operations.gate`
+        circuit: :class:`.QubitCircuit` or list of
+            :class:`.Gate`
             A list of elementary gates that can be implemented in the
             corresponding hardware.
             The gate names have to be in `gate_compiler`.

--- a/qutip/qip/compiler/gatecompiler.py
+++ b/qutip/qip/compiler/gatecompiler.py
@@ -41,64 +41,81 @@ __all__ = ['GateCompiler']
 
 class GateCompiler(object):
     """
-    Base class. It decomposes a :class:`qutip.QubitCircuit` into
-    the pulse sequence for the processor.
+    Base class. It compiles a :class:`qutip.QubitCircuit` into
+    the pulse sequence for the processor. The core member function
+    `compile` calls compiling method from the sub-class and concatenate
+    the compiled pulses.
 
     Parameters
     ----------
     N: int
         The number of the component systems.
 
-    params: dict
+    kwargs:
+        Keyword arguments for the compiler.
+        By default, the hardware parameters `Processor.params` defined
+        in the processor and a map between the pulse label and the
+        position `Processor.pulse_dict` is passed to the compiler
+        when calling it.
+        It adds more flexibility in customizing compiler.
+
+    params: dict, optional
         A Python dictionary contains the name and the value of the parameters,
         such as laser frequency, detuning etc.
+        It will be saved in the class attributes and can be used to calculate
+        the control pulses.
 
-    num_ops: int
-        Dictionary of pulse indices.
+    pulse_dict: dict, optional
+        A map between the pulse label and its index in the pulse list.
+        If given, the compiled pulse can be identified with
+        ``(pulse_label, coeff)``, instead of ``(pulse_index, coeff)``.
+        The number of key-value pairs should match the number of pulses
+        in the processor.
 
     Attributes
     ----------
-    N: int
-        The number of the component systems.
-
-    params: dict
-        A Python dictionary contains the name and the value of the parameters,
-        such as laser frequency, detuning etc.
-
-    pulse_dict: int
-        Dictionary of pulse indices.
-
     gate_compiler: dict
-        The Python dictionary in the form of {gate_name: decompose_function}.
-        It saves the decomposition scheme for each gate.
+        The Python dictionary in the form of {gate_name: compiler_function}.
+        It saves the compiling routine for each gate. See sub-classes
+        for implementation.
     """
-    def __init__(self, N, params, pulse_dict):
+    def __init__(self, N, params=None, pulse_dict=None):
         self.gate_compiler = {}
         self.N = N
-        self.params = params
+        self.params = params if params is not None else {}
         self.pulse_dict = pulse_dict
         self.gate_compiler = {"GLOBALPHASE": self.globalphase_compiler}
+        self.args = {"params": self.params}
+        self.global_phase = 0.
 
-    def globalphase_compiler(self, gate):
+    def globalphase_compiler(self, gate, args):
         """
         Compiler for the GLOBALPHASE gate
         """
         pass
 
-    def compile(self, circuit, schedule_mode=None):
+    def compile(self, circuit, schedule_mode=None, args=None):
         """
-        Compile the the elementary gates
-        into control pulse sequence.
+        Compile the the native gates into control pulse sequence.
+        It calls each compiling method and concatenates
+        the compiled pulses.
 
         Parameters
         ----------
         circuit: :class:`QubitCircuit` or list of :class:`gate`
-            A list of elementary gates that can be implemented in this
-            model. The gate names have to be in `gate_compiler`.
-        
-        schedule_mode: str
-            "ASAP" for "as soon as possible" or
-            "ALAP" for "as late as possible"
+            A list of elementary gates that can be implemented in the
+            corresponding hardware.
+            The gate names have to be in `gate_compiler`.
+
+        schedule_mode: str, optional
+            ``"ASAP"`` for "as soon as possible" or
+            ``"ALAP"`` for "as late as possible" or
+            ``False`` or ``None`` for no schedule.
+            Default is None.
+
+        args: dict, optional
+            A dictionary of arguments used in a specific gate compiler
+            function.
 
         Returns
         -------
@@ -114,55 +131,130 @@ class GateCompiler(object):
             gates = circuit.gates
         else:
             gates = circuit
-        num_ops = len(self.pulse_dict)
+        if args is not None:
+            self.args.update(args)
         instruction_list = []
         for gate in gates:
             if gate.name not in self.gate_compiler:
                 raise ValueError("Unsupported gate %s" % gate.name)
-            compilered_gate = self.gate_compiler[gate.name](gate)
-            if compilered_gate is None:
+            instruction = self.gate_compiler[gate.name](gate, self.args)
+            if instruction is None:
                 continue  # neglecting global phase gate
-            instruction_list += compilered_gate
-
-        # If not scheduling
-        if schedule_mode is None or not schedule_mode:
-            max_step_num = sum([instruction.step_num for instruction in instruction_list])
-            tlist = np.zeros(max_step_num + 1)  # always start form 0
-            coeffs = np.zeros((num_ops, max_step_num))
-            last_time_step = 0
+            instruction_list += instruction
+        if not instruction_list:
+            return None, None
+        if self.pulse_dict is not None:
+            num_pulses = len(self.pulse_dict)
+        else:  # if pulse_dict is not given, compute the number of pulses
+            num_pulses = 0
             for instruction in instruction_list:
-                for pulse_name, coeff in instruction.pulse_info:
-                    pulse_ind = self.pulse_dict[pulse_name]
-                    tlist[last_time_step + 1: last_time_step + instruction.step_num + 1] = instruction.tlist + tlist[last_time_step]
-                    coeffs[pulse_ind, last_time_step: last_time_step + instruction.step_num] = coeff
-                last_time_step += instruction.step_num
+                for pulse_index in instruction_list.pulse_info:
+                    num_pulses = max(num_pulses, pulse_index)
+            num_pulses += 1
 
-            return tlist, coeffs
+        # schedule
+        # scheduled_start_time:
+        #   An ordered list of the start_time for each pulse,
+        #   corresponding to gates in the instruction_list.
+        # instruction_list reordered according to the scheduled result
+        if schedule_mode:
+            scheduler = Scheduler(schedule_mode)
+            scheduled_start_time = scheduler.schedule(instruction_list)
+            time_ordered_pos = np.argsort(scheduled_start_time)
+            instruction_list = [instruction_list[i] for i in time_ordered_pos]
+            scheduled_start_time.sort()
+        else:  # no scheduling
+            time_ordered_pos = list(range(0, len(instruction_list)))
+            scheduled_start_time = [0.]
+            for instruction in instruction_list:
+                scheduled_start_time.append(
+                    instruction.duration + scheduled_start_time[-1])
+            scheduled_start_time = scheduled_start_time[:-1]
 
-
-        # If scheduling
-        scheduler = Scheduler(schedule_mode)
-        scheduled_start_time = scheduler.schedule(instruction_list)
-        time_ordered_pos = np.argsort(scheduled_start_time)
-
-        tlist = [[[0.]] for tmp in range(num_ops)]
-        coeffs = [[] for tmp in range(num_ops)]
-        for ind in time_ordered_pos:
-            instruction = instruction_list[ind]
-            start_time = scheduled_start_time[ind]
+        # compile
+        # An instruction can be composed from several different pulse elements.
+        # We separate them an assign them to each pulse index.
+        pulse_instructions = [[] for tmp in range(num_pulses)]
+        for instruction, start_time in \
+                zip(instruction_list, scheduled_start_time):
             for pulse_name, coeff in instruction.pulse_info:
                 pulse_ind = self.pulse_dict[pulse_name]
-                if np.abs(start_time - tlist[pulse_ind][-1]) > instruction.tlist[-1] * 1.0e-6:
-                    tlist[pulse_ind].append([start_time])
-                    coeffs[pulse_ind].append([0.])
-                tlist[pulse_ind].append(instruction.tlist + start_time)
-                coeffs[pulse_ind].append(coeff)
-        for i in range(num_ops):
-            if not coeffs[i]:
-                tlist[i] = None
-                coeffs[i] = None
-            else:
-                tlist[i] = np.concatenate(tlist[i])
-                coeffs[i] = np.concatenate(coeffs[i])
-        return tlist, coeffs
+                pulse_instructions[pulse_ind].append(
+                    (start_time, instruction.tlist, coeff))
 
+        compiled_tlist = [[[0.]] for tmp in range(num_pulses)]
+        compiled_coeffs = [[] for tmp in range(num_pulses)]
+        for pulse_ind in range(num_pulses):
+            for start_time, tlist, coeff in pulse_instructions[pulse_ind]:
+                if np.isscalar(tlist):
+                    # a single constant rectanglar pulse, where
+                    # tlist and coeff are just float numbers
+                    step_size = tlist
+                    temp_tlist = np.array([tlist])
+                    coeff = np.array([coeff])
+                elif len(tlist) - 1 == len(coeff):
+                    # discrete pulse
+                    step_size = tlist[1] - tlist[0]
+                    temp_tlist = np.asarray(tlist)[1:]
+                    coeff = np.asarray(coeff)
+                elif len(tlist) == len(coeff):
+                    # continuos pulse
+                    step_size = tlist[1] - tlist[0]
+                    if compiled_coeffs[pulse_ind]:  # not first pulse
+                        temp_tlist = np.asarray(tlist)[1:]
+                        coeff = np.asarray(coeff)[1:]
+                    else:  # first pulse
+                        temp_tlist = np.asarray(tlist)[1:]
+                        coeff = np.asarray(coeff)
+                else:
+                    raise ValueError(
+                        "The shape of the compiled pulse is not correct.")
+                # If there is a idling time between the last pulse and
+                # the current one, we need to add zeros in between.
+                # We add sufficient number of zeros at the begining
+                # and the end of the idling to prevent wrong cubic spline.
+                if np.abs(start_time - compiled_tlist[pulse_ind][-1][-1]) \
+                        > step_size * 1.0e-6:
+                    idling_time = (
+                            start_time - compiled_tlist[pulse_ind][-1][-1]
+                        )
+                    if idling_time > 3 * step_size:
+                        idling_tlist1 = np.linspace(
+                            compiled_tlist[pulse_ind][-1][-1] + step_size/5,
+                            compiled_tlist[pulse_ind][-1][-1] + step_size,
+                            5
+                        )
+                        idling_tlist2 = np.linspace(
+                            start_time - step_size,
+                            start_time - step_size/5,
+                            5
+                        )
+                        idling_tlist = np.concatenate(
+                            [idling_tlist1, idling_tlist2])
+                    else:
+                        idling_tlist = np.arange(
+                            compiled_tlist[pulse_ind][-1][-1] + step_size,
+                            start_time - step_size, step_size
+                        )
+                    compiled_tlist[pulse_ind].append(idling_tlist)
+                    compiled_coeffs[pulse_ind].append(
+                        np.zeros(len(idling_tlist))
+                    )
+                    # The pulse should always start with 0
+                    # For rectangular pulse, len(tlist) = 0 and the above
+                    # idling_tlist is empty, hence this is necenssary.
+                    compiled_tlist[pulse_ind].append([start_time])
+                    compiled_coeffs[pulse_ind].append([0.])
+                # add the compiled pulse coeffs to the list
+                compiled_tlist[pulse_ind].append(temp_tlist + start_time)
+                compiled_coeffs[pulse_ind].append(coeff)
+
+        for i in range(num_pulses):
+            if not compiled_coeffs[i]:
+                compiled_tlist[i] = None
+                compiled_coeffs[i] = None
+            else:
+                compiled_tlist[i] = np.concatenate(compiled_tlist[i])
+                compiled_coeffs[i] = np.concatenate(compiled_coeffs[i])
+
+        return compiled_tlist, compiled_coeffs

--- a/qutip/qip/compiler/gatecompiler.py
+++ b/qutip/qip/compiler/gatecompiler.py
@@ -51,14 +51,6 @@ class GateCompiler(object):
     N: int
         The number of the component systems.
 
-    kwargs:
-        Keyword arguments for the compiler.
-        By default, the hardware parameters `Processor.params` defined
-        in the processor and a map between the pulse label and the
-        position `Processor.pulse_dict` is passed to the compiler
-        when calling it.
-        It adds more flexibility in customizing compiler.
-
     params: dict, optional
         A Python dictionary contains the name and the value of the parameters,
         such as laser frequency, detuning etc.
@@ -78,6 +70,10 @@ class GateCompiler(object):
         The Python dictionary in the form of {gate_name: compiler_function}.
         It saves the compiling routine for each gate. See sub-classes
         for implementation.
+
+    args: dict
+        Arguments for individual compiling routines.
+        It adds more flexibility in customizing compiler.
     """
     def __init__(self, N, params=None, pulse_dict=None):
         self.gate_compiler = {}
@@ -102,7 +98,8 @@ class GateCompiler(object):
 
         Parameters
         ----------
-        circuit: :class:`QubitCircuit` or list of :class:`gate`
+        circuit: :class:`qutip.qip.circuit.QubitCircuit` or list of
+            :class:`qutip.qip.operations.gate`
             A list of elementary gates that can be implemented in the
             corresponding hardware.
             The gate names have to be in `gate_compiler`.

--- a/qutip/qip/compiler/gatecompiler.py
+++ b/qutip/qip/compiler/gatecompiler.py
@@ -31,7 +31,7 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 import numpy as np
-from ..scheduler import Instruction
+from ..scheduler import Instruction, Scheduler
 
 
 __all__ = ['GateCompiler']
@@ -89,9 +89,9 @@ class GateCompiler(object):
         self.params = params
         self.num_ops = num_ops
 
-    def decompose(self, gates):
+    def compile(self, gates, schedule_mode=None):
         """
-        Decompose the the elementary gates
+        Compile the the elementary gates
         into control pulse sequence.
 
         Parameters
@@ -122,20 +122,43 @@ class GateCompiler(object):
                 continue  # neglecting global phase gate
             instruction_list += compilered_gate
 
-        max_step_num = sum([instruction.step_num for instruction in instruction_list])
-        dt_list = np.zeros(max_step_num)
-        coeff_list = np.zeros((self.num_ops, max_step_num))
-        last_time_step = 0
-        for instruction in instruction_list:
-            for pulse_ind, coeff in instruction.pulse_coeffs:
-                dt_list[last_time_step: last_time_step + instruction.step_num] = instruction.tlist
-                coeff_list[pulse_ind, last_time_step: last_time_step + instruction.step_num] = coeff
-            last_time_step += instruction.step_num
-        coeffs = np.asarray(coeff_list)
+        # If not scheduling
+        if schedule_mode is None or not schedule_mode:
+            max_step_num = sum([instruction.step_num for instruction in instruction_list])
+            tlist = np.zeros(max_step_num + 1)  # always start form 0
+            coeffs = np.zeros((self.num_ops, max_step_num))
+            last_time_step = 0
+            for instruction in instruction_list:
+                for pulse_ind, coeff in instruction.pulse_coeffs:
+                    tlist[last_time_step + 1: last_time_step + instruction.step_num + 1] = instruction.tlist + tlist[last_time_step]
+                    coeffs[pulse_ind, last_time_step: last_time_step + instruction.step_num] = coeff
+                last_time_step += instruction.step_num
 
-        tlist = np.empty(len(dt_list))
-        t = 0
-        for i in range(len(dt_list)):
-            t += dt_list[i]
-            tlist[i] = t
-        return np.hstack([[0], tlist]), coeffs
+            return tlist, coeffs
+
+
+        # If scheduling
+        scheduler = Scheduler(schedule_mode)
+        scheduled_start_time = scheduler.schedule(instruction_list)
+        time_ordered_pos = np.argsort(scheduled_start_time)
+
+        tlist = [[[0.]] for tmp in range(self.num_ops)]
+        coeffs = [[] for tmp in range(self.num_ops)]
+        for ind in time_ordered_pos:
+            instruction = instruction_list[ind]
+            start_time = scheduled_start_time[ind]
+            for pulse_ind, coeff in instruction.pulse_coeffs:
+                if np.abs(start_time - tlist[pulse_ind][-1]) > instruction.tlist * 1.0e-6:
+                    tlist[pulse_ind].append([start_time])
+                    coeffs[pulse_ind].append([0.])
+                tlist[pulse_ind].append(instruction.tlist + start_time)
+                coeffs[pulse_ind].append(coeff)
+        for i in range(self.num_ops):
+            if not coeffs[i]:
+                tlist[i] = None
+                coeffs[i] = None
+            else:
+                tlist[i] = np.concatenate(tlist[i])
+                coeffs[i] = np.concatenate(coeffs[i])
+        return tlist, coeffs
+

--- a/qutip/qip/compiler/instruction.py
+++ b/qutip/qip/compiler/instruction.py
@@ -31,8 +31,60 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-from .instruction import Instruction
-from .scheduler import Scheduler
-from .gatecompiler import GateCompiler
-from .cavityqedcompiler import CavityQEDCompiler
-from .spinchaincompiler import SpinChainCompiler
+
+__all__ = ['Instruction']
+
+
+class Instruction():
+    """
+    The instruction that implements a quantum gate.
+
+    Parameters
+    ----------
+    name: str
+        Name of the gate.
+    targets: list, optional
+        The target qubits.
+    controls: list, optional
+        The control qubits.
+    duration: list, optional
+        The execution time needed for the instruction.
+
+    Attributes
+    ----------
+    used_qubits: set
+        Union of the control and target qubits.
+    """
+    def __init__(
+            self, gate, tlist=None,
+            pulse_info=(), duration=1):
+        self.gate = gate
+        if self.targets is not None:
+            self.targets.sort()
+        if self.controls is None:
+            self.used_qubits = set(self.targets)
+        else:
+            self.controls.sort()
+            self.used_qubits = set(self.controls).union(set(self.targets))
+        self.tlist = tlist
+        if tlist is not None:
+            self.duration = tlist[-1]
+        else:
+            self.duration = duration
+        self.pulse_info = pulse_info
+
+    @property
+    def name(self):
+        return self.gate.name
+
+    @property
+    def targets(self):
+        return self.gate.targets
+
+    @property
+    def controls(self):
+        return self.gate.controls
+
+    @property
+    def step_num(self):
+        return len(self.tlist)

--- a/qutip/qip/compiler/instruction.py
+++ b/qutip/qip/compiler/instruction.py
@@ -70,13 +70,13 @@ class Instruction():
             self, gate, tlist=None,
             pulse_info=(), duration=1):
         self.gate = deepcopy(gate)
+        self.used_qubits = set()
         if self.targets is not None:
             self.targets.sort()  # Used when comparing the instructions
-        if self.controls is None:
-            self.used_qubits = set(self.targets)
-        else:
+            self.used_qubits |= set(self.targets)
+        if self.controls is not None:
             self.controls.sort()
-            self.used_qubits = set(self.controls).union(set(self.targets))
+            self.used_qubits |= set(self.controls)
         self.tlist = tlist
         if self.tlist is not None:
             if np.isscalar(self.tlist):

--- a/qutip/qip/compiler/instruction.py
+++ b/qutip/qip/compiler/instruction.py
@@ -100,10 +100,3 @@ class Instruction():
     @property
     def controls(self):
         return self.gate.controls
-
-    @property
-    def step_num(self):
-        if np.isscalar(self.tlist):
-            return 1
-        else:
-            return len(self.tlist) - 1

--- a/qutip/qip/compiler/instruction.py
+++ b/qutip/qip/compiler/instruction.py
@@ -81,7 +81,7 @@ class Instruction():
         if self.tlist is not None:
             if np.isscalar(self.tlist):
                 self.duration = self.tlist
-            elif abs(self.tlist[0] - 0.) > 1.e-8:
+            elif abs(self.tlist[0]) > 1.e-8:
                 raise ValueError("Pulse time sequence must start from 0")
             else:
                 self.duration = self.tlist[-1]

--- a/qutip/qip/compiler/instruction.py
+++ b/qutip/qip/compiler/instruction.py
@@ -45,14 +45,14 @@ class Instruction():
 
     Parameters
     ----------
-    gate: :class:`gate`
+    gate: :class:`.Gate`
         The quantum gate.
     duration: list, optional
         The execution time needed for the instruction.
-    tlist: array_like
+    tlist: array_like, optional
         A list of time at which the time-dependent coefficients are
-        applied. See :class:`qutip.qip.Pulse` for detailed information`
-    pulse_info: list
+        applied. See :class:`.Pulse` for detailed information`
+    pulse_info: list, optional
         A list of tuples, each tuple corresponding to a pair of pulse label
         and pulse coefficient, in the format (str, array_like).
         This pulses will implement the desired gate.

--- a/qutip/qip/compiler/scheduler.py
+++ b/qutip/qip/compiler/scheduler.py
@@ -35,47 +35,8 @@ from copy import deepcopy
 from functools import cmp_to_key
 from random import shuffle
 
-from qutip.qip.circuit import QubitCircuit, Gate
-
-
-class Instruction():
-    """
-    The instruction that implements a quantum gate.
-
-    Parameters
-    ----------
-    name: str
-        Name of the gate.
-    targets: list, optional
-        The target qubits.
-    controls: list, optional
-        The control qubits.
-    duration: list, optional
-        The execution time needed for the instruction.
-
-    Attributes
-    ----------
-    used_qubits: set
-        Union of the control and target qubits.
-    """
-    def __init__(self, name, targets=None, controls=None, duration=1):
-        if isinstance(name, Gate):
-            gate = name
-            self.name = gate.name
-            self.targets = gate.targets
-            self.controls = gate.controls
-        else:
-            self.name = name
-            self.targets = targets
-            self.controls = controls
-        if self.targets is not None:
-            self.targets.sort()
-        if self.controls is None:
-            self.used_qubits = set(self.targets)
-        else:
-            self.controls.sort()
-            self.used_qubits = set(self.controls).union(set(self.targets))
-        self.duration = duration
+from ..circuit import QubitCircuit, Gate
+from .instruction import Instruction
 
 
 class InstructionsGraph():
@@ -111,12 +72,7 @@ class InstructionsGraph():
         self.nodes = []
         for instruction in instructions:
             if isinstance(instruction, Gate):
-                self.nodes.append(
-                    Instruction(
-                        instruction.name,
-                        instruction.targets,
-                        instruction.controls)
-                        )
+                self.nodes.append(Instruction(instruction))
             else:
                 self.nodes.append(instruction)
         for node in self.nodes:

--- a/qutip/qip/compiler/spinchaincompiler.py
+++ b/qutip/qip/compiler/spinchaincompiler.py
@@ -33,7 +33,7 @@
 import numpy as np
 
 from qutip.qip.circuit import QubitCircuit, Gate
-from qutip.qip.compiler.gatecompiler import GateCompiler, _PulseInstruction
+from qutip.qip.compiler.gatecompiler import GateCompiler, Instruction
 
 
 __all__ = ['SpinChainCompiler']
@@ -84,7 +84,7 @@ class SpinChainCompiler(GateCompiler):
     global_phase: bool
         Record of the global phase change and will be returned.
     """
-    def __init__(self, N, params, setup, global_phase, pulse_dict):
+    def __init__(self, N, params, pulse_dict, setup="linear", global_phase=0.):
         super(SpinChainCompiler, self).__init__(
             N=N, params=params, pulse_dict=pulse_dict)
         self.gate_compiler = {"ISWAP": self.iswap_compiler,
@@ -93,7 +93,6 @@ class SpinChainCompiler(GateCompiler):
                              "RX": self.rx_compiler,
                              "GLOBALPHASE": self.globalphase_compiler
                              }
-        self.N = N
         self.global_phase = global_phase
 
     def compile(self, gates, schedule_mode=None):
@@ -108,8 +107,8 @@ class SpinChainCompiler(GateCompiler):
         g = self.params["sz"][targets[0]]
         coeff = np.array([np.sign(gate.arg_value) * g])
         tlist = np.array([abs(gate.arg_value) / (2 * g)])
-        pulse_coeffs = [("sz" + str(targets[0]), coeff)]
-        return [_PulseInstruction(gate, tlist, pulse_coeffs)]
+        pulse_info = [("sz" + str(targets[0]), coeff)]
+        return [Instruction(gate, tlist, pulse_info)]
 
     def rx_compiler(self, gate):
         """
@@ -119,8 +118,8 @@ class SpinChainCompiler(GateCompiler):
         g = self.params["sx"][targets[0]]
         coeff = np.array([np.sign(gate.arg_value) * g])
         tlist = np.array([abs(gate.arg_value) / (2 * g)])
-        pulse_coeffs = [("sx" + str(targets[0]), coeff)]
-        return [_PulseInstruction(gate, tlist, pulse_coeffs)]
+        pulse_info = [("sx" + str(targets[0]), coeff)]
+        return [Instruction(gate, tlist, pulse_info)]
 
     def iswap_compiler(self, gate):
         """
@@ -135,8 +134,8 @@ class SpinChainCompiler(GateCompiler):
             pulse_name = "g" + str(q2)
         else:
             pulse_name = "g" + str(q1)
-        pulse_coeffs = [(pulse_name, coeff)]
-        return [_PulseInstruction(gate, tlist, pulse_coeffs)]
+        pulse_info = [(pulse_name, coeff)]
+        return [Instruction(gate, tlist, pulse_info)]
 
     def sqrtiswap_compiler(self, gate):
         """
@@ -151,8 +150,8 @@ class SpinChainCompiler(GateCompiler):
             pulse_name = "g" + str(q2)
         else:
             pulse_name = "g" + str(q1)
-        pulse_coeffs = [(pulse_name, coeff)]
-        return [_PulseInstruction(gate, tlist, pulse_coeffs)]
+        pulse_info = [(pulse_name, coeff)]
+        return [Instruction(gate, tlist, pulse_info)]
 
     def globalphase_compiler(self, gate):
         """

--- a/qutip/qip/compiler/spinchaincompiler.py
+++ b/qutip/qip/compiler/spinchaincompiler.py
@@ -74,7 +74,7 @@ class SpinChainCompiler(GateCompiler):
     num_ops: int
         Number of control Hamiltonians in the processor.
 
-    gate_decomps: dict
+    gate_compiler: dict
         The Python dictionary in the form of {gate_name: decompose_function}.
         It saves the decomposition scheme for each gate.
 
@@ -87,11 +87,11 @@ class SpinChainCompiler(GateCompiler):
     def __init__(self, N, params, setup, global_phase, num_ops):
         super(SpinChainCompiler, self).__init__(
             N=N, params=params, num_ops=num_ops)
-        self.gate_decomps = {"ISWAP": self.iswap_dec,
-                             "SQRTISWAP": self.sqrtiswap_dec,
-                             "RZ": self.rz_dec,
-                             "RX": self.rx_dec,
-                             "GLOBALPHASE": self.globalphase_dec
+        self.gate_compiler = {"ISWAP": self.iswap_compiler,
+                             "SQRTISWAP": self.sqrtiswap_compiler,
+                             "RZ": self.rz_compiler,
+                             "RX": self.rx_compiler,
+                             "GLOBALPHASE": self.globalphase_compiler
                              }
         self.N = N
         self._sx_ind = list(range(0, N))
@@ -106,7 +106,7 @@ class SpinChainCompiler(GateCompiler):
         tlist, coeffs = super(SpinChainCompiler, self).compile(gates, schedule_mode=schedule_mode)
         return tlist, coeffs, self.global_phase
 
-    def rz_dec(self, gate):
+    def rz_compiler(self, gate):
         """
         Compiler for the RZ gate
         """
@@ -118,7 +118,7 @@ class SpinChainCompiler(GateCompiler):
         pulse_coeffs = [(pulse_ind, coeff)]
         return [_PulseInstruction(gate, tlist, pulse_coeffs)]
 
-    def rx_dec(self, gate):
+    def rx_compiler(self, gate):
         """
         Compiler for the RX gate
         """
@@ -130,7 +130,7 @@ class SpinChainCompiler(GateCompiler):
         pulse_coeffs = [(pulse_ind, coeff)]
         return [_PulseInstruction(gate, tlist, pulse_coeffs)]
 
-    def iswap_dec(self, gate):
+    def iswap_compiler(self, gate):
         """
         Compiler for the ISWAP gate
         """
@@ -146,7 +146,7 @@ class SpinChainCompiler(GateCompiler):
         pulse_coeffs = [(pulse_ind, coeff)]
         return [_PulseInstruction(gate, tlist, pulse_coeffs)]
 
-    def sqrtiswap_dec(self, gate):
+    def sqrtiswap_compiler(self, gate):
         """
         Compiler for the SQRTISWAP gate
         """
@@ -162,7 +162,7 @@ class SpinChainCompiler(GateCompiler):
         pulse_coeffs = [(pulse_ind, coeff)]
         return [_PulseInstruction(gate, tlist, pulse_coeffs)]
 
-    def globalphase_dec(self, gate):
+    def globalphase_compiler(self, gate):
         """
         Compiler for the GLOBALPHASE gate
         """

--- a/qutip/qip/compiler/spinchaincompiler.py
+++ b/qutip/qip/compiler/spinchaincompiler.py
@@ -87,17 +87,13 @@ class SpinChainCompiler(GateCompiler):
     def __init__(self, N, params, pulse_dict, setup="linear", global_phase=0.):
         super(SpinChainCompiler, self).__init__(
             N=N, params=params, pulse_dict=pulse_dict)
-        self.gate_compiler = {"ISWAP": self.iswap_compiler,
+        self.gate_compiler.update({"ISWAP": self.iswap_compiler,
                              "SQRTISWAP": self.sqrtiswap_compiler,
                              "RZ": self.rz_compiler,
                              "RX": self.rx_compiler,
                              "GLOBALPHASE": self.globalphase_compiler
-                             }
+                             })
         self.global_phase = global_phase
-
-    def compile(self, gates, schedule_mode=None):
-        tlist, coeffs = super(SpinChainCompiler, self).compile(gates, schedule_mode=schedule_mode)
-        return tlist, coeffs, self.global_phase
 
     def rz_compiler(self, gate):
         """

--- a/qutip/qip/compiler/spinchaincompiler.py
+++ b/qutip/qip/compiler/spinchaincompiler.py
@@ -65,6 +65,8 @@ class SpinChainCompiler(GateCompiler):
         ``(pulse_label, coeff)``, instead of ``(pulse_index, coeff)``.
         The number of key-value pairs should match the number of pulses
         in the processor.
+        If it is empty, an integer ``pulse_index`` needs to be used
+        in the compiling routine saved under the attributes ``gate_compiler``.
 
     Attributes
     ----------

--- a/qutip/qip/compiler/spinchaincompiler.py
+++ b/qutip/qip/compiler/spinchaincompiler.py
@@ -41,7 +41,7 @@ __all__ = ['SpinChainCompiler']
 
 class SpinChainCompiler(GateCompiler):
     """
-    Compile a :class:`qutip.QubitCircuit` into
+    Compile a :class:`qutip.qip.circuit.QubitCircuit` into
     the pulse sequence for the processor.
 
     Parameters
@@ -59,8 +59,12 @@ class SpinChainCompiler(GateCompiler):
     global_phase: bool
         Record of the global phase change and will be returned.
 
-    pulse_dict: dict
-        Dictionary of pulse indices.
+    pulse_dict: dict, optional
+        A map between the pulse label and its index in the pulse list.
+        If given, the compiled pulse can be identified with
+        ``(pulse_label, coeff)``, instead of ``(pulse_index, coeff)``.
+        The number of key-value pairs should match the number of pulses
+        in the processor.
 
     Attributes
     ----------
@@ -72,7 +76,7 @@ class SpinChainCompiler(GateCompiler):
         such as laser frequency, detuning etc.
 
     pulse_dict: dict
-        Dictionary of pulse indices.
+        A map between the pulse label and its index in the pulse list.
 
     gate_compiler: dict
         The Python dictionary in the form of {gate_name: decompose_function}.

--- a/qutip/qip/compiler/spinchaincompiler.py
+++ b/qutip/qip/compiler/spinchaincompiler.py
@@ -41,7 +41,7 @@ __all__ = ['SpinChainCompiler']
 
 class SpinChainCompiler(GateCompiler):
     """
-    Compile a :class:`qutip.qip.circuit.QubitCircuit` into
+    Compile a :class:`.QubitCircuit` into
     the pulse sequence for the processor.
 
     Parameters

--- a/qutip/qip/compiler/spinchaincompiler.py
+++ b/qutip/qip/compiler/spinchaincompiler.py
@@ -41,7 +41,7 @@ __all__ = ['SpinChainCompiler']
 
 class SpinChainCompiler(GateCompiler):
     """
-    Decompose a :class:`qutip.QubitCircuit` into
+    Compile a :class:`qutip.QubitCircuit` into
     the pulse sequence for the processor.
 
     Parameters
@@ -54,7 +54,7 @@ class SpinChainCompiler(GateCompiler):
         such as laser frequency, detuning etc.
 
     setup: string
-        "linear" or "circular" for two sub-calsses.
+        "linear" or "circular" for two sub-classes.
 
     global_phase: bool
         Record of the global phase change and will be returned.
@@ -79,7 +79,7 @@ class SpinChainCompiler(GateCompiler):
         It saves the decomposition scheme for each gate.
 
     setup: string
-        "linear" or "circular" for two sub-calsses.
+        "linear" or "circular" for two sub-classes.
 
     global_phase: bool
         Record of the global phase change and will be returned.
@@ -102,8 +102,8 @@ class SpinChainCompiler(GateCompiler):
             self._sxsy_ind = list(range(2*N, 3*N-1))
         self.global_phase = global_phase
 
-    def decompose(self, gates):
-        tlist, coeffs = super(SpinChainCompiler, self).decompose(gates)
+    def compile(self, gates, schedule_mode=None):
+        tlist, coeffs = super(SpinChainCompiler, self).compile(gates, schedule_mode=schedule_mode)
         return tlist, coeffs, self.global_phase
 
     def rz_dec(self, gate):

--- a/qutip/qip/compiler/spinchaincompiler.py
+++ b/qutip/qip/compiler/spinchaincompiler.py
@@ -87,45 +87,46 @@ class SpinChainCompiler(GateCompiler):
     def __init__(self, N, params, pulse_dict, setup="linear", global_phase=0.):
         super(SpinChainCompiler, self).__init__(
             N=N, params=params, pulse_dict=pulse_dict)
-        self.gate_compiler.update({"ISWAP": self.iswap_compiler,
-                             "SQRTISWAP": self.sqrtiswap_compiler,
-                             "RZ": self.rz_compiler,
-                             "RX": self.rx_compiler,
-                             "GLOBALPHASE": self.globalphase_compiler
-                             })
+        self.gate_compiler.update({
+            "ISWAP": self.iswap_compiler,
+            "SQRTISWAP": self.sqrtiswap_compiler,
+            "RZ": self.rz_compiler,
+            "RX": self.rx_compiler,
+            "GLOBALPHASE": self.globalphase_compiler
+            })
         self.global_phase = global_phase
 
-    def rz_compiler(self, gate):
+    def rz_compiler(self, gate, args):
         """
         Compiler for the RZ gate
         """
         targets = gate.targets
         g = self.params["sz"][targets[0]]
-        coeff = np.array([np.sign(gate.arg_value) * g])
-        tlist = np.array([abs(gate.arg_value) / (2 * g)])
+        coeff = np.sign(gate.arg_value) * g
+        tlist = abs(gate.arg_value) / (2 * g)
         pulse_info = [("sz" + str(targets[0]), coeff)]
         return [Instruction(gate, tlist, pulse_info)]
 
-    def rx_compiler(self, gate):
+    def rx_compiler(self, gate, args):
         """
         Compiler for the RX gate
         """
         targets = gate.targets
         g = self.params["sx"][targets[0]]
-        coeff = np.array([np.sign(gate.arg_value) * g])
-        tlist = np.array([abs(gate.arg_value) / (2 * g)])
+        coeff = np.sign(gate.arg_value) * g
+        tlist = abs(gate.arg_value) / (2 * g)
         pulse_info = [("sx" + str(targets[0]), coeff)]
         return [Instruction(gate, tlist, pulse_info)]
 
-    def iswap_compiler(self, gate):
+    def iswap_compiler(self, gate, args):
         """
         Compiler for the ISWAP gate
         """
         targets = gate.targets
         q1, q2 = min(targets), max(targets)
         g = self.params["sxsy"][q1]
-        coeff = np.array([-g])
-        tlist = np.array([np.pi / (4 * g)])
+        coeff = -g
+        tlist = np.pi / (4 * g)
         if self.N != 2 and q1 == 0 and q2 == self.N - 1:
             pulse_name = "g" + str(q2)
         else:
@@ -133,15 +134,15 @@ class SpinChainCompiler(GateCompiler):
         pulse_info = [(pulse_name, coeff)]
         return [Instruction(gate, tlist, pulse_info)]
 
-    def sqrtiswap_compiler(self, gate):
+    def sqrtiswap_compiler(self, gate, args):
         """
         Compiler for the SQRTISWAP gate
         """
         targets = gate.targets
         q1, q2 = min(targets), max(targets)
         g = self.params["sxsy"][q1]
-        coeff = np.array([-g])
-        tlist = np.array([np.pi / (8 * g)])
+        coeff = -g
+        tlist = np.pi / (8 * g)
         if self.N != 2 and q1 == 0 and q2 == self.N - 1:
             pulse_name = "g" + str(q2)
         else:
@@ -149,7 +150,7 @@ class SpinChainCompiler(GateCompiler):
         pulse_info = [(pulse_name, coeff)]
         return [Instruction(gate, tlist, pulse_info)]
 
-    def globalphase_compiler(self, gate):
+    def globalphase_compiler(self, gate, args):
         """
         Compiler for the GLOBALPHASE gate
         """

--- a/qutip/qip/compiler/spinchaincompiler.py
+++ b/qutip/qip/compiler/spinchaincompiler.py
@@ -33,7 +33,7 @@
 import numpy as np
 
 from qutip.qip.circuit import QubitCircuit, Gate
-from qutip.qip.compiler.gatecompiler import GateCompiler, Instruction
+from qutip.qip.compiler import GateCompiler, Instruction
 
 
 __all__ = ['SpinChainCompiler']

--- a/qutip/qip/compiler/spinchaincompiler.py
+++ b/qutip/qip/compiler/spinchaincompiler.py
@@ -50,8 +50,8 @@ class SpinChainCompiler(GateCompiler):
         The number of qubits in the system.
 
     params: dict
-        A Python dictionary contains the name and the value of the parameters,
-        such as laser frequency, detuning etc.
+        A Python dictionary contains the name and the value of the parameters.
+        See :meth:`.SpinChain.set_up_params` for the definition.
 
     setup: string
         "linear" or "circular" for two sub-classes.

--- a/qutip/qip/device/cavityqed.py
+++ b/qutip/qip/device/cavityqed.py
@@ -306,7 +306,9 @@ class DispersiveCavityQED(ModelProcessor):
             [identity(2) for n in range(self.N)])
         return psi_proj.dag() * U * psi_proj
 
-    def load_circuit(self, qc):
+    def load_circuit(
+            self, qc, schedule_mode="ASAP",
+            compiler_kind=CavityQEDCompiler):
         """
         Decompose a :class:`qutip.QubitCircuit` in to the control
         amplitude generating the corresponding evolution.
@@ -327,9 +329,9 @@ class DispersiveCavityQED(ModelProcessor):
             one Hamiltonian.
         """
         gates = self.optimize_circuit(qc).gates
-        compiler = CavityQEDCompiler(
+        compiler = compiler_kind(
             self.N, self._params,
             global_phase=0., num_ops=len(self.ctrls))
-        tlist, self.coeffs, self.global_phase = compiler.decompose(gates)
+        tlist, self.coeffs, self.global_phase = compiler.compile(gates, schedule_mode=schedule_mode)
         self.set_all_tlist(tlist)
         return tlist, self.coeffs

--- a/qutip/qip/device/cavityqed.py
+++ b/qutip/qip/device/cavityqed.py
@@ -191,6 +191,11 @@ class DispersiveCavityQED(ModelProcessor):
             epsmax, w0, wq, eps, delta, g):
         """
         Save the parameters in the attribute `params` and check the validity.
+        The keys of `params` including "sx", "sz", "w0", "eps", "delta"
+        and "g", each
+        mapped to a list for parameters corresponding to each qubits.
+        For coupling strength "g", list element i is the interaction
+        between qubits i and i+1.
 
         Parameters
         ----------

--- a/qutip/qip/device/cavityqed.py
+++ b/qutip/qip/device/cavityqed.py
@@ -342,8 +342,10 @@ class DispersiveCavityQED(ModelProcessor):
                 self.N, self._params,
                 pulse_dict=deepcopy(self.pulse_dict),
                 global_phase=0.)
-        tlist, self.coeffs = compiler.compile(
+        tlist, coeffs = compiler.compile(
             gates, schedule_mode=schedule_mode)
         self.global_phase = compiler.global_phase
-        self.set_all_tlist(tlist)
+        self.coeffs = coeffs
+        for i in range(len(coeffs)):
+            self.pulses[i].tlist = tlist[i]
         return tlist, self.coeffs

--- a/qutip/qip/device/cavityqed.py
+++ b/qutip/qip/device/cavityqed.py
@@ -185,7 +185,7 @@ class DispersiveCavityQED(ModelProcessor):
                       list(range(N+1)), spline_kind=self.spline_kind))
             self.pulse_dict["g" + str(n)] = index
             index += 1
-    
+
     def set_up_params(
             self, N, num_levels, deltamax,
             epsmax, w0, wq, eps, delta, g):
@@ -316,8 +316,7 @@ class DispersiveCavityQED(ModelProcessor):
         return psi_proj.dag() * U * psi_proj
 
     def load_circuit(
-            self, qc, schedule_mode="ASAP",
-            compiler_kind=CavityQEDCompiler):
+            self, qc, schedule_mode="ASAP", compiler=None):
         """
         Decompose a :class:`qutip.QubitCircuit` in to the control
         amplitude generating the corresponding evolution.
@@ -338,9 +337,13 @@ class DispersiveCavityQED(ModelProcessor):
             one Hamiltonian.
         """
         gates = self.optimize_circuit(qc).gates
-        compiler = compiler_kind(
-            self.N, self._params,
-            global_phase=0., pulse_dict=deepcopy(self.pulse_dict))
-        tlist, self.coeffs, self.global_phase = compiler.compile(gates, schedule_mode=schedule_mode)
+        if compiler is None:
+            compiler = CavityQEDCompiler(
+                self.N, self._params,
+                pulse_dict=deepcopy(self.pulse_dict),
+                global_phase=0.)
+        tlist, self.coeffs = compiler.compile(
+            gates, schedule_mode=schedule_mode)
+        self.global_phase = compiler.global_phase
         self.set_all_tlist(tlist)
         return tlist, self.coeffs

--- a/qutip/qip/device/cavityqed.py
+++ b/qutip/qip/device/cavityqed.py
@@ -60,7 +60,7 @@ class DispersiveCavityQED(ModelProcessor):
     calculate the state evolution under the given control pulse,
     either analytically or numerically.
     (Only additional attributes are documented here, for others please
-    refer to the parent class :class:`qutip.qip.device.ModelProcessor`)
+    refer to the parent class :class:`.ModelProcessor`)
 
     Parameters
     ----------
@@ -292,12 +292,12 @@ class DispersiveCavityQED(ModelProcessor):
 
         Parameters
         ----------
-        qc: :class:`qutip.QubitCircuit`
+        qc: :class:`.QubitCircuit`
             Takes the quantum circuit to be implemented.
 
         Returns
         -------
-        qc: :class:`qutip.QubitCircuit`
+        qc: :class:`.QubitCircuit`
             The circuit representation with elementary gates
             that can be implemented in this model.
         """
@@ -318,12 +318,12 @@ class DispersiveCavityQED(ModelProcessor):
     def load_circuit(
             self, qc, schedule_mode="ASAP", compiler=None):
         """
-        Decompose a :class:`qutip.QubitCircuit` in to the control
+        Decompose a :class:`.QubitCircuit` in to the control
         amplitude generating the corresponding evolution.
 
         Parameters
         ----------
-        qc: :class:`qutip.QubitCircuit`
+        qc: :class:`.QubitCircuit`
             Takes the quantum circuit to be implemented.
 
         Returns

--- a/qutip/qip/device/modelprocessor.py
+++ b/qutip/qip/device/modelprocessor.py
@@ -56,7 +56,7 @@ class ModelProcessor(Processor):
     control pulses either numerically or analytically.
     It cannot be used alone, please refer to the sub-classes.
     (Only additional attributes are documented here, for others please
-    refer to the parent class :class:`qutip.qip.device.Processor`)
+    refer to the parent class :class:`.Processor`)
 
     Parameters
     ----------
@@ -138,7 +138,7 @@ class ModelProcessor(Processor):
         analytical: boolean
             If True, calculate the evolution with matrices exponentiation.
 
-        qc: :class:`qutip.qip.QubitCircuit`, optional
+        qc: :class:`.QubitCircuit`, optional
             A quantum circuit. If given, it first calls the ``load_circuit``
             and then calculate the evolution.
 

--- a/qutip/qip/device/modelprocessor.py
+++ b/qutip/qip/device/modelprocessor.py
@@ -118,7 +118,7 @@ class ModelProcessor(Processor):
 
     @params.setter
     def params(self, par):
-        self._params
+        self._params = par
 
     def run_state(self, init_state=None, analytical=False, qc=None,
                   states=None, **kwargs):

--- a/qutip/qip/device/modelprocessor.py
+++ b/qutip/qip/device/modelprocessor.py
@@ -118,7 +118,7 @@ class ModelProcessor(Processor):
 
     @params.setter
     def params(self, par):
-        self.set_up_params(**par)
+        self._params
 
     def run_state(self, init_state=None, analytical=False, qc=None,
                   states=None, **kwargs):

--- a/qutip/qip/device/optpulseprocessor.py
+++ b/qutip/qip/device/optpulseprocessor.py
@@ -58,7 +58,7 @@ class OptPulseProcessor(Processor):
     The processor can simulate the evolution under the given
     control pulses using :func:`qutip.mesolve`.
     (For attributes documentation, please
-    refer to the parent class :class:`qutip.qip.device.Processor`)
+    refer to the parent class :class:`.Processor`)
 
     Parameters
     ----------
@@ -91,7 +91,8 @@ class OptPulseProcessor(Processor):
     def load_circuit(self, qc, min_fid_err=np.inf, merge_gates=True,
                      setting_args=None, verbose=False, **kwargs):
         """
-        Find the pulses realizing a given :class:`qutip.qip.Circuit` using
+        Find the pulses realizing a given
+        :class:`.QubitCircuit` using
         `qutip.control.optimize_pulse_unitary`. Further parameter for
         for `qutip.control.optimize_pulse_unitary` needs to be given as
         keyword arguments. By default, it first merge all the gates
@@ -130,7 +131,7 @@ class OptPulseProcessor(Processor):
 
         Parameters
         ----------
-        qc: :class:`qutip.QubitCircuit` or list of Qobj
+        qc: :class:`.QubitCircuit` or list of Qobj
             The quantum circuit to be translated.
 
         min_fid_err: float, optional

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -288,15 +288,19 @@ class Processor(object):
             full_tlist = self.get_full_tlist()
         coeffs_list = []
         for pulse in self.pulses:
+            if pulse.tlist is None and pulse.coeff is None:
+                coeffs_list.append(np.zeros(len(full_tlist)))
+                continue
             if not isinstance(pulse.coeff, (bool, np.ndarray)):
                 raise ValueError(
                     "get_full_coeffs only works for "
                     "NumPy array or bool coeff.")
             if isinstance(pulse.coeff, bool):
                 if pulse.coeff:
-                    coeffs_list.append(np.ones(full_tlist))
+                    coeffs_list.append(np.ones(len(full_tlist)))
                 else:
-                    coeffs_list.append(np.zeros(full_tlist))
+                    coeffs_list.append(np.zeros(len(full_tlist)))
+                continue
             if self.spline_kind == "step_func":
                 arg = {"_step_func_coeff": True}
                 coeffs_list.append(
@@ -318,8 +322,12 @@ class Processor(object):
             A list of time at which the time-dependent coefficients are
             applied. See :class:`qutip.qip.Pulse` for detailed information`
         """
-        for pulse in self.pulses:
-            pulse.tlist = tlist
+        if isinstance(tlist, list) and len(tlist) == len(self.pulses):
+            for i, pulse in enumerate(self.pulses):
+                pulse.tlist = tlist[i]
+        else:
+            for pulse in self.pulses:
+                pulse.tlist = tlist
 
     def add_pulse(self, pulse):
         """
@@ -734,7 +742,7 @@ class Processor(object):
             label_list.append(pulse.label)
         return [label_list]
 
-    def plot_pulses(self, title=None, figsize=(12, 6), dpi=None):
+    def plot_pulses(self, title=None, figsize=(12, 6), dpi=None, show_axis=False):
         """
         Plot the ideal pulse coefficients.
 
@@ -788,10 +796,11 @@ class Processor(object):
                     ax.set_ylim((-ymax, ymax))
 
                 # disable frame and ticks
-                ax.set_xticks([])
+                if not show_axis:
+                    ax.set_xticks([])
+                    ax.spines['bottom'].set_visible(False)
                 ax.spines['top'].set_visible(False)
                 ax.spines['right'].set_visible(False)
-                ax.spines['bottom'].set_visible(False)
                 ax.spines['left'].set_visible(False)
                 ax.set_yticks([])
                 ax.set_ylabel(label,  rotation=0)

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -220,6 +220,23 @@ class Processor(object):
         else:
             self.pulses.append(
                 Pulse(qobj, targets, spline_kind=self.spline_kind, label=label))
+    
+    def find_pulse(self, pulse_name):
+        if isinstance(pulse_name, str):
+            try:
+                return self.pulses[self.pulse_dict[pulse_name]]
+            except (AttributeError, KeyError):
+                raise KeyError(
+                    "Pulse name {} undefined. "
+                    "Please define it in the attribute "
+                    "`pulse_dict`.".format(pulse_name))
+        elif isinstance(pulse_name, int):
+            return self.pulses[pulse_name]
+        else:
+            raise TypeError(
+                "pulse_name is either a string or an integer, not "
+                "{}".format(type(pulse_name))
+                )
 
     @property
     def ctrls(self):

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -62,7 +62,7 @@ class Processor(object):
     the decoherence time for each component systems.
     The processor can simulate the evolution under the given
     control pulses. Noisy evolution is supported by
-    :class:`qutip.qip.Noise` and can be added to the processor.
+    :class:`.Noise` and can be added to the processor.
 
     Parameters
     ----------
@@ -101,7 +101,7 @@ class Processor(object):
     N: int
         The number of component systems.
 
-    pulses: list of :class:`qutip.qip.Pulse`
+    pulses: list of :class:`.Pulse`
         A list of control pulses of this device
 
     t1: float or list
@@ -112,11 +112,11 @@ class Processor(object):
         Characterize the decoherence of dephasing for
         each qubit.
 
-    noise: :class:`qutip.qip.Noise`, optional
+    noise: :class:`.Noise`, optional
         A list of noise objects. They will be processed when creating the
         noisy :class:`qutip.QobjEvo` from the processor or run the simulation.
 
-    drift: :class:`qutip.qip.Drift`
+    drift: :class:`qutip.qip.pulse.Drift`
         A `Drift` object representing the drift Hamiltonians.
 
     dims: list
@@ -126,7 +126,7 @@ class Processor(object):
 
     spline_kind: str
         Type of the coefficient interpolation.
-        See parameters of :class:`qutip.qip.Processor` for details.
+        See parameters of :class:`.Processor` for details.
     """
     def __init__(self, N, t1=None, t2=None,
                  dims=None, spline_kind="step_func"):
@@ -176,7 +176,7 @@ class Processor(object):
                     label=None):
         """
         Add a control Hamiltonian to the processor. It creates a new
-        :class:`qutip.qip.Pulse`
+        :class:`.Pulse`
         object for the device that is turned off
         (``tlist = None``, ``coeff = None``). To activate the pulse, one
         can set its `tlist` and `coeff`.
@@ -339,7 +339,7 @@ class Processor(object):
         ----------
         tlist: array-like, optional
             A list of time at which the time-dependent coefficients are
-            applied. See :class:`qutip.qip.Pulse` for detailed information`
+            applied. See :class:`.Pulse` for detailed information`
         """
         if isinstance(tlist, list) and len(tlist) == len(self.pulses):
             for i, pulse in enumerate(self.pulses):
@@ -354,7 +354,7 @@ class Processor(object):
 
         Parameters
         ----------
-        pulse: :class:`qutip.qip.Pulse`
+        pulse: :class:`.Pulse`
             `Pulse` object to be added.
         """
         if isinstance(pulse, Pulse):
@@ -433,7 +433,7 @@ class Processor(object):
 
         Parameters
         ----------
-        noise: :class:`qutip.qip.Noise`
+        noise: :class:`qutip.qip.nosie.Noise`
             The noise object defined outside the processor
         """
         if isinstance(noise, Noise):
@@ -515,7 +515,7 @@ class Processor(object):
 
         Returns
         -------
-        noisy_pulses: list of :class"`qutip.qip.Pulse`/:class:`qutip.qip.Drift`
+        noisy_pulses: list of :class"`:class:`.Pulse``
             A list of noisy pulses.
         """
         pulses = deepcopy(self.pulses)
@@ -597,7 +597,7 @@ class Processor(object):
 
         Parameters
         ----------
-        qc: :class:`qutip.qip.QubitCircuit`, optional
+        qc: :class:`.QubitCircuit`, optional
             Takes the quantum circuit to be implemented. If not given, use
             the quantum circuit saved in the processor by ``load_circuit``.
 
@@ -640,7 +640,7 @@ class Processor(object):
 
         Parameters
         ----------
-        qc: :class:`qutip.qip.QubitCircuit`, optional
+        qc: :class:`.QubitCircuit`, optional
             Takes the quantum circuit to be implemented. If not given, use
             the quantum circuit saved in the processor by `load_circuit`.
 
@@ -746,7 +746,7 @@ class Processor(object):
 
     def load_circuit(self, qc):
         """
-        Translate an :class:`qutip.qip.QubitCircuit` to its
+        Translate an :class:`.QubitCircuit` to its
         corresponding Hamiltonians. (Defined in subclasses)
         """
         raise NotImplementedError("Use the function in the sub-class")

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -249,7 +249,7 @@ class Processor(object):
         for i, coeff in enumerate(coeffs_list):
             self.pulses[i].coeff = coeff
 
-    def get_full_tlist(self):
+    def get_full_tlist(self, tol=1.0e-10):
         """
         Return the full tlist of the ideal pulses.
         If different pulses have different time steps,
@@ -260,11 +260,15 @@ class Processor(object):
         full_tlist: array-like 1d
             The full time sequence for the ideal evolution.
         """
-        all_tlists = [pulse.tlist
+        full_tlist = [pulse.tlist
                       for pulse in self.pulses if pulse.tlist is not None]
-        if not all_tlists:
+        if not full_tlist:
             return None
-        return np.unique(np.sort(np.hstack(all_tlists)))
+        full_tlist = np.unique(np.sort(np.hstack(full_tlist)))
+        # account for inaccuracy in float-point number 
+        diff = np.append(True, np.diff(full_tlist))
+        full_tlist = full_tlist[diff > tol]
+        return full_tlist
 
     def get_full_coeffs(self, full_tlist=None):
         """

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -281,8 +281,8 @@ class Processor(object):
             return None
         full_tlist = np.unique(np.sort(np.hstack(full_tlist)))
         # account for inaccuracy in float-point number
-        diff = np.append(True, np.diff(full_tlist))
-        full_tlist = full_tlist[diff > tol]
+        full_tlist = np.concatenate(
+            (full_tlist[:1], full_tlist[1:][np.diff(full_tlist) > tol]))
         return full_tlist
 
     def get_full_coeffs(self, full_tlist=None):

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -226,7 +226,7 @@ class Processor(object):
         if isinstance(pulse_name, str):
             try:
                 return self.pulses[self.pulse_dict[pulse_name]]
-            except (AttributeError, KeyError):
+            except (KeyError):
                 raise KeyError(
                     "Pulse name {} undefined. "
                     "Please define it in the attribute "
@@ -433,7 +433,7 @@ class Processor(object):
 
         Parameters
         ----------
-        noise: :class:`qutip.qip.nosie.Noise`
+        noise: :class:`.Noise`
             The noise object defined outside the processor
         """
         if isinstance(noise, Noise):
@@ -515,7 +515,7 @@ class Processor(object):
 
         Returns
         -------
-        noisy_pulses: list of :class"`:class:`.Pulse``
+        noisy_pulses: list of :class:`.Pulse`
             A list of noisy pulses.
         """
         pulses = deepcopy(self.pulses)
@@ -579,7 +579,7 @@ class Processor(object):
         # bring all c_ops to the same tlist, won't need it in QuTiP 5
         full_tlist = self.get_full_tlist()
         temp = []
-        for _, c_op in enumerate(c_ops):
+        for c_op in c_ops:
             temp.append(_merge_qobjevo([c_op], full_tlist))
         c_ops = temp
 
@@ -733,7 +733,6 @@ class Processor(object):
 
         # choose solver:
         if solver == "mesolve":
-            solver = mesolve
             evo_result = mesolve(
                 H=noisy_qobjevo, rho0=init_state,
                 tlist=noisy_qobjevo.tlist, **kwargs)

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -261,9 +261,6 @@ class Processor(object):
 
     @coeffs.setter
     def coeffs(self, coeffs_list):
-        if len(coeffs_list) != len(self.pulses):
-            raise ValueError("The row number of coeffs must be same "
-                             "as the number of control pulses.")
         for i, coeff in enumerate(coeffs_list):
             self.pulses[i].coeff = coeff
 

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -219,8 +219,9 @@ class Processor(object):
                           label=temp_label))
         else:
             self.pulses.append(
-                Pulse(qobj, targets, spline_kind=self.spline_kind, label=label))
-    
+                Pulse(qobj, targets, spline_kind=self.spline_kind, label=label)
+                )
+
     def find_pulse(self, pulse_name):
         if isinstance(pulse_name, str):
             try:
@@ -282,7 +283,7 @@ class Processor(object):
         if not full_tlist:
             return None
         full_tlist = np.unique(np.sort(np.hstack(full_tlist)))
-        # account for inaccuracy in float-point number 
+        # account for inaccuracy in float-point number
         diff = np.append(True, np.diff(full_tlist))
         full_tlist = full_tlist[diff > tol]
         return full_tlist
@@ -763,7 +764,8 @@ class Processor(object):
             label_list.append(pulse.label)
         return [label_list]
 
-    def plot_pulses(self, title=None, figsize=(12, 6), dpi=None, show_axis=False):
+    def plot_pulses(
+            self, title=None, figsize=(12, 6), dpi=None, show_axis=False):
         """
         Plot the ideal pulse coefficients.
 

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -579,6 +579,13 @@ class Processor(object):
         final_qu = _merge_qobjevo(qu_list)
         final_qu.args.update(args)
 
+        # bring all c_ops to the same tlist, won't need it in QuTiP 5
+        full_tlist = self.get_full_tlist()
+        temp = []
+        for _, c_op in enumerate(c_ops):
+            temp.append(_merge_qobjevo([c_op], full_tlist))
+        c_ops = temp
+
         if noisy:
             return final_qu, c_ops
         else:
@@ -730,12 +737,14 @@ class Processor(object):
         # choose solver:
         if solver == "mesolve":
             solver = mesolve
+            evo_result = mesolve(
+                H=noisy_qobjevo, rho0=init_state,
+                tlist=noisy_qobjevo.tlist, **kwargs)
         elif solver == "mcsolve":
-            solver = mcsolve
+            evo_result = mcsolve(
+                H=noisy_qobjevo, psi0=init_state,
+                tlist=noisy_qobjevo.tlist, **kwargs)
 
-        evo_result = solver(
-            H=noisy_qobjevo, rho0=init_state,
-            tlist=noisy_qobjevo.tlist, **kwargs)
         return evo_result
 
     def load_circuit(self, qc):

--- a/qutip/qip/device/spinchain.py
+++ b/qutip/qip/device/spinchain.py
@@ -230,10 +230,13 @@ class SpinChain(ModelProcessor):
             compiler = SpinChainCompiler(
                 self.N, self._params, setup=setup,
                 global_phase=0., pulse_dict=deepcopy(self.pulse_dict))
-        tlist, self.coeffs = compiler.compile(
+        tlist, coeffs = compiler.compile(
             gates, schedule_mode=schedule_mode)
         self.global_phase = compiler.global_phase
-        self.set_all_tlist(tlist)
+        self.coeffs = coeffs
+        for i in range(len(coeffs)):
+            print(i)
+            self.pulses[i].tlist = tlist[i]
         return tlist, self.coeffs
 
     def adjacent_gates(self, qc, setup="linear"):

--- a/qutip/qip/device/spinchain.py
+++ b/qutip/qip/device/spinchain.py
@@ -158,6 +158,10 @@ class SpinChain(ModelProcessor):
     def set_up_params(self, sx, sz):
         """
         Save the parameters in the attribute `params` and check the validity.
+        The keys of `params` including "sx", "sz", and "sxsy", each
+        mapped to a list for parameters corresponding to each qubits.
+        For coupling strength "sxsy", list element i is the interaction
+        between qubits i and i+1.
 
         Parameters
         ----------

--- a/qutip/qip/device/spinchain.py
+++ b/qutip/qip/device/spinchain.py
@@ -202,8 +202,7 @@ class SpinChain(ModelProcessor):
         return self.coeffs[2*self.N:]
 
     def load_circuit(
-            self, qc, setup, schedule_mode="ASAP",
-            compiler_kind=SpinChainCompiler):
+            self, qc, setup, schedule_mode="ASAP", compiler=None):
         """
         Decompose a :class:`qutip.QubitCircuit` in to the control
         amplitude generating the corresponding evolution.
@@ -227,10 +226,13 @@ class SpinChain(ModelProcessor):
             one Hamiltonian.
         """
         gates = self.optimize_circuit(qc).gates
-        compiler = compiler_kind(
-            self.N, self._params, setup=setup,
-            global_phase=0., pulse_dict=deepcopy(self.pulse_dict))
-        tlist, self.coeffs, self.global_phase = compiler.compile(gates, schedule_mode=schedule_mode)
+        if compiler is None:
+            compiler = SpinChainCompiler(
+                self.N, self._params, setup=setup,
+                global_phase=0., pulse_dict=deepcopy(self.pulse_dict))
+        tlist, self.coeffs = compiler.compile(
+            gates, schedule_mode=schedule_mode)
+        self.global_phase = compiler.global_phase
         self.set_all_tlist(tlist)
         return tlist, self.coeffs
 
@@ -532,9 +534,9 @@ class LinearSpinChain(SpinChain):
         return self.coeffs[2*self.N: 3*self.N-1]
 
     def load_circuit(
-            self, qc, schedule_mode="ASAP",
-            compiler_kind=SpinChainCompiler):
-        return super(LinearSpinChain, self).load_circuit(qc, "linear", schedule_mode=schedule_mode, compiler_kind=compiler_kind)
+            self, qc, schedule_mode="ASAP", compiler=None):
+        return super(LinearSpinChain, self).load_circuit(
+            qc, "linear", schedule_mode=schedule_mode, compiler=compiler)
 
     def get_operators_labels(self):
         """
@@ -622,9 +624,9 @@ class CircularSpinChain(SpinChain):
         return self.coeffs[2*self.N: 3*self.N]
 
     def load_circuit(
-            self, qc, schedule_mode="ASAP",
-            compiler_kind=SpinChainCompiler):
-        return super(CircularSpinChain, self).load_circuit(qc, "circular", schedule_mode=schedule_mode, compiler_kind=compiler_kind)
+            self, qc, schedule_mode="ASAP", compiler=None):
+        return super(CircularSpinChain, self).load_circuit(
+            qc, "circular", schedule_mode=schedule_mode, compiler=compiler)
 
     def get_operators_labels(self):
         """

--- a/qutip/qip/device/spinchain.py
+++ b/qutip/qip/device/spinchain.py
@@ -53,10 +53,10 @@ class SpinChain(ModelProcessor):
     The processor can simulate the evolution under the given
     control pulses either numerically or analytically.
     It is a base class and should not be used directly, please
-    refer the the subclasses :class:`qutip.qip.LinearSpinChain` and
-    :class:`qutip.qip.CircularSpinChain`.
+    refer the the subclasses :class:`qutip.qip.device.LinearSpinChain` and
+    :class:`qutip.qip.device.CircularSpinChain`.
     (Only additional attributes are documented here, for others please
-    refer to the parent class :class:`qutip.qip.device.ModelProcessor`)
+    refer to the parent class :class:`.ModelProcessor`)
 
     Parameters
     ----------
@@ -204,12 +204,12 @@ class SpinChain(ModelProcessor):
     def load_circuit(
             self, qc, setup, schedule_mode="ASAP", compiler=None):
         """
-        Decompose a :class:`qutip.QubitCircuit` in to the control
+        Decompose a :class:`.QubitCircuit` in to the control
         amplitude generating the corresponding evolution.
 
         Parameters
         ----------
-        qc: :class:`qutip.QubitCircuit`
+        qc: :class:`.QubitCircuit`
             Takes the quantum circuit to be implemented.
 
         setup: string
@@ -247,7 +247,7 @@ class SpinChain(ModelProcessor):
 
         Parameters
         ----------
-        qc: :class:`qutip.QubitCircuit`
+        qc: :class:`.QubitCircuit`
             The circular spin chain circuit to be resolved
 
         setup: Boolean
@@ -255,7 +255,7 @@ class SpinChain(ModelProcessor):
 
         Returns
         -------
-        qc: :class:`qutip.QubitCircuit`
+        qc: :class:`.QubitCircuit`
             Returns QubitCircuit of resolved gates for the qubit circuit in the
             desired basis.
         """
@@ -459,12 +459,12 @@ class SpinChain(ModelProcessor):
 
         Parameters
         ----------
-        qc: :class:`qutip.QubitCircuit`
+        qc: :class:`.QubitCircuit`
             Takes the quantum circuit to be implemented.
 
         Returns
         -------
-        qc: :class:`qutip.QubitCircuit`
+        qc: :class:`.QubitCircuit`
             The circuit representation with elementary gates
             that can be implemented in this model.
         """

--- a/qutip/qip/device/spinchain.py
+++ b/qutip/qip/device/spinchain.py
@@ -191,7 +191,9 @@ class SpinChain(ModelProcessor):
     def sxsy_u(self):
         return self.coeffs[2*self.N:]
 
-    def load_circuit(self, qc, setup):
+    def load_circuit(
+            self, qc, setup, schedule_mode="ASAP",
+            compiler_kind=SpinChainCompiler):
         """
         Decompose a :class:`qutip.QubitCircuit` in to the control
         amplitude generating the corresponding evolution.
@@ -202,7 +204,7 @@ class SpinChain(ModelProcessor):
             Takes the quantum circuit to be implemented.
 
         setup: string
-            "linear" or "circular" for two sub-calsses.
+            "linear" or "circular" for two sub-classes.
 
         Returns
         -------
@@ -216,10 +218,10 @@ class SpinChain(ModelProcessor):
         """
         gates = self.optimize_circuit(qc).gates
 
-        compiler = SpinChainCompiler(
+        compiler = compiler_kind(
             self.N, self._params, setup=setup,
             global_phase=0., num_ops=len(self.ctrls))
-        tlist, self.coeffs, self.global_phase = compiler.decompose(gates)
+        tlist, self.coeffs, self.global_phase = compiler.compile(gates, schedule_mode=schedule_mode)
         self.set_all_tlist(tlist)
         return tlist, self.coeffs
 
@@ -520,8 +522,10 @@ class LinearSpinChain(SpinChain):
     def sxsy_u(self):
         return self.coeffs[2*self.N: 3*self.N-1]
 
-    def load_circuit(self, qc):
-        return super(LinearSpinChain, self).load_circuit(qc, "linear")
+    def load_circuit(
+            self, qc, schedule_mode="ASAP",
+            compiler_kind=SpinChainCompiler):
+        return super(LinearSpinChain, self).load_circuit(qc, "linear", schedule_mode=schedule_mode, compiler_kind=compiler_kind)
 
     def get_operators_labels(self):
         """
@@ -607,8 +611,10 @@ class CircularSpinChain(SpinChain):
     def sxsy_u(self):
         return self.coeffs[2*self.N: 3*self.N]
 
-    def load_circuit(self, qc):
-        return super(CircularSpinChain, self).load_circuit(qc, "circular")
+    def load_circuit(
+            self, qc, schedule_mode="ASAP",
+            compiler_kind=SpinChainCompiler):
+        return super(CircularSpinChain, self).load_circuit(qc, "circular", schedule_mode=schedule_mode, compiler_kind=compiler_kind)
 
     def get_operators_labels(self):
         """

--- a/qutip/qip/device/spinchain.py
+++ b/qutip/qip/device/spinchain.py
@@ -235,7 +235,6 @@ class SpinChain(ModelProcessor):
         self.global_phase = compiler.global_phase
         self.coeffs = coeffs
         for i in range(len(coeffs)):
-            print(i)
             self.pulses[i].tlist = tlist[i]
         return tlist, self.coeffs
 

--- a/qutip/qip/noise.py
+++ b/qutip/qip/noise.py
@@ -22,9 +22,9 @@ def process_noise(pulses, noise_list, dims, t1=None, t2=None,
 
     Parameters
     ----------
-    pulses: list of :class:`qutip.qip.Pulse`
+    pulses: list of :class:`.Pulse`
         The input pulses, on which the noise object will be applied.
-    noise_list: list of :class:`qutip.qip.noise`
+    noise_list: list of :class:`.Noise`
         A list of noise objects.
     dims: int or list
         Dimension of the system.
@@ -42,7 +42,7 @@ def process_noise(pulses, noise_list, dims, t1=None, t2=None,
 
     Returns
     -------
-    noisy_pulses: list of :class:`qutip.qip.Pulse`
+    noisy_pulses: list of :class:`.Pulse`
         The noisy pulses.
     """
     # first the control pulse with noise,
@@ -62,7 +62,7 @@ def process_device_noise(noise_list, dims, t1=None, t2=None):
 
     Parameters
     ----------
-    noise_list: list of :class:`qutip.qip.noise`
+    noise_list: list of :class:`.Noise`
         A list of noise objects.
     dims: int or list
         Dimension of the system.
@@ -77,7 +77,7 @@ def process_device_noise(noise_list, dims, t1=None, t2=None):
 
     Returns
     -------
-    noisy_pulses: list of :class:`qutip.qip.Pulse`
+    noisy_pulses: list of :class:`.Pulse`
         A list of Dummy pulse objects with zero Hamiltonian
         by non-trivial noise.
     """
@@ -101,16 +101,16 @@ def process_pulse_noise(pulses, noise_list, dims):
 
     Parameters
     ----------
-    pulses: list of :class:`qutip.qip.Pulse`
+    pulses: list of :class:`.Pulse`
         The input pulses, on which the noise object will be applied.
-    noise_list: list of :class:`qutip.qip.noise`
+    noise_list: list of :class:`.Noise`
         A list of noise objects.
     dims: int or list
         Dimension of the system.
         If int, we assume it is the number of qubits in the system.
         If list, it is the dimension of the component systems.
 
-    noisy_pulses: list of :class:`qutip.qip.Pulse`
+    noisy_pulses: list of :class:`.Pulse`
         The list of pulses with pulse dependent noise.
     """
     noisy_pulses = deepcopy(pulses)
@@ -125,7 +125,7 @@ def process_pulse_noise(pulses, noise_list, dims):
 class Noise(object):
     """
     The base class representing noise in a processor.
-    The noise object can be added to :class:`qutip.qip.device.Processor` and
+    The noise object can be added to :class:`.Processor` and
     contributes to evolution.
     """
     def __init__(self):
@@ -200,7 +200,7 @@ class DecoherenceNoise(Noise):
 
         Returns
         -------
-        lindblad_noise: list of :class:`qutip.qip.Pulse`
+        lindblad_noise: list of :class:`.Pulse`
             A list of Pulse object with only trivial ideal pulse (H=0) but
             non-trivial lindblad noise.
         """
@@ -296,7 +296,7 @@ class RelaxationNoise(Noise):
 
         Returns
         -------
-        lindblad_noise: list of :class:`qutip.qip.Pulse`
+        lindblad_noise: list of :class:`.Pulse`
             A list of Pulse object with only trivial ideal pulse (H=0) but
             non-trivial relaxation noise.
         """
@@ -379,12 +379,12 @@ class ControlAmpNoise(Noise):
 
         Parameters
         ----------
-        pulses: list of :class:`qutip.qip.Pulse`
+        pulses: list of :class:`.Pulse`
             The input pulses, on which the noise object will be applied.
 
         Returns
         -------
-        noisy_pulses: list of :class:`qutip.qip.Pulse`
+        noisy_pulses: list of :class:`.Pulse`
             The input `Pulse` object with additional coherent noise.
         """
         if self.indices is None:
@@ -461,12 +461,12 @@ class RandomNoise(ControlAmpNoise):
 
         Parameters
         ----------
-        pulses: list of :class:`qutip.qip.Pulse`
+        pulses: list of :class:`.Pulse`
             The input pulses, on which the noise object will be applied.
 
         Returns
         -------
-        noisy_pulses: list of :class:`qutip.qip.Pulse`
+        noisy_pulses: list of :class:`.Pulse`
             The input `Pulse` object with additional coherent noise.
         """
         if self.indices is None:
@@ -511,7 +511,7 @@ class UserNoise(Noise):
 
         Parameters
         ----------
-        pulses: list of :class:`qutip.qip.Pulse`
+        pulses: list of :class:`.Pulse`
             The input pulses, on which the noise object will be applied.
 
         dims: list, optional
@@ -520,7 +520,7 @@ class UserNoise(Noise):
 
         Returns
         -------
-        noisy_pulses: list of :class:`qutip.qip.Pulse`
+        noisy_pulses: list of :class:`.Pulse`
             The input `Pulse` object with additional noise.
         """
         return pulses

--- a/qutip/qip/noise.py
+++ b/qutip/qip/noise.py
@@ -422,7 +422,7 @@ class RandomNoise(ControlAmpNoise):
         parameter as the size of random numbers in the output array.
     indices: list of int, optional
         The indices of target pulse in the list of pulses.
-    kwargs:
+    **kwargs:
         Key word arguments for the random number generator.
 
     Attributes
@@ -435,7 +435,7 @@ class RandomNoise(ControlAmpNoise):
         parameter.
     indices: list of int
         The indices of target pulse in the list of pulses.
-    kwargs:
+    **kwargs:
         Key word arguments for the random number generator.
 
     Examples

--- a/qutip/qip/pulse.py
+++ b/qutip/qip/pulse.py
@@ -418,8 +418,8 @@ class Pulse():
         if not all_tlists:
             return None
         full_tlist = np.unique(np.sort(np.hstack(all_tlists)))
-        diff = np.append(True, np.diff(full_tlist))
-        full_tlist = full_tlist[diff > tol]
+        full_tlist = np.concatenate(
+            (full_tlist[:1], full_tlist[1:][np.diff(full_tlist) > tol]))
         return full_tlist
 
     def print_info(self):
@@ -533,8 +533,8 @@ def _find_common_tlist(qobjevo_list, tol=1.0e-10):
     if not all_tlists:
         return None
     full_tlist = np.unique(np.sort(np.hstack(all_tlists)))
-    diff = np.append(True, np.diff(full_tlist))
-    full_tlist = full_tlist[diff > tol]
+    full_tlist = np.concatenate(
+        (full_tlist[:1], full_tlist[1:][np.diff(full_tlist) > tol]))
     return full_tlist
 
 ########################################################################

--- a/qutip/qip/pulse.py
+++ b/qutip/qip/pulse.py
@@ -17,7 +17,7 @@ class _EvoElement():
     `qobj`, `targets`, `tlist` and `coeff`.
 
     For documentation and use instruction of the attributes, please
-    refer to :class:`qutip.qip.Pulse`.
+    refer to :class:`.Pulse`.
     """
     def __init__(self, qobj, targets, tlist=None, coeff=None):
         self.qobj = qobj
@@ -179,12 +179,12 @@ class Pulse():
 
     Attributes
     ----------
-    ideal_pulse: :class:`qutip.qip.pulse._EvoElement`
+    ideal_pulse: :class:`._EvoElement`
         The ideal dynamic of the control pulse.
-    coherent_noise: list of :class:`qutip.qip.pulse._EvoElement`
+    coherent_noise: list of :class:`._EvoElement`
         The coherent noise caused by the control pulse. Each dynamic element is
         still characterized by a time-dependent Hamiltonian.
-    lindblad_noise: list of :class:`qutip.qip.pulse._EvoElement`
+    lindblad_noise: list of :class:`._EvoElement`
         The dissipative noise of the control pulse. Each dynamic element
         will be treated as a (time-dependent) lindblad operator in the
         master equation.
@@ -289,13 +289,13 @@ class Pulse():
             `tlist` does not have to be equidistant, but must have the same
             length
             or one element shorter compared to `coeff`. See documentation for
-            the parameter `spline_kind` of :class:`qutip.qip.Pulse`.
+            the parameter `spline_kind` of :class:`.Pulse`.
         coeff: array-like or bool, optional
             Time-dependent coefficients of the pulse noise.
             If an array, the length
             must be the same or one element longer compared to `tlist`.
             See documentation for
-            the parameter `spline_kind` of :class:`qutip.qip.Pulse`.
+            the parameter `spline_kind` of :class:`.Pulse`.
             If a bool, the coefficient is a constant 1 or 0.
         """
         self.coherent_noise.append(_EvoElement(qobj, targets, tlist, coeff))
@@ -318,13 +318,13 @@ class Pulse():
             length
             or one element shorter compared to `coeff`.
             See documentation for
-            the parameter `spline_kind` of :class:`qutip.qip.Pulse`.
+            the parameter `spline_kind` of :class:`.Pulse`.
         coeff: array-like or bool, optional
             Time-dependent coefficients of the pulse noise.
             If an array, the length
             must be the same or one element longer compared to `tlist`.
             See documentation for
-            the parameter `spline_kind` of :class:`qutip.qip.Pulse`.
+            the parameter `spline_kind` of :class:`.Pulse`.
             If a bool, the coefficient is a constant 1 or 0.
         """
         self.lindblad_noise.append(_EvoElement(qobj, targets, tlist, coeff))

--- a/qutip/qip/scheduler.py
+++ b/qutip/qip/scheduler.py
@@ -58,17 +58,23 @@ class Instruction():
     used_qubits: set
         Union of the control and target qubits.
     """
-    def __init__(self, name, targets=None, controls=None, duration=None):
-        self.name = name
-        if targets is None:
-            self.targets = []
+    def __init__(self, name, targets=None, controls=None, duration=1):
+        if isinstance(name, Gate):
+            gate = name
+            self.name = gate.name
+            self.targets = gate.targets
+            self.controls = gate.controls
         else:
-            self.targets = sorted(targets)
-        if controls is not None:
-            self.controls = sorted(controls)
+            self.name = name
+            self.targets = targets
+            self.controls = controls
+        if self.targets is not None:
+            self.targets.sort()
+        if self.controls is None:
+            self.used_qubits = set(self.targets)
         else:
-            self.controls = []
-        self.used_qubits = set(self.controls).union(set(self.targets))
+            self.controls.sort()
+            self.used_qubits = set(self.controls).union(set(self.targets))
         self.duration = duration
 
 

--- a/qutip/tests/test_compiler.py
+++ b/qutip/tests/test_compiler.py
@@ -100,6 +100,7 @@ spline_kind = [
 ]
 schedule_mode = [
     pytest.param("ASAP", id="ASAP"),
+    pytest.param("ALAP", id="ALAP"),
     pytest.param(False, id="No schedule"),
 ]
 @pytest.mark.parametrize("spline_kind", spline_kind)

--- a/qutip/tests/test_compiler.py
+++ b/qutip/tests/test_compiler.py
@@ -1,0 +1,120 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+import pytest
+import numpy as np
+
+from qutip.qip.device import DispersiveCavityQED, CircularSpinChain
+from qutip.qip.compiler import CavityQEDCompiler, Instruction
+from qutip.qip.circuit import QubitCircuit
+from qutip import basis, fidelity
+from qutip.qip.circuit import QubitCircuit
+
+
+def test_compiling_with_scheduler():
+    """
+    Here we test if the compiling with scheduler works properly.
+    The non scheduled pulse should be twice as long as the scheduled one.
+    The numerical results are tested in test_device.py
+    """
+    circuit = QubitCircuit(2)
+    circuit.add_gate("X", 0)
+    circuit.add_gate("X", 1)
+    processor = DispersiveCavityQED(2)
+    processor.load_circuit(circuit, schedule_mode=None)
+    tlist = processor.get_full_tlist()
+    time_not_scheduled = tlist[-1]-tlist[0]
+    coeffs, tlist = processor.load_circuit(circuit, schedule_mode="ASAP")
+    tlist = processor.get_full_tlist()
+    time_scheduled1 = tlist[-1]-tlist[0]
+    coeffs, tlist = processor.load_circuit(circuit, schedule_mode="ALAP")
+    tlist = processor.get_full_tlist()
+    time_scheduled2 = tlist[-1]-tlist[0]
+
+    assert(abs(time_scheduled1 * 2 - time_not_scheduled) < 1.0e-10)
+    assert(abs(time_scheduled2 * 2 - time_not_scheduled) < 1.0e-10)
+
+
+def gauss_dist(t, sigma, amplitude, duration):
+    return amplitude/np.sqrt(2*np.pi) /sigma*np.exp(-0.5*((t-duration/2)/sigma)**2)
+
+
+def gauss_rx_compiler(gate, args):
+    """
+    Compiler for the RX gate
+    """
+    targets = gate.targets  # target qubit
+    parameters = args["params"]
+    h_x2pi = parameters["sx"][targets[0]]  # find the coupling strength for the target qubit
+    amplitude = gate.arg_value / 2. / 0.9973 #  0.9973 is just used to compensate the finite pulse duration so that the total area is fixed
+    gate_sigma = h_x2pi / np.sqrt(2*np.pi)
+    duration = 6 * gate_sigma
+    tlist = np.linspace(0, duration, 100)
+    coeff = gauss_dist(tlist, gate_sigma, amplitude, duration)
+    pulse_info = [("sx" + str(targets[0]), coeff)]  #  save the information in a tuple (pulse_name, coeff)
+    return [Instruction(gate, tlist, pulse_info)]
+
+
+from qutip.qip.compiler import GateCompiler
+class MyCompiler(GateCompiler):  # compiler class
+    def __init__(self, num_qubits, params, pulse_dict):
+        super(MyCompiler, self).__init__(
+            num_qubits, params=params, pulse_dict=pulse_dict)
+        # pass our compiler function as a compiler for RX (rotation around X) gate.
+        self.gate_compiler["RX"] = gauss_rx_compiler
+        self.args.update({"params": params})
+
+
+spline_kind = [
+    pytest.param("step_func", id = "discrete"),
+    pytest.param("cubic", id = "continuos"),
+]
+schedule_mode = [
+    pytest.param("ASAP", id = "ASAP"),
+    pytest.param(False, id = "No schedule"),
+]
+@pytest.mark.parametrize("spline_kind", spline_kind)
+@pytest.mark.parametrize("schedule_mode", schedule_mode)
+def test_compiler_with_continous_pulse(spline_kind, schedule_mode):
+    num_qubits = 2
+    circuit = QubitCircuit(num_qubits)
+    circuit.add_gate("X", targets=0)
+    circuit.add_gate("X", targets=1)
+    circuit.add_gate("X", targets=0)
+
+    processor = CircularSpinChain(num_qubits)
+    gauss_compiler = MyCompiler(
+        processor.N, processor.params, processor.pulse_dict)
+    processor.load_circuit(
+        circuit, schedule_mode = schedule_mode, compiler=gauss_compiler)
+    result = processor.run_state(init_state = basis([2,2], [0,0]))
+    assert(abs(fidelity(result.states[-1],basis([2,2],[0,1])) - 1) < 1.e-6)

--- a/qutip/tests/test_compiler.py
+++ b/qutip/tests/test_compiler.py
@@ -39,7 +39,6 @@ from qutip.qip.compiler import (
     )
 from qutip.qip.circuit import QubitCircuit
 from qutip import basis, fidelity
-from qutip.qip.circuit import QubitCircuit
 
 
 def test_compiling_with_scheduler():
@@ -86,7 +85,6 @@ def gauss_rx_compiler(gate, args):
     return [Instruction(gate, tlist, pulse_info)]
 
 
-from qutip.qip.compiler import GateCompiler
 class MyCompiler(GateCompiler):  # compiler class
     def __init__(self, num_qubits, params, pulse_dict):
         super(MyCompiler, self).__init__(
@@ -97,12 +95,12 @@ class MyCompiler(GateCompiler):  # compiler class
 
 
 spline_kind = [
-    pytest.param("step_func", id = "discrete"),
-    pytest.param("cubic", id = "continuos"),
+    pytest.param("step_func", id="discrete"),
+    pytest.param("cubic", id="continuous"),
 ]
 schedule_mode = [
-    pytest.param("ASAP", id = "ASAP"),
-    pytest.param(False, id = "No schedule"),
+    pytest.param("ASAP", id="ASAP"),
+    pytest.param(False, id="No schedule"),
 ]
 @pytest.mark.parametrize("spline_kind", spline_kind)
 @pytest.mark.parametrize("schedule_mode", schedule_mode)

--- a/qutip/tests/test_device.py
+++ b/qutip/tests/test_device.py
@@ -156,11 +156,12 @@ circuit2.add_gate("SQRTISWAP", targets=[0, 2])  # supported only by SpinChain
     pytest.param(circuit2, LinearSpinChain, {}, id = "LinearSpinChain"),
     pytest.param(circuit2, CircularSpinChain, {}, id = "CircularSpinChain"),
 ])
-def test_numerical_circuit(circuit, device_class, kwargs):
+@pytest.mark.parametrize(("schedule_mode"), ["ASAP", "ALAP", None])
+def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
     num_qubits = circuit.N
     with warnings.catch_warnings(record=True):
         device = device_class(circuit.N, **kwargs)
-    device.load_circuit(circuit)
+    device.load_circuit(circuit, schedule_mode=schedule_mode)
 
     state = qutip.rand_ket(2**num_qubits)
     state.dims = [[2]*num_qubits, [1]*num_qubits]

--- a/qutip/tests/test_noise.py
+++ b/qutip/tests/test_noise.py
@@ -24,7 +24,7 @@ class DriftNoise(UserNoise):
 
 
 class TestNoise:
-    def TestDecoherenceNoise(self):
+    def test_decoherence_noise(self):
         """
         Test for the decoherence noise
         """
@@ -55,7 +55,7 @@ class TestNoise:
         assert_allclose(c_ops[0].tlist, tlist)
         assert_allclose(c_ops[1].ops[0].qobj, tensor(qeye(2), sigmax()))
 
-    def TestRelaxationNoise(self):
+    def test_relaxation_noise(self):
         """
         Test for the relaxation noise
         """
@@ -77,7 +77,7 @@ class TestNoise:
         noisy_qu, c_ops = relnoise.get_noisy_dynamics(2).get_noisy_qobjevo(dims=2)
         assert_(len(c_ops) == 4)
 
-    def TestControlAmpNoise(self):
+    def test_control_amplitude_oise(self):
         """
         Test for the control amplitude noise
         """
@@ -91,7 +91,7 @@ class TestNoise:
         assert_allclose(noisy_pulses[0].coherent_noise[0].qobj, sigmaz())
         assert_allclose(noisy_pulses[0].coherent_noise[0].coeff, coeff)
 
-    def TestRandomNoise(self):
+    def test_random_noise(self):
         """
         Test for the white noise
         """
@@ -131,7 +131,7 @@ class TestNoise:
             noisy_pulses[2].coherent_noise[0].tlist,
             np.linspace(1, 6, int(5/0.2) + 1))
 
-    def TestUserNoise(self):
+    def test_user_noise(self):
         """
         Test for the user-defined noise object
         """

--- a/qutip/tests/test_processor.py
+++ b/qutip/tests/test_processor.py
@@ -160,7 +160,7 @@ class TestCircuitProcessor:
             err_msg="Error in t1 & t2 simulation, "
                     "with t1={} and t2={}".format(t1, t2))
 
-    def TestPlot(self):
+    def testPlot(self):
         """
         Test for plotting functions
         """
@@ -186,7 +186,7 @@ class TestCircuitProcessor:
         processor.plot_pulses()
         plt.clf()
 
-    def TestSpline(self):
+    def testSpline(self):
         """
         Test if the spline kind is correctly transfered into
         the arguments in QobjEvo
@@ -223,7 +223,7 @@ class TestCircuitProcessor:
         noisy_qobjevo, c_ops = processor.get_qobjevo(noisy=True)
         assert_(not noisy_qobjevo.args["_step_func_coeff"])
 
-    def TestGetObjevo(self):
+    def testGetObjevo(self):
         tlist = np.array([1, 2, 3, 4, 5, 6], dtype=float)
         coeff = np.array([1, 1, 1, 1, 1, 1], dtype=float)
         processor = Processor(N=1)
@@ -277,7 +277,7 @@ class TestCircuitProcessor:
         assert_equal(sigmaz(), noisy_qobjevo.ops[0].qobj)
         assert_allclose(coeff, noisy_qobjevo.ops[0].coeff, rtol=1.e-10)
 
-    def TestNoise(self):
+    def testNoise(self):
         """
         Test for Processor with noise
         """
@@ -308,7 +308,7 @@ class TestCircuitProcessor:
         proc.add_noise(white_noise)
         result = proc.run_state(init_state=init_state)
 
-    def TestMultiLevelSystem(self):
+    def testMultiLevelSystem(self):
         """
         Test for processor with multi-level system
         """
@@ -319,7 +319,7 @@ class TestCircuitProcessor:
         proc.pulses[0].tlist = np.array([0., 1., 2])
         proc.run_state(init_state=tensor([basis(2, 0), basis(3, 1)]))
 
-    def TestDrift(self):
+    def testDrift(self):
         """
         Test for the drift Hamiltonian
         """
@@ -330,7 +330,7 @@ class TestCircuitProcessor:
         ideal_qobjevo, _ = processor.get_qobjevo(noisy=True)
         assert_equal(ideal_qobjevo.cte, sigmaz())
 
-    def TestChooseSolver(self):
+    def testChooseSolver(self):
         # setup and fidelity without noise
         init_state = qubit_states(2, [0, 0, 0, 0])
         tlist = np.array([0., np.pi/2.])

--- a/qutip/tests/test_scheduler.py
+++ b/qutip/tests/test_scheduler.py
@@ -34,7 +34,7 @@ import pytest
 from copy import deepcopy
 
 from qutip.qip.circuit import QubitCircuit
-from qutip.qip.scheduler import Instruction, Scheduler
+from qutip.qip.compiler import Instruction, Scheduler
 from qutip.qip.operations.gates import gate_sequence_product
 from qutip import process_fidelity, qeye, tracedist
 from qutip.qip.circuit import Gate
@@ -70,16 +70,23 @@ def _circuit2():
     return circuit2
 
 def _instructions1():
-    instruction_list = [
-        Instruction("SNOT", [0], duration=1),
-        Instruction("SNOT", [1], duration=1),
-        Instruction("CNOT", [2], [3], duration=2),
-        Instruction("CNOT", [1], [2], duration=2),
-        Instruction("CNOT", [1], [0], duration=2),
-        Instruction("SNOT", [3], duration=1),
-        Instruction("CNOT", [1], [3], duration=2),
-        Instruction("CNOT", [1], [3], duration=2)
-    ]
+    circuit3 = QubitCircuit(6)
+    circuit3.add_gate("SNOT", 0)
+    circuit3.add_gate("SNOT", 1)
+    circuit3.add_gate("CNOT", 2, 3)
+    circuit3.add_gate("CNOT", 1, 2)
+    circuit3.add_gate("CNOT", 1, 0)
+    circuit3.add_gate("SNOT", 3)
+    circuit3.add_gate("CNOT", 1, 3)
+    circuit3.add_gate("CNOT", 1, 3)
+
+    instruction_list = []
+    for gate in circuit3.gates:
+        if gate.name == "SNOT":
+            instruction_list.append(Instruction(gate, duration=1))
+        else:
+            instruction_list.append(Instruction(gate, duration=2))
+
     return instruction_list
 
 


### PR DESCRIPTION
**Description**
- Integrate scheduler into the compiler. The compiler can now schedule quantum gates to reduce the duration of the compiled pulses.
- Improve the structure and readability of the `Compiler` class. The compiler class was separated for clarity when the `Processor` class was built upon old code in `qutip.qip`. But it has never been opened as a public API. This PR improves the readability and, most importantly, makes it easier for users to customize the compiler class.
- Add a map `pulse_dict` between the pulse label and the indices in `Processor`, so that customizing class becomes much easier.

**Files description**
- `scheduler.py` is moved to compiler folder and split to two files : `instruction.py` and `scheduler.py` for clarity.
- Changes in `gatecompiler.py`, `cavityqedcompiler.py` and `spinchaincompiler.py` are for integrating the scheduler.
- Others are adaptations

**Changelog**
Integrate the scheduler into the compiler
