### PR TITLE
Allow rerunning of dnorm tests, refactor test_metrics.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ _mac_generic_setup: &mac_generic_setup
   os: osx
   language: generic
   install:
-    - conda install nomkl blas=*=openblas numpy scipy matplotlib cython pytest
+    - conda install nomkl blas=*=openblas numpy scipy matplotlib cython
+    - pip install pytest pytest-rerunfailures
     - python setup.py install
 
 jobs:
@@ -54,7 +55,8 @@ jobs:
     - name: "Linux, Python 3.8: regular"
       python: 3.8
       install:
-        - conda install numpy scipy matplotlib pytest cython
+        - conda install numpy scipy matplotlib cython
+        - pip install pytest pytest-rerunfailures
         - python setup.py install
 
     - name: "Linux, Python 3.7: OpenMP, MKL, scipy<1.5 (coverage)"
@@ -68,7 +70,8 @@ jobs:
       # This is why we use `setup.py develop` here, and why we don't change
       # directories.
       install:
-        - conda install mkl blas=*=mkl numpy 'scipy<1.5' matplotlib cython pytest pytest-cov coveralls cvxopt
+        - conda install mkl blas=*=mkl numpy 'scipy<1.5' matplotlib cython cvxopt
+        - pip install pytest pytest-rerunfailures pytest-cov coveralls
         - conda install -c conda-forge cvxpy
         - python setup.py develop --with-openmp
       before_script:
@@ -83,7 +86,8 @@ jobs:
     - name: "Linux, Python 3.6: No Cython, OpenBLAS"
       python: 3.6
       install:
-      - conda install nomkl blas=*=openblas numpy scipy matplotlib pytest
+      - conda install nomkl blas=*=openblas numpy scipy matplotlib
+      - pip install pytest pytest-rerunfailures
       - conda install cython --freeze-installed
       - conda list
       - python setup.py install

--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -321,9 +321,6 @@ def hellinger_dist(A, B, sparse=False, tol=0):
     >>> y=coherent_dm(5,1)
     >>> np.testing.assert_almost_equal(hellinger_dist(x,y), 1.3725145002591095)
     """
-    if A.dims != B.dims:
-        raise TypeError("A and B do not have same dimensions.")
-
     if A.isket or A.isbra:
         sqrtmA = ket2dm(A)
     else:
@@ -333,13 +330,15 @@ def hellinger_dist(A, B, sparse=False, tol=0):
     else:
         sqrtmB = B.sqrtm(sparse=sparse, tol=tol)
 
-    product = sqrtmA*sqrtmB
+    if sqrtmA.dims != sqrtmB.dims:
+        raise TypeError("A and B do not have compatible dimensions.")
 
+    product = sqrtmA*sqrtmB
     eigs = sp_eigs(product.data,
                    isherm=product.isherm, vecs=False, sparse=sparse, tol=tol)
-    #np.maximum() is to avoid nan appearing sometimes due to numerical
-    #instabilities causing np.sum(eigs) slightly (~1e-8) larger than 1
-    #when hellinger_dist(A, B) is called for A=B
+    # np.maximum() is to avoid nan appearing sometimes due to numerical
+    # instabilities causing np.sum(eigs) slightly (~1e-8) larger than 1
+    # when hellinger_dist(A, B) is called for A=B
     return np.sqrt(2.0 * np.maximum(0., (1.0 - np.real(np.sum(eigs)))))
 
 

--- a/qutip/tests/test_metrics.py
+++ b/qutip/tests/test_metrics.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-Simple tests for metrics and pseudometrics implemented in
-the qutip.metrics module.
-"""
-
 # This file is part of QuTiP: Quantum Toolbox in Python.
 #
 #    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
@@ -36,353 +31,237 @@ the qutip.metrics module.
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-from __future__ import division
-import pytest
-
-
-import numpy as np
-from numpy import abs, sqrt, ones, diag
-from numpy.testing import (
-    assert_, run_module_suite, assert_approx_equal,
-    assert_almost_equal
-)
-from numpy.random import rand
-
-from qutip.operators import (
-    create, destroy, jmat, identity, qdiags, sigmax, sigmay, sigmaz, qeye
-)
-from qutip.states import fock_dm, basis
-from qutip.propagator import propagator
-from qutip.random_objects import (
-    rand_herm, rand_dm, rand_unitary, rand_ket, rand_super_bcsz,
-    rand_ket_haar, rand_dm_ginibre, rand_unitary_haar
-)
-from qutip.qobj import Qobj
-from qutip.superop_reps import to_super, to_choi, kraus_to_choi
-from qutip.qip.operations.gates import hadamard_transform, swap
-from qutip.tensor import tensor
-from qutip.metrics import *
-
-import qutip.settings
 
 import platform
