### PR TITLE
Support class for solvers

### DIFF
--- a/qutip/core/__init__.py
+++ b/qutip/core/__init__.py
@@ -3,6 +3,7 @@ from .coefficient import *
 from .interpolate import *
 from .qobj import *
 from .qobjevo import *
+from .qobjevofunc import *
 from .expect import *
 from .tensor import *
 from .states import *

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -28,7 +28,8 @@ from .cy.coefficient import (InterpolateCoefficient, InterCoefficient,
                              Coefficient)
 
 
-__all__ = ["coefficient", "CompilationOptions", "Coefficient"]
+__all__ = ["coefficient", "CompilationOptions", "Coefficient",
+           "clean_compiled_coefficient"]
 
 
 class StringParsingWarning(Warning):
@@ -236,6 +237,26 @@ def get_root():
     return root
 
 
+def clean_compiled_coefficient(all=False):
+    """
+    Remove previouly compiled string Coefficient.
+
+    Parameter:
+    ----------
+    all: bool
+        If not `all` will remove only previous version.
+    """
+    import glob
+    import shutil
+    tmproot = qset.install['tmproot']
+    root = os.path.join(tmproot, 'qutip_coeffs_{}'.format(COEFF_VERSION))
+    folders = glob.glob(os.path.join(tmproot, 'qutip_coeffs_') + "*")
+    for folder in folders:
+        if all or folder != root:
+            shutil.rmtree(folder)
+
+
+
 def proj(x):
     if np.isfinite(x):
         return (x)
@@ -341,9 +362,9 @@ def try_import(file_name, parsed_in):
             return None, file_name_
 
     if mod.parsed_code != parsed_in:
-        # At least 10 coeff with the same hash!?
-        # Giveup
-        raise ValueError("string hash collision, change the string or ")
+        # At least 10 coeff with the same hash!? Giveup...
+        raise ValueError("string hash collision, change the string "
+                         "or clean files in qutip.settings.install['tmproot']")
     else:
         return mod.StrCoefficient, file_name
 
@@ -364,7 +385,10 @@ def make_cy_code(code, variables, constants, raw, compile_opt):
     for i, (name, val, ctype) in enumerate(variables):
         cdef_var += "        str key{}\n".format(i)
         cdef_var += "        {} {}\n".format(ctype, name[5:])
-        init_var += "        self.key{} = var[{}]\n".format(i, i)
+        if not raw:
+            init_var += "        self.key{} = var[{}]\n".format(i, i)
+        else:
+            init_var += "        self.key{} = '{}'\n".format(i, val)
         args_var += "        if self.key{} in args:\n".format(i)
         args_var += "            {} = args[self.key{}]\n".format(name, i)
         if raw:
@@ -620,7 +644,8 @@ def try_parse(code, args, args_ctypes, compile_opt):
     Try to parse and verify that the result is still usable.
     """
     if not compile_opt['try_parse']:
-        variables = [("self." + name, name, "object") for name in args]
+        variables = [("self." + name, name, "object") for name in args
+                     if name in code]
         code, variables = use_hinted_type(variables, code, args_ctypes)
         return code, variables, [], True
     ncode, variables, constants = parse(code, args, compile_opt)
@@ -630,12 +655,11 @@ def try_parse(code, args, args_ctypes, compile_opt):
         constants = [(f, s, "object") for f, s, _ in constants]
     ncode, variables = use_hinted_type(variables, ncode, args_ctypes)
     if (
-        compile_opt['extra_import']
-        and not compile_opt['extra_import'].isspace()
+        (compile_opt['extra_import']
+        and not compile_opt['extra_import'].isspace())
+        or test_parsed(ncode, variables, constants, args)
     ):
-        return ncode + ";", variables, constants, False
-    if test_parsed(ncode, variables, constants, args):
-            return ncode, variables, constants, False
+        return ncode, variables, constants, False
     else:
         warn("Could not find c types", StringParsingWarning)
         remaped_variable = []

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -9,6 +9,7 @@ import glob
 import importlib
 import shutil
 import numbers
+from contextlib import contextmanager
 from collections import defaultdict
 from setuptools import setup, Extension
 try:
@@ -321,14 +322,13 @@ def coeff_from_str(base, args, args_ctypes, compile_opt):
     hash_ = hashlib.sha256(bytes(parsed, encoding='utf8'))
     file_name = "qtcoeff_" + hash_.hexdigest()[:30]
     # See if it already exist, if not write and cythonize it
-    coeff, file_name = try_import(file_name, parsed)
+    coeff = try_import(file_name, parsed)
     if coeff is None or compile_opt['recompile']:
         code = make_cy_code(parsed, variables, constants,
                             raw, compile_opt)
         coeff = compile_code(code, file_name, parsed, compile_opt)
     keys = [key for _, key, _ in variables]
     const = [fromstr(val) for _, val, _ in constants]
-    print(keys, variables)
     return coeff(base, keys, const, args)
 
 
@@ -342,31 +342,14 @@ def try_import(file_name, parsed_in):
         mod = importlib.import_module(file_name)
     except ModuleNotFoundError:
         # Coefficient does not exist, to compile as file_name
-        return None, file_name
+        return None
 
     if mod.parsed_code == parsed_in:
         # Coefficient found!
-        return mod.StrCoefficient, file_name
-
-    # hash collision!
-    # Increment filename
-    tries = -1
-    file_name_ = file_name
-    while mod.parsed_code != parsed_in and tries < 10:
-        tries += 1
-        file_name_ = file_name + str(tries)
-        try:
-            mod = importlib.import_module(file_name_)
-        except ModuleNotFoundError:
-            # Coefficient does not exist, to compile as file_name_
-            return None, file_name_
-
-    if mod.parsed_code != parsed_in:
-        # At least 10 coeff with the same hash!? Giveup...
+        return mod.StrCoefficient
+    else:
         raise ValueError("string hash collision, change the string "
                          "or clean files in qutip.settings.install['tmproot']")
-    else:
-        return mod.StrCoefficient, file_name
 
 
 def make_cy_code(code, variables, constants, raw, compile_opt):
@@ -436,34 +419,32 @@ cdef class StrCoefficient(Coefficient):
 
 
 def compile_code(code, file_name, parsed, c_opt):
-    root = get_root()
     pwd = os.getcwd()
-    os.chdir(root)
-    [os.remove(file) for file in glob.glob(file_name + "*")]
-    full_file_name = os.path.join(root, file_name)
-    file_ = open(full_file_name + ".pyx", "w")
-    file_.writelines(code)
-    file_.close()
-    oldargs = sys.argv
+    root = get_root()
     try:
-        sys.argv = ["setup.py", "build_ext", "--inplace"]
-        coeff_file = Extension(file_name,
-                               sources=[full_file_name + ".pyx"],
-                               extra_compile_args=c_opt['compiler_flags'].split(),
-                               extra_link_args=c_opt['link_flags'].split(),
-                               include_dirs=[np.get_include()],
-                               language='c++')
-        setup(ext_modules=cythonize(coeff_file, force=c_opt['recompile']))
-    except Exception as e:
-        raise Exception("Could not compile") from e
-    try:
-        libfile = glob.glob(file_name + "*")[0]
-        shutil.move(libfile, os.path.join(root, libfile))
-    except Exception:
-        warn("File")
-    sys.argv = oldargs
-    os.chdir(pwd)
-    return try_import(file_name, parsed)[0]
+        os.chdir(root)
+        [os.remove(file) for file in glob.glob(file_name + "*")]
+        full_file_name = os.path.join(root, file_name)
+        file_ = open(full_file_name + ".pyx", "w")
+        file_.writelines(code)
+        file_.close()
+        oldargs = sys.argv
+        try:
+            sys.argv = ["setup.py", "build_ext", "--inplace"]
+            coeff_file = Extension(file_name,
+                                   sources=[full_file_name + ".pyx"],
+                                   extra_compile_args=c_opt['compiler_flags'].split(),
+                                   extra_link_args=c_opt['link_flags'].split(),
+                                   include_dirs=[np.get_include()],
+                                   language='c++')
+            setup(ext_modules=cythonize(coeff_file, force=c_opt['recompile']))
+        except Exception as e:
+            raise Exception("Could not compile") from e
+        finally:
+            sys.argv = oldargs
+    finally:
+        os.chdir(pwd)
+    return try_import(file_name, parsed)
 
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -22,7 +22,7 @@ cdef class Coefficient:
         return 0j
 
     cpdef void arguments(self, dict args) except *:
-        self.args = args
+        self.args.update(args)
 
     def __call__(self, double t, dict args={}):
         """update args and return the
@@ -67,7 +67,7 @@ cdef class Coefficient:
 cdef class FunctionCoefficient(Coefficient):
     cdef object func
 
-    def __init__(self, func, args):
+    def __init__(self, func, dict args):
         self.func = func
         self.args = args
 
@@ -119,7 +119,7 @@ cdef class StrFunctionCoefficient(Coefficient):
         "np": np,
         "spe": scipy.special}
 
