### PR TITLE
Update diag_liou_mult test tolerances

### DIFF
--- a/qutip/tests/test_brtools.py
+++ b/qutip/tests/test_brtools.py
@@ -131,7 +131,7 @@ def test_diag_liou_mult(dimension):
     calculated = np.zeros_like(coefficients)
     target = L.data.dot(coefficients)
     _test_diag_liou_mult(evals, coefficients, calculated, dimension)
-    np.testing.assert_allclose(target, calculated, atol=1e-11, rtol=1e-6)
+    np.testing.assert_allclose(target, calculated, atol=1e-9, rtol=1e-6)
 
 
 def test_cop_super_mult():


### PR DESCRIPTION
I did this previously a handful of commits ago in b7df1b5, but the
tolerances chosen there weren't ideal.

This is only especially relevant for cases where we have to use generic
eigenvalue solvers in place of Hermitian ones (e.g. when the Hermitian
ones have temperamental segfaults).  I ran test_diag_liou_mult for all
dimensions from 2 to 99 inclusive 2000 times, and measured the maximum
absolute and relative tolerance for each case.  I found that 3 times out
of 2000 the absolute tolerance exceeded 1e-10, and 12 times out of 2000
the relative tolerance exceeded 1e-7.  The max values seen were 4.24e-10
and 3.12e-7 respectively.

This updates the tolerances to 1e-9 (absolute) and 1e-6 (relative),
which still seem like reasonable tolerances, and should ensure that
we're testing correctly.

See also #1474.