### PR TITLE
Improve plotting and add pulse_mode

### DIFF
--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -140,6 +140,7 @@ class Processor(object):
             self.dims = [2] * N
         else:
             self.dims = dims
+        self.pulse_mode = "discrete"
         self.spline_kind = spline_kind
 
     def add_drift(self, qobj, targets, cyclic_permutation=False):
@@ -248,6 +249,30 @@ class Processor(object):
                              "as the number of control pulses.")
         for i, coeff in enumerate(coeffs_list):
             self.pulses[i].coeff = coeff
+
+    @property
+    def pulse_mode(self):
+        if self.spline_kind == "step_func":
+            return "discrete"
+        elif self.spline_kind == "cubic":
+            return "continuous"
+        else:
+            raise ValueError(
+                "Saved spline_kind not understood.")
+
+    @pulse_mode.setter
+    def pulse_mode(self, mode):
+        if mode == "discrete":
+            spline_kind = "step_func"
+        elif mode == "continuous":
+            spline_kind = "cubic"
+        else:
+            raise ValueError(
+                "Pulse mode must be either discrete or continuous.")
+
+        self.spline_kind = spline_kind
+        for pulse in self.pulses:
+            pulse.spline_kind = spline_kind
 
     def get_full_tlist(self):
         """

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -143,6 +143,14 @@ class Processor(object):
         self.pulse_mode = "discrete"
         self.spline_kind = spline_kind
 
+    @property
+    def num_qubits(self):
+        return self.N
+
+    @num_qubits.setter
+    def num_qubits(self, value):
+        self.N = value
+
     def add_drift(self, qobj, targets, cyclic_permutation=False):
         """
         Add a drift Hamiltonians. The drift Hamiltonians are intrinsic


### PR DESCRIPTION
**Description**
- The plotting method is made more robust.
- Add `pulse_mode` as a wrapper for spline_kind, for discrete and continuous pulses. They are more friendly names for experimentalists.
- Add `num_qubits` as a replacement for `N`. In QuTiP capital letter are used for operators, like `H` for Hamiltonian. Due to historical reason, `N` is used in `qip` for the number of qubits. We would like to replace it with `num_qubits` in `qutip_qip`. Start from this wrapper and promoting the usage of this in notebooks guide.

**Changelog**
Minor