-    def __init__(self, base, args):
+    def __init__(self, base, dict args):
         code = """
 def coeff(t, args):
 {}
@@ -152,6 +152,7 @@ cdef class InterpolateCoefficient(Coefficient):
         self.higher_bound = splineObj.b
         self.spline_data = splineObj.coeffs.astype(np.complex128)
         self.spline = splineObj
+        self.args = {}
 
     @cython.initializedcheck(False)
     cdef complex _call(self, double t) except *:
@@ -184,6 +185,7 @@ cdef class InterCoefficient(Coefficient):
         self.second_derr = self.second_np
         self.dt = tlist[1] - tlist[0]
         self.n_t = len(tlist)
+        self.args = {}
 
     @cython.initializedcheck(False)
     cdef complex _call(self, double t) except *:
@@ -242,6 +244,7 @@ cdef class StepCoefficient(Coefficient):
             self.cte = cte
         self.dt = tlist[1] - tlist[0]
         self.n_t = len(tlist)
+        self.args = {}
 
     @cython.initializedcheck(False)
     cdef complex _call(self, double t) except *:

--- a/qutip/core/cy/cqobjevo.pxd
+++ b/qutip/core/cy/cqobjevo.pxd
@@ -52,12 +52,16 @@ cdef class CQobjEvo:
 
     cdef void _factor(self, double t) except *
 
+    # To remove when safe
     cdef bint has_dynamic_args
     cdef list dynamic_arguments
     cdef dict args
     cdef object op
 
-    cpdef Data matmul(self, double t, Data matrix)
+    cpdef Data matmul(self, double t, Data matrix, Data out=*)
     cpdef Dense matmul_dense(self, double t, Dense matrix, Dense out=*)
     cpdef double complex expect(self, double t, Data matrix) except *
     cpdef double complex expect_dense(self, double t, Dense matrix) except *
+
+cdef class CQobjFunc(CQobjEvo):
+    cdef object base

--- a/qutip/core/cy/cqobjevo.pyx
+++ b/qutip/core/cy/cqobjevo.pyx
@@ -130,7 +130,7 @@ cdef class CQobjEvo:
 
     cpdef Data matmul(self, double t, Data matrix, Data out=None):
         cdef size_t i
-        if type(matrix) is Dense and (out is None or type(out) is None):
+        if type(matrix) is Dense and (out is None or type(out) is Dense):
             return self.matmul_dense(t, matrix, out)
         self._factor(t)
         if out is None:
@@ -220,6 +220,8 @@ cdef class CQobjFunc(CQobjEvo):
         return self.base(t, data=data)
 
     cpdef Data matmul(self, double t, Data matrix, Data out=None):
+        if type(matrix) is Dense and (out is None or type(out) is Dense):
+            return self.matmul_dense(t, matrix, out)
         cdef Data objdata = self.call(t, data=True)
         if out is not None:
             out = _data.add(_data.matmul(objdata, matrix), out)

--- a/qutip/core/cy/cqobjevo.pyx
+++ b/qutip/core/cy/cqobjevo.pyx
@@ -128,12 +128,15 @@ cdef class CQobjEvo:
             self.coefficients[i] = coeff._call(t)
         return
 
-    cpdef Data matmul(self, double t, Data matrix):
+    cpdef Data matmul(self, double t, Data matrix, Data out=None):
         cdef size_t i
-        if isinstance(matrix, Dense):
-            return self.matmul_dense(t, matrix)
+        if type(matrix) is Dense and (out is None or type(out) is None):
+            return self.matmul_dense(t, matrix, out)
         self._factor(t)
-        out = _data.matmul(self.constant, matrix)
+        if out is None:
+            out = _data.matmul(self.constant, matrix)
+        else:
+            out = _data.add(out, _data.matmul(self.constant, matrix))
         for i in range(self.n_ops):
             out = _data.add(out,
                             _data.matmul(<Data> self.ops[i],
@@ -203,10 +206,10 @@ cdef class CQobjEvo:
 
 
 cdef class CQobjFunc(CQobjEvo):
-    cdef object base
     def __init__(self, base):
         self.base = base
         self.reset_shape()
+        self.n_ops = 0
 
     def reset_shape(self):
         self.shape = self.base.shape
@@ -216,19 +219,20 @@ cdef class CQobjFunc(CQobjEvo):
     def call(self, double t, int data=0):
         return self.base(t, data=data)
 
-    cpdef Data matmul(self, double t, Data matrix):
-        cdef Data objdata = self.base(t, data=True)
-        out = _data.matmul(objdata, matrix)
+    cpdef Data matmul(self, double t, Data matrix, Data out=None):
+        cdef Data objdata = self.call(t, data=True)
+        if out is not None:
+            out = _data.add(_data.matmul(objdata, matrix), out)
+        else:
+            out = _data.matmul(objdata, matrix)
         return out
 
     cpdef Dense matmul_dense(self, double t, Dense matrix, Dense out=None):
-        cdef Data objdata = self.base(t).data
+        cdef Data objdata = self.call(t, data=True)
         if out is None:
-            # out = _data.matmul(objdata, matrix)
             out = matmul_data_dense(objdata, matrix)
         else:
             imatmul_data_dense(objdata, matrix, 1, out)
-            #iadd_dense(out, _data.matmul[type(objdata), Dense, Dense](objdata, matrix, 1))
         return out
 
     cpdef double complex expect(self, double t, Data matrix) except *:
@@ -240,7 +244,7 @@ cdef class CQobjFunc(CQobjEvo):
         """
         cdef double complex out
         cdef int nrow
-        cdef Data objdata = self.base(t, data=True)
+        cdef Data objdata = self.call(t, data=True)
         if self.issuper:
             matrix = _data.column_stack(matrix)
             out = _data.expect_super(objdata, matrix)
@@ -257,7 +261,7 @@ cdef class CQobjFunc(CQobjEvo):
         """
         cdef double complex out
         cdef int nrow
-        cdef Data objdata = self.base(t, data=True)
+        cdef Data objdata = self.call(t, data=True)
         if self.issuper:
             matrix = _data.column_stack(matrix)
             out = _data.expect_super(objdata, matrix)

--- a/qutip/core/data/base.pxd
+++ b/qutip/core/data/base.pxd
@@ -14,3 +14,4 @@ cdef class Data:
     cpdef Data adjoint(self)
     cpdef Data conj(self)
     cpdef Data transpose(self)
+    cpdef Data copy(self)

--- a/qutip/core/data/base.pyx
+++ b/qutip/core/data/base.pyx
@@ -23,6 +23,8 @@ cdef class Data:
         raise NotImplementedError
     cpdef Data transpose(self):
         raise NotImplementedError
+    cpdef Data copy(self):
+        raise NotImplementedError
 
 class EfficiencyWarning(Warning):
     pass

--- a/qutip/core/data/mul.pxd
+++ b/qutip/core/data/mul.pxd
@@ -1,6 +1,6 @@
 #cython: language_level=3
 
-from qutip.core.data cimport CSR, Dense
+from qutip.core.data cimport CSR, Dense, Data
 
 cpdef CSR imul_csr(CSR matrix, double complex value)
 cpdef CSR mul_csr(CSR matrix, double complex value)
@@ -9,3 +9,5 @@ cpdef CSR neg_csr(CSR matrix)
 cpdef Dense imul_dense(Dense matrix, double complex value)
 cpdef Dense mul_dense(Dense matrix, double complex value)
 cpdef Dense neg_dense(Dense matrix)
+
+cpdef Data imul_data(Data matrix, double complex value)

--- a/qutip/core/data/mul.pyx
+++ b/qutip/core/data/mul.pyx
@@ -1,11 +1,11 @@
 #cython: language_level=3
 #cython: boundscheck=False, wrapround=False, initializedcheck=False
 
-from qutip.core.data cimport idxint, csr, CSR, dense, Dense
+from qutip.core.data cimport idxint, csr, CSR, dense, Dense, Data
 
 __all__ = [
     'mul', 'mul_csr', 'mul_dense',
-    'imul', 'imul_csr', 'imul_dense',
+    'imul', 'imul_csr', 'imul_dense', 'imul_data',
     'neg', 'neg_csr', 'neg_dense',
 ]
 
@@ -123,3 +123,12 @@ neg.add_specialisations([
 ], _defer=True)
 
 del _inspect, _Dispatcher
+
+
+cpdef Data imul_data(Data matrix, double complex value):
+    if type(matrix) is CSR:
+        return imul_csr(matrix, value)
+    elif type(matrix) is Dense:
+        return imul_dense(matrix, value)
+    else:
+        return imul(matrix, value)

--- a/qutip/core/data/norm.pxd
+++ b/qutip/core/data/norm.pxd
@@ -1,7 +1,7 @@
 #cython: language_level=3
 #cython: boundscheck=False, wraparound=False, initializedcheck=False
 
-from qutip.core.data cimport CSR, Dense
+from qutip.core.data cimport CSR, Dense, Data
 
 cpdef double one_csr(CSR matrix) except -1
 cpdef double trace_csr(CSR matrix) except -1
@@ -11,3 +11,5 @@ cpdef double l2_csr(CSR matrix) nogil except -1
 
 cpdef double frobenius_dense(Dense matrix) nogil
 cpdef double l2_dense(Dense matrix) nogil except -1
+
+cpdef double frobenius_data(Data state)

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -7,7 +7,7 @@ from cpython cimport mem
 
 from scipy.linalg cimport cython_blas as blas
 
-from qutip.core.data cimport CSR, Dense, csr, dense
+from qutip.core.data cimport CSR, Dense, csr, dense, Data
 
 from qutip.core.data.adjoint cimport adjoint_csr, adjoint_dense
 from qutip.core.data.matmul cimport matmul_csr
@@ -213,3 +213,12 @@ trace.__doc__ =\
 trace.add_specialisations([
     (CSR, trace_csr),
 ], _defer=True)
+
+
+cpdef double frobenius_data(Data state):
+    if type(state) is Dense:
+        return frobenius_dense(state)
+    elif type(state) is CSR:
+        return frobenius_csr(state)
+    else:
+        return frobenius(state)

--- a/qutip/core/qobjevofunc.py
+++ b/qutip/core/qobjevofunc.py
@@ -329,6 +329,7 @@ class QobjEvoFunc(QobjEvoBase):
     def __neg__(self):
         res = self.copy()
         res.operation_stack.append(_Block_neg())
+        res._check_validity()
         return res
 
     def __and__(self, other):
@@ -342,22 +343,26 @@ class QobjEvoFunc(QobjEvoBase):
     def trans(self):
         res = self.copy()
         res.operation_stack.append(_Block_trans())
+        res._check_validity()
         return res
 
     def conj(self):
         res = self.copy()
         res.operation_stack.append(_Block_conj())
+        res._check_validity()
         return res
 
     def dag(self):
         res = self.copy()
         res.operation_stack.append(_Block_dag())
+        res._check_validity()
         return res
 
     def _cdc(self):
         """return a.dag * a """
         res = self.copy()
         res.operation_stack.append(_Block_cdc())
+        res._check_validity()
         return res
 
     def _tensor(self, other):
@@ -410,6 +415,7 @@ class QobjEvoFunc(QobjEvoBase):
         res = self.copy()
         res._shifted = True
         res.args["_t0"] = 0
+        res._check_validity()
         return res
 
     # Unitary function of Qobj
@@ -440,7 +446,7 @@ class QobjEvoFunc(QobjEvoBase):
     # function to apply custom transformations
     def linear_map(self, op_mapping):
         """
-        Apply function to each Qobj contribution.
+        Apply mapping to each Qobj contribution.
         """
         if op_mapping is spre:
             return self._spre()
@@ -449,6 +455,33 @@ class QobjEvoFunc(QobjEvoBase):
 
         res = self.copy()
         res.operation_stack.append(_Block_linear_map(op_mapping))
+        res._check_validity()
+        return res
+
+    def to(self, data_type):
+        """
+        Convert the underlying data store of all component into the desired
+        storage representation.
+
+        The different storage representations available are the "data-layer
+        types".  By default, these are `qutip.data.Dense` and `qutip.data.CSR`,
+        which respectively construct a dense matrix store and a compressed
+        sparse row one.
+
+        The `QobjEvo` is transformed inplace.
+
+        Arguments
+        ---------
+        data_type : type
+            The data-layer type that the data of this `Qobj` should be
+            converted to.
+
+        Returns
+        -------
+        None
+        """
+        res = self.copy()
+        res.operation_stack.append(_Block_to(data_type))
         res._check_validity()
         return res
 
@@ -575,5 +608,16 @@ class _Block_linear_map(_Block_transform):
 
     def __call__(self, obj, t, args={}):
         return self.func(obj)
+
+
+class _Block_to(_Block_transform):
+    def __init__(self, data_type):
+        self.data_type = data_type
+
+    def copy(self):
+        return _Block_to(self.data_type)
+
+    def __call__(self, obj, t, args={}):
+        return obj.to(self.data_type)
 
 from .tensor import tensor

--- a/qutip/installsettings.py
+++ b/qutip/installsettings.py
@@ -58,18 +58,12 @@ class InstallSettings:
         _logger = None
 
     try:
-        qutip_conf_dir = os.path.join(os.path.expanduser("~"), '.qutip')
-        if not os.path.exists(qutip_conf_dir):
-            os.mkdir(qutip_conf_dir)
-        tmproot = os.path.join(qutip_conf_dir, 'coeffs')
+        tmproot = os.path.join(os.path.expanduser("~"), '.qutip')
         if not os.path.exists(tmproot):
             os.mkdir(tmproot)
         assert os.access(tmproot, os.W_OK)
-        del qutip_conf_dir
     except Exception:
         tmproot = "."
-    if tmproot not in sys.path:
-        sys.path.insert(0, tmproot)
 
     # ------------------------------------------------------------------------
     # Check if we're in IPython.

--- a/qutip/optionsclass.py
+++ b/qutip/optionsclass.py
@@ -138,6 +138,15 @@ def __init__(self, file='', *,
 {attributes_set}
     if file:
         self.load(file)
+    if hasattr(self, "extra_options"):
+        other_kw = dict()
+        for kw in kwargs:
+            if kw in self.extra_options:
+                self.options[kw] = kwargs[kw]
+            else:
+                other_kw[kw] = kwargs[kw]
+        kwargs = other_kw
+    self._children = []
     for child in self._defaultInstance._children:
         self._children.append(child.__class__(file, _child_instance=True,
                                               **kwargs))

--- a/qutip/solver/__init__.py
+++ b/qutip/solver/__init__.py
@@ -1,0 +1,2 @@
+from .result import *
+from .options import *

--- a/qutip/solver/options.py
+++ b/qutip/solver/options.py
@@ -29,9 +29,9 @@ class SolverOptions:
     -------
     progress_bar : str {'text', 'enhanced', 'tqdm', ''}
         How to present the solver progress.
-        'tqdm' use the python module of the same name and raise an error if
-        not installed.
         True will result in 'text'.
+        'tqdm' uses the python module of the same name and raise an error if
+        not installed.
         Empty string or False will disable the bar.
 
     progress_kwargs : dict
@@ -49,9 +49,9 @@ class SolverOptions:
 @optionsclass("ode", SolverOptions)
 class SolverOdeOptions:
     """
