### PR TITLE
set explicit dtype=np.complex128 in csr_matrix

### DIFF
--- a/qutip/cy/piqs.pyx
+++ b/qutip/cy/piqs.pyx
@@ -430,7 +430,8 @@ cdef class Dicke(object):
 
         cdef lindblad_matrix = csr_matrix((lindblad_data,
                                           (lindblad_row, lindblad_col)),
-                                          shape=(nds**2, nds**2))
+                                          shape=(nds**2, nds**2),
+                                          dtype=np.complex128)
 
         # make matrix a Qobj superoperator with expected dims
         llind_dims = [[[nds], [nds]], [[nds], [nds]]]


### PR DESCRIPTION
Required due to changes in scipy 1.6.1. Using an explicit dtype will make matrix construction more robust.

Fixes qutip Issue #1451.

Tested on Debian unstable, with this patch tests/test_sparse.py now passes with scipy 1.6.1.

**Description**

scipy 1.6.1 changed the API for constructing sparse matrices with `scipy.sparse.csr_matrix` (affecting the COO format). This caused qutip TestDicke tests in test_piqs.py (test_lindbladian, test_lindbladian_dims, test_liouvillian)  to fail. 

This patch avoids the problem by setting the dtype explicitly to np,complex128. 

**Related issues or PRs**

fixes #1451

**Changelog**
Provide explicit dtype=np.complex128 when constructing sparse matrixes with csr_matrix. Required for working with scipy 1.6.1.