### PR TITLE
Fix OpenMP calibration and tidyup __init__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ jobs:
         - python setup.py develop --with-openmp
       before_script:
         - QUTIP_INSTALL="${QUTIP_DOWNLOAD}/qutip"
+        - export QUTIP_NUM_PROCESSES=2
       script:
         - python -c "import qutip; qutip.about()"
         - pytest --verbosity=1 --cov=qutip --cov-config="${QUTIP_DOWNLOAD}/.coveragerc" --rootdir="${QUTIP_INSTALL}/tests" -c "${QUTIP_INSTALL}/tests/pytest.ini" --pyargs qutip

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -30,9 +30,7 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-from __future__ import division, print_function, absolute_import
 import os
-import sys
 import warnings
 
 import qutip.settings
@@ -112,6 +110,8 @@ if qutip.settings.num_cpus == 0:
             qutip.settings.num_cpus = multiprocessing.cpu_count()
         except NotImplementedError:
             qutip.settings.num_cpus = 1
+
+del multiprocessing
 
 
 # Find MKL library if it exists
@@ -239,4 +239,4 @@ if has_rc:
 # -----------------------------------------------------------------------------
 # Clean name space
 #
-del os, sys, multiprocessing, warnings
+del os, warnings

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -48,22 +48,6 @@ try:
 except:
     qutip.settings.ipython = False
 
-# -----------------------------------------------------------------------------
-# check to see if running from install directory for released versions.
-#
-top_path = os.path.dirname(os.path.dirname(__file__))
-try:
-    setup_file = open(top_path + '/setup.py', 'r')
-except:
-    pass
-else:
-    if ('QuTiP' in setup_file.readlines()[1][3:]) and qutip.version.release:
-        print("You are in the installation directory. " +
-              "Change directories before running QuTiP.")
-    setup_file.close()
-
-del top_path
-
 
 # -----------------------------------------------------------------------------
 # Look to see if we are running with OPENMP

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -207,12 +207,6 @@ from qutip.fileio import *
 from qutip.about import *
 from qutip.cite import *
 
-# Remove -Wstrict-prototypes from cflags
-import distutils.sysconfig
-cfg_vars = distutils.sysconfig.get_config_vars()
-if "CFLAGS" in cfg_vars:
-    cfg_vars["CFLAGS"] = cfg_vars["CFLAGS"].replace("-Wstrict-prototypes", "")
-
 # -----------------------------------------------------------------------------
 # Load user configuration if present: override defaults.
 #
@@ -245,4 +239,4 @@ if has_rc:
 # -----------------------------------------------------------------------------
 # Clean name space
 #
-del os, sys, multiprocessing, distutils, warnings
+del os, sys, multiprocessing, warnings

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -268,7 +268,7 @@ if qutip.settings.has_openmp and (not has_rc):
         #bench OPENMP
         print('Calibrating OPENMP threshold...')
         thrsh = calculate_openmp_thresh()
-        qutip.configrc.write_rc_key(rc_file, 'openmp_thresh', thrsh)
+        qutip.configrc.write_rc_key('openmp_thresh', thrsh, rc_file=rc_file)
 # Make OPENMP if has_rc but 'openmp_thresh' not in keys
 elif qutip.settings.has_openmp and has_rc:
     has_omp_key = qutip.configrc.has_rc_key(rc_file, 'openmp_thresh')
@@ -276,7 +276,7 @@ elif qutip.settings.has_openmp and has_rc:
         from qutip.cy.openmp.bench_openmp import calculate_openmp_thresh
         print('Calibrating OPENMP threshold...')
         thrsh = calculate_openmp_thresh()
-        qutip.configrc.write_rc_key(rc_file, 'openmp_thresh', thrsh)
+        qutip.configrc.write_rc_key('openmp_thresh', thrsh, rc_file=rc_file)
 
 # Load the config file
 if has_rc:

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -49,31 +49,6 @@ except:
     qutip.settings.ipython = False
 
 # -----------------------------------------------------------------------------
-# Check for minimum requirements of dependencies, give the user a warning
-# if the requirements aren't fulfilled
-#
-
-numpy_requirement = "1.12.0"
-try:
-    import numpy
-    if _version2int(numpy.__version__) < _version2int(numpy_requirement):
-        print("QuTiP warning: old version of numpy detected " +
-              ("(%s), requiring %s." %
-               (numpy.__version__, numpy_requirement)))
-except:
-    warnings.warn("numpy not found.")
-
-scipy_requirement = "1.0.0"
-try:
-    import scipy
-    if _version2int(scipy.__version__) < _version2int(scipy_requirement):
-        print("QuTiP warning: old version of scipy detected " +
-              ("(%s), requiring %s." %
-               (scipy.__version__, scipy_requirement)))
-except:
-    warnings.warn("scipy not found.")
-
-# -----------------------------------------------------------------------------
 # check to see if running from install directory for released versions.
 #
 top_path = os.path.dirname(os.path.dirname(__file__))
@@ -285,4 +260,4 @@ if has_rc:
 # -----------------------------------------------------------------------------
 # Clean name space
 #
-del os, sys, numpy, scipy, multiprocessing, distutils
+del os, sys, multiprocessing, distutils

--- a/qutip/cy/pyxbuilder.py
+++ b/qutip/cy/pyxbuilder.py
@@ -40,6 +40,14 @@ old_get_distutils_extension = pyximport.pyximport.get_distutils_extension
 
 
 def new_get_distutils_extension(modname, pyxfilename, language_level=None):