-    Class of options for evolution solvers such as :func:`qutip.mesolve` and
-    :func:`qutip.mcsolve`. Options can be specified either as arguments to the
-    SolverOptions constructor::
+    Class of options for the ODE integrator of solvers such as
+    :func:`qutip.mesolve` and :func:`qutip.mcsolve`. Options can be
+    specified either as arguments to the SolverOptions constructor::
 
         opts = SolverOptions(method=bdf, ...)
 
@@ -170,7 +170,9 @@ class SolverResultsOptions:
 
     normalize_output : str {"", "ket", "all"}
         normalize output state to hide ODE numerical errors.
+        "all" will normalize both ket and dm.
         On "ket", only 'ket' output are normalized.
+        Leave empty for no normalization.
     """
     options = {
         # store final state?

--- a/qutip/solver/options.py
+++ b/qutip/solver/options.py
@@ -1,0 +1,257 @@
+__all__ = ['SolverOptions',
+           'SolverResultsOptions', 'SolverOdeOptions',
+           'McOptions']
+
+from ..optionsclass import optionsclass
+import multiprocessing
+
+@optionsclass("solver")
+class SolverOptions:
+    """
+    Class of options for evolution solvers such as :func:`qutip.mesolve` and
+    :func:`qutip.mcsolve`. Options can be specified either as arguments to the
+    constructor::
+
+        opts = SolverOptions(order=10, ...)
+
+    or by changing the class attributes after creation::
+
+        opts = SolverOptions()
+        opts.order = 10
+
+    Returns options class to be used as options in evolution solvers.
+
+    The default can be changed by::
+
+        qutip.settings.solver['order'] = 10
+
+    Options
+    -------
+    progress_bar : str {'text', 'enhanced', 'tqdm', ''}
+        How to present the solver progress.
+        'tqdm' use the python module of the same name and raise an error if
+        not installed.
+        True will result in 'text'.
+        Empty string or False will disable the bar.
+
+    progress_kwargs : dict
+        kwargs to pass to the progress_bar. Qutip's bars use `chunk_size`.
+    """
+    options = {
+        # (turned off for batch unitary propagator mode)
+        "progress_bar": "text",
+        # Normalize output of solvers
+        # (turned off for batch unitary propagator mode)
+        "progress_kwargs": {"chunk_size":10},
+    }
+
+
+@optionsclass("ode", SolverOptions)
+class SolverOdeOptions:
+    """
+    Class of options for evolution solvers such as :func:`qutip.mesolve` and
+    :func:`qutip.mcsolve`. Options can be specified either as arguments to the
+    constructor::
+
+        opts = SolverOptions(order=10, ...)
+
+    or by changing the class attributes after creation::
+
+        opts = SolverOptions()
+        opts.order = 10
+
+    Returns options class to be used as options in evolution solvers.
+
+    The default can be changed by::
+
+        qutip.settings.solver['order'] = 10
+
+    Options
+    -------
+    method : str {'adams', 'bdf', 'dop853', 'lsoda', 'vern7', 'vern9', 'diag'}
+        Integration method.
+
+    atol : float {1e-8}
+        Absolute tolerance.
+
+    rtol : float {1e-6}
+        Relative tolerance.
+
+    order : int {12}
+        Order of integrator (<=12 'adams', <=5 'bdf')
+
+    nsteps : int {2500}
+        Max. number of internal steps/call.
+
+    first_step : float {0}
+        Size of initial step (0 = automatic).
+
+    min_step : float {0}
+        Minimum step size (0 = automatic).
+
+    max_step : float {0}
+        Maximum step size (0 = automatic)
+
+    tidy: bool {True}
+        tidyup Hamiltonian before calculation
+
+    Operator_data_type: :class:`qutip.data.Data`, str {"input"}
+        Data type of the system, some method can overwrite it.
+
+    State_data_type: :class:`qutip.data.Data`, str {qutip.data.Dense}
+        Data type of the state, most solver can only work with `Dense`.
+
+    feedback_normalize: bool
+
+
+    """
+    options = {
+        # Integration method (default = 'adams', for stiff 'bdf')
+        "method": 'adams',
+
+        "rhs": '',
+
+        # Absolute tolerance (default = 1e-8)
+        "atol": 1e-8,
+        # Relative tolerance (default = 1e-6)
+        "rtol": 1e-6,
+        # Maximum order used by integrator (<=12 for 'adams', <=5 for 'bdf')
+        "order": 12,
+        # Max. number of internal steps/call
+        "nsteps": 2500,
+        # Size of initial step (0 = determined by solver)
+        "first_step": 0,
+        # Max step size (0 = determined by solver)
+        "max_step": 0,
+        # Minimal step size (0 = determined by solver)
+        "min_step": 0,
+        # tidyup Hamiltonian before calculation (default = True)
+        "tidy": True,
+
+        "Operator_data_type": "input",
+
+        "State_data_type": "dense",
+        # Normalize the states received in feedback_args
+        "feedback_normalize": True,
+    }
+    extra_options = set()
+
+
+@optionsclass("results", SolverOptions)
+class SolverResultsOptions:
+    """
+    Class of options for evolution solvers such as :func:`qutip.mesolve` and
+    :func:`qutip.mcsolve`. Options can be specified either as arguments to the
+    constructor::
+
+        opts = SolverOptions(order=10, ...)
+
+    or by changing the class attributes after creation::
+
+        opts = SolverOptions()
+        opts.order = 10
+
+    Returns options class to be used as options in evolution solvers.
+
+    The default can be changed by::
+
+        qutip.settings.solver['order'] = 10
+
+    Options
+    -------
+    store_final_state : bool {False, True}
+        Whether or not to store the final state of the evolution in the
+        result class.
+    store_states : bool {False, True}
+        Whether or not to store the state vectors or density matrices in the
+        result class, even if expectation values operators are given. If no
+        expectation are provided, then states are stored by default and this
+        option has no effect.
+    normalize_output : str {"", "ket", "all"}
+        normalize output state to hide ODE numerical errors.
+        On "ket", only 'ket' output are normalized.
+    """
+    options = {
+        # store final state?
+        "store_final_state": False,
+        # store states even if expectation operators are given?
+        "store_states": False,
+        # Normalize output of solvers
+        # (turned off for batch unitary propagator mode)
+        "normalize_output": "ket",
+    }
+
+
+@optionsclass("mcsolve", SolverOptions)
+class McOptions:
+    """
+    Class of options for evolution solvers such as :func:`qutip.mesolve` and
+    :func:`qutip.mcsolve`. Options can be specified either as arguments to the
+    constructor::
+
+        opts = SolverOptions(norm_tol=1e-3, ...)
+
+    or by changing the class attributes after creation::
+
+        opts = SolverOptions()
+        opts['norm_tol'] = 1e-3
+
+    Returns options class to be used as options in evolution solvers.
+
+    The default can be changed by::
+
+        qutip.settings.options.mcsolve['norm_tol'] = 1e-3
+
+    Options
+    -------
+
+    norm_tol : float {1e-4}
+        Tolerance used when finding wavefunction norm in mcsolve.
+
+    norm_t_tol : float {1e-6}
+        Tolerance used when finding wavefunction time in mcsolve.
+
+    norm_steps : int {5}
+        Max. number of steps used to find wavefunction norm to within norm_tol
+        in mcsolve.
+
+    keep_runs_results: bool
+        Keep all trajectories results or save only the average.
+
+    map : str  {'parallel', 'serial', 'loky'}
+        How to run the trajectories.
+        'parallel' use python's multiprocessing.
+        'loky' use the pyhon module of the same name (not installed with qutip).
+
+    map_options: dict
+        keys:
+            'num_cpus': number of cpus to use.
+            'timeout': maximum time for all trajectories. (sec)
+            'job_timeout': maximum time per trajectory. (sec)
+        Only finished trajectories will be returned when timeout is reached.
+
+    mc_corr_eps : float {1e-10}
+        Arbitrarily small value for eliminating any divide-by-zero errors in
+        correlation calculations when using mcsolve.
+    """
+    options = {
+        # Tolerance for wavefunction norm (mcsolve only)
+        "norm_tol": 1e-4,
+        # Tolerance for collapse time precision (mcsolve only)
+        "norm_t_tol": 1e-6,
+        # Max. number of steps taken to find wavefunction norm to within
+        # norm_tol (mcsolve only)
+        "norm_steps": 5,
+
+        "map": "parallel_map",
+
+        "keep_runs_results": False,
+
+        "mc_corr_eps": 1e-10,
+
+        "map_options": {
+            'num_cpus': multiprocessing.cpu_count(),
+            'timeout':1e8,
+            'job_timeout':1e8
+        },
+    }

--- a/qutip/solver/options.py
+++ b/qutip/solver/options.py
@@ -12,18 +12,18 @@ class SolverOptions:
     :func:`qutip.mcsolve`. Options can be specified either as arguments to the
     constructor::
 
-        opts = SolverOptions(order=10, ...)
+        opts = SolverOptions(progress_bar='enhanced', ...)
 
     or by changing the class attributes after creation::
 
         opts = SolverOptions()
-        opts.order = 10
+        opts['progress_bar'] = 'enhanced'
 
     Returns options class to be used as options in evolution solvers.
 
     The default can be changed by::
 
-        qutip.settings.solver['order'] = 10
+        qutip.settings.solver['progress_bar'] = 'enhanced'
 
     Options
     -------
@@ -51,20 +51,20 @@ class SolverOdeOptions:
     """
     Class of options for evolution solvers such as :func:`qutip.mesolve` and
     :func:`qutip.mcsolve`. Options can be specified either as arguments to the
-    constructor::
+    SolverOptions constructor::
 
-        opts = SolverOptions(order=10, ...)
+        opts = SolverOptions(method=bdf, ...)
 
     or by changing the class attributes after creation::
 
         opts = SolverOptions()
-        opts.order = 10
+        opts.ode['method'] = 'bdf'
 
     Returns options class to be used as options in evolution solvers.
 
     The default can be changed by::
 
-        qutip.settings.solver['order'] = 10
+        qutip.settings.solver.ode['method'] = 'bdf'
 
     Options
     -------
