### PR TITLE
Core update for solvers.

### DIFF
--- a/qutip/core/__init__.py
+++ b/qutip/core/__init__.py
@@ -3,6 +3,7 @@ from .coefficient import *
 from .interpolate import *
 from .qobj import *
 from .qobjevo import *
+from .qobjevofunc import *
 from .expect import *
 from .tensor import *
 from .states import *

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -442,11 +442,6 @@ def compile_code(code, file_name, parsed, c_opt):
             raise Exception("Could not compile") from e
         finally:
             sys.argv = oldargs
-        try:
-            libfile = glob.glob(file_name + "*")[0]
-            shutil.move(libfile, os.path.join(root, libfile))
-        except Exception:
-            warn("File")
     finally:
         os.chdir(pwd)
     return try_import(file_name, parsed)

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -334,7 +334,13 @@ def try_import(file_name, parsed_in):
         except ModuleNotFoundError:
             # Coefficient does not exist, to compile as file_name_
             return None, file_name_
-    return mod.StrCoefficient, file_name_
+
+    if mod.parsed_code != parsed_in:
+        # At least 10 coeff with the same hash!?
+        # Overwrite the last file,
+        return None, file_name_
+    else:
+        return mod.StrCoefficient, file_name
 
 
 def make_cy_code(code, variables, constants, raw, compile_opt):

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -104,7 +104,7 @@ def coefficient(base, *, tlist=None, args={}, args_ctypes={},
 
     elif callable(base):
         # TODO add tests?
-        return FunctionCoefficient(base, args)
+        return FunctionCoefficient(base, args.copy())
     else:
         raise ValueError("coefficient format not understood")
 

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -341,9 +341,9 @@ def try_import(file_name, parsed_in):
             return None, file_name_
 
     if mod.parsed_code != parsed_in:
-        # At least 10 coeff with the same hash!?
-        # Giveup
-        raise ValueError("string hash collision, change the string or ")
+        # At least 10 coeff with the same hash!? Giveup...
+        raise ValueError("string hash collision, change the string "
+                         "or clean files in qutip.settings.install['tmproot']")
     else:
         return mod.StrCoefficient, file_name
 
@@ -630,12 +630,11 @@ def try_parse(code, args, args_ctypes, compile_opt):
         constants = [(f, s, "object") for f, s, _ in constants]
     ncode, variables = use_hinted_type(variables, ncode, args_ctypes)
     if (
-        compile_opt['extra_import']
-        and not compile_opt['extra_import'].isspace()
+        (compile_opt['extra_import']
+        and not compile_opt['extra_import'].isspace())
+        or test_parsed(ncode, variables, constants, args)
     ):
-        return ncode + ";", variables, constants, False
-    if test_parsed(ncode, variables, constants, args):
-            return ncode, variables, constants, False
+        return ncode, variables, constants, False
     else:
         warn("Could not find c types", StringParsingWarning)
         remaped_variable = []

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -190,6 +190,10 @@ class CompilationOptions:
     options = {
         # use cython for compiling string coefficient
         "use_cython": _use_cython,
+        # try to parse the string so qutip recognise similar string as one
+        # compiled coefficient:
+        # "a*t", "a * t", "b*t" would all use one compiled version
+        "try_parse": True,
         # In compiled Coefficient, are int kept as int?
         # None indicate to look for list subscription
         "accept_int": None,
@@ -337,8 +341,8 @@ def try_import(file_name, parsed_in):
 
     if mod.parsed_code != parsed_in:
         # At least 10 coeff with the same hash!?
-        # Overwrite the last file,
-        return None, file_name_
+        # Giveup
+        raise ValueError("")
     else:
         return mod.StrCoefficient, file_name
 
@@ -608,6 +612,9 @@ def try_parse(code, args, args_ctypes, compile_opt):
     """
     Try to parse and verify that the result is still usable.
     """
+    if not compile_opt['try_parse']:
+        variable = [("self." + name, name, "object") for name in args]
+        return code, variable, [], True
     ncode, variables, constants = parse(code, args, compile_opt)
     if compile_opt['no_types']:
         # Fallback to all object

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -307,6 +307,7 @@ def coeff_from_str(base, args, args_ctypes, compile_opt):
         coeff = compile_code(code, file_name, parsed, compile_opt)
     keys = [key for _, key, _ in variables]
     const = [fromstr(val) for _, val, _ in constants]
+    print(keys, variables)
     return coeff(base, keys, const, args)
 
 
@@ -342,7 +343,7 @@ def try_import(file_name, parsed_in):
     if mod.parsed_code != parsed_in:
         # At least 10 coeff with the same hash!?
         # Giveup
-        raise ValueError("")
+        raise ValueError("string hash collision, change the string or ")
     else:
         return mod.StrCoefficient, file_name
 
@@ -602,10 +603,16 @@ def parse(code, args, compile_opt):
     return code, variables, ordered_constants
 
 
-def use_hinted_type(var_tuple, ncode, args_ctypes):
-    name, key, type_ = var_tuple
-    if key in args_ctypes:
-        code = code.replace(cte, cte[0] + name, 1)
+def use_hinted_type(variables, code, args_ctypes):
+    variables_manually_typed = []
+    for i, (name, key, type_) in enumerate(variables):
+        if key in args_ctypes:
+            new_name = "self._custom_" + args_ctypes[key] + str(i)
+            code = code.replace(name, new_name)
+            variables_manually_typed.append((new_name, key, args_ctypes[key]))
+        else:
+            variables_manually_typed.append((name, key, type_))
+    return code, variables_manually_typed
 
 
 def try_parse(code, args, args_ctypes, compile_opt):
@@ -613,24 +620,21 @@ def try_parse(code, args, args_ctypes, compile_opt):
     Try to parse and verify that the result is still usable.
     """
     if not compile_opt['try_parse']:
-        variable = [("self." + name, name, "object") for name in args]
-        return code, variable, [], True
+        variables = [("self." + name, name, "object") for name in args]
+        code, variables = use_hinted_type(variables, code, args_ctypes)
+        return code, variables, [], True
     ncode, variables, constants = parse(code, args, compile_opt)
     if compile_opt['no_types']:
         # Fallback to all object
         variables = [(f, s, "object") for f, s, _ in variables]
         constants = [(f, s, "object") for f, s, _ in constants]
-    variables_manually_typed = []
-    for i, (name, key, type_) in enumerate(variables):
-        if key in args_ctypes:
-            new_name = "self._custom_" + args_ctypes[key] + str(i)
-            ncode = ncode.replace(name, new_name)
-            variables_manually_typed.append((new_name, key, args_ctypes[key]))
-        else:
-            variables_manually_typed.append((name, key, type_))
-    variables = variables_manually_typed
-    if (compile_opt['extra_import'] or
-        test_parsed(ncode, variables, constants, args)):
+    ncode, variables = use_hinted_type(variables, ncode, args_ctypes)
+    if (
+        compile_opt['extra_import']
+        and not compile_opt['extra_import'].isspace()
+    ):
+        return ncode + ";", variables, constants, False
+    if test_parsed(ncode, variables, constants, args):
             return ncode, variables, constants, False
     else:
         warn("Could not find c types", StringParsingWarning)

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -184,7 +184,6 @@ cdef class InterCoefficient(Coefficient):
             self.cte = cte
         self.second_derr = self.second_np
         self.dt = tlist[1] - tlist[0]
-        self.n_t = len(tlist)
         self.args = {}
 
     @cython.initializedcheck(False)
@@ -194,15 +193,12 @@ cdef class InterCoefficient(Coefficient):
             coeff = _spline_complex_cte_second(t,
                                                self.tlist,
                                                self.coeff_arr,
-                                               self.second_derr,
-                                               self.n_t,
-                                               self.dt)
+                                               self.second_derr)
         else:
             coeff = _spline_complex_t_second(t,
                                              self.tlist,
                                              self.coeff_arr,
-                                             self.second_derr,
-                                             self.n_t)
+                                             self.second_derr)
         return coeff
 
     def __reduce__(self):
@@ -243,16 +239,15 @@ cdef class StepCoefficient(Coefficient):
         else:
             self.cte = cte
         self.dt = tlist[1] - tlist[0]
-        self.n_t = len(tlist)
         self.args = {}
 
     @cython.initializedcheck(False)
     cdef complex _call(self, double t) except *:
         cdef complex coeff
         if self.cte:
-            coeff = _step_complex_cte(t, self.tlist, self.coeff_arr, self.n_t)
+            coeff = _step_complex_cte(t, self.tlist, self.coeff_arr)
         else:
-            coeff = _step_complex_t(t, self.tlist, self.coeff_arr, self.n_t)
+            coeff = _step_complex_t(t, self.tlist, self.coeff_arr)
         return coeff
 
     def __reduce__(self):

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -22,7 +22,7 @@ cdef class Coefficient:
         return 0j
 
     cpdef void arguments(self, dict args) except *:
-        self.args = args
+        self.args.update(args)
 
     def __call__(self, double t, dict args={}):
         """update args and return the
@@ -67,7 +67,7 @@ cdef class Coefficient:
 cdef class FunctionCoefficient(Coefficient):
     cdef object func
 
-    def __init__(self, func, args):
+    def __init__(self, func, dict args):
         self.func = func
         self.args = args
 
@@ -119,7 +119,7 @@ cdef class StrFunctionCoefficient(Coefficient):
         "np": np,
         "spe": scipy.special}
 
-    def __init__(self, base, args):
+    def __init__(self, base, dict args):
         code = """
 def coeff(t, args):
 {}
@@ -152,6 +152,7 @@ cdef class InterpolateCoefficient(Coefficient):
         self.higher_bound = splineObj.b
         self.spline_data = splineObj.coeffs.astype(np.complex128)
         self.spline = splineObj
+        self.args = {}
 
     @cython.initializedcheck(False)
     cdef complex _call(self, double t) except *:
@@ -184,6 +185,7 @@ cdef class InterCoefficient(Coefficient):
         self.second_derr = self.second_np
         self.dt = tlist[1] - tlist[0]
         self.n_t = len(tlist)
+        self.args = {}
 
     @cython.initializedcheck(False)
     cdef complex _call(self, double t) except *:
@@ -242,6 +244,7 @@ cdef class StepCoefficient(Coefficient):
             self.cte = cte
         self.dt = tlist[1] - tlist[0]
         self.n_t = len(tlist)
+        self.args = {}
 
     @cython.initializedcheck(False)
     cdef complex _call(self, double t) except *:

--- a/qutip/core/cy/cqobjevo.pxd
+++ b/qutip/core/cy/cqobjevo.pxd
@@ -52,12 +52,16 @@ cdef class CQobjEvo:
 
     cdef void _factor(self, double t) except *
 
+    # To remove when safe
     cdef bint has_dynamic_args
     cdef list dynamic_arguments
     cdef dict args
     cdef object op
 
-    cpdef Data matmul(self, double t, Data matrix)
+    cpdef Data matmul(self, double t, Data matrix, Data out=*)
     cpdef Dense matmul_dense(self, double t, Dense matrix, Dense out=*)
     cpdef double complex expect(self, double t, Data matrix) except *
     cpdef double complex expect_dense(self, double t, Dense matrix) except *
+
+cdef class CQobjFunc(CQobjEvo):
+    cdef object base

--- a/qutip/core/cy/cqobjevo.pyx
+++ b/qutip/core/cy/cqobjevo.pyx
@@ -130,7 +130,7 @@ cdef class CQobjEvo:
 
     cpdef Data matmul(self, double t, Data matrix, Data out=None):
         cdef size_t i
-        if type(matrix) is Dense and (out is None or type(out) is None):
+        if type(matrix) is Dense and (out is None or type(out) is Dense):
             return self.matmul_dense(t, matrix, out)
         self._factor(t)
         if out is None:
@@ -220,6 +220,8 @@ cdef class CQobjFunc(CQobjEvo):
         return self.base(t, data=data)
 
     cpdef Data matmul(self, double t, Data matrix, Data out=None):
+        if type(matrix) is Dense and (out is None or type(out) is Dense):
+            return self.matmul_dense(t, matrix, out)
         cdef Data objdata = self.call(t, data=True)
         if out is not None:
             out = _data.add(_data.matmul(objdata, matrix), out)

--- a/qutip/core/cy/cqobjevo.pyx
+++ b/qutip/core/cy/cqobjevo.pyx
@@ -128,12 +128,15 @@ cdef class CQobjEvo:
             self.coefficients[i] = coeff._call(t)
         return
 
-    cpdef Data matmul(self, double t, Data matrix):
+    cpdef Data matmul(self, double t, Data matrix, Data out=None):
         cdef size_t i
-        if isinstance(matrix, Dense):
-            return self.matmul_dense(t, matrix)
+        if type(matrix) is Dense and (out is None or type(out) is None):
+            return self.matmul_dense(t, matrix, out)
         self._factor(t)
-        out = _data.matmul(self.constant, matrix)
+        if out is None:
+            out = _data.matmul(self.constant, matrix)
+        else:
+            out = _data.add(out, _data.matmul(self.constant, matrix))
         for i in range(self.n_ops):
             out = _data.add(out,
                             _data.matmul(<Data> self.ops[i],
@@ -203,10 +206,10 @@ cdef class CQobjEvo:
 
 
 cdef class CQobjFunc(CQobjEvo):
-    cdef object base
     def __init__(self, base):
         self.base = base
         self.reset_shape()
+        self.n_ops = 0
 
     def reset_shape(self):
         self.shape = self.base.shape
@@ -216,19 +219,20 @@ cdef class CQobjFunc(CQobjEvo):
     def call(self, double t, int data=0):
         return self.base(t, data=data)
 
-    cpdef Data matmul(self, double t, Data matrix):
-        cdef Data objdata = self.base(t, data=True)
-        out = _data.matmul(objdata, matrix)
+    cpdef Data matmul(self, double t, Data matrix, Data out=None):
+        cdef Data objdata = self.call(t, data=True)
+        if out is not None:
+            out = _data.add(_data.matmul(objdata, matrix), out)
+        else:
+            out = _data.matmul(objdata, matrix)
         return out
 
     cpdef Dense matmul_dense(self, double t, Dense matrix, Dense out=None):
-        cdef Data objdata = self.base(t).data
+        cdef Data objdata = self.call(t, data=True)
         if out is None:
-            # out = _data.matmul(objdata, matrix)
             out = matmul_data_dense(objdata, matrix)
         else:
             imatmul_data_dense(objdata, matrix, 1, out)
-            #iadd_dense(out, _data.matmul[type(objdata), Dense, Dense](objdata, matrix, 1))
         return out
 
     cpdef double complex expect(self, double t, Data matrix) except *:
@@ -240,7 +244,7 @@ cdef class CQobjFunc(CQobjEvo):
         """
         cdef double complex out
         cdef int nrow
-        cdef Data objdata = self.base(t, data=True)
+        cdef Data objdata = self.call(t, data=True)
         if self.issuper:
             matrix = _data.column_stack(matrix)
             out = _data.expect_super(objdata, matrix)
@@ -257,7 +261,7 @@ cdef class CQobjFunc(CQobjEvo):
         """
         cdef double complex out
         cdef int nrow
-        cdef Data objdata = self.base(t, data=True)
+        cdef Data objdata = self.call(t, data=True)
         if self.issuper:
             matrix = _data.column_stack(matrix)
             out = _data.expect_super(objdata, matrix)

--- a/qutip/core/cy/inter.pxd
+++ b/qutip/core/cy/inter.pxd
@@ -33,25 +33,21 @@
 ###############################################################################
 
 cdef complex _spline_complex_t_second(double x, double[::1] t,
-                                      complex[::1] y, complex[::1] M,
-                                      int N)
+                                      complex[::1] y, complex[::1] M)
 
 cdef complex _spline_complex_cte_second(double x, double[::1] t,
-                                        complex[::1] y, complex[::1] M,
-                                        int N, double dt)
+                                        complex[::1] y, complex[::1] M)
 
 cdef double _spline_float_t_second(double x, double[::1] t,
-                                   double[::1] y, double[::1] M,
-                                   int N)
+                                   double[::1] y, double[::1] M)
 
 cdef double _spline_float_cte_second(double x, double[::1] t,
-                                     double[::1] y, double[::1] M,
-                                     int N, double dt)
+                                     double[::1] y, double[::1] M)
 
-cdef double _step_float_cte(double x, double[::1] t, double[::1] y, int n_t)
+cdef double _step_float_cte(double x, double[::1] t, double[::1] y)
 
-cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y, int n_t)
+cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y)
 
-cdef double _step_float_t(double x, double[::1] t, double[::1] y, int n_t)
+cdef double _step_float_t(double x, double[::1] t, double[::1] y)
 
-cdef complex _step_complex_t(double x, double[::1] t, complex[::1] y, int n_t)
+cdef complex _step_complex_t(double x, double[::1] t, complex[::1] y)

--- a/qutip/core/cy/inter.pyx
+++ b/qutip/core/cy/inter.pyx
@@ -113,9 +113,9 @@ cdef double _spline_float_cte_second(double x,
                                      int n_t,
                                      double dt):
     # inbound?
-    if x < t[0]:
+    if x <= t[0]:
         return y[0]
-    elif x > t[n_t-1]:
+    elif x >= t[n_t-1]:
         return y[n_t-1]
     cdef double xx = (x-t[0])/dt
     cdef int p = <int>xx
@@ -137,9 +137,9 @@ cdef double _spline_float_t_second(double x,
                                    double[::1] M,
                                    int n_t):
     # inbound?
-    if x < t[0]:
+    if x <= t[0]:
         return y[0]
-    elif x > t[n_t-1]:
+    elif x >= t[n_t-1]:
         return y[n_t-1]
     cdef int p = _binary_search(x, t, n_t)
     cdef double dt = t[p+1] - t[p]
@@ -162,9 +162,9 @@ cdef complex _spline_complex_cte_second(double x,
                                         int n_t,
                                         double dt):
     # inbound?
-    if x < t[0]:
+    if x <= t[0]:
         return y[0]
-    elif x > t[n_t-1]:
+    elif x >= t[n_t-1]:
         return y[n_t-1]
     cdef double xx = (x-t[0])/dt
     cdef int p = <int>xx
@@ -186,9 +186,9 @@ cdef complex _spline_complex_t_second(double x,
                                       complex[::1] M,
                                       int n_t):
     # inbound?
-    if x < t[0]:
+    if x <= t[0]:
         return y[0]
-    elif x > t[n_t-1]:
+    elif x >= t[n_t-1]:
         return y[n_t-1]
     cdef int p = _binary_search(x, t, n_t)
     cdef double dt = t[p+1] - t[p]
@@ -205,7 +205,7 @@ cdef complex _spline_complex_t_second(double x,
 @cython.boundscheck(False)
 @cython.cdivision(True)
 cdef double _step_float_cte(double x, double[::1] t, double[::1] y, int n_t):
-    if x < t[0]:
+    if x <= t[0]:
         return y[0]
     elif x >= t[n_t-1]:
         return y[n_t-1]
@@ -217,7 +217,7 @@ cdef double _step_float_cte(double x, double[::1] t, double[::1] y, int n_t):
 @cython.boundscheck(False)
 @cython.cdivision(True)
 cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y, int n_t):
-    if x < t[0]:
+    if x <= t[0]:
         return y[0]
     elif x >= t[n_t-1]:
         return y[n_t-1]
@@ -229,7 +229,7 @@ cdef complex _step_complex_cte(double x, double[::1] t, complex[::1] y, int n_t)
 @cython.boundscheck(False)
 @cython.cdivision(True)
 cdef double _step_float_t(double x, double[::1] t, double[::1] y, int n_t):
-    if x < t[0]:
+    if x <= t[0]:
         return y[0]
     elif x >= t[n_t-1]:
         return y[n_t-1]
@@ -242,7 +242,7 @@ cdef double _step_float_t(double x, double[::1] t, double[::1] y, int n_t):
 @cython.boundscheck(False)
 @cython.cdivision(True)
 cdef complex _step_complex_t(double x, double[::1] t, complex[::1] y, int n_t):
-    if x < t[0]:
+    if x <= t[0]:
         return y[0]
     elif x >= t[n_t-1]:
         return y[n_t-1]

--- a/qutip/core/data/base.pxd
+++ b/qutip/core/data/base.pxd
@@ -14,3 +14,4 @@ cdef class Data:
     cpdef Data adjoint(self)
     cpdef Data conj(self)
     cpdef Data transpose(self)
+    cpdef Data copy(self)

--- a/qutip/core/data/base.pyx
+++ b/qutip/core/data/base.pyx
@@ -23,6 +23,8 @@ cdef class Data:
         raise NotImplementedError
     cpdef Data transpose(self):
         raise NotImplementedError
+    cpdef Data copy(self):
+        raise NotImplementedError
 
 class EfficiencyWarning(Warning):
     pass

--- a/qutip/core/data/mul.pxd
+++ b/qutip/core/data/mul.pxd
@@ -1,6 +1,6 @@
 #cython: language_level=3
 
-from qutip.core.data cimport CSR, Dense
+from qutip.core.data cimport CSR, Dense, Data
 
 cpdef CSR imul_csr(CSR matrix, double complex value)
 cpdef CSR mul_csr(CSR matrix, double complex value)
@@ -9,3 +9,5 @@ cpdef CSR neg_csr(CSR matrix)
 cpdef Dense imul_dense(Dense matrix, double complex value)
 cpdef Dense mul_dense(Dense matrix, double complex value)
 cpdef Dense neg_dense(Dense matrix)
+
+cpdef Data imul_data(Data matrix, double complex value)

--- a/qutip/core/data/mul.pyx
+++ b/qutip/core/data/mul.pyx
@@ -1,11 +1,11 @@
 #cython: language_level=3
 #cython: boundscheck=False, wrapround=False, initializedcheck=False
 
-from qutip.core.data cimport idxint, csr, CSR, dense, Dense
+from qutip.core.data cimport idxint, csr, CSR, dense, Dense, Data
 
 __all__ = [
     'mul', 'mul_csr', 'mul_dense',
-    'imul', 'imul_csr', 'imul_dense',
+    'imul', 'imul_csr', 'imul_dense', 'imul_data',
     'neg', 'neg_csr', 'neg_dense',
 ]
 
@@ -123,3 +123,12 @@ neg.add_specialisations([
 ], _defer=True)
 
 del _inspect, _Dispatcher
+
+
+cpdef Data imul_data(Data matrix, double complex value):
+    if type(matrix) is CSR:
+        return imul_csr(matrix, value)
+    elif type(matrix) is Dense:
+        return imul_dense(matrix, value)
+    else:
+        return imul(matrix, value)

--- a/qutip/core/data/norm.pxd
+++ b/qutip/core/data/norm.pxd
@@ -1,7 +1,7 @@
 #cython: language_level=3
 #cython: boundscheck=False, wraparound=False, initializedcheck=False
 
-from qutip.core.data cimport CSR, Dense
+from qutip.core.data cimport CSR, Dense, Data
 
 cpdef double one_csr(CSR matrix) except -1
 cpdef double trace_csr(CSR matrix) except -1
@@ -11,3 +11,5 @@ cpdef double l2_csr(CSR matrix) nogil except -1
 
 cpdef double frobenius_dense(Dense matrix) nogil
 cpdef double l2_dense(Dense matrix) nogil except -1
+
+cpdef double frobenius_data(Data state)

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -7,7 +7,7 @@ from cpython cimport mem
 
 from scipy.linalg cimport cython_blas as blas
 
-from qutip.core.data cimport CSR, Dense, csr, dense
+from qutip.core.data cimport CSR, Dense, csr, dense, Data
 
 from qutip.core.data.adjoint cimport adjoint_csr, adjoint_dense
 from qutip.core.data.matmul cimport matmul_csr
@@ -213,3 +213,12 @@ trace.__doc__ =\
 trace.add_specialisations([
     (CSR, trace_csr),
 ], _defer=True)
+
+
+cpdef double frobenius_data(Data state):
+    if type(state) is Dense:
+        return frobenius_dense(state)
+    elif type(state) is CSR:
+        return frobenius_csr(state)
+    else:
+        return frobenius(state)

--- a/qutip/core/qobjevofunc.py
+++ b/qutip/core/qobjevofunc.py
@@ -329,6 +329,7 @@ class QobjEvoFunc(QobjEvoBase):
     def __neg__(self):
         res = self.copy()
         res.operation_stack.append(_Block_neg())
+        res._check_validity()
         return res
 
     def __and__(self, other):
@@ -342,22 +343,26 @@ class QobjEvoFunc(QobjEvoBase):
     def trans(self):
         res = self.copy()
         res.operation_stack.append(_Block_trans())
+        res._check_validity()
         return res
 
     def conj(self):
         res = self.copy()
         res.operation_stack.append(_Block_conj())
+        res._check_validity()
         return res
 
     def dag(self):
         res = self.copy()
         res.operation_stack.append(_Block_dag())
+        res._check_validity()
         return res
 
     def _cdc(self):
         """return a.dag * a """
         res = self.copy()
         res.operation_stack.append(_Block_cdc())
+        res._check_validity()
         return res
 
     def _tensor(self, other):
@@ -410,6 +415,7 @@ class QobjEvoFunc(QobjEvoBase):
         res = self.copy()
         res._shifted = True
         res.args["_t0"] = 0
+        res._check_validity()
         return res
 
     # Unitary function of Qobj
@@ -440,7 +446,7 @@ class QobjEvoFunc(QobjEvoBase):
     # function to apply custom transformations
     def linear_map(self, op_mapping):
         """
-        Apply function to each Qobj contribution.
+        Apply mapping to each Qobj contribution.
         """
         if op_mapping is spre:
             return self._spre()
@@ -449,6 +455,33 @@ class QobjEvoFunc(QobjEvoBase):
 
         res = self.copy()
         res.operation_stack.append(_Block_linear_map(op_mapping))
+        res._check_validity()
+        return res
+
+    def to(self, data_type):
+        """
+        Convert the underlying data store of all component into the desired
+        storage representation.
+
+        The different storage representations available are the "data-layer
+        types".  By default, these are `qutip.data.Dense` and `qutip.data.CSR`,
+        which respectively construct a dense matrix store and a compressed
+        sparse row one.
+
+        The `QobjEvo` is transformed inplace.
+
+        Arguments
+        ---------
+        data_type : type
+            The data-layer type that the data of this `Qobj` should be
+            converted to.
+
+        Returns
+        -------
+        None
+        """
+        res = self.copy()
+        res.operation_stack.append(_Block_to(data_type))
         res._check_validity()
         return res
 
@@ -575,5 +608,16 @@ class _Block_linear_map(_Block_transform):
 
     def __call__(self, obj, t, args={}):
         return self.func(obj)
+
+
+class _Block_to(_Block_transform):
+    def __init__(self, data_type):
+        self.data_type = data_type
+
+    def copy(self):
+        return _Block_to(self.data_type)
+
+    def __call__(self, obj, t, args={}):
+        return obj.to(self.data_type)
 
 from .tensor import tensor

--- a/qutip/installsettings.py
+++ b/qutip/installsettings.py
@@ -58,18 +58,12 @@ class InstallSettings:
         _logger = None
 
     try:
-        qutip_conf_dir = os.path.join(os.path.expanduser("~"), '.qutip')
-        if not os.path.exists(qutip_conf_dir):
-            os.mkdir(qutip_conf_dir)
-        tmproot = os.path.join(qutip_conf_dir, 'coeffs')
+        tmproot = os.path.join(os.path.expanduser("~"), '.qutip')
         if not os.path.exists(tmproot):
             os.mkdir(tmproot)
         assert os.access(tmproot, os.W_OK)
-        del qutip_conf_dir
     except Exception:
         tmproot = "."
-    if tmproot not in sys.path:
-        sys.path.insert(0, tmproot)
 
     # ------------------------------------------------------------------------
     # Check if we're in IPython.

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -46,6 +46,10 @@ def g(t, args):
     return np.cos(args["w"] * t * np.pi)
 
 
+def h(t, args):
+    return args["a"] + args["b"] +t
+
+
 args = {"w": 1j}
 tlist = np.linspace(0, 1, 101)
 f_asarray = f(tlist, args)
@@ -116,8 +120,23 @@ def test_CoeffCallArgs(base, kwargs, tol):
     t = np.random.rand() * 0.9 + 0.05
     w = np.random.rand() + 0.5j
     val = np.exp(w * t * np.pi)
-    coeff = coefficient(f, **kwargs)
+    coeff = coefficient(base, **kwargs)
     assert np.allclose(coeff(t, {"w": w}), val, rtol=tol)
+
+
+@pytest.mark.parametrize(['base', 'tol'], [
+    pytest.param(h, 1e-10, id="func"),
+    pytest.param("a + b + t", 1e-10, id="string")
+])
+def test_CoeffCallArguments(base, tol):
+    # Partial args update
+    t = np.random.rand() * 0.9 + 0.05
+    args = {"a": 1, "b": 1}
+    a = np.random.rand()
+    val = a + 1 + t
+    coeff = coefficient(base, args=args)
+    coeff.arguments({"a": a})
+    assert np.allclose(coeff(t), val, rtol=tol)
 
 
 @pytest.mark.parametrize(['style'], [

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -35,7 +35,13 @@ import pickle
 import qutip as qt
 import numpy as np
 from qutip.core.coefficient import (coefficient, norm, conj, shift,
-                                    reduce, CompilationOptions)
+                                    reduce, CompilationOptions,
+                                    clean_compiled_coefficient
+                                   )
+
+
+# Ensure the latest version is tested
+clean_compiled_coefficient(True)
 
 
 def f(t, args):

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -208,7 +208,10 @@ def test_CoeffOptions():
     options.append(CompilationOptions(accept_float=False))
     options.append(CompilationOptions(no_types=True))
     options.append(CompilationOptions(use_cython=False))
+    options.append(CompilationOptions(try_parse=False))
     coeffs = [coefficient(base, compile_opt=opt) for opt in options]
+    for coeff in coeffs:
+        assert coeff(0) == 2+1j
     for coeff1, coeff2 in combinations(coeffs, 2):
         assert not isinstance(coeff1, coeff2.__class__)
 

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -53,7 +53,7 @@ def g(t, args):
 
 
 def h(t, args):
-    return args["a"] + args["b"] +t
+    return args["a"] + args["b"] + t
 
 
 args = {"w": 1j}

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -151,6 +151,9 @@ def _trans(a):
 def _neg(a):
     return -a
 
+def _to(a, dtype):
+    return a.to(dtype)
+
 def _cdc(a):
     if isinstance(a, Qobj):
         return a.dag() * a


### PR DESCRIPTION
<!--
**Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.

- [ ] Please read [Contributing to QuTiP Development](https://github.com/qutip/qutip-doc/blob/master/CONTRIBUTING.md)
- [ ] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
- [ ] Please add tests to cover your changes if applicable.
- [ ] If the behavior of the code has changed or new feature has been added, please also update the [documentation](https://github.com/qutip/qutip-doc) and the [notebook](https://github.com/qutip/qutip-notebooks). Feel free to ask if you are not sure.

Delete this checklist after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.
-->

**Description**
As proposed by @hodgestar, I am splitting #1409 into smaller PRs. This is part 1/3, but contain some change in core that would come later in the Solver PR:

- Add manual cython dispatched function. Used by vern ODE method.

- Add `to` to `QobjEvoFunc` and some check. Used by brmesolve rework.

- Add a version to string Coefficient, a 'try_parsing' options, partial arguments update and basic cleaning function.
This comes mostly from talk with @jakelishman.
When updating coefficient with new argument, it no longer require all coefficient to be given, but will simply update those available. 
Since those change must overwrite old version of the coefficient, a version tag is added to the coefficient folder and a function to erase the old version. It use it's own `COEFF_VERSION`, not qutip version since I don't expect most qutip update will not touch `coefficient.pyx` so we need not to force user to recompile. But it raise the risk of forgetting to change it when working on them. 
Lastly, I added an option to disable the string coefficient parsing since there seems to have some reservation in the last meeting.
But there is a weakness when using that form if unused args are passed: the `key = args['key']` code could be generated for those extra `args` but will not affect the hash name. 

**Related issues or PRs**
Will replace part of #1409.
