### PR TITLE
Issue#1460

### DIFF
--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -116,7 +116,7 @@ def correlation_2op_1t(H, state0, taulist, c_ops, a_op, b_op,
     Returns
     -------
     corr_vec : ndarray
-        An array of correlation values for the times specified by `tlist`.
+        An array of correlation values for the times specified by `taulist`.
 
     References
     ----------

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -537,6 +537,7 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
 
     if opt.store_final_state:
         cdata = get_curr_state_data(r)
-        output.final_state = Qobj(cdata, dims=dims, isherm=True)
+        output.final_state = Qobj(cdata, dims=dims,
+                                  isherm=rho0.isherm or None)
 
     return output

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -510,18 +510,20 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
 
         if opt.store_states or expt_callback:
             cdata = get_curr_state_data(r)
+            fdata = dense2D_to_fastcsr_fmode(cdata, size, size)
+
+            # Try to guess if there is a fast path for rho_t
+            if issuper(rho0) or not rho0.isherm:
+                rho_t = Qobj(fdata, dims=dims)
+            else:
+                rho_t = Qobj(fdata, dims=dims, fast="mc-dm")
 
         if opt.store_states:
-            if issuper(rho0):
-                fdata = dense2D_to_fastcsr_fmode(cdata, size, size)
-                output.states.append(Qobj(fdata, dims=dims))
-            else:
-                fdata = dense2D_to_fastcsr_fmode(cdata, size, size)
-                output.states.append(Qobj(fdata, dims=dims, fast="mc-dm"))
+            output.states.append(rho_t)
 
         if expt_callback:
             # use callback method
-            output.expect.append(e_ops(t, Qobj(cdata, dims=dims)))
+            output.expect.append(e_ops(t, rho_t))
 
         for m in range(n_expt_op):
             output.expect[m][t_idx] = expect_rho_vec(e_ops_data[m], r.y,

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -525,7 +525,8 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
 
         for m in range(n_expt_op):
             output.expect[m][t_idx] = expect_rho_vec(e_ops_data[m], r.y,
-                                                     e_ops[m].isherm and rho0.isherm)
+                                                     e_ops[m].isherm
+                                                     and rho0.isherm)
 
         if t_idx < n_tsteps - 1:
             r.integrate(r.t + dt[t_idx])

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -525,7 +525,7 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
 
         for m in range(n_expt_op):
             output.expect[m][t_idx] = expect_rho_vec(e_ops_data[m], r.y,
-                                                     e_ops[m].isherm)
+                                                     e_ops[m].isherm and rho0.isherm)
 
         if t_idx < n_tsteps - 1:
             r.integrate(r.t + dt[t_idx])

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -269,7 +269,12 @@ def test_hamiltonian_order_unimportant():
                          ids=["hermitian", "nonhermitian"])
 @pytest.mark.parametrize("w", [1, 2])
 @pytest.mark.parametrize("gamma", [1, 10])