@@ -102,8 +102,8 @@ class SolverOdeOptions:
         Data type of the state, most solver can only work with `Dense`.
 
     feedback_normalize: bool
-
-
+        Normalize the state before passing it to coefficient when using
+        feedback.
     """
     options = {
         # Integration method (default = 'adams', for stiff 'bdf')
@@ -140,33 +140,34 @@ class SolverOdeOptions:
 @optionsclass("results", SolverOptions)
 class SolverResultsOptions:
     """
-    Class of options for evolution solvers such as :func:`qutip.mesolve` and
-    :func:`qutip.mcsolve`. Options can be specified either as arguments to the
-    constructor::
+    Class of options for Results of evolution solvers such as
+    :func:`qutip.mesolve` and :func:`qutip.mcsolve`.
+    Options can be specified when constructing SolverOptions
 
-        opts = SolverOptions(order=10, ...)
+        opts = SolverOptions(store_final_state=True, ...)
 
     or by changing the class attributes after creation::
 
         opts = SolverOptions()
-        opts.order = 10
+        opts.results["store_final_state"] = True
 
     Returns options class to be used as options in evolution solvers.
 
     The default can be changed by::
 
-        qutip.settings.solver['order'] = 10
+        qutip.settings.solver.result['store_final_state'] = True
 
     Options
     -------
     store_final_state : bool {False, True}
         Whether or not to store the final state of the evolution in the
         result class.
-    store_states : bool {False, True}
-        Whether or not to store the state vectors or density matrices in the
-        result class, even if expectation values operators are given. If no
-        expectation are provided, then states are stored by default and this
-        option has no effect.
+
+    store_states : bool {False, True, None}
+        Whether or not to store the state vectors or density matrices.
+        On `None` the states will be saved if no expectation operators are
+        given.
+
     normalize_output : str {"", "ket", "all"}
         normalize output state to hide ODE numerical errors.
         On "ket", only 'ket' output are normalized.
@@ -175,7 +176,7 @@ class SolverResultsOptions:
         # store final state?
         "store_final_state": False,
         # store states even if expectation operators are given?
-        "store_states": False,
+        "store_states": None,
         # Normalize output of solvers
         # (turned off for batch unitary propagator mode)
         "normalize_output": "ket",
@@ -185,16 +186,16 @@ class SolverResultsOptions:
 @optionsclass("mcsolve", SolverOptions)
 class McOptions:
     """
-    Class of options for evolution solvers such as :func:`qutip.mesolve` and
-    :func:`qutip.mcsolve`. Options can be specified either as arguments to the
-    constructor::
+    Class of options specific for :func:`qutip.mcsolve`.
+    Options can be specified either as arguments to the constructor of
+    SolverOptions::
 
         opts = SolverOptions(norm_tol=1e-3, ...)
 
     or by changing the class attributes after creation::
 
         opts = SolverOptions()
-        opts['norm_tol'] = 1e-3
+        opts.mcsolve['norm_tol'] = 1e-3
 
     Returns options class to be used as options in evolution solvers.
 

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -1,0 +1,290 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+"""
+This function provides functions for parallel execution of loops and function
+mappings, using the builtin Python module multiprocessing.
+"""
+__all__ = ['parallel_map', 'serial_map', 'loky_pmap', 'get_map']
+
+from scipy import array
+import multiprocessing
+from functools import partial
+import os
+import sys
+import time
+import signal
+from qutip.settings import settings as qset
+from qutip.ui.progressbar import get_progess_bar
+
+
+if sys.platform == 'darwin':
+    Pool = multiprocessing.get_context('fork').Pool
+else:
+    Pool = multiprocessing.Pool
+
+map_kw = {
+    'job_timeout': 1e8,
+    'timeout': 1e8,
+    'num_cpus': multiprocessing.cpu_count(),
+}
+
+def serial_map(task, values, task_args=None, task_kwargs=None,
+               reduce_func=None, map_kw=map_kw,
+               progress_bar=None, progress_bar_kwargs={}):
+    """
+    Serial mapping function with the same call signature as parallel_map, for
+    easy switching between serial and parallel execution. This
+    is functionally equivalent to::
+
+        result = [task(value, *task_args, **task_kwargs) for value in values]
+
+    This function work as a drop-in replacement of :func:`qutip.parallel_map`.
+
+    Parameters
+    ----------
+    task : a Python function
+        The function that is to be called for each value in ``task_vec``.
+    values : array / list
+        The list or array of values for which the ``task`` function is to be
+        evaluated.
+    task_args : list / dictionary
+        The optional additional argument to the ``task`` function.
+    task_kwargs : list / dictionary
+        The optional additional keyword argument to the ``task`` function.
+    progress_bar : string
+        Progress bar options's string for showing progress.
+    progress_bar_kwargs : dict
+        Options for the progress bar
+    map_kw:
+        Other options
+
+    Returns
+    --------
+    result : list
+        The result list contains the value of
+        ``task(value, *task_args, **task_kwargs)`` for each
+        value in ``values``.
+
+    """
+    if task_args is None:
+        task_args = ()
+    if task_kwargs is None:
+        task_kwargs = {}
+    progress_bar = get_progess_bar(progress_bar)
+    progress_bar.start(len(values), **progress_bar_kwargs)
+    end_time = map_kw['timeout'] + time.time()
+    results = []
+    for n, value in enumerate(values):
+        if time.time() > end_time:
+            break
+        progress_bar.update(n)
+        result = task(value, *task_args, **task_kwargs)
+        if reduce_func is not None:
+            reduce_func(result)
+        else:
+            results.append(result)
+    progress_bar.finished()
+
+    return results
+
+
+def parallel_map(task, values, task_args=None, task_kwargs=None,
+                 reduce_func=None, map_kw=map_kw,
+                 progress_bar=None, progress_bar_kwargs={}):
+    """
+    Parallel execution of a mapping of `values` to the function `task`. This
+    is functionally equivalent to::
+
+        result = [task(value, *task_args, **task_kwargs) for value in values]
+
+    Parameters
+    ----------
+    task : a Python function
+        The function that is to be called for each value in ``task_vec``.
+    values : array / list
+        The list or array of values for which the ``task`` function is to be
+        evaluated.
+    task_args : list / dictionary
+        The optional additional argument to the ``task`` function.
+    task_kwargs : list / dictionary
+        The optional additional keyword argument to the ``task`` function.
+    progress_bar : string
+        Progress bar options's string for showing progress.
+    progress_bar_kwargs : dict
+        Options for the progress bar
+    map_kw:
+        Other options
+
+    Returns
+    --------
+    result : list
+        The result list contains the value of
+        ``task(value, *task_args, **task_kwargs)`` for
+        each value in ``values``.
+
+    """
+    if task_args is None:
+        task_args = ()
+    if task_kwargs is None:
+        task_kwargs = {}
+    os.environ['QUTIP_IN_PARALLEL'] = 'TRUE'
+    end_time = map_kw['timeout'] + time.time()
+    job_time = map_kw['job_timeout']
+
+    progress_bar = get_progess_bar(progress_bar)
+    progress_bar.start(len(values), **progress_bar_kwargs)
+
+    results = []
+    try:
+        pool = Pool(processes=map_kw['num_cpus'])
+
+        async_res = [pool.apply_async(task, (value,) + task_args, task_kwargs)
+                     for value in values]
+
+        for job in async_res:
+            remaining_time = min(end_time - time.time(), job_time)
+            result = job.get(remaining_time)
+            if reduce_func is not None:
+                reduce_func(result)
+            else:
+                results.append(result)
+            progress_bar.update()
+
+    except KeyboardInterrupt as e:
+        raise e
+
+    except multiprocessing.TimeoutError:
+        pass
+
+    finally:
+        os.environ['QUTIP_IN_PARALLEL'] = 'FALSE'
+        pool.terminate()
+        pool.join()
+
+    progress_bar.finished()
+    return results
+
+
+def loky_pmap(task, values, task_args=None, task_kwargs=None,
+              reduce_func=None, map_kw=map_kw,
+              progress_bar=None, progress_bar_kwargs={}):
+    """
+    Parallel execution of a mapping of `values` to the function `task`. This
+    is functionally equivalent to::
+
+        result = [task(value, *task_args, **task_kwargs) for value in values]
+
+    Use the loky module instead of multiprocessing.
+
+    Parameters
+    ----------
+    task : a Python function
+        The function that is to be called for each value in ``task_vec``.
+    values : array / list
+        The list or array of values for which the ``task`` function is to be
+        evaluated.
+    task_args : list / dictionary
+        The optional additional argument to the ``task`` function.
+    task_kwargs : list / dictionary
+        The optional additional keyword argument to the ``task`` function.
+    progress_bar : string
+        Progress bar options's string for showing progress.
+    progress_bar_kwargs : dict
+        Options for the progress bar
+    **kwargs:
+        Other options to pass to loky
+
+    Returns
+    --------
+    result : list
+        The result list contains the value of
+        ``task(value, *task_args, **task_kwargs)`` for
+        each value in ``values``.
+
+    """
+    if task_args is None:
+        task_args = ()
+    if task_kwargs is None:
+        task_kwargs = {}
+    os.environ['QUTIP_IN_PARALLEL'] = 'TRUE'
+    from loky import get_reusable_executor, TimeoutError
+
+    # kw = _default_kwargs()
+    # kw.update(kwargs)
+    kw = map_kw
+
+    progress_bar = get_progess_bar(progress_bar)
+    progress_bar.start(len(values), **progress_bar_kwargs)
+
+    executor = get_reusable_executor(max_workers=kw['num_cpus'])
+    end_time = kw['timeout'] + time.time()
+    job_time = kw['job_timeout']
+    results = []
+
+    try:
+        jobs = [executor.submit(task, value, *task_args, **task_kwargs)
+               for value in values]
+
+        for job in jobs:
+            remaining_time = min(end_time - time.time(), job_time)
+            result = job.result(remaining_time)
+            if reduce_func is not None:
+                reduce_func(result)
+            else:
+                results.append(result)
+            progress_bar.update()
+
+    except KeyboardInterrupt as e:
+        [job.cancel() for job in jobs]
+        raise e
+
+    except TimeoutError:
+        [job.cancel() for job in jobs]
+
+    finally:
+        executor.shutdown()
+    progress_bar.finished()
+    os.environ['QUTIP_IN_PARALLEL'] = 'FALSE'
+    return results
+
+
+def get_map(options):
+    if "parallel" in options['map']:
+        return parallel_map
+    elif "serial" in options['map']:
+        return serial_map
+    elif "loky" in options['map']:
+        return loky_pmap
+    else:
+        raise ValueError("map not found, available options are 'parallel',"
+                         " 'serial' and 'loky'")

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -31,8 +31,8 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 """
-This function provides functions for parallel execution of loops and function
-mappings, using the builtin Python module multiprocessing.
+This module provides functions for parallel execution of loops and function
+mappings, using the builtin Python module multiprocessing or the loky parallel execution library. 
 """
 __all__ = ['parallel_map', 'serial_map', 'loky_pmap', 'get_map']
 

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -235,8 +235,6 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
     os.environ['QUTIP_IN_PARALLEL'] = 'TRUE'
     from loky import get_reusable_executor, TimeoutError
 
-    # kw = _default_kwargs()
-    # kw.update(kwargs)
     kw = map_kw
 
     progress_bar = get_progess_bar(progress_bar)

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -36,16 +36,11 @@ mappings, using the builtin Python module multiprocessing.
 """
 __all__ = ['parallel_map', 'serial_map', 'loky_pmap', 'get_map']
 
