### PR TITLE
Fix diag_liou_mult tests

### DIFF
--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -131,7 +131,7 @@ def test_diag_liou_mult(dimension):
     calculated = np.zeros_like(coefficients)
     target = L.data.dot(coefficients)
     _test_diag_liou_mult(evals, coefficients, calculated, dimension)
-    np.testing.assert_allclose(target, calculated, atol=1e-12)
+    np.testing.assert_allclose(target, calculated, atol=1e-11, rtol=1e-6)
 
 
 def test_cop_super_mult():

--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -42,25 +42,25 @@ from qutip.cy.brtools_checks import (
 )
 
 
-def test_zheevr():
+@pytest.mark.parametrize('dimension', list(range(2, 100)))
+def test_zheevr(dimension):
     """
     zheevr: store eigenvalues in the passed array, and return the eigenvectors
     of a complex Hermitian matrix.
     """
-    for dimension in range(2, 100):
-        H = qutip.rand_herm(dimension, 1/dimension)
-        Hf = H.full()
-        evals = np.zeros(dimension, dtype=np.float64)
-        # This routine modifies its arguments inplace, so we must make a copy.
-        evecs = _test_zheevr(Hf.copy(order='F'), evals).T
-        # Assert linear independence of all the eigenvectors.
-        assert abs(scipy.linalg.det(evecs)) > 1e-12
-        for value, vector in zip(evals, evecs):
-            # Assert the eigenvector satisfies the eigenvalue equation.
-            unit = vector / scipy.linalg.norm(vector)
-            test_value = np.conj(unit.T) @ Hf @ unit
-            assert abs(test_value.imag) < 1e-12
-            assert abs(test_value - value) < 1e-12
+    H = qutip.rand_herm(dimension, 1/dimension)
+    Hf = H.full()
+    evals = np.zeros(dimension, dtype=np.float64)
+    # This routine modifies its arguments inplace, so we must make a copy.
+    evecs = _test_zheevr(Hf.copy(order='F'), evals).T
+    # Assert linear independence of all the eigenvectors.
+    assert abs(scipy.linalg.det(evecs)) > 1e-12
+    for value, vector in zip(evals, evecs):
+        # Assert the eigenvector satisfies the eigenvalue equation.
+        unit = vector / scipy.linalg.norm(vector)
+        test_value = np.conj(unit.T) @ Hf @ unit
+        assert abs(test_value.imag) < 1e-12
+        assert abs(test_value - value) < 1e-12
 
 
 @pytest.mark.parametrize("operator", [
@@ -121,17 +121,17 @@ def test_vector_roundtrip():
                                    atol=1e-12)
 
 
-def test_diag_liou_mult():
+@pytest.mark.parametrize('dimension', list(range(2, 100)))
+def test_diag_liou_mult(dimension):
     "BR Tools : Diagonal Liouvillian mult"
-    for dimension in range(2, 100):
-        H = qutip.rand_dm(dimension, 0.5)
-        evals, evecs = H.eigenstates()
-        L = qutip.liouvillian(H.transform(evecs))
-        coefficients = np.ones((dimension*dimension,), dtype=np.complex128)
-        calculated = np.zeros_like(coefficients)
-        target = L.data.dot(coefficients)
-        _test_diag_liou_mult(evals, coefficients, calculated, dimension)
-        np.testing.assert_allclose(target, calculated, atol=1e-12)
+    H = qutip.rand_dm(dimension, 0.5)
+    evals, evecs = H.eigenstates()
+    L = qutip.liouvillian(H.transform(evecs))
+    coefficients = np.ones((dimension*dimension,), dtype=np.complex128)
+    calculated = np.zeros_like(coefficients)
+    target = L.data.dot(coefficients)
+    _test_diag_liou_mult(evals, coefficients, calculated, dimension)
+    np.testing.assert_allclose(target, calculated, atol=1e-12)
 
 
 def test_cop_super_mult():


### PR DESCRIPTION
This test would fail approximately 1 in 10 times.  I have parametrised the test case so pytest sees the different dimension runs as separate elements, which gives us better information on what's going on.

I have only seen the test fail on CI on Mac, as best as I remember, and after a bit of experimentation, I was able to reproduce the issue on my Mac at approximately the same frequency as we saw it on Travis, if I was using OpenBLAS.  I couldn't reproduce the failures with MKL, so I'm fairly sure this is to do with our use of `eig` instead of `eigh` on Mac/OpenBLAS to avoid segfaults (see #1197, #1288).  This makes some sense - the tolerances of `eig` are effectively slightly more permissive than `eigh` when dealing with real numbers, because there's more scope for an eigenvalue to be different by having a small imaginary component (contributes in quadrature) as opposed to only having the linear difference.

I'm pretty confident that there's no logic error that caused the tolerances to slip a little, it's just a reality of dealing with an imperfect eigensystem solver, so I've relaxed the test tolerances by just a little.

Fix #1431