### PR TITLE
Avoid matrix tidyup in trace norm

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1015,8 +1015,8 @@ class Qobj(object):
         """
         if self.type in ['oper', 'super']:
             if norm is None or norm == 'tr':
-                _op = self*self.dag()
-                vals = sp_eigs(_op.data, _op.isherm, vecs=False,
+                _op = self.data * zcsr_adjoint(self.data)
+                vals = sp_eigs(_op, True, vecs=False,
                                sparse=sparse, tol=tol, maxiter=maxiter)
                 return np.sum(np.sqrt(np.abs(vals)))
             elif norm == 'fro':


### PR DESCRIPTION
The first step of calculating the trace norm is to do `A @ A.dag()`, which we did internally in Qobj.norm.  This creates a temporary `Qobj`, and those created from `Qobj.__mul__` are subject to tidyup by default, so this temporary structure may incorrectly get tidied to the zero matrix.

For example, the code
```python
qutip.qdiags(1e-7 * np.random.rand(10), 0).norm()
```
would previously give 0, as clearly all elements of `A @ A.dag()` would be less than 1e-14, and subject to tidyup.

We avoid the call that may be tidied up by jumping straight to CSR-CSR matrix multiplication, and set `isherm=True` without going via Qobj, since the operation is Hermitian for any matrix.

Fix gh-952