-from scipy import array
 import multiprocessing
-from functools import partial
 import os
 import sys
 import time
-import signal
-from qutip.settings import settings as qset
 from qutip.ui.progressbar import get_progess_bar
-
 
 if sys.platform == 'darwin':
     Pool = multiprocessing.get_context('fork').Pool
@@ -57,6 +52,7 @@ map_kw = {
     'timeout': 1e8,
     'num_cpus': multiprocessing.cpu_count(),
 }
+
 
 def serial_map(task, values, task_args=None, task_kwargs=None,
                reduce_func=None, map_kw=map_kw,

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -1,0 +1,598 @@
+
+
+import numpy as np
+from ..core import Qobj, QobjEvo, spre, issuper
+
+
+__all__ = ["Result", "MultiTrajResult", "MultiTrajResultAveraged"]
+
+
+class Result:
+    """
+    Result for one trajectory of an solver evolution.
+
+    Property
+    --------
+    states : list of Qobj
+        Every state of the evolution
+
+    final_state : Qobj
+        Last state of the evolution
+
+    expect : list
+        list of list of expectation values
+        expect[e_ops][t]
+
+    times : list
+        list of the times at which the expectation values and
+        states where taken.
+    """
+    def __init__(self, e_ops, options, super_):
+        self.e_ops = e_ops
+        self.times = []
+
+        self._raw_e_ops = e_ops
+        self._states = []
+        self._expects = []
+        self._last_state = None
+        self._super = super_
+
+        self._read_e_ops(super_)
+        self._read_options(options)
+        self.collapse = None
+        self.stats = {}
+
+    def _read_e_ops(self, _super):
+        self._e_ops_dict = False
+        self._e_num = 0
+        self._e_ops = []
+        self._e_type = []
+
+        if isinstance(self._raw_e_ops, (Qobj, QobjEvo)):
+            e_ops = [self._raw_e_ops]
+        elif isinstance(self._raw_e_ops, dict):
+            self._e_ops_dict = self._raw_e_ops
+            e_ops = [e for e in self._raw_e_ops.values()]
+        elif callable(self._raw_e_ops):
+            e_ops = [self._raw_e_ops]
+        else:
+            e_ops = self._raw_e_ops
+
+        for e in e_ops:
+            if isinstance(e, Qobj):
+                if not issuper(e) and _super:
+                    e = spre(e)
+                self._e_ops.append(QobjEvo(e).expect)
+                self._e_type.append(e.isherm)
+            elif isinstance(e, QobjEvo):
+                if not issuper(e.cte) and _super:
+                    e = spre(e)
+                self._e_ops.append(e.expect)
+                self._e_type.append(e.isherm)
+            elif callable(e):
+                self._e_ops.append(e)
+                self._e_type.append(False)
+            self._expects.append([])
+
+        self._e_num = len(e_ops)
+
+    def _read_options(self, options):
+        self._store_states = self._e_num == 0 or options['store_states']
+        self._store_final_state = options['store_final_state']
+        if self._super:
+            self._normalize_outputs = options['normalize_output'] in ['dm', True, 'all']
+        else:
+            self._normalize_outputs = options['normalize_output'] in ['ket', True, 'all']
+
+    def _normalize(self, state):
+        if state.shape[1] == 1:
+            return state * (1/state.norm())
+        elif state.shape[1] == state.shape[0] and self._super:
+            return state * (1/state.norm())
+        else:
+            # TODO add normalization for propagator evolution.
+            pass
+
+    def add(self, t, state):
+        """
+        Add a state to the results for the time t of the evolution.
+        The state is expected to be a Qobj with the right dims.
+        """
+        self.times.append(t)
+        # this is so we don't make a copy if normalize is
+        # false and states are not stored
+        state_norm = False
+        if self._normalize_outputs:
+            state_norm = self._normalize(state)
+
+        if self._store_states:
+            self._states.append(state_norm or state.copy())
+        elif self._store_final_state:
+            self._last_state = state_norm or state.copy()
+
+        for i, e_call in enumerate(self._e_ops):
+            self._expects[i].append(e_call(t, state_norm or state))
+
+    def copy(self):
+        return Result(self._raw_e_ops, self.options, self.super)
+
+    @property
+    def states(self):
+        return self._states
+
+    @property
+    def final_state(self):
+        if self._store_states:
+            return self._states[-1]
+        elif self._store_final_state:
+            return self._last_state
+        else:
+            return None
+
+    @property
+    def expect(self):
+        result = []
+        for expect_vals, isreal  in zip(self._expects, self._e_type):
+            es = np.array(expect_vals)
+            if isreal:
+                es = es.real
+            result.append(es)
+        if self._e_ops_dict:
+            result = {e: result[n]
+                      for n, e in enumerate(self._e_ops_dict.keys())}
+        return result
+
+    @property
+    def num_expect(self):
+        return self._e_num
+
+    def __repr__(self):
+        out = ""
+        out += self.stats['solver'] + "\n"
+        out += "solver : " + self.stats['method'] + "\n"
+        out += "number of expect : {}\n".format(self._e_num)
+        if self._store_states:
+            out += "State saved\n"
+        elif self._store_final_state:
+            out += "Final state saved\n"
+        else:
+            out += "State not available\n"
+        out += "times from {} to {} in {} steps\n".format(self.times[0],
+                                                          self.times[-1],
+                                                          len(self.times))
+        return out
+
+
+class MultiTrajResult:
+    """
+    Contain result of simulations with multiple trajectories.
+    """
+    def __init__(self, num_c_ops=0):
+        """
+        Parameters:
+        -----------
+        num_c_ops: int
+            Number of collapses operator used in the McSolver
+        """
+        self.trajectories = []
+        self._to_dm = True # MCsolve
+        self.num_c_ops = num_c_ops
+        self.tlist = None
+
+    def add(self, one_traj):
+        self.trajectories.append(one_traj)
+
+    @property
+    def runs_states(self):
+        return [traj.states for traj in self.trajectories]
+
+    @property
+    def average_states(self):
+        if self._to_dm:
+            finals = [state.proj() for state in self.trajectories[0].states]
+            for i in range(1, len(self.trajectories)):
+                finals = [state.proj() + final for final, state
+                          in zip(finals, self.trajectories[i].states)]
+        else:
+            finals = [state for state in self.trajectories[0].states]
+            for i in range(1, len(self.trajectories)):
+                finals = [state + final for final, state
+                          in zip(finals, self.trajectories[i].states)]
+        return [final / len(self.trajectories) for final in finals]
+
+    @property
+    def runs_final_states(self):
+        return [traj.final_state for traj in self.trajectories]
+
+    @property
+    def average_final_state(self):
+        if self._to_dm:
+            final = sum(traj.final_state.proj() for traj in self.trajectories)
+        else:
+            final = sum(traj.final_state for traj in self.trajectories)
+        return final / len(self.trajectories)
+
+    @property
+    def steady_state(self):
+        avg = self.average_states
+        return sum(avg) / len(avg)
+
+    @property
+    def average_expect(self):
+        num_e = self.trajectories[0]._e_num
+        _e_type = self.trajectories[0]._e_type
+        _e_ops_dict = self.trajectories[0]._e_ops_dict
+        avg = [np.mean(np.stack([traj._expects[i]
+                    for traj in self.trajectories]), axis=0)
+               for i in range(num_e)]
+
+        result = []
+        for expect_vals, isreal  in zip(avg, _e_type):
+            if isreal:
+                expect_vals = expect_vals.real
+            result.append(expect_vals)
+
+        if _e_ops_dict:
+            result = {e: result[n]
+                      for n, e in enumerate(_e_ops_dict.keys())}
+        return result
+
+    @property
+    def std_expect(self):
+        num_e = self.trajectories[0]._e_num
+        _e_type = self.trajectories[0]._e_type
+        _e_ops_dict = self.trajectories[0]._e_ops_dict
+        avg = [np.std(np.stack([traj._expects[i]
+                    for traj in self.trajectories]), axis=0)
+               for i in range(num_e)]
+
+        result = []
+        for expect_vals, isreal  in zip(avg, _e_type):
+            if isreal:
+                expect_vals = expect_vals.real
+            result.append(expect_vals)
+
+        if _e_ops_dict:
+            result = {e: result[n]
+                      for n, e in enumerate(_e_ops_dict.keys())}
+        return result
+
+    @property
+    def runs_expect(self):
+        num_e = self.trajectories[0]._e_num
+        _e_type = self.trajectories[0]._e_type
+        _e_ops_dict = self.trajectories[0]._e_ops_dict
+        avg = [np.stack([traj._expects[i] for traj in self.trajectories])
+               for i in range(num_e)]
+
+        result = []
+        for expect_vals, isreal  in zip(avg, _e_type):
+            if isreal:
+                expect_vals = expect_vals.real
+            result.append(expect_vals)
+
+        if _e_ops_dict:
+            result = {e: result[n]
+                      for n, e in enumerate(_e_ops_dict.keys())}
+        return result
+
+    def expect_traj_avg(self, ntraj=-1):
+        num_e = self.trajectories[0]._e_num
+        _e_type = self.trajectories[0]._e_type
+        _e_ops_dict = self.trajectories[0]._e_ops_dict
+        avg = [np.mean(np.stack([traj._expects[i]
+                    for traj in self.trajectories[:ntraj]]), axis=0)
+               for i in range(num_e)]
+
+        result = []
+        for expect_vals, isreal  in zip(avg, _e_type):
+            if isreal:
+                expect_vals = expect_vals.real
+            result.append(expect_vals)
+
+        if _e_ops_dict:
+            result = {e: result[n]
+                      for n, e in enumerate(_e_ops_dict.keys())}
+        return result
+
+    def expect_traj_std(self, ntraj=-1):
+        num_e = self.trajectories[0]._e_num
+        _e_type = self.trajectories[0]._e_type
+        _e_ops_dict = self.trajectories[0]._e_ops_dict
+        avg = [np.std(np.stack([traj._expects[i]
+                    for traj in self.trajectories[:ntraj]]), axis=0)
+               for i in range(num_e)]
+
+        result = []
+        for expect_vals, isreal  in zip(avg, _e_type):
+            if isreal:
+                expect_vals = expect_vals.real
+            result.append(expect_vals)
+
+        if _e_ops_dict:
+            result = {e: result[n]
+                      for n, e in enumerate(_e_ops_dict.keys())}
+        return result
+
+    @property
+    def collapse(self):
+        return [traj.collapse for traj in self.trajectories]
+
+    @property
+    def col_times(self):
+        out = []
+        for col_ in self.collapse:
+            col = list(zip(*col_))
+            col = ([] if len(col) == 0 else col[0])
+            out.append(col)
+        return out
+
+    @property
+    def col_which(self):
+        out = []
+        for col_ in self.collapse:
+            col = list(zip(*col_))
+            col = ([] if len(col) == 0 else col[1])
+            out.append(col)
+        return out
+
+    @property
+    def photocurrent(self):
+        cols = {}
+        tlist = self.trajectories[0].times
+        for traj in self.trajectories:
+            for t, which in traj.collapse:
+                if which in cols:
+                    cols[which].append(t)
+                else:
+                    cols[which] = [t]
+        mesurement = []
+        for i in range(self.num_c_ops):
+            mesurement += [(np.histogram(cols.get(i,[]), tlist)[0]
+                          / np.diff(tlist) / len(self.trajectories))]
+        return mesurement
+
+    @property
+    def run_stats(self):
+        return self.trajectories[0].stats
+
+    def __repr__(self):
+        out = ""
+        out += self.run_stats['solver'] + "\n"
+        out += "solver : " + self.stats['method'] + "\n"
+        out += "{} runs saved\n".format(self.num_traj)
+        out += "number of expect : {}\n".format(self.trajectories[0]._e_num)
+        if self.trajectories[0]._store_states:
+            out += "Runs states saved\n"
+        elif self.trajectories[0]._store_final_state:
+            out += "Runs final state saved\n"
+        else:
+            out += "State not available\n"
+        out += "times from {} to {} in {} steps\n".format(self.times[0],
+                                                          self.times[-1],
+                                                          len(self.times))
+        return out
+
+    @property
+    def times(self):
+        return self.trajectories[0].times
+
+    @property
+    def states(self):
+        return self.average_states
+
+    @property
+    def expect(self):
+        return self.average_expect
+
+    @property
+    def final_state(self):
+        return self.average_final_state
+
+    @property
+    def num_traj(self):
+        return len(self.trajectories)
+
+
+class MultiTrajResultAveraged:
+    """
+    Contain result of simulations with multiple trajectories.
+    """
+    def __init__(self, num_c_ops=0):
+        """
+        Parameters:
+        -----------
+        num_c_ops: int
+            Number of collapses operator used in the McSolver
+        """
+        self.trajectories = None
+        self._sum_states = None
+        self._sum_last_states = None
+        self._sum_expect = None
+        self._sum2_expect = None
+        self._to_dm = True # MCsolve
+        self.num_c_ops = num_c_ops
+        self._num = 0
+        self._collapse = []
+
+    def add(self, one_traj):
+        if self._num == 0:
+            self.trajectories = one_traj
+            if self._to_dm and one_traj.states:
+                self._sum_states = [state.proj() for state in one_traj.states]
+            else:
+                self._sum_states = one_traj.states
+            if self._to_dm and one_traj.final_state:
+                self._sum_last_states = one_traj.final_state.proj()
+            else:
+                self._sum_last_states = one_traj.final_state
+            self._sum_expect = [np.array(expect) for expect in one_traj._expects]
+            self._sum2_expect = [np.array(expect)**2 for expect in one_traj._expects]
+        else:
+            if self._to_dm:
+                if self._sum_states:
+                    self._sum_states = [state.proj() + accu for accu, state
+                                    in zip(self._sum_states, one_traj.states)]
+                if self._sum_last_states:
+                    self._sum_last_states += one_traj.final_state.proj()
+            else:
+                if self._sum_states:
+                    self._sum_states = [state + accu for accu, state
+                                    in zip(self._sum_states, one_traj.states)]
+                if self._sum_last_states:
+                    self._sum_last_states += one_traj.final_state
+            if self._sum_expect:
+                self._sum_expect = [np.array(one) + accu for one, accu in
+                                    zip(one_traj._expects, self._sum_expect)]
+                self._sum2_expect = [np.array(one)**2 + accu for one, accu in
+                                     zip(one_traj._expects, self._sum2_expect)]
+        self._collapse.append(one_traj.collapse)
+        self._num += 1
+
+    @property
+    def runs_states(self):
+        return None
+
+    @property
+    def average_states(self):
+        return [final / self._num for final in self._sum_states]
+
+    @property
+    def runs_final_states(self):
+        return None
+
+    @property
+    def average_final_state(self):
+        return self._sum_last_states / self._num
+
+    @property
+    def steady_state(self):
+        avg = self._sum_states
+        return sum(avg) / len(avg)
+
+    @property
+    def average_expect(self):
+        num_e = self.trajectories._e_num
+        _e_type = self.trajectories._e_type
+        _e_ops_dict = self.trajectories._e_ops_dict
+        avg = [_sum / self._num for _sum in self._sum_expect]
+
+        result = []
+        for expect_vals, isreal  in zip(avg, _e_type):
+            if isreal:
+                expect_vals = expect_vals.real
+            result.append(expect_vals)
+
+        if _e_ops_dict:
+            result = {e: result[n]
+                      for n, e in enumerate(_e_ops_dict.keys())}
+        return result
+
+    @property
+    def std_expect(self):
+        num_e = self.trajectories._e_num
+        _e_type = self.trajectories._e_type
+        _e_ops_dict = self.trajectories._e_ops_dict
+        avg = [_sum / self._num for _sum in self._sum_expect]
+        avg2 = [_sum2 / self._num for _sum2 in self._sum2_expect]
+        std = [np.sqrt(a2 - a*a) for a, a2 in zip(avg, avg2)]
+
+        result = []
+        for expect_vals, isreal  in zip(std, _e_type):
+            if isreal:
+                expect_vals = expect_vals.real
+            result.append(expect_vals)
+
+        if _e_ops_dict:
+            result = {e: result[n]
+                      for n, e in enumerate(_e_ops_dict.keys())}
+        return result
+
+    @property
+    def runs_expect(self):
+        return None
+
+    def expect_traj_avg(self, ntraj=-1):
+        return None
+
+    def expect_traj_std(self, ntraj=-1):
+        return None
+
+    @property
+    def collapse(self):
+        return self._collapse
+
+    @property
+    def col_times(self):
+        out = []
+        for col_ in self.collapse:
+            col = list(zip(*col_))
+            col = ([] if len(col) == 0 else col[0])
+            out.append(col)
+        return out
+
+    @property
+    def col_which(self):
+        out = []
+        for col_ in self.collapse:
+            col = list(zip(*col_))
+            col = ([] if len(col) == 0 else col[1])
+            out.append(col)
+        return out
+
+    @property
+    def photocurrent(self):
+        cols = {}
+        tlist = self.trajectories.times
+        for collapses in self.collapse:
+            for t, which in collapses:
+                if which in cols:
+                    cols[which].append(t)
+                else:
+                    cols[which] = [t]
+        mesurement = []
+        for i in range(self.num_c_ops):
+            mesurement += [(np.histogram(cols.get(i,[]), tlist)[0]
+                          / np.diff(tlist) / self._num)]
+        return mesurement
+
+    @property
+    def run_stats(self):
+        return self.trajectories.stats
+
+    def __repr__(self):
+        out = ""
+        out += self.run_stats['solver'] + "\n"
+        out += "solver : " + self.stats['method'] + "\n"
+        out += "{} trajectories averaged\n".format(self.num_traj)
+        out += "number of expect : {}\n".format(self.trajectories._e_num)
+        if self.trajectories._store_states:
+            out += "States saved\n"
+        elif self.trajectories._store_final_state:
+            out += "Final state saved\n"
+        else:
+            out += "State not available\n"
+        out += "times from {} to {} in {} steps\n".format(self.times[0],
+                                                          self.times[-1],
+                                                          len(self.times))
+        return out
+
+    @property
+    def times(self):
+        return self.trajectories.times
+
+    @property
+    def states(self):
+        return self.average_states
+
+    @property
+    def expect(self):
+        return self.average_expect
+
+    @property
+    def final_state(self):
+        return self.average_final_state
+
+    @property
+    def num_traj(self):
+        return self._num

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -255,64 +255,6 @@ class MultiTrajResult:
     expect_traj_std(ntraj):
         Standard derivation of expectation values over `ntraj` trajectories.
         Last state of each trajectories. (ket)
-
-    average_final_state : Qobj
-        Average last state. (density matrix)
-
-    steady_state : Qobj
-        Average state of each time and trajectories. (density matrix)
-
-    runs_expect : list of list of list of number
-        Expectation values for each [e_ops, trajectory, time]
-
-    average_expect : list of list of number
-        Averaged expectation values over trajectories.
-
-    std_expect : list of list of number
-        Standard derivation of each averaged expectation values.
-
-    expect : list
-        list of list of averaged expectation values.
-
-    times : list
-        list of the times at which the expectation values and
-        states where taken.
-
-    stats :
-        Diverse statistics of the evolution.
-
-    num_expect : int
-        Number of expectation value operators in simulation.
-
-    num_collapse : int
-        Number of collapse operators in simualation.
-
-    num_traj : int/list
-        Number of trajectories (for stochastic solvers). A list indicates
-        that averaging of expectation values was done over a subset of total
-        number of trajectories.
-
-    col_times : list
-        Times at which state collpase occurred. Only for Monte Carlo solver.
-
-    col_which : list
-        Which collapse operator was responsible for each collapse in
-        ``col_times``. Only for Monte Carlo solver.
-
-    collapse : list
-        Each collapse per trajectory as a (time, which_oper)
-
-    photocurrent : list
-        photocurrent corresponding to each collapse operator.
-
-    Methods
-    -------
-    expect_traj_avg(ntraj):
-        Averaged expectation values over `ntraj` trajectories.
-
-    expect_traj_std(ntraj):
-        Standard derivation of expectation values over `ntraj` trajectories.
-
     """
     def __init__(self, num_c_ops=0):
         """

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -46,6 +46,10 @@ def g(t, args):
     return np.cos(args["w"] * t * np.pi)
 
 
+def h(t, args):
+    return args["a"] + args["b"] +t
+
+
 args = {"w": 1j}
 tlist = np.linspace(0, 1, 101)
 f_asarray = f(tlist, args)
@@ -116,8 +120,23 @@ def test_CoeffCallArgs(base, kwargs, tol):
     t = np.random.rand() * 0.9 + 0.05
     w = np.random.rand() + 0.5j
     val = np.exp(w * t * np.pi)
-    coeff = coefficient(f, **kwargs)
+    coeff = coefficient(base, **kwargs)
     assert np.allclose(coeff(t, {"w": w}), val, rtol=tol)
+
+
+@pytest.mark.parametrize(['base', 'tol'], [
+    pytest.param(h, 1e-10, id="func"),
+    pytest.param("a + b + t", 1e-10, id="string")
+])
+def test_CoeffCallArguments(base, tol):
+    # Partial args update
+    t = np.random.rand() * 0.9 + 0.05
+    args = {"a": 1, "b": 1}
+    a = np.random.rand()
+    val = a + 1 + t
+    coeff = coefficient(base, args=args)
+    coeff.arguments({"a": a})
+    assert np.allclose(coeff(t), val, rtol=tol)
 
 
 @pytest.mark.parametrize(['style'], [
@@ -189,7 +208,10 @@ def test_CoeffOptions():
     options.append(CompilationOptions(accept_float=False))
     options.append(CompilationOptions(no_types=True))
     options.append(CompilationOptions(use_cython=False))
+    options.append(CompilationOptions(try_parse=False))
     coeffs = [coefficient(base, compile_opt=opt) for opt in options]
+    for coeff in coeffs:
+        assert coeff(0) == 2+1j
     for coeff1, coeff2 in combinations(coeffs, 2):
         assert not isinstance(coeff1, coeff2.__class__)
 

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -35,7 +35,13 @@ import pickle
 import qutip as qt
 import numpy as np
 from qutip.core.coefficient import (coefficient, norm, conj, shift,
-                                    reduce, CompilationOptions)
+                                    reduce, CompilationOptions,
+                                    clean_compiled_coefficient
+                                   )
+
+
+# Ensure the latest version is tested
+clean_compiled_coefficient(True)
 
 
 def f(t, args):

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -34,6 +34,7 @@ import pytest
 import pickle
 import qutip as qt
 import numpy as np
+from functools import partial
 from qutip.core.coefficient import (coefficient, norm, conj, shift,
                                     reduce, CompilationOptions,
                                     clean_compiled_coefficient
@@ -53,7 +54,15 @@ def g(t, args):
 
 
 def h(t, args):
-    return args["a"] + args["b"] +t
+    return args["a"] + args["b"] + t
+
+
+def _assert_eq_over_interval(coeff1, coeff2,
+                             t_start=0.05, t_end=0.95, rtol=1e-12):
+    ts = np.linspace(t_start, t_end, 17)
+    c1 = [coeff1(t) for t in ts]
+    c2 = [coeff2(t) for t in ts]
+    np.testing.assert_allclose(c1, c2, rtol=rtol, atol=1e-15)
 
 
 args = {"w": 1j}
@@ -109,10 +118,9 @@ def coeff_generator(style, func):
 ])
 def test_CoeffCreationCall(base, kwargs, tol):
     CompilationOptions.recompile = True
-    t = np.random.rand() * 0.9 + 0.05
-    val = np.exp(1j * t * np.pi)
+    expected = lambda t: np.exp(1j * t * np.pi)
     coeff = coefficient(base, **kwargs)
-    assert np.allclose(coeff(t), val, rtol=tol)
+    _assert_eq_over_interval(coeff, expected, rtol=tol)
     CompilationOptions.recompile = False
 
 
@@ -123,11 +131,10 @@ def test_CoeffCreationCall(base, kwargs, tol):
                  1e-10, id="string")
 ])
 def test_CoeffCallArgs(base, kwargs, tol):