+    # Remove -Wstrict-prototypes from cflags; we build in C++ mode, where the
+    # flag is invalid, but for some reason distutils still has it as a default,
+    # and tries to append CFLAGS to the compile even in C++ mode.
+    import distutils.sysconfig
+    cfg_vars = distutils.sysconfig.get_config_vars()
+    if "CFLAGS" in cfg_vars:
+        cfg_vars["CFLAGS"] = cfg_vars["CFLAGS"].replace("-Wstrict-prototypes",
+                                                        "")
     extension_mod, setup_args =\
         old_get_distutils_extension(modname, pyxfilename, language_level)
     extension_mod.language = 'c++'

--- a/qutip/cy/pyxbuilder.py
+++ b/qutip/cy/pyxbuilder.py
@@ -30,33 +30,34 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-import sys, os
-try:
-    import pyximport    
-    from pyximport import install
+import sys
+import os
 
-    old_get_distutils_extension = pyximport.pyximport.get_distutils_extension
+import numpy as np
+import pyximport
 
-    def new_get_distutils_extension(modname, pyxfilename, language_level=None):
-        extension_mod, setup_args = old_get_distutils_extension(modname,
-                                                                pyxfilename,
-                                                                language_level)
-        extension_mod.language='c++'
-        # If on Win and Python version >= 3.5 and not in MSYS2
-        # (i.e. Visual studio compile)
-        if sys.platform == 'win32' and \
-                int(str(sys.version_info[0]) +
-                    str(sys.version_info[1])) >= 35 and \
-                os.environ.get('MSYSTEM') is None:
-            extension_mod.extra_compile_args = ['/w', '/O1']
-        else:
-            extension_mod.extra_compile_args = ['-w', '-O1']
-            if sys.platform == 'darwin':
-                extension_mod.extra_compile_args.append(
-                                                '-mmacosx-version-min=10.9')
-                extension_mod.extra_link_args = ['-mmacosx-version-min=10.9']
-        return extension_mod,setup_args
+old_get_distutils_extension = pyximport.pyximport.get_distutils_extension
 
-    pyximport.pyximport.get_distutils_extension = new_get_distutils_extension
-except Exception:
-    pass
+
+def new_get_distutils_extension(modname, pyxfilename, language_level=None):
+    extension_mod, setup_args =\
+        old_get_distutils_extension(modname, pyxfilename, language_level)
+    extension_mod.language = 'c++'
+    # If on Win and Python version >= 3.5 and not in MSYS2
+    # (i.e. Visual studio compile)
+    if sys.platform == 'win32' and os.environ.get('MSYSTEM') is None:
+        extension_mod.extra_compile_args = ['/w', '/O1']
+    else:
+        extension_mod.extra_compile_args = ['-w', '-O1']
+    if sys.platform == 'darwin':
+        extension_mod.extra_compile_args.append('-mmacosx-version-min=10.9')
+        extension_mod.extra_link_args.append('-mmacosx-version-min=10.9')
+    return extension_mod, setup_args
+
+
+pyximport.pyximport.get_distutils_extension = new_get_distutils_extension
+
+
+def install():
+    """Install the pyximport interface."""
+    return pyximport.install(setup_args={'include_dirs': [np.get_include()]})

--- a/qutip/tests/test_sp_eigs.py
+++ b/qutip/tests/test_sp_eigs.py
@@ -37,11 +37,8 @@ from numpy.testing import assert_equal, run_module_suite, assert_
 import unittest
 
 from qutip import num, rand_herm, expect, rand_unitary
-from qutip import _version2int
 
 
-@unittest.skipIf(_version2int(scipy.__version__) < _version2int('0.10'),
-                 'Known to fail on SciPy ' + scipy.__version__)
 def test_SparseHermValsVecs():
     """
     Sparse eigs Hermitian
@@ -105,8 +102,6 @@ def test_SparseValsVecs():
     assert_equal(len(spvals), 9)
 
 
-@unittest.skipIf(_version2int(scipy.__version__) < _version2int('0.10'),
-                 'Known to fail on SciPy ' + scipy.__version__)
 def test_SparseValsOnly():
     """
     Sparse eigvals only Hermitian.


### PR DESCRIPTION
This fixes the calls to the `qutip.configrc` module in `qutip/__init__.py` when setting up OpenMP.

Also, this tidies up a lot of very old code out of `__init__.py` that was testing for ancient versions of SciPy and Numpy.  Since we have hard requirements at installation time for those, it's fine for us not to test their versions at initialisation.  We still should check the version of Cython because it's an optional dependency, so isn't always constrained by the package manager.

Some of the changes deliberately make `qutip/__init__.py` less forgiving of exceptions, especially when it comes to loading up `pyximport`.  This is deliberate, even though it may make a couple more errors surface that have previously gone undetected.  As it stands right now, the file will causes several errors to be silently ignored, even if they weren't the error we were testing for.  That masks problems for a short while, but they usually resurface during use when they're much harder to debug.  We should be solving the underlying problems, not sweeping them under the rug.  In particular, we've frequently had complaints about `pyximport` failing, or trying to import OpenMP modules that have previously been compiled but aren't currently active, and things like that.  This patch won't fix all those problems, but it hopefully will make some of them easier to debug when they do appear.

There is more explanation to the logic behind each change in the commit messages.

Fix #1470.