-import unittest
 
-try:
-    import cvxpy
-except ImportError:
-    cvxpy = None
-try:
-    import cvxopt
-except ImportError:
-    cvxopt = None
+import numpy as np
+import pytest
 
-dnorm_test = pytest.mark.skipif((cvxpy is None) or (cvxopt is None), reason='requires cvxpy and cvxopt')
-
-#FIXME: Try to resolve the average_gate_fidelity issues on MACOS
-avg_gate_fidelity_test = unittest.skipIf(platform.system().startswith("Darwin"),
-                "average_gate_fidelity tests were failing on MacOS "
-                "as of July 2019.")
-
-"""
-A test class for the metrics and pseudo-metrics included with QuTiP.
-"""
+from qutip import (
+    Qobj, tensor, fock_dm, basis, destroy, qdiags, sigmax, sigmay, sigmaz,
+    qeye, rand_ket, rand_super_bcsz, rand_ket_haar, rand_dm_ginibre, rand_dm,
+    rand_unitary, rand_unitary_haar, to_super, to_choi, kraus_to_choi,
+)
+from qutip.qip.operations import (
+    hadamard_transform, swap,
+)
+# These ones are the metrics functions that we actually want to test.
+from qutip import (
+    fidelity, tracedist, hellinger_dist, dnorm, average_gate_fidelity,
+    unitarity, hilbert_dist, bures_dist,
+)
 
 
-def test_fid_trdist_limits():
-    """
-    Metrics: Fidelity / trace distance limiting cases
-    """
-    rho = rand_dm(25, 0.25)
-    assert_(abs(fidelity(rho, rho)-1) < 1e-6)
-    assert_(tracedist(rho, rho) < 1e-6)
-    rho1 = fock_dm(5, 1)
-    rho2 = fock_dm(5, 2)
-    assert_(fidelity(rho1, rho2) < 1e-6)
-    assert_(abs(tracedist(rho1, rho2)-1) < 1e-6)
+@pytest.fixture(scope="function", params=[2, 5, 10, 15, 25, 100])
+def dimension(request):
+    # There are also some cases in the file where this fixture is explicitly
+    # overridden by a more local mark.  That is deliberate; this dimension is
+    # intended for non-superoperators, and may cause inordinantly long tests if
+    # (for example) something uses dimension=100 then makes a superoperator out
+    # of it.
+    return request.param
 
 
-def test_fidelity1():
-    """
-    Metrics: Fidelity, mixed state inequality
-    """
-    for k in range(10):
-        rho1 = rand_dm(25, 0.25)
-        rho2 = rand_dm(25, 0.25)
+@pytest.fixture(scope="function", params=[
+    pytest.param(rand_ket_haar, id="pure"),
+    pytest.param(rand_dm_ginibre, id="mixed"),
+])
+def state(request, dimension):
+    return request.param(dimension)
+
+
+# Also parametrise left, right as if they're the names of two states for tests
+# that need to take two states.
+left = right = state
+
+
+class Test_fidelity:
+    def test_mixed_state_inequality(self, dimension):
+        tol = 1e-7
+        rho1 = rand_dm(dimension, 0.25)
+        rho2 = rand_dm(dimension, 0.25)
         F = fidelity(rho1, rho2)
-        assert_(1-F <= sqrt(1-F**2))
+        assert 1 - F <= np.sqrt(1 - F*F) + tol
 