-    t = np.random.rand() * 0.9 + 0.05
-    w = np.random.rand() + 0.5j
-    val = np.exp(w * t * np.pi)
+    w = np.e + 0.5j
+    expected = lambda t: np.exp(w * t * np.pi)
     coeff = coefficient(base, **kwargs)
-    assert np.allclose(coeff(t, {"w": w}), val, rtol=tol)
+    _assert_eq_over_interval(partial(coeff, args={"w": w}), expected, rtol=tol)
 
 
 @pytest.mark.parametrize(['base', 'tol'], [
@@ -136,13 +143,12 @@ def test_CoeffCallArgs(base, kwargs, tol):
 ])
 def test_CoeffCallArguments(base, tol):
     # Partial args update
-    t = np.random.rand() * 0.9 + 0.05
     args = {"a": 1, "b": 1}
-    a = np.random.rand()
-    val = a + 1 + t
+    a = np.e
+    expected = lambda t: a + 1 + t
     coeff = coefficient(base, args=args)
     coeff.arguments({"a": a})
-    assert np.allclose(coeff(t), val, rtol=tol)
+    _assert_eq_over_interval(coeff, expected, rtol=tol)
 
 
 @pytest.mark.parametrize(['style'], [
@@ -154,15 +160,29 @@ def test_CoeffCallArguments(base, tol):
     pytest.param("steparray", id="steparray"),
     pytest.param("steparraylog", id="steparraylog")
 ])