-def test_correlation_2op_1t(solver, state, is_e_op_hermitian, w, gamma):
+def test_correlation_2op_1t_known_cases(solver,
+                                        state,
+                                        is_e_op_hermitian,
+                                        w,
+                                        gamma,
+                                       ):
     """This test compares the output correlation_2op_1 solution to an analytical
     solution."""
 

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -58,6 +58,7 @@ def test_correlation_solver_equivalence(solver, start, legacy):
     system.
     """
     a = qutip.destroy(_equivalence_dimension)
+    x = ( a +a.dag() )/np.sqrt(2)
     H = a.dag() * a
     G1 = 0.75
     n_th = 2
@@ -74,8 +75,8 @@ def test_correlation_solver_equivalence(solver, start, legacy):
     # broken, whereas if only one fails, then it implies that only that one is
     # broken.  We test that all solvers are equivalent by transitive equality
     # to the "me" solver.
-    base = correlation(H, start, None, times, c_ops, a.dag(), a, solver="me")
-    cmp = correlation(H, start, None, times, c_ops, a.dag(), a, solver=solver)
+    base = correlation(H, start, None, times, c_ops, x, x, solver="me")
+    cmp = correlation(H, start, None, times, c_ops, x, x, solver=solver)
     np.testing.assert_allclose(base, cmp, atol=tol)
 
 

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -76,8 +76,8 @@ def test_correlation_solver_equivalence(solver, start, legacy):
     # broken, whereas if only one fails, then it implies that only that one is
     # broken.  We test that all solvers are equivalent by transitive equality
     # to the "me" solver.
-    base = correlation(H, start, None, times, c_ops, a, a.dag(), solver="me")
-    cmp = correlation(H, start, None, times, c_ops, a, a.dag(), solver=solver)
+    base = correlation(H, start, None, times, c_ops, a.dag(), a, solver="me")
+    cmp = correlation(H, start, None, times, c_ops, a.dag(), a, solver=solver)
     np.testing.assert_allclose(base, cmp, atol=tol)
 
 

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -75,8 +75,8 @@ def test_correlation_solver_equivalence(solver, start, legacy):
     # broken, whereas if only one fails, then it implies that only that one is
     # broken.  We test that all solvers are equivalent by transitive equality
     # to the "me" solver.
-    base = correlation(H, start, None, times, c_ops, x, x, solver="me")
-    cmp = correlation(H, start, None, times, c_ops, x, x, solver=solver)
+    base = correlation(H, start, None, times, c_ops, a, a.dag(), solver="me")
+    cmp = correlation(H, start, None, times, c_ops, a, a.dag(), solver=solver)
     np.testing.assert_allclose(base, cmp, atol=tol)
 
 

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -273,7 +273,6 @@ args_slow = list(product(solver_list, start_list, e_op_list, w_list, gamma_list)
 args += [pytest.param(*arg, marks = pytest.mark.slow) for arg in args_slow]
 
 
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize(["solver", "start", "e_op", "w", "gamma"], args)
 def test_correlation_2op_1t(solver, start, e_op, w, gamma):
     """This test compares the output correlation_2op_1 solution to an analytical

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -252,3 +252,39 @@ def test_hamiltonian_order_unimportant():
     backwards = qutip.correlation_2op_2t(H[::-1], start, times, times, [sp],
                                          sp.dag(), sp)
     np.testing.assert_allclose(forwards, backwards, atol=1e-6)