+    @pytest.mark.parametrize('right_dm', [True, False], ids=['mixed', 'pure'])
+    @pytest.mark.parametrize('left_dm', [True, False], ids=['mixed', 'pure'])
+    def test_orthogonal(self, left_dm, right_dm, dimension):
+        left = basis(dimension, 0)
+        right = basis(dimension, dimension//2)
+        if left_dm:
+            left = left.proj()
+        if right_dm:
+            right = right.proj()
+        assert fidelity(left, right) == pytest.approx(0, abs=1e-6)
 
-def test_fidelity2():
-    """
-    Metrics: Fidelity, invariance under unitary trans.
-    """
-    for k in range(10):
-        rho1 = rand_dm(25, 0.25)
-        rho2 = rand_dm(25, 0.25)
-        U = rand_unitary(25, 0.25)
+    def test_invariant_under_unitary_transformation(self, dimension):
+        rho1 = rand_dm(dimension, 0.25)
+        rho2 = rand_dm(dimension, 0.25)
+        U = rand_unitary(dimension, 0.25)
         F = fidelity(rho1, rho2)
         FU = fidelity(U*rho1*U.dag(), U*rho2*U.dag())
-        assert_(abs((F-FU)/F) < 1e-5)
+        assert F == pytest.approx(FU, rel=1e-5)
+
+    def test_state_with_itself(self, state):
+        assert fidelity(state, state) == pytest.approx(1, abs=1e-6)
+
+    def test_bounded(self, left, right, dimension):
+        """Test that fidelity is bounded on [0, 1]."""
+        tol = 1e-7
+        assert -tol <= fidelity(left, right) <= 1 + tol
+
+    def test_pure_state_equivalent_to_overlap(self, dimension):
+        """Check fidelity against pure-state overlap, see gh-361."""
+        psi = rand_ket_haar(dimension)
+        phi = rand_ket_haar(dimension)
+        overlap = np.abs(psi.overlap(phi))
+        assert fidelity(psi, phi) == pytest.approx(overlap, abs=1e-7)
+
+    ket_0 = basis(2, 0)
+    ket_1 = basis(2, 1)
+    ket_p = (ket_0 + ket_1).unit()
+    ket_py = (ket_0 + np.exp(0.25j*np.pi)*ket_1).unit()
+    max_mixed = qeye(2).unit()
+
+    @pytest.mark.parametrize(['left', 'right', 'expected'], [
+        pytest.param(ket_0, ket_p, np.sqrt(0.5), id="|0>,|+>"),
+        pytest.param(ket_0, ket_1, 0, id="|0>,|1>"),
+        pytest.param(ket_0, max_mixed, np.sqrt(0.5), id="|0>,id/2"),
+        pytest.param(ket_p, ket_py, np.sqrt(0.125 + (0.5+np.sqrt(0.125))**2),
+                     id="|+>,|+'>"),
+    ])
+    def test_known_cases(self, left, right, expected):
+        assert fidelity(left, right) == pytest.approx(expected, abs=1e-7)
 
 
-def test_fidelity_max():
-    """
-    Metrics: Fidelity of a pure state w/ itself should be 1.
-    """
-    for _ in range(10):
-        psi = rand_ket_haar(13)
-        assert_almost_equal(fidelity(psi, psi), 1)
+class Test_tracedist:
+    def test_state_with_itself(self, state):
+        assert tracedist(state, state) == pytest.approx(0, abs=1e-6)
 
+    @pytest.mark.parametrize('right_dm', [True, False], ids=['mixed', 'pure'])
+    @pytest.mark.parametrize('left_dm', [True, False], ids=['mixed', 'pure'])
+    def test_orthogonal(self, left_dm, right_dm, dimension):
+        left = basis(dimension, 0)
+        right = basis(dimension, dimension//2)
+        if left_dm:
+            left = left.proj()
+        if right_dm:
+            right = right.proj()
+        assert tracedist(left, right) == pytest.approx(1, abs=1e-6)
 
-def test_fidelity_bounded_purepure(tol=1e-7):
-    """
-    Metrics: Fidelity of pure states within [0, 1].
-    """
-    for _ in range(10):
-        psi = rand_ket_haar(17)
-        phi = rand_ket_haar(17)
-        F = fidelity(psi, phi)
-        assert_(-tol <= F <= 1 + tol)
-
-
-def test_fidelity_bounded_puremixed(tol=1e-7):
-    """
-    Metrics: Fidelity of pure states against mixed states within [0, 1].
-    """
-    for _ in range(10):
-        psi = rand_ket_haar(11)
-        sigma = rand_dm_ginibre(11)
-        F = fidelity(psi, sigma)
-        assert_(-tol <= F <= 1 + tol)
-
-
-def test_fidelity_bounded_mixedmixed(tol=1e-7):
-    """
-    Metrics: Fidelity of mixed states within [0, 1].
-    """
-    for _ in range(10):
-        rho = rand_dm_ginibre(11)
-        sigma = rand_dm_ginibre(11)
-        F = fidelity(rho, sigma)
-        assert_(-tol <= F <= 1 + tol)
-
-
-def test_fidelity_known_cases():
-    """
-    Metrics: Checks fidelity against known cases.
-    """
-    ket0 = basis(2, 0)
-    ket1 = basis(2, 1)
-    ketp = (ket0 + ket1).unit()
-    # A state that almost overlaps with |+> should serve as
-    # a nice test case, especially since we can analytically
-    # calculate its overlap with |+>.
-    ketpy = (ket0 + np.exp(1j * np.pi / 4) * ket1).unit()
-
-    mms = qeye(2).unit()
-
-    assert_almost_equal(fidelity(ket0, ketp), 1 / np.sqrt(2))
-    assert_almost_equal(fidelity(ket0, ket1), 0)
-    assert_almost_equal(fidelity(ket0, mms),  1 / np.sqrt(2))
-    assert_almost_equal(fidelity(ketp, ketpy),
-        np.sqrt(
-            (1 / 8) + (1 / 2 + 1 / (2 * np.sqrt(2))) ** 2
-        )
-    )
-
-
-def test_fidelity_overlap():
-    """
-    Metrics: Checks fidelity against pure-state overlap. (#631)
-    """
-    for _ in range(10):
-        psi = rand_ket_haar(7)
-        phi = rand_ket_haar(7)
-
-        assert_almost_equal(
-            fidelity(psi, phi),
-            np.abs((psi.dag() * phi)[0, 0])
-        )
-
-def test_tracedist1():
-    """
-    Metrics: Trace dist., invariance under unitary trans.
-    """
-    for k in range(10):
-        rho1 = rand_dm(25, 0.25)
-        rho2 = rand_dm(25, 0.25)
-        U = rand_unitary(25, 0.25)
+    def test_invariant_under_unitary_transformation(self, dimension):
+        rho1 = rand_dm(dimension, 0.25)
+        rho2 = rand_dm(dimension, 0.25)
+        U = rand_unitary(dimension, 0.25)
         D = tracedist(rho1, rho2)
         DU = tracedist(U*rho1*U.dag(), U*rho2*U.dag())
-        assert_(abs((D-DU)/D) < 1e-5)
+        assert D == pytest.approx(DU, rel=1e-5)
 
 
-def test_tracedist2():
-    """
-    Metrics: Trace dist. & Fidelity mixed/mixed inequality
-    """
-    for k in range(10):
-        rho1 = rand_dm(25, 0.25)
-        rho2 = rand_dm(25, 0.25)
-        F = fidelity(rho1, rho2)
-        D = tracedist(rho1, rho2)
-        assert_(1-F <= D)
+class Test_hellinger_dist:
+    @pytest.mark.parametrize('right_dm', [True, False], ids=['mixed', 'pure'])
+    @pytest.mark.parametrize('left_dm', [True, False], ids=['mixed', 'pure'])
+    def test_orthogonal(self, left_dm, right_dm, dimension):
+        left = basis(dimension, 0)
+        right = basis(dimension, dimension//2)
+        if left_dm:
+            left = left.proj()
+        if right_dm:
+            right = right.proj()
+        expected = np.sqrt(2)
+        assert hellinger_dist(left, right) == pytest.approx(expected, abs=1e-6)
+
+    def test_state_with_itself(self, state):
+        assert hellinger_dist(state, state) == pytest.approx(0, abs=1e-6)
+
+    def test_known_cases_pure_states(self, dimension):
+        left = rand_ket(dimension)
+        right = rand_ket(dimension)
+        expected = np.sqrt(2 * (1 - np.abs(left.overlap(right))**2))
+        assert hellinger_dist(left, right) == pytest.approx(expected, abs=1e-7)
+
+    @pytest.mark.parametrize('dimension', [2, 5, 10, 25])
+    def test_monotonicity(self, dimension):
+        """
+        Check monotonicity w.r.t. tensor product, see. Eq. (45) in
+        arXiv:1611.03449v2:
+            hellinger_dist(rhoA & rhoB, sigmaA & sigmaB)
+            >= hellinger_dist(rhoA, sigmaA)
+        with equality iff sigmaB = rhoB where '&' is the tensor product.
+        """
+        tol = 1e-5
+        rhoA, rhoB, sigmaA, sigmaB = [rand_dm(dimension) for _ in [None]*4]
+        rho = tensor(rhoA, rhoB)
+        rho_sim = tensor(rhoA, sigmaB)
+        sigma = tensor(sigmaA, sigmaB)
+        dist = hellinger_dist(rhoA, sigmaA)
+        assert hellinger_dist(rho, sigma) + tol > dist
+        assert hellinger_dist(rho_sim, sigma) == pytest.approx(dist, abs=tol)
 
 
-def test_tracedist3():
-    """
-    Metrics: Trace dist. & Fidelity mixed/pure inequality
-    """
-    for k in range(10):
-        ket = rand_ket(25, 0.25)
-        rho1 = ket*ket.dag()
-        rho2 = rand_dm(25, 0.25)
-        F = fidelity(rho1, rho2)
-        D = tracedist(rho1, rho2)
-        assert_(1-F**2 <= D)
+# TODO: resolve the Mac failures.
+@pytest.mark.skipif(
+    "Darwin" in platform.system(),
+    reason="average gate fidelity tests broken on macOS as of July 2019",
+)
+class Test_average_gate_fidelity:
+    def test_identity(self, dimension):
+        id = qeye(dimension)
+        assert average_gate_fidelity(id) == pytest.approx(1, abs=1e-12)
 
+    @pytest.mark.parametrize('dimension', [2, 5, 10, 20])
+    def test_bounded(self, dimension):
+        tol = 1e-7
+        channel = rand_super_bcsz(dimension)
+        assert -tol <= average_gate_fidelity(channel) <= 1 + tol
 
-def test_hellinger_corner():
-    """
-    Metrics: Hellinger dist.: check corner cases:
-    same states, orthogonal states
-    """
-    orth1 = basis(40, 1)
-    orth2 = basis(40, 3)
-    orth3 = basis(40, 38)
-    s2 = np.sqrt(2.0)
-    assert_almost_equal(hellinger_dist(orth1, orth2), s2)
-    assert_almost_equal(hellinger_dist(orth2, orth3), s2)
-    assert_almost_equal(hellinger_dist(orth3, orth1), s2)
-    for _ in range(10):
-        ket = rand_ket(25, 0.25)
-        rho = rand_dm(18, 0.75)
-        assert_almost_equal(hellinger_dist(ket, ket), 0.)
-        assert_almost_equal(hellinger_dist(rho, rho), 0.)
-
-
-def test_hellinger_pure():
-    """
-    Metrics: Hellinger dist.: check against a simple
-    expression which applies to pure states
-    """
-    for _ in range(10):
-        ket1 = rand_ket(25, 0.25)
-        ket2 = rand_ket(25, 0.25)
-        hellinger = hellinger_dist(ket1, ket2)
-        sqr_overlap = np.square(np.abs(ket1.overlap(ket2)))
-        simple_expr = np.sqrt(2.0*(1.0-sqr_overlap))
-        assert_almost_equal(hellinger, simple_expr)
-
-
-def test_hellinger_inequality():
-    """
-    Metrics: Hellinger dist.: check whether Hellinger
-    distance is indeed larger than Bures distance
-    """
-    for _ in range(10):
-        rho1 = rand_dm(25, 0.25)
-        rho2 = rand_dm(25, 0.25)
-        hellinger = hellinger_dist(rho1, rho2)
-        bures = bures_dist(rho1, rho2)
-        assert_(hellinger >= bures)
-        ket1 = rand_ket(40, 0.25)
-        ket2 = rand_ket(40, 0.25)
-        hellinger = hellinger_dist(ket1, ket2)
-        bures = bures_dist(ket1, ket2)
-        assert_(hellinger >= bures)
-
-
-def test_hellinger_monotonicity():
-    """
-    Metrics: Hellinger dist.: check monotonicity
-    w.r.t. tensor product, see. Eq. (45) in
-    arXiv:1611.03449v2:
-    hellinger_dist(rhoA*rhoB, sigmaA*sigmaB)>=
-    hellinger_dist(rhoA, sigmaA)
-    with equality iff sigmaB=rhoB
-    """
-    for _ in range(10):
-        rhoA = rand_dm(8, 0.5)
-        sigmaA = rand_dm(8, 0.5)
-        rhoB = rand_dm(8, 0.5)
-        sigmaB = rand_dm(8, 0.5)
-        hellA = hellinger_dist(rhoA, sigmaA)
-        hell_tensor = hellinger_dist(tensor(rhoA, rhoB),
-                                     tensor(sigmaA, sigmaB))
-        #inequality when sigmaB!=rhoB
-        assert_(hell_tensor >= hellA)
-        #equality iff sigmaB=rhoB
-        rhoB = sigmaB
-        hell_tensor = hellinger_dist(tensor(rhoA, rhoB),
-                                     tensor(sigmaA, sigmaB))
-        assert_almost_equal(hell_tensor, hellA)
-
-
-def rand_super():
-    h_5 = rand_herm(5)
-    return propagator(h_5, rand(), [
-        create(5), destroy(5), jmat(2, 'z')
-    ])
-
-
-@avg_gate_fidelity_test
-def test_average_gate_fidelity():
-    """
-    Metrics: Check avg gate fidelities for random
-    maps (equal to 1 for id maps).
-    """
-    for dims in range(2, 5):
-        assert_(abs(average_gate_fidelity(identity(dims)) - 1) <= 1e-12)
-    assert_(0 <= average_gate_fidelity(rand_super()) <= 1)
-
-@avg_gate_fidelity_test
-def test_average_gate_fidelity_target():
-    """
-    Metrics: Tests that for random unitaries U, AGF(U, U) = 1.
-    """
-    for _ in range(10):
-        U = rand_unitary_haar(13)
+    @pytest.mark.parametrize('dimension', [2, 5, 10, 20])
+    def test_unitaries_equal_1(self, dimension):
+        """Tests that for random unitaries U, AGF(U, U) = 1."""
+        tol = 1e-7
+        U = rand_unitary_haar(dimension)
         SU = to_super(U)
-        assert_almost_equal(average_gate_fidelity(SU, target=U), 1)
+        assert average_gate_fidelity(SU, target=U) == pytest.approx(1, abs=tol)
 
 
-def test_hilbert_dist():
-    """
-    Metrics: Hilbert distance.
-    """
-    diag1 = np.array([0.5, 0.5, 0, 0])
-    diag2 = np.array([0, 0, 0.5, 0.5])
-    r1 = qdiags(diag1, 0)
-    r2 = qdiags(diag2, 0)
-    assert_(abs(hilbert_dist(r1, r2)-1) <= 1e-6)
+class Test_hilbert_dist:
+    def test_known_cases(self):
+        r1 = qdiags(np.array([0.5, 0.5, 0, 0]), 0)
+        r2 = qdiags(np.array([0, 0, 0.5, 0.5]), 0)
+        assert hilbert_dist(r1, r2) == pytest.approx(1, abs=1e-6)
 
 
-def test_unitarity_known():
-    """
-    Metrics: Unitarity for known cases.
-    """
-    def case(q_oper, known_unitarity):
-        assert_almost_equal(unitarity(q_oper), known_unitarity)
+paulis = [qeye(2), sigmax(), sigmay(), sigmaz()]
 
-    yield case, to_super(sigmax()), 1.0
-    yield case, sum(map(
-        to_super, [qeye(2), sigmax(), sigmay(), sigmaz()]
-    )) / 4, 0.0
-    yield case, sum(map(
-        to_super, [qeye(2), sigmax()]
-    )) / 2, 1 / 3.0
 
-def test_unitarity_bounded(nq=3, n_cases=10):
-    """
-    Metrics: Unitarity in [0, 1].
-    """
-    def case(q_oper):
-        assert_(0.0 <= unitarity(q_oper) <= 1.0)
+class Test_unitarity:
+    @pytest.mark.parametrize(['operator', 'expected'], [
+        pytest.param(to_super(sigmax()), 1, id="sigmax"),
+        pytest.param(0.25 * sum(to_super(x) for x in paulis), 0, id="paulis"),
+        pytest.param(0.5 * (to_super(qeye(2)) + to_super(sigmax())), 1/3,
+                     id="id+sigmax"),
+    ])
+    def test_known_cases(self, operator, expected):
+        assert unitarity(operator) == pytest.approx(expected, abs=1e-7)
 
-    for _ in range(n_cases):
-        yield case, rand_super_bcsz(2**nq)
+    @pytest.mark.parametrize('n_qubits', [1, 2, 3, 4, 5])
+    def test_bounded(self, n_qubits):
+        tol = 1e-7
+        operator = rand_super_bcsz(2**n_qubits)
+        assert -tol <= unitarity(operator) <= 1 + tol
+
+
+class TestComparisons:
+    """Test some known inequalities between two different metrics."""
+    def test_inequality_tracedist_to_fidelity(self, left, right):
+        tol = 1e-7
+        assert 1 - fidelity(left, right) <= tracedist(left, right) + tol
+
+    def test_inequality_hellinger_dist_to_bures_dist(self, left, right):
+        tol = 1e-7
+        hellinger = hellinger_dist(left, right)
+        bures = bures_dist(left, right)
+        assert bures <= hellinger + tol
 
 
 def overrotation(x):
@@ -397,21 +276,19 @@ def had_mixture(x):
 
 
 def swap_map(x):
-    W = swap()
-    S = (1j * x * W).expm()
-    S._type = None
-    S.dims = [[[2], [2]], [[2], [2]]]
-    S.superrep = 'super'
-    return S
+    base = (1j * x * swap()).expm()
+    dims = [[[2], [2]], [[2], [2]]]
+    return Qobj(base, dims=dims, type='super', superrep='super')
 
 
-class TestDiamondMetrics:
-    """
-    A test class for the QuTiP functions for metric calculation.
-    """
-    @dnorm_test
+class Test_dnorm:
+    # Skip dnorm tests if we don't have cvxpy or cvxopt available, since it
+    # depends on them.
+    pytest.importorskip("cvxpy")
+    pytest.importorskip("cvxopt")
+
     @pytest.mark.repeat(10)
-    def test_dnorm_on_sparse_matrix(self):
+    def test_on_sparse_matrix(self):
         """
         Tests sparse versus dense dnorm calculation on sparse matrices.
         """
@@ -429,13 +306,12 @@ class TestDiamondMetrics:
         sparse_run_result = dnorm(A, B, force_solve=force_solve, sparse=True)
         assert dense_run_result == pytest.approx(sparse_run_result, abs=1e-7)
 
-    @dnorm_test
     @pytest.mark.repeat(10)
     @pytest.mark.parametrize(["dim"], [
         pytest.param(2, id="dim2"),
         pytest.param(3, id="dim3"),
     ])
-    def test_dnorm_on_dense_matrix(self, dim):
+    def test_on_dense_matrix(self, dim):
         """
         Metrics: Tests sparse versus dense dnorm calculation on dense matrices.
         """
@@ -445,9 +321,8 @@ class TestDiamondMetrics:
         sparse_run_result = dnorm(A, force_solve=force_solve, sparse=True)
         assert dense_run_result == pytest.approx(sparse_run_result, abs=1e-7)
 
-    @dnorm_test
     @pytest.mark.repeat(10)
-    def test_dnorm_bounded(self):
+    def test_bounded(self):
         """
         Metrics: dnorm(A - B) in [0, 2] for random superops A, B.
         """
@@ -455,16 +330,14 @@ class TestDiamondMetrics:
         norm_result = dnorm(A, B)
         assert 1 == pytest.approx(norm_result, abs=1 + 1e-7)
 
-    @dnorm_test
-    def test_dnorm_qubit_simple_known_cases(self):
+    def test_qubit_simple_known_cases(self):
         """
         Metrics: check agreement for known qubit channels.
         """
         id_chan = to_choi(qeye(2))
         X_chan = to_choi(sigmax())
         depol = to_choi(Qobj(
-            diag(ones((4,))),
-            dims=[[[2], [2]], [[2], [2]]], superrep='chi'
+            qeye(4), dims=[[[2], [2]], [[2], [2]]], superrep='chi',
         ))
         # We need to restrict the number of iterations for things on the
         # boundary, such as perfectly distinguishable channels.
@@ -476,7 +349,6 @@ class TestDiamondMetrics:
         assert np.sqrt(2) == pytest.approx(dnorm(Qobj([[1, 1], [-1, 1]])
                                            / np.sqrt(2), qeye(2)))
 
-    @dnorm_test
     @pytest.mark.parametrize(["variable", 'target', 'matrix_creator'], [
         [1.000000e-03, 3.141591e-03, 'overrotation'],
         [3.100000e-03, 9.738899e-03, 'overrotation'],
@@ -497,7 +369,7 @@ class TestDiamondMetrics:
         [1.000000e-01, 1.999162e-01, 'swap_map'],
         [3.100000e-01, 6.173918e-01, 'swap_map'],
     ])
-    def test_dnorm_qubit_known_cases(self, variable, target, matrix_creator):
+    def test_qubit_known_cases(self, variable, target, matrix_creator):
         # Next, we'll generate some test cases based on comparisons to
         # pre-existing dnorm() implementations. In particular, the targets for
         # the following test cases were generated using QuantumUtils for MATLAB
@@ -515,12 +387,11 @@ class TestDiamondMetrics:
             assert target == pytest.approx(dnorm(swap_map(variable),
                                                  id_chan), abs=1e-7)
 
-    @dnorm_test
     @pytest.mark.parametrize(["dim"], [
         pytest.param(2, id="dim2"),
         pytest.param(2, id="dim3"),
     ])
-    def test_dnorm_qubit_scalar(self, dim):
+    def test_qubit_scalar(self, dim):
         """
         Metrics: checks that dnorm(a * A) == a * dnorm(A) for scalar a, qobj A.
         """
@@ -529,12 +400,11 @@ class TestDiamondMetrics:
         B = rand_super_bcsz(dim)
         assert dnorm(a * A, a * B) == pytest.approx(a * dnorm(A, B), abs=1e-7)
 
-    @dnorm_test
     @pytest.mark.parametrize(["dim"], [
         pytest.param(2, id="dim2"),
         pytest.param(3, id="dim3")
     ])
-    def test_dnorm_qubit_triangle(self, dim):
+    def test_qubit_triangle(self, dim):
         """
         Metrics: checks that dnorm(A + B) ≤ dnorm(A) + dnorm(B).
         """
@@ -542,7 +412,6 @@ class TestDiamondMetrics:
         B = rand_super_bcsz(dim)
         assert dnorm(A + B) <= dnorm(A) + dnorm(B) + 1e-7
 
-    @dnorm_test
     @pytest.mark.repeat(10)
     @pytest.mark.parametrize(["dim", 'matrix_generator'], [
         pytest.param(2, 'bcsz', id="dim2"),
@@ -550,7 +419,7 @@ class TestDiamondMetrics:
         pytest.param(2, 'haar', id="dim2"),
         pytest.param(3, 'haar', id="dim3"),
     ])
-    def test_dnorm_force_solve(self, dim, matrix_generator):
+    def test_force_solve(self, dim, matrix_generator):
         """
         Metrics: checks that special cases for dnorm agree with SDP solutions.
         """
@@ -565,19 +434,14 @@ class TestDiamondMetrics:
             == pytest.approx(dnorm(A, B, force_solve=True), abs=1e-5)
         )
 
-    @dnorm_test
     @pytest.mark.repeat(10)
     @pytest.mark.parametrize(["dim"], [
         pytest.param(2, id="dim2"),
         pytest.param(3, id="dim3"),
     ])
-    def test_dnorm_cptp(self, dim):
+    def test_cptp(self, dim):
         """
         Metrics: checks that the diamond norm is one for CPTP maps.
         """
         A = rand_super_bcsz(dim)
         assert 1 == pytest.approx(dnorm(A, force_solve=True), abs=1e-7)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,3 +40,9 @@ include = qutip*
 [options.extras_require]
 graphics = matplotlib>=1.2.1
 runtime_compilation = cython>=0.29.20
+semidefinite =
+    cvxpy>=1.0
+    cvxopt
+tests =
+    pytest>=5.2
+    pytest-rerunfailures


### PR DESCRIPTION
dnorm tests have historically been very flaky, and for as long as we're using random tests (which we possibly shouldn't be), we always run the risk of temperamental failures.  In particular, the semidefinite solvers used in dnorm fail every now and again on random states; we historically haven't treated this as a bug, since it's pretty similar to an integration failing to converge because the system was too stiff.  It means that the user has to adjust some settings and try again.

To prevent this sort of error from failing our test suite, however, we can mark the tests as being allowed to rerun twice on a failure.  We had a relatively small sample to judge the test failure rate by, but my very very approximate guess is that we'd have a failure about 1 in 10 runs on Travis.  We counter this with two strategies:

1. parametrise the tests in pytest style, so each random repetition is a separate instance, and known to pytest (some of this was done in earlier commits)
2. allow 2 reruns of every dnorm test

The two of these together should remove all random failures; since all random loops have been moved into pytest-handled repeats, there are far fewer calls to dnorm handled within each test. This means less chance that an individual test run will fail, but a slightly higher chance the entire suite will.  Now with the test re-running a single failure point is tried again up to twice more, to determine if it was just a one-off, or if the test is truly broken.

The reruns are handled by a pytest plugin pytest-rerunfailures.  It's quite nontrivial behaviour to hook this in to the pytest mechanism, so better to use an external dependency to do it than to vendor in a custom version.

The dnorm problems have resurfaced a little after lying dormant for a long time, because #1463 reactivated them.  Before that, they'd not actually been running because none of the test runners had cvxpy installed.