-def test_CoeffUnitaryTransform(style):
+@pytest.mark.parametrize(['transform', 'expected'], [
+    pytest.param(norm, lambda val: np.abs(val)**2, id="norm"),
+    pytest.param(conj, lambda val: np.conj(val), id="conj"),
+])
+def test_CoeffUnitaryTransform(style, transform, expected):
     coeff = coeff_generator(style, "f")
-    t = np.random.rand() * 0.7 + 0.05
-    dt = np.random.rand() * 0.2
-    val = coeff(t)
-    val_dt = coeff(t+dt)
-    assert np.allclose(norm(coeff)(t), np.abs(val)**2)
-    assert np.allclose(conj(coeff)(t), np.conj(val))
-    assert np.allclose(shift(coeff, dt)(t), val_dt)
+    _assert_eq_over_interval(transform(coeff), lambda t: expected(coeff(t)))
+
+
+@pytest.mark.parametrize(['style'], [
+    pytest.param("func", id="func"),
+    pytest.param("array", id="array"),
+    pytest.param("arraylog", id="logarray"),
+    pytest.param("spline", id="Cubic_Spline"),
+    pytest.param("string", id="string"),
+    pytest.param("steparray", id="steparray"),
+    pytest.param("steparraylog", id="steparraylog")
+])
+def test_CoeffShift(style):
+    coeff = coeff_generator(style, "f")
+    dt = np.e / 30
+    _assert_eq_over_interval(shift(coeff, dt),
+                             lambda t: coeff(t + dt), .05, .75)
 
 
 @pytest.mark.parametrize(['style_left'], [
@@ -183,16 +203,17 @@ def test_CoeffUnitaryTransform(style):
     pytest.param("steparray", id="steparray"),
     pytest.param("steparraylog", id="steparraylog")
 ])
-def test_CoeffOperation(style_left, style_right):
+@pytest.mark.parametrize(['oper'], [
+    pytest.param(lambda a, b: a+b, id="sum"),
+    pytest.param(lambda a, b: a*b, id="prod"),
+])
+def test_CoeffOperation(style_left, style_right, oper):
     coeff_left = coeff_generator(style_left, "f")
     coeff_right = coeff_generator(style_right, "g")
-    t = np.random.rand() * 0.9 + 0.05
-    val_l = coeff_left(t)
-    val_r = coeff_right(t)
-    coeff_sum = coeff_left + coeff_right
-    assert np.allclose(coeff_sum(t), val_l + val_r)
-    coeff_prod = coeff_left * coeff_right
-    assert np.allclose(coeff_prod(t), val_l * val_r)
+    _assert_eq_over_interval(
+        oper(coeff_left, coeff_right),
+        lambda t: oper(coeff_left(t), coeff_right(t))
+    )
 
 
 @pytest.mark.requires_cython
@@ -207,7 +228,6 @@ def test_CoeffReuse():
 @pytest.mark.requires_cython
 def test_CoeffOptions():
     from itertools import combinations
-    t = np.random.rand() * 0.9 + 0.05
     base = "1 + 1. + 1j"
     options = []
     options.append(CompilationOptions(accept_int=True))
@@ -242,9 +262,8 @@ def test_CoeffOptions():
 ])
 def test_CoeffParsingStressTest(codestring, args, reference):
     CompilationOptions.recompile = True
-    t = np.random.rand() * 0.9 + 0.05
     coeff = coefficient(codestring, args=args)
-    assert np.allclose(coeff(t), reference(t))
+    _assert_eq_over_interval(coeff, reference)
     CompilationOptions.recompile = False
 
 
@@ -276,11 +295,10 @@ from qutip.core.data.expect cimport expect_csr
 
 @pytest.mark.requires_cython
 def test_CoeffReduce():
-    t = np.random.rand() * 0.9 + 0.05
     coeff = coefficient("exp(w * t * pi)", args={'w': 1.0j})
     apad = coeff + conj(coeff)
     reduced = reduce(apad, {'w': 1.0j})
-    assert np.allclose(apad(t), reduced(t))
+    _assert_eq_over_interval(apad, reduced)
 
 
 def _add(coeff):
@@ -318,11 +336,9 @@ def _shift(coeff):
 ])
 def test_Coeffpickle(style, transform):
     coeff = coeff_generator(style, "f")
-    t = np.random.rand() * 0.85 + 0.05
     coeff = transform(coeff)
     coeff_pick = pickle.loads(pickle.dumps(coeff, -1))
-    # Check for const case
-    assert coeff(t) == coeff_pick(t)
+    _assert_eq_over_interval(coeff, coeff_pick, 0.5, 0.90)
 
 
 @pytest.mark.parametrize(['style'], [
@@ -344,8 +360,6 @@ def test_Coeffpickle(style, transform):
 ])
 def test_Coeffcopy(style, transform):
     coeff = coeff_generator(style, "f")
-    t = np.random.rand() * 0.85 + 0.05
     coeff = transform(coeff)
     coeff_cp = coeff.copy()
-    # Check for const case
-    assert coeff(t) == coeff_cp(t)
+    _assert_eq_over_interval(coeff, coeff_cp)

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -151,6 +151,9 @@ def _trans(a):
 def _neg(a):
     return -a
 
+def _to(a, dtype):
+    return a.to(dtype)
+
 def _cdc(a):
     if isinstance(a, Qobj):
         return a.dag() * a

--- a/qutip/tests/solve/test_mesolve.py
+++ b/qutip/tests/solve/test_mesolve.py
@@ -853,7 +853,7 @@ class TestMESolveStepFuncCoeff:
             tlist=tlist, args={"_step_func_coeff": 1})
         result = mesolve(qu, rho0=rho0, tlist=tlist)
         assert_allclose(
-            fidelity(result.states[-1], sigmax()*rho0), 1, rtol=1.e-7)
+            fidelity(result.states[-1], sigmax()*rho0), 1, rtol=3.e-7)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/solver/test_parallel.py
+++ b/qutip/tests/solver/test_parallel.py
@@ -36,12 +36,7 @@ import time
 import pytest
 
 from qutip.solver.parallel import parallel_map, serial_map, loky_pmap
-"""
-try:
-    import loky
-except ModuleNotFoundError:
-    loky = False
-"""
+
 
 def _func1(x):
     return x**2
@@ -54,17 +49,17 @@ def _func2(x, a, b, c, d=0, e=0, f=0):
     time.sleep(np.random.rand() * 0.1)  # random delay
     return x**2
 
-@pytest.mark.parametrize('map',
-                         [parallel_map, loky_pmap, serial_map],
-                         ids=['parallel_map', 'loky_pmap', 'serial_map'])
+@pytest.mark.parametrize('map', [
+    pytest.param(parallel_map, id='parallel_map'),
+    pytest.param(loky_pmap, id='loky_pmap'),
+    pytest.param(serial_map, id='serial_map'),
+])
 @pytest.mark.parametrize('num_cpus',
                          [1, 2],
                          ids=['1', '2'])
 def test_map(map, num_cpus):
     if map is loky_pmap:
         loky = pytest.importorskip("loky")
-    # if map is loky_pmap and not loky:
-    #     pytest.skip("module loky not available")
 
     args = (1, 2, 3)
     kwargs = {'d': 4, 'e': 5, 'f': 6}
@@ -81,7 +76,7 @@ def test_map(map, num_cpus):
     assert ((np.array(y1) == np.array(y2)).all())
 
 
