### PR TITLE
Fix zspmv_openmp.cpp missing in srcdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ recursive-include qutip *.hpp
 recursive-include qutip *.pxd
 recursive-include qutip *.ini
 recursive-include qutip/tests/qasm_files *.qasm
+include qutip/cy/openmp/src/zspmv_openmp.cpp


### PR DESCRIPTION
QuTiP 4.5.3 fails to build from source distribution on PyPI, e.g. on Windows:
```
c1xx: fatal error C1083: Cannot open source file: 'qutip/cy/openmp/src/zspmv_openmp.cpp': No such file or directory
```
**Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.

- [ ] Please read [Contributing to QuTiP Development](https://github.com/qutip/qutip-doc/blob/master/CONTRIBUTING.md)
- [ ] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
- [ ] Please add tests to cover your changes if applicable.
- [ ] If the behavior of the code has changed or new feature has been added, please also update the [documentation](https://github.com/qutip/qutip-doc) and the [notebook](https://github.com/qutip/qutip-notebooks). Feel free to ask if you are not sure.

Delete this checklist after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.

**Description**
Describe here the proposed change.

**Related issues or PRs**
Please mention the related issues or PRs here. If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id, e.g. fix #1184

**Changelog**
Give a short description of the PR in a few words. This will be shown in the QuTiP change log after the PR gets merged.
For example: 
Fixed error checking for null matrix in essolve.
Added option for specifying resolution in Bloch.save function.
