### PR TITLE
Update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,8 +1,27 @@
-Paul Nation <nonhermitian@gmail.com> Paul Nation <paul@Pauls-MacBook-Pro.local>
-Paul Nation <nonhermitian@gmail.com> Paul Nation <paul@Pauls-Air.local>
-Anubhav Vardhan <anubhavvardhan@gmail.com> Anubhav <anubhavvardhan@gmail.com>
-Christopher Granade <cgranade@cgranade.com> Chris Granade <cgranade@gmail.com>
-Markus Baden <markus.baden@gmail.com> Markus Baden <Markus.Baden@gmail.com>
-kafischer <fischer.kevin.a@gmail.com> kevinf <fischer.kevin.a@gmail.com>
-Alexander Pitchford <alex.pitchford@gmail.com> ajgpitch <alex.pitchford@gmail.com>
+Markus Baden <markus.baden@gmail.com> <Markus.Baden@gmail.com>
+Ivan Carvalho <ivan.carvalho@alumni.ubc.ca> <ivan.ivancps.cn@gmail.com>
+Ben Criger <bcriger@gmail.com>
+Simon Cross <hodgestar@gmail.com> <hodgestar+github@gmail.com>
+Kevin Fischer <fischer.kevin.a@gmail.com>
+Eric Giguère <eric.giguere@calculquebec.ca>
+Canoming <canoming@163.com>
+Canoming <canoming@163.com> <36161480+Canoming@users.noreply.github.com>
+Christopher Granade <cgranade@cgranade.com>
+Christopher Granade <cgranade@cgranade.com> <cgranade@gmail.com>
+Arne Grimsmo <arne.grimsmo@gmail.com>
+Stefan Krastanov <krastanov.stefan@gmail.com> <stefan@debian.krastanov>
+Neill Lambert <nwlambert@gmail.com>
+Boxi Li <etamin1201@gmail.com>
+Jake Lishman <jake@binhbar.com> <jakelishman@gmail.com>
+Paul Nation <nonhermitian@gmail.com> <paul@Pauls-Air.local>
+Paul Nation <nonhermitian@gmail.com> <paul@Pauls-MacBook-Pro.local>
+Alexander Pitchford <alex.pitchford@gmail.com>
 Alexander Pitchford <alex.pitchford@gmail.com> Alexander James Pitchford <agp1@aber.ac.uk>
+Nicolas Quesada <zeitus@gmail.com> <nicolas@xanadu.ai>
+Tarun Raheja <trolldemort9@gmail.com>
+Tarun Raheja <trolldemort9@gmail.com> <31796197+tehruhn@users.noreply.github.com>
+Sidhant Saraogi <ssaraogi@uwaterloo.ca>
+Sidhant Saraogi <ssaraogi@uwaterloo.ca> sid <ssaraogi@edu.uwaterloo.ca>
+Anubhav Vardhan <anubhavvardhan@gmail.com>
+Lucas Verney <phyks@phyks.me>
+Florestan Ziem <flo.zie@gmx.de>


### PR DESCRIPTION
Updates the `.mailmap` file that git uses to link people and emails (try `git shortlog` with vs without this patch).  Just general book-keeping.