-@pytest.mark.parametrize('map',[
+@pytest.mark.parametrize('map', [
     pytest.param(parallel_map, id='parallel_map'),
     pytest.param(loky_pmap, id='loky_pmap'),
     pytest.param(serial_map, id='serial_map'),

--- a/qutip/tests/solver/test_parallel.py
+++ b/qutip/tests/solver/test_parallel.py
@@ -1,0 +1,108 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+import numpy as np
+import time
+import pytest
+
+from qutip.solver.parallel import parallel_map, serial_map, loky_pmap
+"""
+try:
+    import loky
+except ModuleNotFoundError:
+    loky = False
+"""
+
+def _func1(x):
+    return x**2
+
+
+def _func2(x, a, b, c, d=0, e=0, f=0):
+    assert d > 0
+    assert e > 0
+    assert f > 0
+    time.sleep(np.random.rand() * 0.1)  # random delay
+    return x**2
+
+@pytest.mark.parametrize('map',
+                         [parallel_map, loky_pmap, serial_map],
+                         ids=['parallel_map', 'loky_pmap', 'serial_map'])
+@pytest.mark.parametrize('num_cpus',
+                         [1, 2],
+                         ids=['1', '2'])
+def test_map(map, num_cpus):
+    if map is loky_pmap:
+        loky = pytest.importorskip("loky")
+    # if map is loky_pmap and not loky:
+    #     pytest.skip("module loky not available")
+
+    args = (1, 2, 3)
+    kwargs = {'d': 4, 'e': 5, 'f': 6}
+    map_kw = {
+        'job_timeout': 1e8,
+        'timeout': 1e8,
+        'num_cpus': num_cpus,
+    }
+
+    x = np.arange(10)
+    y1 = [_func1(xx) for xx in x]
+
+    y2 = map(_func2, x, args, kwargs, map_kw=map_kw)
+    assert ((np.array(y1) == np.array(y2)).all())
+
+
+@pytest.mark.parametrize('map',[
+    pytest.param(parallel_map, id='parallel_map'),
+    pytest.param(loky_pmap, id='loky_pmap'),
+    pytest.param(serial_map, id='serial_map'),
+])
+@pytest.mark.parametrize('num_cpus',
+                         [1, 2],
+                         ids=['1', '2'])
+def test_map_accumulator(map, num_cpus):
+    if map is loky_pmap:
+        loky = pytest.importorskip("loky")
+    args = (1, 2, 3)
+    kwargs = {'d': 4, 'e': 5, 'f': 6}
+    map_kw = {
+        'job_timeout': 1e8,
+        'timeout': 1e8,
+        'num_cpus': num_cpus,
+    }
+    y2 = []
+
+    x = np.arange(10)
+    y1 = [_func1(xx) for xx in x]
+
+    map(_func2, x, args, kwargs, reduce_func=y2.append, map_kw=map_kw)
+    assert ((np.array(y1) == np.array(y2)).all())

--- a/qutip/tests/solver/test_results.py
+++ b/qutip/tests/solver/test_results.py
@@ -1,0 +1,84 @@
+from qutip.solver.result import *
+import qutip as qt
+import numpy as np
+
+def test_result_states():
+    N = 10
+    res = Result([], qt.solver.SolverResultsOptions(), False)
+    for i in range(N):
+        res.add(i, qt.basis(N,i))
+    for i in range(N):
+        assert res.states[i] == qt.basis(N,i)
+    assert res.final_state == qt.basis(N,N-1)
+    np.testing.assert_allclose(np.array(res.times), np.arange(N))
+
+def test_result_expect():
+    N = 10
+    res = Result([qt.num(N), qt.qeye(N)],
+                 qt.solver.SolverResultsOptions(store_final_state=False,
+                                                store_states=False), False)
+    for i in range(N):
+        res.add(i, qt.basis(N,i))
+    np.testing.assert_allclose(res.expect[0], np.arange(N))
+    np.testing.assert_allclose(res.expect[1], np.ones(N))
+    assert res.final_state is None
+    assert not res.states
+
+def test_result_normalize():
+    N = 10
+    res = Result([qt.num(N), qt.qeye(N)],
+                 qt.solver.SolverResultsOptions(store_states=True,
+                                                normalize_output=True), False)
+    for i in range(N):
+        res.add(i, qt.basis(N,i)/2)
+    np.testing.assert_allclose(res.expect[0], np.arange(N))
+    np.testing.assert_allclose(res.expect[1], np.ones(N))
+    assert res.final_state == qt.basis(N,N-1)
+    for i in range(N):
+        assert res.states[i] == qt.basis(N,i)
+
+def test_multitraj_results():
+    N = 10
+    e_ops = [qt.num(N), qt.qeye(N)]
+    m_res = MultiTrajResult(3)
+    opt = qt.solver.SolverResultsOptions(store_states=True,
+                                         normalize_output=True)
+    for _ in range(5):
+        res = Result(e_ops, opt, False)
+        res.collapse = []
+        for i in range(N):
+            res.add(i, qt.basis(N,i)/2)
+            res.collapse.append((i+0.5, i%2))
+        m_res.add(res)
+
+    np.testing.assert_allclose(m_res.average_expect[0], np.arange(N))
+    np.testing.assert_allclose(m_res.average_expect[1], np.ones(N))
+    np.testing.assert_allclose(m_res.std_expect[1], np.zeros(N))
+    for i in range(N):
+        assert m_res.average_states[i] == qt.basis(N,i) * qt.basis(N,i).dag()
+    assert m_res.average_final_state == qt.basis(N,N-1) * qt.basis(N,N-1).dag()
+    assert len(m_res.runs_states) == 5
+    assert len(m_res.runs_states[0]) == N
+    for i in range(5):
+        assert m_res.runs_final_states[i] == qt.basis(N,N-1)
+    assert np.all(np.array(m_res.col_which) < 2)
+
+def test_multitrajavg_results():
+    N = 10
+    e_ops = [qt.num(N), qt.qeye(N)]
+    m_res = MultiTrajResultAveraged(3)
+    opt = qt.solver.SolverResultsOptions(store_final_state=True,
+                                         normalize_output=True)
+    for _ in range(5):
+        res = Result(e_ops, opt, False)
+        res.collapse = []
+        for i in range(N):
+            res.add(i, qt.basis(N,i)/2)
+            res.collapse.append((i+0.5, i%2))
+        m_res.add(res)
+
+    np.testing.assert_allclose(m_res.average_expect[0], np.arange(N))
+    np.testing.assert_allclose(m_res.average_expect[1], np.ones(N))
+    np.testing.assert_allclose(m_res.std_expect[1], np.zeros(N))
+    assert m_res.average_final_state == qt.basis(N,N-1) * qt.basis(N,N-1).dag()
+    assert np.all(np.array(m_res.col_which) < 2)

--- a/qutip/ui/progressbar.py
+++ b/qutip/ui/progressbar.py
@@ -32,7 +32,9 @@
 ###############################################################################
 from __future__ import print_function
 
-__all__ = ['BaseProgressBar', 'TextProgressBar', 'EnhancedTextProgressBar']
+__all__ = ['BaseProgressBar', 'TextProgressBar',
+           'EnhancedTextProgressBar', 'TqdmProgressBar',
+           'get_progess_bar']
 
 import time
 import datetime
@@ -57,14 +59,19 @@ class BaseProgressBar(object):
     def __init__(self, iterations=0, chunk_size=10):
         pass
 
-    def start(self, iterations, chunk_size=10):
+    def start(self, iterations, chunk_size=10, **kwargs):
         self.N = float(iterations)
+        self.n = 0
         self.p_chunk_size = chunk_size
         self.p_chunk = chunk_size
         self.t_start = time.time()
+        self.t_done = self.t_start - 1
 
-    def update(self, n):
+    def update(self, n=None):
         pass
+
+    def total_time(self):
+        return self.t_done - self.t_start
 
     def time_elapsed(self):
         return "%6.2fs" % (time.time() - self.t_start)
@@ -82,7 +89,7 @@ class BaseProgressBar(object):
         return time_string
 
     def finished(self):
-        pass
+        self.t_done = time.time()
 
 
 class TextProgressBar(BaseProgressBar):
@@ -91,12 +98,15 @@ class TextProgressBar(BaseProgressBar):
     """
 
     def __init__(self, iterations=0, chunk_size=10):
+        pass
+        # super(TextProgressBar, self).start(iterations, chunk_size)
+
+    def start(self, iterations, chunk_size=10, **kwargs):
         super(TextProgressBar, self).start(iterations, chunk_size)
 
-    def start(self, iterations, chunk_size=10):
-        super(TextProgressBar, self).start(iterations, chunk_size)
-
-    def update(self, n):
+    def update(self, n=None):
+        self.n += 1
+        n = self.n
         p = (n / self.N) * 100.0
         if p >= self.p_chunk:
             print("%4.1f%%." % p +
@@ -116,14 +126,17 @@ class EnhancedTextProgressBar(BaseProgressBar):
     """
 
     def __init__(self, iterations=0, chunk_size=10):
-        super(EnhancedTextProgressBar, self).start(iterations, chunk_size)
+        pass
+        # super(EnhancedTextProgressBar, self).start(iterations, chunk_size)
 
-    def start(self, iterations, chunk_size=10):
+    def start(self, iterations, chunk_size=10, **kwargs):
         super(EnhancedTextProgressBar, self).start(iterations, chunk_size)
         self.fill_char = '*'
         self.width = 25
 
-    def update(self, n):
+    def update(self, n=None):
+        self.n += 1
+        n = self.n
         percent_done = int(round(n / self.N * 100.0))
         all_full = self.width - 2
         num_hashes = int(round((percent_done / 100.0) * all_full))
@@ -142,3 +155,41 @@ class EnhancedTextProgressBar(BaseProgressBar):
     def finished(self):
         self.t_done = time.time()
         print("\r", "Total run time: %s" % self.time_elapsed())
+
+
+class TqdmProgressBar(BaseProgressBar):
+    """
+    A progress bar using tqdm module
+    """
+
+    def __init__(self, iterations=0, chunk_size=10):
+        from tqdm.auto import tqdm
+        self.tqdm = tqdm
+
+    def start(self, iterations, **kwargs):
+        self.pbar = self.tqdm(total=iterations, **kwargs)
+        self.t_start = time.time()
+        self.t_done = self.t_start - 1
+
+    def update(self, n=None):
+        self.pbar.update()
+
+    def finished(self):
+        self.pbar.close()
+        self.t_done = time.time()
+
+
+def get_progess_bar(opt):
+    if isinstance(opt, BaseProgressBar):
+        return opt
+    if opt in ["Enhanced", "enhanced"]:
+        progress_bar = EnhancedTextProgressBar()
+    elif opt in [True, "Text", "text"]:
+        progress_bar = TextProgressBar()
+    elif opt in ["Tqdm", "tqdm"]:
+        progress_bar = TqdmProgressBar()
+    elif opt in [False, "", None]:
+        progress_bar = BaseProgressBar()
+    else:
+        raise ValueError("Progress Bar not understood")
+    return progress_bar

--- a/qutip/ui/progressbar.py
+++ b/qutip/ui/progressbar.py
@@ -30,8 +30,6 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-from __future__ import print_function
-
 __all__ = ['BaseProgressBar', 'TextProgressBar',
            'EnhancedTextProgressBar', 'TqdmProgressBar',
            'get_progess_bar']


### PR DESCRIPTION
**Description**
Splitting #1409, part 2/3.
Contain the non Integrator/Evoler part of the PR.

##### Options
Add move some options around and add a class for ODE options. 
parallel_map and progress_bar will become options, not arguments to the `solve` function.
`store_states` default is None so that `store_states=False` is not overwritten when no e_ops given. (#1437)

##### Result
With this version, the `Result` object is responsible to know if states are stored and to compute expectation values, in the method `add(t, state: Qobj)`. The solver will be responsible to create the `Qobj` for the state.
(#1460): The type of the expectation value [float, complex] is set by the `expect` function, `QobjEvo.expect` or user provided expect function. 
(#1238): Multiple callback function can be given as expectation: `e_ops=expect_func`, `e_ops=[expect_func1, expect_func2]`, are both valid.
`mcsolve` (and probably stochactic) use `MultiTrajResult` or `MultiTrajResultAveraged`. They have both `average_state` and `run_states` instead of `states` which content change depending on options. They can also compute the `photocurrent` from the collapse. (making photocurrent_sesolve useless).

##### parallel
Add a `reduce_func` which allows to treat a results without waiting for all task to be done. Presently even when using `average_states`, all states are saved and the average is only computed at the end, which is not the behaviour expected by the users. 
(#1092 ) Add a loky based parallel map. It does not pickle object the same way as multiprocessing.

##### progress bar
Add a bar based on `tqdm`, which is a standard progress bar in python.