+
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.parametrize(["solver", "start", "legacy"], [
+    pytest.param("me", _equivalence_coherent, False, id="me"),
+    # pytest.param("es", _equivalence_coherent, True, id="es-legacy"),
+    # pytest.param("es", None, False, id="es-steady state"),
+    # pytest.param("es", None, True, id="es-steady state-legacy"),
+    # pytest.param("mc", _equivalence_fock, False, id="mc",
+                 # marks=pytest.mark.slow),
+])
+def test_correlation_2op_1t(solver, start, legacy):
+    """This test compares the solvers solution to an analytical solution."""
+    w = 1
+    gamma = 2
+
+    # Set up some operators
+    a = qutip.destroy(_equivalence_dimension)
+    x = (a + a.dag())/np.sqrt(2)
+
+    n = qutip.num(_equivalence_dimension)
+    H = w * n
+
+    psi0 = start
+    n_0 = qutip.expect(n, psi0)
+
+    c_ops = [np.sqrt(gamma) * a]
+
+    times = np.linspace(0, 1, 100)
+
+    base = np.exp(-1j*w*times - gamma*times/2)*(n_0+1)
+
+    cmp = qutip.correlation_2op_1t(H, psi0, times, c_ops, a, a.dag(), solver=solver)
+
+    np.testing.assert_allclose(base,cmp, atol=1e-6)
+
+

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -254,15 +254,16 @@ def test_hamiltonian_order_unimportant():
     np.testing.assert_allclose(forwards, backwards, atol=1e-6)
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
-@pytest.mark.parametrize(["solver", "start", "legacy"], [
-    pytest.param("me", _equivalence_coherent, False, id="me"),
+@pytest.mark.parametrize(["solver", "start", "legacy", "op"], [
+    pytest.param("me", _equivalence_coherent, False, "x", id="me"),
+    pytest.param("me", _equivalence_coherent, False, "a", id="me_a"),
     # pytest.param("es", _equivalence_coherent, True, id="es-legacy"),
     # pytest.param("es", None, False, id="es-steady state"),
     # pytest.param("es", None, True, id="es-steady state-legacy"),
     # pytest.param("mc", _equivalence_fock, False, id="mc",
                  # marks=pytest.mark.slow),
 ])
-def test_correlation_2op_1t(solver, start, legacy):
+def test_correlation_2op_1t(solver, start, legacy, op):
     """This test compares the solvers solution to an analytical solution."""
     w = 1
     gamma = 2
@@ -271,19 +272,27 @@ def test_correlation_2op_1t(solver, start, legacy):
     a = qutip.destroy(_equivalence_dimension)
     x = (a + a.dag())/np.sqrt(2)
 
-    n = qutip.num(_equivalence_dimension)
-    H = w * n
+    H = w * a.dag() * a
 
     psi0 = start
-    n_0 = qutip.expect(n, psi0)
 
+    a_op = a if op=='a' else x
+    b_op = a.dag() if op=='a' else x
     c_ops = [np.sqrt(gamma) * a]
 
     times = np.linspace(0, 1, 100)
 
-    base = np.exp(-1j*w*times - gamma*times/2)*(n_0+1)
+    if op == 'x':
+        # Analitycal solution for x,x as operators.
+        base = 0
+        base += qutip.expect(a*x, psi0)*np.exp(-1j*w*times - gamma*times/2)
+        base += qutip.expect(a.dag()*x, psi0)*np.exp(1j*w*times - gamma*times/2)
+        base /= np.sqrt(2)
+    else:
+        # Analitycal solution for a,adag as operators.
+        base = qutip.expect(a*a.dag(), psi0)*np.exp(-1j*w*times - gamma*times/2)
 
-    cmp = qutip.correlation_2op_1t(H, psi0, times, c_ops, a, a.dag(), solver=solver)
+    cmp = qutip.correlation_2op_1t(H, psi0, times, c_ops, a_op, b_op, solver=solver)
 
     np.testing.assert_allclose(base,cmp, atol=1e-6)
 

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -941,6 +941,10 @@ def test_non_hermitian_dm():
 
     result = mesolve(H, rho0, tlist, e_ops=[x], options=options)
 
+    msg = ('Mesolve is not working properly with a non Hermitian density' +
+       ' matrix as input. Check computation of '
+      )
+
     imag_part = np.abs(np.imag(result.expect[0][-1]))
     # Since we used an initial state that is not Hermitian, the expectation of
     # x must be imaginary for t>0.

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -945,14 +945,15 @@ def test_non_hermitian_dm():
     msg = 'Mesolve is not working properly with a non Hermitian density ' +
     ' matrix as input. Check computation of '
 
-    assert_(imag_part > 0, msg + "expectation values. They should be imaginary")
+    assert_(imag_part > 0,
+            msg + "expectation values. They should be imaginary")
 
-    # Check that the output state is not hermitian since the input was not 
+    # Check that the output state is not hermitian since the input was not
     # Hermitian either.
     assert_(not result.final_state.isherm,
             msg + " final density  matrix. It should not be hermitian")
     assert_(not result.states[-1].isherm,
-           msg + " states. They should not be hermitian.")
+            msg + " states. They should not be hermitian.")
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -927,11 +927,12 @@ def test_non_hermitian_dm():
     """
     N = 2
     a = destroy(N)
-    n = num(N)
     x = (a + a.dag())/np.sqrt(2)
     H = a.dag() * a
 
+    # Create non-Hermitian initial state.
     rho0 = x*fock_dm(N, 0)
+
     tlist = np.linspace(0, 0.1, 2)
 
     options = Options()
@@ -943,9 +944,6 @@ def test_non_hermitian_dm():
     imag_part = np.abs(np.imag(result.expect[0][-1]))
     # Since we used an initial state that is not Hermitian, the expectation of
     # x must be imaginary for t>0.
-    msg = ('Mesolve is not working properly with a non Hermitian density ' +
-           ' matrix as input. Check computation of '
-          )
     assert_(imag_part > 0,
             msg + "expectation values. They should be imaginary")
 
@@ -956,7 +954,7 @@ def test_non_hermitian_dm():
     assert_(not result.states[-1].isherm,
             msg + " states. They should not be hermitian.")
 
-    # Check that when suing a callable we get the same result as previously.
+    # Check that when suing a callable we get imaginary expectation values.
     def callable_x(t, rho):
         "Dummy callable_x expectation operator."
         return expect(rho, x)
@@ -965,7 +963,7 @@ def test_non_hermitian_dm():
     imag_part = np.abs(np.imag(result.expect[-1]))
     assert_(imag_part > 0,
             msg + "expectation values when using callable operator." +
-            "It should be imaginary.")
+            "They should be imaginary.")
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -965,7 +965,7 @@ def test_non_hermitian_dm():
     imag_part = np.abs(np.imag(result.expect[-1]))
     assert_(imag_part > 0,
             msg + "expectation values when using callable operator." +
-            "They should be imaginary")
+            "It should be imaginary.")
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -934,12 +934,25 @@ def test_non_hermitian_dm():
     rho0 = x*fock_dm(N, 0)
     tlist = np.linspace(0, 0.1, 2)
 
-    result = mesolve(H, rho0, tlist, e_ops=[x])
+    options = Options()
+    options.store_final_state = True
+    options.store_states = True
+    result = mesolve(H, rho0, tlist, e_ops=[x], options=options)
 
     imag_part = np.abs(np.imag(result.expect[0][-1]))
     # Since we used an initial state that is not Hermitian, the expectation of
     # x must be imaginary for t>0.
-    assert(imag_part > 0)
+    msg = 'Mesolve is not working properly with a non Hermitian density ' +
+    ' matrix as input. Check computation of '
+
+    assert_(imag_part > 0, msg + "expectation values. They should be imaginary")
+
+    # Check that the output state is not hermitian since the input was not 
+    # Hermitian either.
+    assert_(not result.final_state.isherm,
+            msg + " final density  matrix. It should not be hermitian")
+    assert_(not result.states[-1].isherm,
+           msg + " states. They should not be hermitian.")
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -937,14 +937,15 @@ def test_non_hermitian_dm():
     options = Options()
     options.store_final_state = True
     options.store_states = True
+
     result = mesolve(H, rho0, tlist, e_ops=[x], options=options)
 
     imag_part = np.abs(np.imag(result.expect[0][-1]))
     # Since we used an initial state that is not Hermitian, the expectation of
     # x must be imaginary for t>0.
-    msg = 'Mesolve is not working properly with a non Hermitian density ' +
-    ' matrix as input. Check computation of '
-
+    msg = ('Mesolve is not working properly with a non Hermitian density ' +
+           ' matrix as input. Check computation of '
+          )
     assert_(imag_part > 0,
             msg + "expectation values. They should be imaginary")
 
@@ -954,6 +955,17 @@ def test_non_hermitian_dm():
             msg + " final density  matrix. It should not be hermitian")
     assert_(not result.states[-1].isherm,
             msg + " states. They should not be hermitian.")
+
+    # Check that when suing a callable we get the same result as previously.
+    def callable_x(t, rho):
+        "Dummy callable_x expectation operator."
+        return expect(rho, x)
+    result = mesolve(H, rho0, tlist, e_ops=callable_x)
+
+    imag_part = np.abs(np.imag(result.expect[-1]))
+    assert_(imag_part > 0,
+            msg + "expectation values when using callable operator." +
+            "They should be imaginary")
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -919,6 +919,7 @@ class TestMESolveStepFuncCoeff:
         assert_(max(abs(res.expect[0][5:])) < tol,
             msg="evolution with feedback not proceding as expected")
 
+
 def test_non_hermitian_dm():
     """Test that mesolve works correctly for density matrices that are
     not Hermitian.
@@ -930,14 +931,15 @@ def test_non_hermitian_dm():
     x = (a + a.dag())/np.sqrt(2)
     H = a.dag() * a
 
-    rho0 = x*fock_dm(N,0)
+    rho0 = x*fock_dm(N, 0)
     tlist = np.linspace(0, 0.1, 2)
 
-    result = mesolve(H, rho0, tlist, e_ops = [x])
+    result = mesolve(H, rho0, tlist, e_ops=[x])
 
     imag_part = np.abs(np.imag(result.expect[0][-1]))
-    # Since we used an
-    assert(imag_part> 0)
+    # Since we used an initial state that is not Hermitian, the expectation of
+    # x must be imaginary for t>0.
+    assert(imag_part > 0)
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -919,6 +919,26 @@ class TestMESolveStepFuncCoeff:
         assert_(max(abs(res.expect[0][5:])) < tol,
             msg="evolution with feedback not proceding as expected")
 
+def test_non_hermitian_dm():
+    """Test that mesolve works correctly for density matrices that are
+    not Hermitian.
+    See Issue #1460
+    """
+    N = 2
+    a = destroy(N)
+    n = num(N)
+    x = (a + a.dag())/np.sqrt(2)
+    H = a.dag() * a
+
+    rho0 = x*fock_dm(N,0)
+    tlist = np.linspace(0, 0.1, 2)
+
+    result = mesolve(H, rho0, tlist, e_ops = [x])
+
+    imag_part = np.abs(np.imag(result.expect[0][-1]))
+    # Since we used an
+    assert(imag_part> 0)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
**Description**
The function mesolve was not including the complex part of the expectation value when the initial state was a not Hermitian. This led to an error in `correlation_2op_1t()` which uses an initial state that is not Hermitian to compute the correlation.
I also fixed an error in the documentation where `tlist` was referenced instead of `taulist` (`tlist` is not an argument in `correlation_2op_1t()`) and included a test for `correlation_2op_1t()`.

**Related issues or PRs**
Fix #1460

**Changelog**
Fixed error where complex expectation value for non Hermitian initial state was not being included in results when using mesolve.
Fix doxumentation error in `correlation_2op_1t()`.
Added test for `correlation_2op_1t()`.

