### PR TITLE
Fix improperly formed docstrings

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -69,69 +69,67 @@ except:
     pass
 
 
-class Bloch():
-    """Class for plotting data on the Bloch sphere.  Valid data can be
-    either points, vectors, or qobj objects.
+class Bloch:
+    r"""
+    Class for plotting data on the Bloch sphere.  Valid data can be either
+    points, vectors, or Qobj objects.
 
     Attributes
     ----------
-
-    axes : instance {None}
+    axes : matplotlib.axes.Axes
         User supplied Matplotlib axes for Bloch sphere animation.
-    fig : instance {None}
+    fig : matplotlib.figure.Figure
         User supplied Matplotlib Figure instance for plotting Bloch sphere.
-    font_color : str {'black'}
+    font_color : str, default 'black'
         Color of font used for Bloch sphere labels.
-    font_size : int {20}
+    font_size : int, default 20
         Size of font used for Bloch sphere labels.
-    frame_alpha : float {0.1}
+    frame_alpha : float, default 0.1
         Sets transparency of Bloch sphere frame.
-    frame_color : str {'gray'}
+    frame_color : str, default 'gray'
         Color of sphere wireframe.
-    frame_width : int {1}
+    frame_width : int, default 1
         Width of wireframe.
-    point_color : list {["b","r","g","#CC6600"]}
-        List of colors for Bloch sphere point markers to cycle through.
-        i.e. By default, points 0 and 4 will both be blue ('b').
-    point_marker : list {["o","s","d","^"]}
+    point_color : list, default ["b", "r", "g", "#CC6600"]
+        List of colors for Bloch sphere point markers to cycle through, i.e.
+        by default, points 0 and 4 will both be blue ('b').
+    point_marker : list, default ["o", "s", "d", "^"]
         List of point marker shapes to cycle through.
-    point_size : list {[25,32,35,45]}
-        List of point marker sizes. Note, not all point markers look
-        the same size when plotted!
-    sphere_alpha : float {0.2}
+    point_size : list, default [25, 32, 35, 45]
+        List of point marker sizes. Note, not all point markers look the same
+        size when plotted!
+    sphere_alpha : float, default 0.2
         Transparency of Bloch sphere itself.
-    sphere_color : str {'#FFDDDD'}
+    sphere_color : str, default '#FFDDDD'
         Color of Bloch sphere.
-    figsize : list {[7,7]}
+    figsize : list, default [7, 7]
         Figure size of Bloch sphere plot.  Best to have both numbers the same;
         otherwise you will have a Bloch sphere that looks like a football.
-    vector_color : list {["g","#CC6600","b","r"]}
+    vector_color : list, ["g", "#CC6600", "b", "r"]
         List of vector colors to cycle through.
-    vector_width : int {5}
+    vector_width : int, default 5
         Width of displayed vectors.
-    vector_style : str {'-|>', 'simple', 'fancy', ''}
+    vector_style : str, default '-\|>'
         Vector arrowhead style (from matplotlib's arrow style).
-    vector_mutation : int {20}
+    vector_mutation : int, default 20
         Width of vectors arrowhead.
-    view : list {[-60,30]}
+    view : list, default [-60, 30]
         Azimuthal and Elevation viewing angles.
-    xlabel : list {["$x$",""]}
+    xlabel : list, default ["$x$", ""]
         List of strings corresponding to +x and -x axes labels, respectively.
-    xlpos : list {[1.1,-1.1]}
+    xlpos : list, default [1.1, -1.1]
         Positions of +x and -x labels respectively.
-    ylabel : list {["$y$",""]}
+    ylabel : list, default ["$y$", ""]
         List of strings corresponding to +y and -y axes labels, respectively.
-    ylpos : list {[1.2,-1.2]}
+    ylpos : list, default [1.2, -1.2]
         Positions of +y and -y labels respectively.
-    zlabel : list {[r'$\\left|0\\right>$',r'$\\left|1\\right>$']}
+    zlabel : list, default ['$\\left\|0\\right>$', '$\\left\|1\\right>$']
         List of strings corresponding to +z and -z axes labels, respectively.
-    zlpos : list {[1.2,-1.2]}
+    zlpos : list, default [1.2, -1.2]
         Positions of +z and -z labels respectively.
-
     """
     def __init__(self, fig=None, axes=None, view=None, figsize=None,
                  background=False):
-
         # Figure and axes
         self.fig = fig
         self.axes = axes
@@ -160,7 +158,7 @@ class Bloch():
         # Position of y-axis labels, default = [1.1, -1.1]
         self.ylpos = [1.2, -1.2]
         # Labels for z-axis (in LaTex),
-        # default = [r'$\left|0\right>$', r'$\left|1\right>$']
+        # default = [r'$\left\|0\right>$', r'$\left|1\right>$']
         self.zlabel = [r'$\left|0\right>$', r'$\left|1\right>$']
         # Position of z-axis labels, default = [1.2, -1.2]
         self.zlpos = [1.2, -1.2]
@@ -175,7 +173,7 @@ class Bloch():
         self.vector_color = ['g', '#CC6600', 'b', 'r']
         #: Width of Bloch vectors, default = 5
         self.vector_width = 3
-        #: Style of Bloch vectors, default = '-|>' (or 'simple')
+        #: Style of Bloch vectors, default = '-\|>' (or 'simple')
         self.vector_style = '-|>'
         #: Sets the width of the vectors arrowhead
         self.vector_mutation = 20
@@ -216,16 +214,15 @@ class Bloch():
         convention : string
             One of the following:
 
-                - "original"
-                - "xyz"
-                - "sx sy sz"
-                - "01"
-                - "polarization jones"
-                - "polarization jones letters"
-                  see also: http://en.wikipedia.org/wiki/Jones_calculus
-                - "polarization stokes"
-                  see also: http://en.wikipedia.org/wiki/Stokes_parameters
-
+            - "original"
+            - "xyz"
+            - "sx sy sz"
+            - "01"
+            - "polarization jones"
+            - "polarization jones letters"
+              see also: http://en.wikipedia.org/wiki/Jones_calculus
+            - "polarization stokes"
+              see also: http://en.wikipedia.org/wiki/Stokes_parameters
         """
         ketex = "$\\left.|%s\\right\\rangle$"
         # \left.| is on purpose, so that every ket has the same size
@@ -324,13 +321,12 @@ class Bloch():
 
         Parameters
         ----------
-        points : array/list
+        points : array_like
             Collection of data points.
 
-        meth : str {'s', 'm', 'l'}
+        meth : {'s', 'm', 'l'}
             Type of points to plot, use 'm' for multicolored, 'l' for points
             connected with a line.
-
         """
         if not isinstance(points[0], (list, ndarray)):
             points = [[points[0]], [points[1]], [points[2]]]
@@ -355,12 +351,11 @@ class Bloch():
 
         Parameters
         ----------
-        state : qobj
+        state : Qobj
             Input state vector.
 
-        kind : str {'vector','point'}
+        kind : {'vector', 'point'}
             Type of object to plot.
-
         """
         if isinstance(state, Qobj):
             state = [state]
@@ -382,7 +377,6 @@ class Bloch():
         ----------
         vectors : array_like
             Array with vectors of unit length or smaller.
-
         """
         if isinstance(vectors[0], (list, ndarray)):
             for vec in vectors:
@@ -391,8 +385,9 @@ class Bloch():
             self.vectors.append(vectors)
 
     def add_annotation(self, state_or_vector, text, **kwargs):
-        """Add a text or LaTeX annotation to Bloch sphere,
-        parametrized by a qubit state or a vector.
+        """
+        Add a text or LaTeX annotation to Bloch sphere, parametrized by a qubit
+        state or a vector.
 
         Parameters
         ----------
@@ -400,14 +395,14 @@ class Bloch():
             Position for the annotaion.
             Qobj of a qubit or a vector of 3 elements.
 
-        text : str/unicode
+        text : str
             Annotation text.
             You can use LaTeX, but remember to use raw string
             e.g. r"$\\langle x \\rangle$"
             or escape backslashes
             e.g. "$\\\\langle x \\\\rangle$".
 
-        **kwargs :
+        kwargs :
             Options as for mplot3d.axes3d.text, including:
             fontsize, color, horizontalalignment, verticalalignment.
 

--- a/qutip/control/dump.py
+++ b/qutip/control/dump.py
@@ -155,10 +155,17 @@ class Dump(object):
     @property
     def level(self):
         """
-        The level of data dumping that will occur
-         - SUMMARY : A summary will be recorded
-         - FULL : All possible dumping
-         - CUSTOM : Some customised level of dumping
+        The level of data dumping that will occur.
+
+        SUMMARY
+            A summary will be recorded
+
+        FULL
+            All possible dumping
+
+        CUSTOM
+            Some customised level of dumping
+
         When first set to CUSTOM this is equivalent to SUMMARY. It is then up
         to the user to specify what specifically is dumped
         """
@@ -507,15 +514,14 @@ class OptimDump(Dump):
 
 class DynamicsDump(Dump):
     """
-    A container for dumps of dynamics data.
-    Mainly time evolution calculations
+    A container for dumps of dynamics data. Mainly time evolution calculations.
 
     Attributes
     ----------
     dump_summary : bool
         If True a summary is recorded
 
-    evo_summary : list of :class:`tslotcomp.EvoCompSummary'
+    evo_summary : list of :class:`tslotcomp.EvoCompSummary`
         Summary items are appended if dump_summary is True
         at each recomputation of the evolution.
 
@@ -686,15 +692,16 @@ class DynamicsDump(Dump):
         return ecs
 
     def writeout(self, f=None):
-        """write all the dump items and the summary out to file(s)
+        """
+        Write all the dump items and the summary out to file(s).
+
         Parameters
         ----------
         f : filename or filehandle
             If specified then all summary and object data will go in one file.
-            If None is specified then type specific files will be generated
-            in the dump_dir
-            If a filehandle is specified then it must be a byte mode file
-            as numpy.savetxt is used, and requires this.
+            If None is specified then type specific files will be generated in
+            the dump_dir.  If a filehandle is specified then it must be a byte
+            mode file as numpy.savetxt is used, and requires this.
         """
         fall = None
         # If specific file given then write everything to it
@@ -746,18 +753,20 @@ class DynamicsDump(Dump):
             else:
                 logger.info("Dynamics dump saved to {}".format(self.dump_dir))
 
-class DumpItem(object):
+
+class DumpItem:
     """
     An item in a dump list
     """
     def __init__(self):
         pass
 
+
 class EvoCompDumpItem(DumpItem):
     """
-    A copy of all objects generated to calculate one time evolution
-    Note the attributes are only set if the corresponding
-    :class:`DynamicsDump` dump_ attribute is set.
+    A copy of all objects generated to calculate one time evolution. Note the
+    attributes are only set if the corresponding :class:`DynamicsDump`
+    ``dump_*`` attribute is set.
     """
     def __init__(self, dump):
         if not isinstance(dump, DynamicsDump):
@@ -931,11 +940,12 @@ class EvoCompDumpItem(DumpItem):
         if closefall:
             fall.close()
 
-class DumpSummaryItem(object):
-    """A summary of the most recent iteration
-    Abstract class only
+class DumpSummaryItem:
+    """
+    A summary of the most recent iteration.  Abstract class only.
 
-    Attributes:
+    Attributes
+    ----------
     idx : int
         Index in the summary list in which this is stored
     """

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -514,13 +514,15 @@ class Dynamics(object):
         """
         The level of data dumping that will occur during the time evolution
         calculation.
-         - NONE : No processing data dumped (Default)
-         - SUMMARY : A summary of each time evolution will be recorded
-         - FULL : All operators used or created in the calculation dumped
-         - CUSTOM : Some customised level of dumping
+
+        - NONE : No processing data dumped (Default)
+        - SUMMARY : A summary of each time evolution will be recorded
+        - FULL : All operators used or created in the calculation dumped
+        - CUSTOM : Some customised level of dumping
+
         When first set to CUSTOM this is equivalent to SUMMARY. It is then up
-        to the user to specify which operators are dumped
-        WARNING: FULL could consume a lot of memory!
+        to the user to specify which operators are dumped.  WARNING: FULL could
+        consume a lot of memory!
         """
         if self.dump is None:
             lvl = 'NONE'
@@ -867,11 +869,13 @@ class Dynamics(object):
         """
         phase_application : scalar(string), default='preop'
         Determines how the phase is applied to the dynamics generators
-         - 'preop'  : P = expm(phase*dyn_gen)
-         - 'postop' : P = expm(dyn_gen*phase)
-         - 'custom' : Customised phase application
+
+        - 'preop'  : P = expm(phase*dyn_gen)
+        - 'postop' : P = expm(dyn_gen*phase)
+        - 'custom' : Customised phase application
+
         The 'custom' option assumes that the _apply_phase method has been
-        set to a custom function
+        set to a custom function.
         """
         return self._phase_application
 

--- a/qutip/control/optimizer.py
+++ b/qutip/control/optimizer.py
@@ -57,9 +57,9 @@ the maximum time allowed has been exceeded
 
 These function optimisation methods are so far from SciPy.optimize
 The two methods implemented are:
-    
+
     BFGS - Broyden–Fletcher–Goldfarb–Shanno algorithm
-        
+
         This a quasi second order Newton method. It uses successive calls to
         the gradient function to make an estimation of the curvature (Hessian)
         and hence direct its search for the function minima
@@ -68,7 +68,7 @@ The two methods implemented are:
         use subclass: OptimizerBFGS
 
     L-BFGS-B - Bounded, limited memory BFGS
-        
+
         This a version of the BFGS method where the Hessian approximation is
         only based on a set of the most recent gradient calls. It generally
         performs better where the are a large number of variables
@@ -121,41 +121,37 @@ def _is_string(var):
 class Optimizer(object):
     """
     Base class for all control pulse optimisers. This class should not be
-    instantiated, use its subclasses
-    This class implements the fidelity, gradient and interation callback
-    functions.
-    All subclass objects must be initialised with a
-        
-        OptimConfig instance - various configuration options
-        Dynamics instance - describes the dynamics of the (quantum) system
-                            to be control optimised
+    instantiated, use its subclasses.  This class implements the fidelity,
+    gradient and interation callback functions.  All subclass objects must be
+    initialised with a
+
+    - ``OptimConfig`` instance - various configuration options
+    - ``Dynamics`` instance - describes the dynamics of the (quantum) system
+      to be control optimised
 
     Attributes
     ----------
     log_level : integer
-        level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
-        in decreasing levels of messaging, are:
+        level of messaging output from the logger.  Options are attributes of
+        qutip.logging_utils, in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
-        Anything WARN or above is effectively 'quiet' execution,
-        assuming everything runs as expected.
-        The default NOTSET implies that the level will be taken from
-        the QuTiP settings file, which by default is WARN
+        Anything WARN or above is effectively 'quiet' execution, assuming
+        everything runs as expected.  The default NOTSET implies that the level
+        will be taken from the QuTiP settings file, which by default is WARN.
 
     params:  Dictionary
-        The key value pairs are the attribute name and value
-        Note: attributes are created if they do not exist already,
-        and are overwritten if they do.
+        The key value pairs are the attribute name and value. Note: attributes
+        are created if they do not exist already, and are overwritten if they
+        do.
 
     alg : string
-        Algorithm to use in pulse optimisation.
-        Options are:
-            'GRAPE' (default) - GRadient Ascent Pulse Engineering
-            'CRAB' - Chopped RAndom Basis
+        Algorithm to use in pulse optimisation.  Options are:
+
+        - 'GRAPE' (default) - GRadient Ascent Pulse Engineering
+        - 'CRAB' - Chopped RAndom Basis
 
     alg_params : Dictionary
-        options that are specific to the pulse optim algorithm
-        that is GRAPE or CRAB
+        Options that are specific to the pulse optim algorithm ``alg``.
 
     disp_conv_msg : bool
         Set true to display a convergence message
@@ -243,7 +239,6 @@ class Optimizer(object):
     iter_summary : :class:`OptimIterSummary`
         Summary of the most recent iteration.
         Note this is only set if dummping is on
-    
     """
 
     def __init__(self, config, dyn, params=None):
@@ -324,10 +319,12 @@ class Optimizer(object):
     def dumping(self):
         """
         The level of data dumping that will occur during the optimisation
-         - NONE : No processing data dumped (Default)
-         - SUMMARY : A summary at each iteration will be recorded
-         - FULL : All logs will be generated and dumped
-         - CUSTOM : Some customised level of dumping
+
+        - NONE : No processing data dumped (Default)
+        - SUMMARY : A summary at each iteration will be recorded
+        - FULL : All logs will be generated and dumped
+        - CUSTOM : Some customised level of dumping
+
         When first set to CUSTOM this is equivalent to SUMMARY. It is then up
         to the user to specify which logs are dumped
         """
@@ -1155,18 +1152,18 @@ class OptimizerCrab(Optimizer):
 
 class OptimizerCrabFmin(OptimizerCrab):
     """
-    Optimises the pulse using the CRAB algorithm [1, 2].
-    It uses the scipy.optimize.fmin function which is effectively a wrapper
-    for the Nelder-mead method.
-    It minimises the fidelity error function with respect to the CRAB
-    basis function coefficients.
-    This is the default Optimizer for CRAB.
+    Optimises the pulse using the CRAB algorithm [1]_, [2]_.
+    It uses the ``scipy.optimize.fmin`` function which is effectively a wrapper
+    for the Nelder-Mead method.  It minimises the fidelity error function with
+    respect to the CRAB basis function coefficients.  This is the default
+    Optimizer for CRAB.
 
-    Notes
-    -----
-    [1] P. Doria, T. Calarco & S. Montangero. Phys. Rev. Lett. 106,
-        190501 (2011).
-    [2] T. Caneva, T. Calarco, & S. Montangero. Phys. Rev. A 84, 022326 (2011).
+    References
+    ----------
+    .. [1] P. Doria, T. Calarco & S. Montangero. Phys. Rev. Lett. 106, 190501
+       (2011).
+    .. [2] T. Caneva, T. Calarco, & S. Montangero. Phys. Rev. A 84, 022326
+       (2011).
     """
 
     def reset(self):

--- a/qutip/control/propcomp.py
+++ b/qutip/control/propcomp.py
@@ -387,11 +387,10 @@ class PropCompAugMat(PropagatorComputer):
 
 class PropCompFrechet(PropagatorComputer):
     """
-    Frechet method for calculating the propagator:
-        exponentiating the combined dynamics generator
-    and the propagator gradient
-    It should work for all systems, e.g. unitary, open, symplectic
-    There are other PropagatorComputer subclasses that may be more efficient
+    Frechet method for calculating the propagator: exponentiating the combined
+    dynamics generator and the propagator gradient. It should work for all
+    systems, e.g. unitary, open, symplectic. There are other
+    :obj:`PropagatorComputer` subclasses that may be more efficient.
     """
     def reset(self):
         PropagatorComputer.reset(self)

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -143,237 +143,219 @@ def optimize_pulse(
         ramping_pulse_type=None, ramping_pulse_params=None,
         log_level=logging.NOTSET, out_file_ext=None, gen_stats=False):
     """
-    Optimise a control pulse to minimise the fidelity error.
-    The dynamics of the system in any given timeslot are governed
-    by the combined dynamics generator,
-    i.e. the sum of the drift+ctrl_amp[j]*ctrls[j]
-    The control pulse is an [n_ts, n_ctrls)] array of piecewise amplitudes
-    Starting from an intital (typically random) pulse,
-    a multivariable optimisation algorithm attempts to determines the
-    optimal values for the control pulse to minimise the fidelity error
-    The fidelity error is some measure of distance of the system evolution
-    from the given target evolution in the time allowed for the evolution.
+    Optimise a control pulse to minimise the fidelity error.  The dynamics of
+    the system in any given timeslot are governed by the combined dynamics
+    generator, i.e. the sum of the ``drift + ctrl_amp[j]*ctrls[j]``.
+
+    The control pulse is an ``[n_ts, n_ctrls]`` array of piecewise amplitudes
+    Starting from an initial (typically random) pulse, a multivariable
+    optimisation algorithm attempts to determines the optimal values for the
+    control pulse to minimise the fidelity error.  The fidelity error is some
+    measure of distance of the system evolution from the given target evolution
+    in the time allowed for the evolution.
 
     Parameters
     ----------
     drift : Qobj or list of Qobj
-        the underlying dynamics generator of the system
-        can provide list (of length num_tslots) for time dependent drift
+        The underlying dynamics generator of the system can provide list (of
+        length ``num_tslots``) for time dependent drift.
 
     ctrls : List of Qobj or array like [num_tslots, evo_time]
-        a list of control dynamics generators. These are scaled by
-        the amplitudes to alter the overall dynamics
-        Array like imput can be provided for time dependent control generators
+        A list of control dynamics generators. These are scaled by the
+        amplitudes to alter the overall dynamics.  Array-like input can be
+        provided for time dependent control generators.
 
     initial : Qobj
-        starting point for the evolution.
-        Typically the identity matrix
+        Starting point for the evolution.  Typically the identity matrix.
 
     target : Qobj
-        target transformation, e.g. gate or state, for the time evolution
+        Target transformation, e.g. gate or state, for the time evolution.
 
     num_tslots : integer or None
-        number of timeslots.
-        None implies that timeslots will be given in the tau array
+        Number of timeslots.  ``None`` implies that timeslots will be given in
+        the tau array.
 
     evo_time : float or None
-        total time for the evolution
-        None implies that timeslots will be given in the tau array
+        Total time for the evolution.  ``None`` implies that timeslots will be
+        given in the tau array.
 
     tau : array[num_tslots] of floats or None
-        durations for the timeslots.
-        if this is given then num_tslots and evo_time are dervived
-        from it
-        None implies that timeslot durations will be equal and
-        calculated as evo_time/num_tslots
+        Durations for the timeslots.  If this is given then ``num_tslots`` and
+        ``evo_time`` are derived from it.  ``None`` implies that timeslot
+        durations will be equal and calculated as ``evo_time/num_tslots``.
 
     amp_lbound : float or list of floats
-        lower boundaries for the control amplitudes
-        Can be a scalar value applied to all controls
-        or a list of bounds for each control
+        Lower boundaries for the control amplitudes.  Can be a scalar value
+        applied to all controls or a list of bounds for each control.
 
     amp_ubound : float or list of floats
-        upper boundaries for the control amplitudes
-        Can be a scalar value applied to all controls
-        or a list of bounds for each control
+        Upper boundaries for the control amplitudes.  Can be a scalar value
+        applied to all controls or a list of bounds for each control.
 
     fid_err_targ : float
-        Fidelity error target. Pulse optimisation will
-        terminate when the fidelity error falls below this value
+        Fidelity error target. Pulse optimisation will terminate when the
+        fidelity error falls below this value.
 
     mim_grad : float
-        Minimum gradient. When the sum of the squares of the
-        gradients wrt to the control amplitudes falls below this
-        value, the optimisation terminates, assuming local minima
+        Minimum gradient. When the sum of the squares of the gradients wrt to
+        the control amplitudes falls below this value, the optimisation
+        terminates, assuming local minima.
 
     max_iter : integer
-        Maximum number of iterations of the optimisation algorithm
+        Maximum number of iterations of the optimisation algorithm.
 
     max_wall_time : float
-        Maximum allowed elapsed time for the  optimisation algorithm
+        Maximum allowed elapsed time for the  optimisation algorithm.
 
     alg : string
-        Algorithm to use in pulse optimisation.
-        Options are:
+        Algorithm to use in pulse optimisation.  Options are:
 
-            'GRAPE' (default) - GRadient Ascent Pulse Engineering
-            'CRAB' - Chopped RAndom Basis
+        - 'GRAPE' (default) - GRadient Ascent Pulse Engineering
+        - 'CRAB' - Chopped RAndom Basis
 
     alg_params : Dictionary
-        options that are specific to the algorithm see above
+        Options that are specific to the algorithm see above.
 
     optim_params : Dictionary
-        The key value pairs are the attribute name and value
-        used to set attribute values
-        Note: attributes are created if they do not exist already,
-        and are overwritten if they do.
-        Note: method_params are applied afterwards and so may override these
+        The key value pairs are the attribute name and value used to set
+        attribute values.  Note: attributes are created if they do not exist
+        already, and are overwritten if they do.  Note: ``method_params`` are
+        applied afterwards and so may override these.
 
     optim_method : string
-        a scipy.optimize.minimize method that will be used to optimise
-        the pulse for minimum fidelity error
-        Note that FMIN, FMIN_BFGS & FMIN_L_BFGS_B will all result
-        in calling these specific scipy.optimize methods
-        Note the LBFGSB is equivalent to FMIN_L_BFGS_B for backwards
-        capatibility reasons.
-        Supplying DEF will given alg dependent result:
-            GRAPE - Default optim_method is FMIN_L_BFGS_B
-            CRAB - Default optim_method is FMIN
+        A ``scipy.optimize.minimize`` method that will be used to optimise the
+        pulse for minimum fidelity error.  Note that ``FMIN``, ``FMIN_BFGS`` &
+        ``FMIN_L_BFGS_B`` will all result in calling these specific
+        ``scipy.optimize methods``.  Note the ``LBFGSB`` is equivalent to
+        ``FMIN_L_BFGS_B`` for backwards compatibility reasons.  Supplying DEF
+        will given alg dependent result:
+
+        - GRAPE - Default ``optim_method`` is ``FMIN_L_BFGS_B``
+        - CRAB - Default ``optim_method`` is ``FMIN``
 
     method_params : dict
-        Parameters for the optim_method.
-        Note that where there is an attribute of the
-        Optimizer object or the termination_conditions matching the key
-        that attribute. Otherwise, and in some case also,
-        they are assumed to be method_options
-        for the scipy.optimize.minimize method.
+        Parameters for the ``optim_method``.  Note that where there is an
+        attribute of the :obj:`~Optimizer` object or the termination_conditions
+        matching the key that attribute. Otherwise, and in some case also, they
+        are assumed to be method_options for the ``scipy.optimize.minimize``
+        method.
 
     optim_alg : string
-        Deprecated. Use optim_method.
+        Deprecated. Use ``optim_method``.
 
     max_metric_corr : integer
-        Deprecated. Use method_params instead
+        Deprecated. Use ``method_params`` instead.
 
     accuracy_factor : float
-        Deprecated. Use method_params instead
+        Deprecated. Use ``method_params`` instead.
 
     dyn_type : string
-        Dynamics type, i.e. the type of matrix used to describe
-        the dynamics. Options are UNIT, GEN_MAT, SYMPL
-        (see Dynamics classes for details)
+        Dynamics type, i.e. the type of matrix used to describe the dynamics.
+        Options are ``UNIT``, ``GEN_MAT``, ``SYMPL`` (see :obj:`~Dynamics`
+        classes for details).
 
     dyn_params : dict
-        Parameters for the Dynamics object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~Dynamics` object.  The key value pairs are
+        assumed to be attribute name value pairs.  They applied after the
+        object is created.
 
     prop_type : string
-        Propagator type i.e. the method used to calculate the
-        propagtors and propagtor gradient for each timeslot
-        options are DEF, APPROX, DIAG, FRECHET, AUG_MAT
-        DEF will use the default for the specific dyn_type
-        (see PropagatorComputer classes for details)
+        Propagator type i.e. the method used to calculate the propagators and
+        propagator gradient for each timeslot options are DEF, APPROX, DIAG,
+        FRECHET, AUG_MAT.  DEF will use the default for the specific
+        ``dyn_type`` (see :obj:`~PropagatorComputer` classes for details).
 
     prop_params : dict
-        Parameters for the PropagatorComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~PropagatorComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
     fid_type : string
-        Fidelity error (and fidelity error gradient) computation method
-        Options are DEF, UNIT, TRACEDIFF, TD_APPROX
-        DEF will use the default for the specific dyn_type
-        (See FidelityComputer classes for details)
+        Fidelity error (and fidelity error gradient) computation method.
+        Options are DEF, UNIT, TRACEDIFF, TD_APPROX.  DEF will use the default
+        for the specific ``dyn_type`` (See :obj:`~FidelityComputer` classes for
+        details).
 
     fid_params : dict
-        Parameters for the FidelityComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~FidelityComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
     phase_option : string
-        Deprecated. Pass in fid_params instead.
+        Deprecated. Pass in ``fid_params`` instead.
 
     fid_err_scale_factor : float
-        Deprecated. Use scale_factor key in fid_params instead.
+        Deprecated. Use ``scale_factor`` key in ``fid_params`` instead.
 
     tslot_type : string
-        Method for computing the dynamics generators, propagators and
-        evolution in the timeslots.
-        Options: DEF, UPDATE_ALL, DYNAMIC
-        UPDATE_ALL is the only one that currently works
-        (See TimeslotComputer classes for details)
+        Method for computing the dynamics generators, propagators and evolution
+        in the timeslots.  Options: DEF, UPDATE_ALL, DYNAMIC.  UPDATE_ALL is
+        the only one that currently works.  (See :obj:`~TimeslotComputer`
+        classes for details.)
 
     tslot_params : dict
-        Parameters for the TimeslotComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~TimeslotComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
     amp_update_mode : string
-        Deprecated. Use tslot_type instead.
+        Deprecated. Use ``tslot_type`` instead.
 
     init_pulse_type : string
-        type / shape of pulse(s) used to initialise the
-        the control amplitudes.
-        Options (GRAPE) include:
-            RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW
-        DEF is RND
-        (see PulseGen classes for details)
-        For the CRAB the this the guess_pulse_type.
+        Type / shape of pulse(s) used to initialise the control amplitudes.
+        Options (GRAPE) include: RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW.
+        Default is RND.  (see :obj:`~PulseGen` classes for details.) For the
+        CRAB the this the ``guess_pulse_type``.
 
     init_pulse_params : dict
-        Parameters for the initial / guess pulse generator object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the initial / guess pulse generator object.
+        The key value pairs are assumed to be attribute name value pairs.
+        They applied after the object is created.
 
     pulse_scaling : float
-        Linear scale factor for generated initial / guess pulses
-        By default initial pulses are generated with amplitudes in the
-        range (-1.0, 1.0). These will be scaled by this parameter
+        Linear scale factor for generated initial / guess pulses.  By default
+        initial pulses are generated with amplitudes in the range (-1.0, 1.0).
+        These will be scaled by this parameter.
 
     pulse_offset : float
-        Linear offset for the pulse. That is this value will be added
-        to any initial / guess pulses generated.
+        Linear offset for the pulse. That is this value will be added to any
+        initial / guess pulses generated.
 
     ramping_pulse_type : string
-        Type of pulse used to modulate the control pulse.
-        It's intended use for a ramping modulation, which is often required in
-        experimental setups.
-        This is only currently implemented in CRAB.
-        GAUSSIAN_EDGE was added for this purpose.
+        Type of pulse used to modulate the control pulse.  It's intended use
+        for a ramping modulation, which is often required in experimental
+        setups.  This is only currently implemented in CRAB.  GAUSSIAN_EDGE was
+        added for this purpose.
 
     ramping_pulse_params : dict
-        Parameters for the ramping pulse generator object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the ramping pulse generator object.  The key value pairs
+        are assumed to be attribute name value pairs.  They applied after the
+        object is created.
 
     log_level : integer
-        level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
-        in decreasing levels of messaging, are:
-        DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
-        Anything WARN or above is effectively 'quiet' execution,
-        assuming everything runs as expected.
-        The default NOTSET implies that the level will be taken from
-        the QuTiP settings file, which by default is WARN
+        Level of messaging output from the logger.  Options are attributes of
+        :obj:`qutip.logging_utils`, in decreasing levels of messaging, are:
+        DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL.
+        Anything WARN or above is effectively 'quiet' execution, assuming
+        everything runs as expected.  The default NOTSET implies that the level
+        will be taken from the QuTiP settings file, which by default is WARN.
 
     out_file_ext : string or None
-        files containing the initial and final control pulse
-        amplitudes are saved to the current directory.
-        The default name will be postfixed with this extension
-        Setting this to None will suppress the output of files
+        Files containing the initial and final control pulse amplitudes are
+        saved to the current directory.  The default name will be postfixed
+        with this extension.  Setting this to None will suppress the output of
+        files.
 
     gen_stats : boolean
-        if set to True then statistics for the optimisation
-        run will be generated - accessible through attributes
-        of the stats object
+        If set to True then statistics for the optimisation run will be
+        generated - accessible through attributes of the stats object.
 
     Returns
     -------
     opt : OptimResult
-        Returns instance of OptimResult, which has attributes giving the
-        reason for termination, final fidelity error, final evolution
-        final amplitudes, statistics etc
-
+        Returns instance of :obj:`~OptimResult`, which has attributes giving
+        the reason for termination, final fidelity error, final evolution final
+        amplitudes, statistics etc.
     """
     if log_level == logging.NOTSET:
         log_level = logger.getEffectiveLevel()
@@ -537,227 +519,206 @@ def optimize_pulse_unitary(
         log_level=logging.NOTSET, out_file_ext=None, gen_stats=False):
 
     """
-    Optimise a control pulse to minimise the fidelity error, assuming that
-    the dynamics of the system are generated by unitary operators.
-    This function is simply a wrapper for optimize_pulse, where the
-    appropriate options for unitary dynamics are chosen and the parameter
-    names are in the format familiar to unitary dynamics
-    The dynamics of the system  in any given timeslot are governed
-    by the combined Hamiltonian,
-    i.e. the sum of the H_d + ctrl_amp[j]*H_c[j]
-    The control pulse is an [n_ts, n_ctrls] array of piecewise amplitudes
-    Starting from an intital (typically random) pulse,
-    a multivariable optimisation algorithm attempts to determines the
-    optimal values for the control pulse to minimise the fidelity error
-    The maximum fidelity for a unitary system is 1, i.e. when the
-    time evolution resulting from the pulse is equivalent to the target.
-    And therefore the fidelity error is 1 - fidelity
+    Optimise a control pulse to minimise the fidelity error, assuming that the
+    dynamics of the system are generated by unitary operators.  This function
+    is simply a wrapper for optimize_pulse, where the appropriate options for
+    unitary dynamics are chosen and the parameter names are in the format
+    familiar to unitary dynamics The dynamics of the system  in any given
+    timeslot are governed by the combined Hamiltonian, i.e. the sum of the
+    ``H_d + ctrl_amp[j]*H_c[j]`` The control pulse is an ``[n_ts, n_ctrls]``
+    array of piecewise amplitudes Starting from an initial (typically random)
+    pulse, a multivariable optimisation algorithm attempts to determines the
+    optimal values for the control pulse to minimise the fidelity error The
+    maximum fidelity for a unitary system is 1, i.e. when the time evolution
+    resulting from the pulse is equivalent to the target.  And therefore the
+    fidelity error is ``1 - fidelity``.
 
     Parameters
     ----------
     H_d : Qobj or list of Qobj
-        Drift (aka system) the underlying Hamiltonian of the system
-        can provide list (of length num_tslots) for time dependent drift
+        Drift (aka system) the underlying Hamiltonian of the system can provide
+        list (of length ``num_tslots``) for time dependent drift.
 
     H_c : List of Qobj or array like [num_tslots, evo_time]
-        a list of control Hamiltonians. These are scaled by
-        the amplitudes to alter the overall dynamics
-        Array like imput can be provided for time dependent control generators
+        A list of control Hamiltonians. These are scaled by the amplitudes to
+        alter the overall dynamics.  Array-like input can be provided for time
+        dependent control generators.
 
     U_0 : Qobj
-        starting point for the evolution.
-        Typically the identity matrix
+        Starting point for the evolution.  Typically the identity matrix.
 
     U_targ : Qobj
-        target transformation, e.g. gate or state, for the time evolution
+        Target transformation, e.g. gate or state, for the time evolution.
 
     num_tslots : integer or None
-        number of timeslots.
-        None implies that timeslots will be given in the tau array
+        Number of timeslots.  ``None`` implies that timeslots will be given in
+        the tau array.
 
     evo_time : float or None
-        total time for the evolution
-        None implies that timeslots will be given in the tau array
+        Total time for the evolution.  ``None`` implies that timeslots will be
+        given in the tau array.
 
     tau : array[num_tslots] of floats or None
-        durations for the timeslots.
-        if this is given then num_tslots and evo_time are dervived
-        from it
-        None implies that timeslot durations will be equal and
-        calculated as evo_time/num_tslots
+        Durations for the timeslots.  If this is given then ``num_tslots`` and
+        ``evo_time`` are derived from it.  ``None`` implies that timeslot
+        durations will be equal and calculated as ``evo_time/num_tslots``.
 
     amp_lbound : float or list of floats
-        lower boundaries for the control amplitudes
-        Can be a scalar value applied to all controls
-        or a list of bounds for each control
+        Lower boundaries for the control amplitudes.  Can be a scalar value
+        applied to all controls or a list of bounds for each control.
 
     amp_ubound : float or list of floats
-        upper boundaries for the control amplitudes
-        Can be a scalar value applied to all controls
-        or a list of bounds for each control
+        Upper boundaries for the control amplitudes.  Can be a scalar value
+        applied to all controls or a list of bounds for each control.
 
     fid_err_targ : float
-        Fidelity error target. Pulse optimisation will
-        terminate when the fidelity error falls below this value
+        Fidelity error target. Pulse optimisation will terminate when the
+        fidelity error falls below this value.
 
     mim_grad : float
-        Minimum gradient. When the sum of the squares of the
-        gradients wrt to the control amplitudes falls below this
-        value, the optimisation terminates, assuming local minima
+        Minimum gradient. When the sum of the squares of the gradients wrt to
+        the control amplitudes falls below this value, the optimisation
+        terminates, assuming local minima.
 
     max_iter : integer
-        Maximum number of iterations of the optimisation algorithm
+        Maximum number of iterations of the optimisation algorithm.
 
     max_wall_time : float
-        Maximum allowed elapsed time for the  optimisation algorithm
+        Maximum allowed elapsed time for the optimisation algorithm.
 
     alg : string
-        Algorithm to use in pulse optimisation.
-        Options are:
-            'GRAPE' (default) - GRadient Ascent Pulse Engineering
-            'CRAB' - Chopped RAndom Basis
+        Algorithm to use in pulse optimisation.  Options are:
+
+        - 'GRAPE' (default) - GRadient Ascent Pulse Engineering
+        - 'CRAB' - Chopped RAndom Basis
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
 
     optim_params : Dictionary
-        The key value pairs are the attribute name and value
-        used to set attribute values
-        Note: attributes are created if they do not exist already,
-        and are overwritten if they do.
-        Note: method_params are applied afterwards and so may override these
+        The key value pairs are the attribute name and value used to set
+        attribute values.  Note: attributes are created if they do not exist
+        already, and are overwritten if they do.  Note: ``method_params`` are
+        applied afterwards and so may override these.
 
     optim_method : string
-        a scipy.optimize.minimize method that will be used to optimise
-        the pulse for minimum fidelity error
-        Note that FMIN, FMIN_BFGS & FMIN_L_BFGS_B will all result
-        in calling these specific scipy.optimize methods
-        Note the LBFGSB is equivalent to FMIN_L_BFGS_B for backwards
-        capatibility reasons.
-        Supplying DEF will given alg dependent result:
+        A ``scipy.optimize.minimize`` method that will be used to optimise the
+        pulse for minimum fidelity error Note that ``FMIN``, ``FMIN_BFGS`` &
+        ``FMIN_L_BFGS_B`` will all result in calling these specific
+        scipy.optimize methods Note the ``LBFGSB`` is equivalent to
+        ``FMIN_L_BFGS_B`` for backwards compatibility reasons.  Supplying
+        ``DEF`` will given algorithm-dependent result:
 
-            GRAPE - Default optim_method is FMIN_L_BFGS_B
-            CRAB - Default optim_method is FMIN
+        - GRAPE - Default ``optim_method`` is FMIN_L_BFGS_B
+        - CRAB - Default ``optim_method`` is FMIN
 
     method_params : dict
-        Parameters for the optim_method.
-        Note that where there is an attribute of the
-        Optimizer object or the termination_conditions matching the key
-        that attribute. Otherwise, and in some case also,
-        they are assumed to be method_options
-        for the scipy.optimize.minimize method.
+        Parameters for the ``optim_method``.  Note that where there is an
+        attribute of the :obj:`~Optimizer` object or the
+        ``termination_conditions`` matching the key that attribute. Otherwise,
+        and in some case also, they are assumed to be method_options for the
+        ``scipy.optimize.minimize`` method.
 
     optim_alg : string
-        Deprecated. Use optim_method.
+        Deprecated. Use ``optim_method``.
 
     max_metric_corr : integer
-        Deprecated. Use method_params instead
+        Deprecated. Use ``method_params`` instead.
 
     accuracy_factor : float
-        Deprecated. Use method_params instead
+        Deprecated. Use ``method_params`` instead.
 
     phase_option : string
-        determines how global phase is treated in fidelity
-        calculations (fid_type='UNIT' only). Options:
+        Determines how global phase is treated in fidelity calculations
+        (``fid_type='UNIT'`` only). Options:
 
-            PSU - global phase ignored
-            SU - global phase included
+        - PSU - global phase ignored
+        - SU - global phase included
 
     dyn_params : dict
-        Parameters for the Dynamics object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~Dynamics` object.  The key value pairs are
+        assumed to be attribute name value pairs.  They applied after the
+        object is created.
 
     prop_params : dict
-        Parameters for the PropagatorComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~PropagatorComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
     fid_params : dict
-        Parameters for the FidelityComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~FidelityComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
     tslot_type : string
-        Method for computing the dynamics generators, propagators and
-        evolution in the timeslots.
-        Options: DEF, UPDATE_ALL, DYNAMIC
-        UPDATE_ALL is the only one that currently works
-        (See TimeslotComputer classes for details)
+        Method for computing the dynamics generators, propagators and evolution
+        in the timeslots.  Options: ``DEF``, ``UPDATE_ALL``, ``DYNAMIC``.
+        ``UPDATE_ALL`` is the only one that currently works.  (See
+        :obj:`~TimeslotComputer` classes for details.)
 
     tslot_params : dict
-        Parameters for the TimeslotComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~TimeslotComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
     amp_update_mode : string
-        Deprecated. Use tslot_type instead.
+        Deprecated. Use ``tslot_type`` instead.
 
     init_pulse_type : string
-        type / shape of pulse(s) used to initialise the
-        the control amplitudes.
-        Options (GRAPE) include:
-
-            RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW
-            DEF is RND
-
-        (see PulseGen classes for details)
-        For the CRAB the this the guess_pulse_type.
+        Type / shape of pulse(s) used to initialise the control amplitudes.
+        Options (GRAPE) include: RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW.
+        DEF is RND.  (see :obj:`~PulseGen` classes for details.) For the CRAB
+        the this the guess_pulse_type.
 
     init_pulse_params : dict
-        Parameters for the initial / guess pulse generator object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the initial / guess pulse generator object.  The key
+        value pairs are assumed to be attribute name value pairs.  They applied
+        after the object is created.
 
     pulse_scaling : float
-        Linear scale factor for generated initial / guess pulses
-        By default initial pulses are generated with amplitudes in the
-        range (-1.0, 1.0). These will be scaled by this parameter
+        Linear scale factor for generated initial / guess pulses.  By default
+        initial pulses are generated with amplitudes in the range (-1.0, 1.0).
+        These will be scaled by this parameter.
 
     pulse_offset : float
-        Linear offset for the pulse. That is this value will be added
-        to any initial / guess pulses generated.
+        Linear offset for the pulse. That is this value will be added to any
+        initial / guess pulses generated.
 
     ramping_pulse_type : string
-        Type of pulse used to modulate the control pulse.
-        It's intended use for a ramping modulation, which is often required in
-        experimental setups.
-        This is only currently implemented in CRAB.
-        GAUSSIAN_EDGE was added for this purpose.
+        Type of pulse used to modulate the control pulse.  It's intended use
+        for a ramping modulation, which is often required in experimental
+        setups.  This is only currently implemented in CRAB.  GAUSSIAN_EDGE was
+        added for this purpose.
 
     ramping_pulse_params : dict
-        Parameters for the ramping pulse generator object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the ramping pulse generator object.  The key value pairs
+        are assumed to be attribute name value pairs.  They applied after the
+        object is created.
 
     log_level : integer
-        level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
-        in decreasing levels of messaging, are:
+        Level of messaging output from the logger.  Options are attributes of
+        :obj:`qutip.logging_utils` in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
-        Anything WARN or above is effectively 'quiet' execution,
-        assuming everything runs as expected.
-        The default NOTSET implies that the level will be taken from
-        the QuTiP settings file, which by default is WARN
+        Anything WARN or above is effectively 'quiet' execution, assuming
+        everything runs as expected.  The default NOTSET implies that the level
+        will be taken from the QuTiP settings file, which by default is WARN.
 
     out_file_ext : string or None
-        files containing the initial and final control pulse
-        amplitudes are saved to the current directory.
-        The default name will be postfixed with this extension
-        Setting this to None will suppress the output of files
+        Files containing the initial and final control pulse amplitudes are
+        saved to the current directory.  The default name will be postfixed
+        with this extension.  Setting this to ``None`` will suppress the output
+        of files.
 
     gen_stats : boolean
-        if set to True then statistics for the optimisation
-        run will be generated - accessible through attributes
-        of the stats object
+        If set to ``True`` then statistics for the optimisation run will be
+        generated - accessible through attributes of the stats object.
 
     Returns
     -------
     opt : OptimResult
-        Returns instance of OptimResult, which has attributes giving the
-        reason for termination, final fidelity error, final evolution
-        final amplitudes, statistics etc
-
+        Returns instance of :obj:`~OptimResult`, which has attributes giving
+        the reason for termination, final fidelity error, final evolution final
+        amplitudes, statistics etc.
     """
 
     # parameters are checked in create pulse optimiser
@@ -871,190 +832,171 @@ def opt_pulse_crab(
         Array like imput can be provided for time dependent control generators
 
     initial : Qobj
-        starting point for the evolution.
-        Typically the identity matrix
+        Starting point for the evolution.  Typically the identity matrix.
 
     target : Qobj
-        target transformation, e.g. gate or state, for the time evolution
+        Target transformation, e.g. gate or state, for the time evolution.
 
     num_tslots : integer or None
-        number of timeslots.
-        None implies that timeslots will be given in the tau array
+        Number of timeslots.  ``None`` implies that timeslots will be given in
+        the tau array.
 
     evo_time : float or None
-        total time for the evolution
-        None implies that timeslots will be given in the tau array
+        Total time for the evolution.  ``None`` implies that timeslots will be
+        given in the tau array.
 
     tau : array[num_tslots] of floats or None
-        durations for the timeslots.
-        if this is given then num_tslots and evo_time are dervived
-        from it
-        None implies that timeslot durations will be equal and
-        calculated as evo_time/num_tslots
+        Durations for the timeslots.  If this is given then ``num_tslots`` and
+        ``evo_time`` are dervived from it.
+        ``None`` implies that timeslot durations will be equal and calculated
+        as ``evo_time/num_tslots``.
 
     amp_lbound : float or list of floats
-        lower boundaries for the control amplitudes
-        Can be a scalar value applied to all controls
-        or a list of bounds for each control
+        Lower boundaries for the control amplitudes.  Can be a scalar value
+        applied to all controls or a list of bounds for each control.
 
     amp_ubound : float or list of floats
-        upper boundaries for the control amplitudes
-        Can be a scalar value applied to all controls
-        or a list of bounds for each control
+        Upper boundaries for the control amplitudes.  Can be a scalar value
+        applied to all controls or a list of bounds for each control.
 
     fid_err_targ : float
-        Fidelity error target. Pulse optimisation will
-        terminate when the fidelity error falls below this value
+        Fidelity error target. Pulse optimisation will terminate when the
+        fidelity error falls below this value.
 
     max_iter : integer
-        Maximum number of iterations of the optimisation algorithm
+        Maximum number of iterations of the optimisation algorithm.
 
     max_wall_time : float
-        Maximum allowed elapsed time for the  optimisation algorithm
+        Maximum allowed elapsed time for the  optimisation algorithm.
 
     alg_params : Dictionary
-        options that are specific to the algorithm see above
+        Options that are specific to the algorithm see above.
 
     optim_params : Dictionary
-        The key value pairs are the attribute name and value
-        used to set attribute values
-        Note: attributes are created if they do not exist already,
-        and are overwritten if they do.
-        Note: method_params are applied afterwards and so may override these
+        The key value pairs are the attribute name and value used to set
+        attribute values.  Note: attributes are created if they do not exist
+        already, and are overwritten if they do.  Note: method_params are
+        applied afterwards and so may override these.
 
     coeff_scaling : float
-        Linear scale factor for the random basis coefficients
-        By default these range from -1.0 to 1.0
-        Note this is overridden by alg_params (if given there)
+        Linear scale factor for the random basis coefficients.  By default
+        these range from -1.0 to 1.0.  Note this is overridden by alg_params
+        (if given there).
 
     num_coeffs : integer
-        Number of coefficients used for each basis function
-        Note this is calculated automatically based on the dimension of the
-        dynamics if not given. It is crucial to the performane of the
-        algorithm that it is set as low as possible, while still giving
-        high enough frequencies.
-        Note this is overridden by alg_params (if given there)
+        Number of coefficients used for each basis function.  Note this is
+        calculated automatically based on the dimension of the dynamics if not
+        given. It is crucial to the performane of the algorithm that it is set
+        as low as possible, while still giving high enough frequencies.  Note
+        this is overridden by alg_params (if given there).
 
     optim_method : string
-        Multi-variable optimisation method
-        The only tested options are 'fmin' and 'Nelder-mead'
-        In theory any non-gradient method implemented in
+        Multi-variable optimisation method.  The only tested options are 'fmin'
+        and 'Nelder-mead'.  In theory any non-gradient method implemented in
         scipy.optimize.mininize could be used.
 
     method_params : dict
-        Parameters for the optim_method.
-        Note that where there is an attribute of the
-        Optimizer object or the termination_conditions matching the key
-        that attribute. Otherwise, and in some case also,
-        they are assumed to be method_options
-        for the scipy.optimize.minimize method.
-        The commonly used parameter are:
-            xtol - limit on variable change for convergence
-            ftol - limit on fidelity error change for convergence
+        Parameters for the optim_method.  Note that where there is an attribute
+        of the :obj:`~Optimizer` object or the termination_conditions matching
+        the key that attribute. Otherwise, and in some case also, they are
+        assumed to be method_options for the ``scipy.optimize.minimize``
+        method.  The commonly used parameter are:
+
+        - xtol - limit on variable change for convergence
+        - ftol - limit on fidelity error change for convergence
 
     dyn_type : string
-        Dynamics type, i.e. the type of matrix used to describe
-        the dynamics. Options are UNIT, GEN_MAT, SYMPL
-        (see Dynamics classes for details)
+        Dynamics type, i.e. the type of matrix used to describe the dynamics.
+        Options are UNIT, GEN_MAT, SYMPL (see Dynamics classes for details).
 
     dyn_params : dict
-        Parameters for the Dynamics object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the Dynamics object.  The key value pairs are assumed to
+        be attribute name value pairs.  They applied after the object is
+        created.
 
     prop_type : string
-        Propagator type i.e. the method used to calculate the
-        propagtors and propagtor gradient for each timeslot
-        options are DEF, APPROX, DIAG, FRECHET, AUG_MAT
-        DEF will use the default for the specific dyn_type
-        (see PropagatorComputer classes for details)
+        Propagator type i.e. the method used to calculate the propagtors and
+        propagtor gradient for each timeslot options are DEF, APPROX, DIAG,
+        FRECHET, AUG_MAT DEF will use the default for the specific dyn_type
+        (see :obj:`~PropagatorComputer` classes for details).
 
     prop_params : dict
-        Parameters for the PropagatorComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~PropagatorComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
     fid_type : string
-        Fidelity error (and fidelity error gradient) computation method
-        Options are DEF, UNIT, TRACEDIFF, TD_APPROX
-        DEF will use the default for the specific dyn_type
-        (See FidelityComputer classes for details)
+        Fidelity error (and fidelity error gradient) computation method.
+        Options are DEF, UNIT, TRACEDIFF, TD_APPROX.  DEF will use the default
+        for the specific dyn_type.  (See :obj:`~FidelityComputer` classes for
+        details).
 
     fid_params : dict
-        Parameters for the FidelityComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~FidelityComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
     tslot_type : string
-        Method for computing the dynamics generators, propagators and
-        evolution in the timeslots.
-        Options: DEF, UPDATE_ALL, DYNAMIC
-        UPDATE_ALL is the only one that currently works
-        (See TimeslotComputer classes for details)
+        Method for computing the dynamics generators, propagators and evolution
+        in the timeslots.  Options: DEF, UPDATE_ALL, DYNAMIC UPDATE_ALL is the
+        only one that currently works.  (See :obj:`~TimeslotComputer` classes
+        for details).
 
     tslot_params : dict
-        Parameters for the TimeslotComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~TimeslotComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
-    guess_pulse_type : string
-        type / shape of pulse(s) used modulate the control amplitudes.
-        Options include:
-            RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW, GAUSSIAN
-        Default is None
+    guess_pulse_type : string, default None
+        Type / shape of pulse(s) used modulate the control amplitudes.
+        Options include: RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW, GAUSSIAN.
 
     guess_pulse_params : dict
-        Parameters for the guess pulse generator object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the guess pulse generator object.  The key value pairs
+        are assumed to be attribute name value pairs.  They applied after the
+        object is created.
 
-    guess_pulse_action : string
-        Determines how the guess pulse is applied to the pulse generated
-        by the basis expansion.
-        Options are: MODULATE, ADD
-        Default is MODULATE
+    guess_pulse_action : string, default 'MODULATE'
+        Determines how the guess pulse is applied to the pulse generated by the
+        basis expansion.  Options are: MODULATE, ADD.
 
     pulse_scaling : float
-        Linear scale factor for generated guess pulses
-        By default initial pulses are generated with amplitudes in the
-        range (-1.0, 1.0). These will be scaled by this parameter
+        Linear scale factor for generated guess pulses.  By default initial
+        pulses are generated with amplitudes in the range (-1.0, 1.0). These
+        will be scaled by this parameter.
 
     pulse_offset : float
-        Linear offset for the pulse. That is this value will be added
-        to any guess pulses generated.
+        Linear offset for the pulse. That is this value will be added to any
+        guess pulses generated.
 
     ramping_pulse_type : string
-        Type of pulse used to modulate the control pulse.
-        It's intended use for a ramping modulation, which is often required in
-        experimental setups.
-        This is only currently implemented in CRAB.
-        GAUSSIAN_EDGE was added for this purpose.
+        Type of pulse used to modulate the control pulse.  It's intended use
+        for a ramping modulation, which is often required in experimental
+        setups.  This is only currently implemented in CRAB.  GAUSSIAN_EDGE was
+        added for this purpose.
 
     ramping_pulse_params : dict
-        Parameters for the ramping pulse generator object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the ramping pulse generator object.  The key value pairs
+        are assumed to be attribute name value pairs.  They applied after the
+        object is created.
 
     log_level : integer
-        level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
-        in decreasing levels of messaging, are:
+        level of messaging output from the logger.  Options are attributes of
+        :obj:`qutip.logging_utils`, in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
-        Anything WARN or above is effectively 'quiet' execution,
-        assuming everything runs as expected.
-        The default NOTSET implies that the level will be taken from
-        the QuTiP settings file, which by default is WARN
+        Anything WARN or above is effectively 'quiet' execution, assuming
+        everything runs as expected.  The default NOTSET implies that the level
+        will be taken from the QuTiP settings file, which by default is WARN.
 
     out_file_ext : string or None
-        files containing the initial and final control pulse
-        amplitudes are saved to the current directory.
-        The default name will be postfixed with this extension
-        Setting this to None will suppress the output of files
+        Files containing the initial and final control pulse.  Amplitudes are
+        saved to the current directory.  The default name will be postfixed
+        with this extension.  Setting this to ``None`` will suppress the output
+        of files.
 
     gen_stats : boolean
-        if set to True then statistics for the optimisation
-        run will be generated - accessible through attributes
-        of the stats object
+        If set to ``True`` then statistics for the optimisation run will be
+        generated - accessible through attributes of the stats object.
 
     Returns
     -------
@@ -1062,7 +1004,6 @@ def opt_pulse_crab(
         Returns instance of OptimResult, which has attributes giving the
         reason for termination, final fidelity error, final evolution
         final amplitudes, statistics etc
-
     """
 
     # The parameters are checked in create_pulse_optimizer
@@ -1075,8 +1016,8 @@ def opt_pulse_crab(
 
     # build the algorithm options
     if not isinstance(alg_params, dict):
-        alg_params = {'num_coeffs':num_coeffs,
-                       'init_coeff_scaling':init_coeff_scaling}
+        alg_params = {'num_coeffs': num_coeffs,
+                      'init_coeff_scaling': init_coeff_scaling}
     else:
         if (num_coeffs is not None and
             not 'num_coeffs' in alg_params):
@@ -1137,216 +1078,197 @@ def opt_pulse_crab_unitary(
         ramping_pulse_type=None, ramping_pulse_params=None,
         log_level=logging.NOTSET, out_file_ext=None, gen_stats=False):
     """
-    Optimise a control pulse to minimise the fidelity error, assuming that
-    the dynamics of the system are generated by unitary operators.
-    This function is simply a wrapper for optimize_pulse, where the
-    appropriate options for unitary dynamics are chosen and the parameter
-    names are in the format familiar to unitary dynamics
-    The dynamics of the system  in any given timeslot are governed
-    by the combined Hamiltonian,
-    i.e. the sum of the H_d + ctrl_amp[j]*H_c[j]
-    The control pulse is an [n_ts, n_ctrls] array of piecewise amplitudes
+    Optimise a control pulse to minimise the fidelity error, assuming that the
+    dynamics of the system are generated by unitary operators.  This function
+    is simply a wrapper for optimize_pulse, where the appropriate options for
+    unitary dynamics are chosen and the parameter names are in the format
+    familiar to unitary dynamics.  The dynamics of the system  in any given
+    timeslot are governed by the combined Hamiltonian, i.e. the sum of the
+    ``H_d + ctrl_amp[j]*H_c[j]`` The control pulse is an ``[n_ts, n_ctrls]``
+    array of piecewise amplitudes.
 
     The CRAB algorithm uses basis function coefficents as the variables to
-    optimise. It does NOT use any gradient function.
-    A multivariable optimisation algorithm attempts to determines the
-    optimal values for the control pulse to minimise the fidelity error
-    The fidelity error is some measure of distance of the system evolution
-    from the given target evolution in the time allowed for the evolution.
+    optimise. It does NOT use any gradient function.  A multivariable
+    optimisation algorithm attempts to determines the optimal values for the
+    control pulse to minimise the fidelity error.  The fidelity error is some
+    measure of distance of the system evolution from the given target evolution
+    in the time allowed for the evolution.
 
     Parameters
     ----------
 
     H_d : Qobj or list of Qobj
-        Drift (aka system) the underlying Hamiltonian of the system
-        can provide list (of length num_tslots) for time dependent drift
+        Drift (aka system) the underlying Hamiltonian of the system can provide
+        list (of length num_tslots) for time dependent drift.
 
     H_c : List of Qobj or array like [num_tslots, evo_time]
-        a list of control Hamiltonians. These are scaled by
-        the amplitudes to alter the overall dynamics
-        Array like imput can be provided for time dependent control generators
+        A list of control Hamiltonians. These are scaled by the amplitudes to
+        alter the overall dynamics.  Array like imput can be provided for time
+        dependent control generators.
 
     U_0 : Qobj
-        starting point for the evolution.
-        Typically the identity matrix
+        Starting point for the evolution.  Typically the identity matrix.
 
     U_targ : Qobj
-        target transformation, e.g. gate or state, for the time evolution
+        Target transformation, e.g. gate or state, for the time evolution.
 
     num_tslots : integer or None
-        number of timeslots.
-        None implies that timeslots will be given in the tau array
+        Number of timeslots.  ``None`` implies that timeslots will be given in
+        the tau array.
 
     evo_time : float or None
-        total time for the evolution
-        None implies that timeslots will be given in the tau array
+        Total time for the evolution.  ``None`` implies that timeslots will be
+        given in the tau array.
 
     tau : array[num_tslots] of floats or None
-        durations for the timeslots.
-        if this is given then num_tslots and evo_time are dervived
-        from it
-        None implies that timeslot durations will be equal and
-        calculated as evo_time/num_tslots
+        Durations for the timeslots.  If this is given then ``num_tslots`` and
+        ``evo_time`` are derived from it.  ``None`` implies that timeslot
+        durations will be equal and calculated as ``evo_time/num_tslots``.
 
     amp_lbound : float or list of floats
-        lower boundaries for the control amplitudes
-        Can be a scalar value applied to all controls
-        or a list of bounds for each control
+        Lower boundaries for the control amplitudes.  Can be a scalar value
+        applied to all controls or a list of bounds for each control.
 
     amp_ubound : float or list of floats
-        upper boundaries for the control amplitudes
-        Can be a scalar value applied to all controls
-        or a list of bounds for each control
+        Upper boundaries for the control amplitudes.  Can be a scalar value
+        applied to all controls or a list of bounds for each control.
 
     fid_err_targ : float
-        Fidelity error target. Pulse optimisation will
-        terminate when the fidelity error falls below this value
+        Fidelity error target. Pulse optimisation will terminate when the
+        fidelity error falls below this value.
 
     max_iter : integer
-        Maximum number of iterations of the optimisation algorithm
+        Maximum number of iterations of the optimisation algorithm.
 
     max_wall_time : float
-        Maximum allowed elapsed time for the  optimisation algorithm
+        Maximum allowed elapsed time for the optimisation algorithm.
 
     alg_params : Dictionary
-        options that are specific to the algorithm see above
+        Options that are specific to the algorithm see above.
 
     optim_params : Dictionary
-        The key value pairs are the attribute name and value
-        used to set attribute values
-        Note: attributes are created if they do not exist already,
-        and are overwritten if they do.
-        Note: method_params are applied afterwards and so may override these
+        The key value pairs are the attribute name and value used to set
+        attribute values.  Note: attributes are created if they do not exist
+        already, and are overwritten if they do.  Note: ``method_params`` are
+        applied afterwards and so may override these.
 
     coeff_scaling : float
-        Linear scale factor for the random basis coefficients
-        By default these range from -1.0 to 1.0
-        Note this is overridden by alg_params (if given there)
+        Linear scale factor for the random basis coefficients.  By default
+        these range from -1.0 to 1.0.  Note this is overridden by
+        ``alg_params`` (if given there).
 
     num_coeffs : integer
-        Number of coefficients used for each basis function
-        Note this is calculated automatically based on the dimension of the
-        dynamics if not given. It is crucial to the performane of the
-        algorithm that it is set as low as possible, while still giving
-        high enough frequencies.
-        Note this is overridden by alg_params (if given there)
+        Number of coefficients used for each basis function.  Note this is
+        calculated automatically based on the dimension of the dynamics if not
+        given. It is crucial to the performance of the algorithm that it is set
+        as low as possible, while still giving high enough frequencies.  Note
+        this is overridden by ``alg_params`` (if given there).
 
     optim_method : string
-        Multi-variable optimisation method
-        The only tested options are 'fmin' and 'Nelder-mead'
-        In theory any non-gradient method implemented in
-        scipy.optimize.mininize could be used.
+        Multi-variable optimisation method.  The only tested options are 'fmin'
+        and 'Nelder-mead'.  In theory any non-gradient method implemented in
+        ``scipy.optimize.minimize`` could be used.
 
     method_params : dict
-        Parameters for the optim_method.
-        Note that where there is an attribute of the
-        Optimizer object or the termination_conditions matching the key
-        that attribute. Otherwise, and in some case also,
-        they are assumed to be method_options
-        for the scipy.optimize.minimize method.
-        The commonly used parameter are:
-            xtol - limit on variable change for convergence
-            ftol - limit on fidelity error change for convergence
+        Parameters for the ``optim_method``.  Note that where there is an
+        attribute of the :obj:`~Optimizer` object or the termination_conditions
+        matching the key that attribute. Otherwise, and in some case also, they
+        are assumed to be method_options for the ``scipy.optimize.minimize``
+        method.  The commonly used parameter are:
+
+        - xtol - limit on variable change for convergence
+        - ftol - limit on fidelity error change for convergence
 
     phase_option : string
-        determines how global phase is treated in fidelity
-        calculations (fid_type='UNIT' only). Options:
-            PSU - global phase ignored
-            SU - global phase included
+        Determines how global phase is treated in fidelity calculations
+        (``fid_type='UNIT'`` only). Options:
+
+        - PSU - global phase ignored
+        - SU - global phase included
 
     dyn_params : dict
-        Parameters for the Dynamics object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~Dynamics` object.  The key value pairs are
+        assumed to be attribute name value pairs.  They applied after the
+        object is created.
 
     prop_params : dict
-        Parameters for the PropagatorComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~PropagatorComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
     fid_params : dict
-        Parameters for the FidelityComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~FidelityComputer` object.  The key value
+        pairs are assumed to be attribute name value pairs.  They applied after
+        the object is created.
 
     tslot_type : string
-        Method for computing the dynamics generators, propagators and
-        evolution in the timeslots.
-        Options: DEF, UPDATE_ALL, DYNAMIC
-        UPDATE_ALL is the only one that currently works
-        (See TimeslotComputer classes for details)
+        Method for computing the dynamics generators, propagators and evolution
+        in the timeslots.  Options: DEF, UPDATE_ALL, DYNAMIC.  UPDATE_ALL is
+        the only one that currently works.  (See :obj:`~TimeslotComputer`
+        classes for details).
 
     tslot_params : dict
-        Parameters for the TimeslotComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the :obj:`~TimeslotComputer` object The key value pairs
+        are assumed to be attribute name value pairs. They applied after the
+        object is created.
 
-    guess_pulse_type : string
-        type / shape of pulse(s) used modulate the control amplitudes.
-        Options include:
-            RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW, GAUSSIAN
-        Default is None
+    guess_pulse_type : string, optional
+        Type / shape of pulse(s) used modulate the control amplitudes.
+        Options include: RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW, GAUSSIAN.
 
     guess_pulse_params : dict
-        Parameters for the guess pulse generator object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the guess pulse generator object.  The key value pairs
+        are assumed to be attribute name value pairs.  They applied after the
+        object is created.
 
-    guess_pulse_action : string
-        Determines how the guess pulse is applied to the pulse generated
-        by the basis expansion.
-        Options are: MODULATE, ADD
-        Default is MODULATE
+    guess_pulse_action : string, 'MODULATE'
+        Determines how the guess pulse is applied to the pulse generated by the
+        basis expansion.  Options are: MODULATE, ADD.
 
     pulse_scaling : float
-        Linear scale factor for generated guess pulses
-        By default initial pulses are generated with amplitudes in the
-        range (-1.0, 1.0). These will be scaled by this parameter
+        Linear scale factor for generated guess pulses.  By default initial
+        pulses are generated with amplitudes in the range (-1.0, 1.0). These
+        will be scaled by this parameter.
 
     pulse_offset : float
-        Linear offset for the pulse. That is this value will be added
-        to any guess pulses generated.
+        Linear offset for the pulse. That is this value will be added to any
+        guess pulses generated.
 
     ramping_pulse_type : string
-        Type of pulse used to modulate the control pulse.
-        It's intended use for a ramping modulation, which is often required in
-        experimental setups.
-        This is only currently implemented in CRAB.
-        GAUSSIAN_EDGE was added for this purpose.
+        Type of pulse used to modulate the control pulse.  It's intended use
+        for a ramping modulation, which is often required in experimental
+        setups.  This is only currently implemented in CRAB.  GAUSSIAN_EDGE was
+        added for this purpose.
 
     ramping_pulse_params : dict
-        Parameters for the ramping pulse generator object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the ramping pulse generator object.  The key value pairs
+        are assumed to be attribute name value pairs.  They applied after the
+        object is created.
 
     log_level : integer
-        level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
-        in decreasing levels of messaging, are:
-        DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
-        Anything WARN or above is effectively 'quiet' execution,
-        assuming everything runs as expected.
-        The default NOTSET implies that the level will be taken from
-        the QuTiP settings file, which by default is WARN
+        Level of messaging output from the logger.  Options are attributes of
+        :obj:`qutip.logging_utils`, in decreasing levels of messaging, are:
+        DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL.
+        Anything WARN or above is effectively 'quiet' execution, assuming
+        everything runs as expected.  The default NOTSET implies that the level
+        will be taken from the QuTiP settings file, which by default is WARN.
 
     out_file_ext : string or None
-        files containing the initial and final control pulse
-        amplitudes are saved to the current directory.
-        The default name will be postfixed with this extension
-        Setting this to None will suppress the output of files
+        Files containing the initial and final control pulse amplitudes are
+        saved to the current directory.  The default name will be postfixed
+        with this extension.  Setting this to None will suppress the output of
+        files.
 
     gen_stats : boolean
-        if set to True then statistics for the optimisation
-        run will be generated - accessible through attributes
-        of the stats object
+        If set to ``True`` then statistics for the optimisation run will be
+        generated - accessible through attributes of the stats object.
 
     Returns
     -------
     opt : OptimResult
-        Returns instance of OptimResult, which has attributes giving the
-        reason for termination, final fidelity error, final evolution
-        final amplitudes, statistics etc
-
+        Returns instance of :obj:`~OptimResult`, which has attributes giving
+        the reason for termination, final fidelity error, final evolution final
+        amplitudes, statistics etc.
     """
 
     # The parameters are checked in create_pulse_optimizer
@@ -1423,87 +1345,81 @@ def create_pulse_optimizer(
         log_level=logging.NOTSET, gen_stats=False):
 
     """
-    Generate the objects of the appropriate subclasses
-    required for the pulse optmisation based on the parameters given
-    Note this method may be preferable to calling optimize_pulse
-    if more detailed configuration is required before running the
-    optmisation algorthim, or the algorithm will be run many times,
-    for instances when trying to finding global the optimum or
+    Generate the objects of the appropriate subclasses required for the pulse
+    optmisation based on the parameters given Note this method may be
+    preferable to calling optimize_pulse if more detailed configuration is
+    required before running the optmisation algorthim, or the algorithm will be
+    run many times, for instances when trying to finding global the optimum or
     minimum time optimisation
 
     Parameters
     ----------
     drift : Qobj or list of Qobj
-        the underlying dynamics generator of the system
-        can provide list (of length num_tslots) for time dependent drift
+        The underlying dynamics generator of the system can provide list (of
+        length num_tslots) for time dependent drift.
 
     ctrls : List of Qobj or array like [num_tslots, evo_time]
-        a list of control dynamics generators. These are scaled by
-        the amplitudes to alter the overall dynamics
-        Array like imput can be provided for time dependent control generators
+        A list of control dynamics generators. These are scaled by the
+        amplitudes to alter the overall dynamics.  Array-like input can be
+        provided for time dependent control generators.
 
     initial : Qobj
-        starting point for the evolution.
-        Typically the identity matrix
+        Starting point for the evolution.  Typically the identity matrix.
 
     target : Qobj
-        target transformation, e.g. gate or state, for the time evolution
+        Target transformation, e.g. gate or state, for the time evolution.
 
     num_tslots : integer or None
-        number of timeslots.
-        None implies that timeslots will be given in the tau array
+        Number of timeslots.  ``None`` implies that timeslots will be given in
+        the tau array.
 
     evo_time : float or None
-        total time for the evolution
-        None implies that timeslots will be given in the tau array
+        Total time for the evolution.  ``None`` implies that timeslots will be
+        given in the tau array.
 
     tau : array[num_tslots] of floats or None
-        durations for the timeslots.
-        if this is given then num_tslots and evo_time are dervived
-        from it
-        None implies that timeslot durations will be equal and
-        calculated as evo_time/num_tslots
+        Durations for the timeslots.  If this is given then ``num_tslots`` and
+        ``evo_time`` are dervived from it.  ``None`` implies that timeslot
+        durations will be equal and calculated as ``evo_time/num_tslots``.
 
     amp_lbound : float or list of floats
-        lower boundaries for the control amplitudes
-        Can be a scalar value applied to all controls
-        or a list of bounds for each control
+        Lower boundaries for the control amplitudes.  Can be a scalar value
+        applied to all controls or a list of bounds for each control.
 
     amp_ubound : float or list of floats
-        upper boundaries for the control amplitudes
-        Can be a scalar value applied to all controls
-        or a list of bounds for each control
+        Upper boundaries for the control amplitudes.  Can be a scalar value
+        applied to all controls or a list of bounds for each control.
 
     fid_err_targ : float
-        Fidelity error target. Pulse optimisation will
-        terminate when the fidelity error falls below this value
+        Fidelity error target. Pulse optimisation will terminate when the
+        fidelity error falls below this value.
 
     mim_grad : float
-        Minimum gradient. When the sum of the squares of the
-        gradients wrt to the control amplitudes falls below this
-        value, the optimisation terminates, assuming local minima
+        Minimum gradient. When the sum of the squares of the gradients wrt to
+        the control amplitudes falls below this value, the optimisation
+        terminates, assuming local minima.
 
     max_iter : integer
-        Maximum number of iterations of the optimisation algorithm
+        Maximum number of iterations of the optimisation algorithm.
 
     max_wall_time : float
-        Maximum allowed elapsed time for the optimisation algorithm
+        Maximum allowed elapsed time for the optimisation algorithm.
 
     alg : string
         Algorithm to use in pulse optimisation.
         Options are:
-            'GRAPE' (default) - GRadient Ascent Pulse Engineering
-            'CRAB' - Chopped RAndom Basis
+
+        - 'GRAPE' (default) - GRadient Ascent Pulse Engineering
+        - 'CRAB' - Chopped RAndom Basis
 
     alg_params : Dictionary
         options that are specific to the algorithm see above
 
     optim_params : Dictionary
-        The key value pairs are the attribute name and value
-        used to set attribute values
-        Note: attributes are created if they do not exist already,
-        and are overwritten if they do.
-        Note: method_params are applied afterwards and so may override these
+        The key value pairs are the attribute name and value used to set
+        attribute values.  Note: attributes are created if they do not exist
+        already, and are overwritten if they do.  Note: method_params are
+        applied afterwards and so may override these.
 
     optim_method : string
         a scipy.optimize.minimize method that will be used to optimise
@@ -1513,8 +1429,9 @@ def create_pulse_optimizer(
         Note the LBFGSB is equivalent to FMIN_L_BFGS_B for backwards
         capatibility reasons.
         Supplying DEF will given alg dependent result:
-            - GRAPE - Default optim_method is FMIN_L_BFGS_B
-            - CRAB - Default optim_method is Nelder-Mead
+
+        - GRAPE - Default optim_method is FMIN_L_BFGS_B
+        - CRAB - Default optim_method is Nelder-Mead
 
     method_params : dict
         Parameters for the optim_method.

--- a/qutip/eseries.py
+++ b/qutip/eseries.py
@@ -45,6 +45,10 @@ class eseries():
     Class representation of an exponential-series expansion of
     time-dependent quantum objects.
 
+    .. deprecated:: 4.6.0
+        :obj:`~eseries` will be removed in QuTiP 5.  Please use :obj:`~QobjEvo`
+        for general time-dependence.
+
     Attributes
     ----------
     ampl : ndarray

--- a/qutip/essolve.py
+++ b/qutip/essolve.py
@@ -77,6 +77,12 @@ def essolve(H, rho0, tlist, c_op_list, e_ops):
     the state vector at arbitrary points in time (`tlist`), or the
     expectation values of the supplied operators (`e_ops`).
 
+    .. deprecated:: 4.6.0
+        :obj:`~essolev` will be removed in QuTiP 5.  Please use :obj:`~sesolve`
+        or :obj:`~mesolve` for general-purpose integration of the
+        Schroedinger/Lindblad master equation.  This will likely be faster than
+        :obj:`~essolve` for you.
+
     Parameters
     ----------
     H : qobj/function_type
@@ -143,6 +149,11 @@ def ode2es(L, rho0):
     """Creates an exponential series that describes the time evolution for the
     initial density matrix (or state vector) `rho0`, given the Liouvillian
     (or Hamiltonian) `L`.
+
+    .. deprecated:: 4.6.0
+        :obj:`~ode2es` will be removed in QuTiP 5.  Please use
+        :obj:`Qobj.eigenstates` to get the eigenstates and -values, and use
+        :obj:`~QobjEvo` for general time-dependence.
 
     Parameters
     ----------

--- a/qutip/lattice.py
+++ b/qutip/lattice.py
@@ -254,39 +254,6 @@ class Lattice1d():
         The list of coupling terms between unit cells of the lattice.
     is_real : bool
         Indicates if the Hamiltonian is real or not.
-
-    Methods
-    -------
-    Hamiltonian()
-        Hamiltonian of the crystal.
-    basis()
-        basis with the particle localized at a certain cell, site with
-        specified degree of freedom.
-    distribute_operator()
-        Distributes an input operator over all the cells.
-    x()
-        Position operator for the crystal.
-    k()
-        Crystal momentum operator for the crystal.
-    operator_at_cells()
-        Distributes an input operator over user specified cells .
-    operator_between_cells()
-        A function that returns an operator matrix that applies an operator
-        between a two specified cells.
-    plot_dispersion()
-        Plots dispersion relation of the crystal.
-    get_dispersion()
-        Returns the dispersion relation of the crystal.
-    bloch_wave_functions()
-        Returns the eigenstates of the Hamiltonian (which are Bloch
-        wavefunctions) for a translationally symmetric periodic lattice.
-    array_of_unk()
-        Returns eigenvectors of the bulk Hamiltonian, i.e. the cell periodic
-        part of the Bloch wavefunctios in a numpy.ndarray for translationally
-        symmetric lattices with periodic boundary condition.
-    bulk_Hamiltonians()
-        Returns the bulk Hamiltonian for the lattice at the good quantum
-        numbers of lattice momentum, k in a numpy ndarray of Qobj's.
     """
     def __init__(self, num_cell=10, boundary="periodic", cell_num_site=1,
                  cell_site_dof=[1], Hamiltonian_of_cell=None,
@@ -834,6 +801,7 @@ class Lattice1d():
 
         .. math::
             :nowrap:
+
             \begin{eqnarray}
             |\psi_n(k) \rangle = |k \rangle \otimes | u_{n}(k) \rangle   \\
             | u_{n}(k) \rangle = a_n(k)|a\rangle  + b_n(k)|b\rangle \\
@@ -870,6 +838,7 @@ class Lattice1d():
 
         .. math::
             :nowrap:
+
             \begin{eqnarray}
             |\psi_n(k) \rangle = |k \rangle \otimes | u_{n}(k) \rangle   \\
             | u_{n}(k) \rangle = a_n(k)|a\rangle  + b_n(k)|b\rangle \\

--- a/qutip/measurement.py
+++ b/qutip/measurement.py
@@ -61,32 +61,32 @@ def _verify_input(op, state):
 
 
 def _measurement_statistics_povm_ket(state, ops):
-    '''
+    r"""
     Returns measurement statistics (resultant states and probabilities)
     for a measurements specified by a set of positive operator valued
     measurements on a specified ket.
 
     Parameters
     ----------
-    state : :class:.Qobj (ket)
+    state : :class:`.Qobj` (ket)
             The ket specifying the state to measure.
-    ops : list of :class:.Qobj
-          list of measurement operators M_i
-          (specifying a POVM s.t. E_i = dagger(M_i) * M_i)
+
+    ops : list of :class:`.Qobj`
+      List of measurement operators :math:`M_i` (specifying a POVM such that
+      :math:`E_i = M_i^\dagger M_i`).
 
 
     Returns
     -------
-    collapsed_states : List of :class:.Qobj (kets)
-                    the collapsed states (kets)
-                    obtained after measuring the qubits
-                    and obtaining the qubit specified by the target in the
-                    state specified by the index.
-    probabilities : List of floats
-                    the probability of measuring a state in a the state
-                    specified by the index.
-    '''
+    collapsed_states : list of :class:`.Qobj` (kets)
+        The collapsed states (kets) obtained after measuring the qubits and
+        obtaining the qubit specified by the target in the state specified by
+        the index.
 
+    probabilities : list of floats
+        The probability of measuring a state in a the state specified by the
+        index.
+    """
     probabilities = []
     collapsed_states = []
 
@@ -102,32 +102,31 @@ def _measurement_statistics_povm_ket(state, ops):
 
 
 def _measurement_statistics_povm_dm(density_mat, ops):
-    '''
+    r"""
     Returns measurement statistics (resultant states and probabilities)
     for a measurements specified by a set of positive operator valued
     measurements on a specified ket or density matrix.
 
     Parameters
     ----------
-    state : :class:.Qobj (density matrix)
-            The ket or density matrix specifying the state to measure.
-    ops : list of :class:.Qobj
-          list of measurement operators M_i
-          (specifying a POVM s.t. E_i = dagger(M_i) * M_i)
+    state : :class:`.Qobj` (density matrix)
+        The ket or density matrix specifying the state to measure.
 
+    ops : list of :class:`.Qobj`
+        List of measurement operators :math:`M_i` (specifying a POVM s.t.
+        :mathm:`E_i = M_i^\dagger M_i`)
 
     Returns
     -------
-    collapsed_states : List of :class:.Qobj
-                    the collapsed states (density matrices) obtained after
-                    measuring the qubits and obtaining the
-                    qubit specified by the target in the state
-                    specified by the index.
-    probabilities : List of floats
-                    the probability of measuring a state in a the state
-                    specified by the index.
-    '''
+    collapsed_states : list of :class:`.Qobj`
+        The collapsed states (density matrices) obtained after measuring the
+        qubits and obtaining the qubit specified by the target in the state
+        specified by the index.
 
+    probabilities : list of float
+        The probability of measuring a state in a the state specified by the
+        index.
+    """
     probabilities = []
     collapsed_states = []
 
@@ -144,22 +143,24 @@ def _measurement_statistics_povm_dm(density_mat, ops):
 
 
 def measurement_statistics_povm(state, ops, targets=None):
-    '''
-    Returns measurement statistics (resultant states and probabilities)
-    for a measurement specified by a set of positive operator valued
-    measurements on a specified ket or density matrix.
+    r"""
+    Returns measurement statistics (resultant states and probabilities) for a
+    measurement specified by a set of positive operator valued measurements on
+    a specified ket or density matrix.
 
     Parameters
     ----------
     state : :class:`.Qobj`
-            The ket or density matrix specifying the state to measure.
+        The ket or density matrix specifying the state to measure.
+
     ops : list of :class:`.Qobj`
-          list of measurement operators M_i or kets
-          Either:
-          1. specifying a POVM s.t. E_i = dagger(M_i) * M_i
-          2. projection operators if ops correspond to
-             projectors (s.t. E_i = dagger(M_i) = M_i)
-          3. kets (transformed to projectors)
+        List of measurement operators :math:`M_i` or kets.  Either:
+
+        1. specifying a POVM s.t. :math:`E_i = M_i^\dagger M_i`
+        2. projection operators if ops correspond to
+           projectors (s.t. :math:`E_i = M_i^\dagger = M_i`)
+        3. kets (transformed to projectors)
+
     targets : list of ints, optional
               Specifies a list of target "qubit" indices on which to apply
               the measurement using qutip.qip.gates.expand_operator to expand
@@ -168,15 +169,14 @@ def measurement_statistics_povm(state, ops, targets=None):
 
     Returns
     -------
-    collapsed_states : List of :class:`.Qobj`
-                    the collapsed states obtained after measuring the qubits
-                    and obtaining the qubit specified by the target in the
-                    state specified by the index.
-    probabilities : List of floats
-                    the probability of measuring a state in a the state
-                    specified by the index.
-    '''
+    collapsed_states : list of :class:`.Qobj`
+        The collapsed states obtained after measuring the qubits and obtaining
+        the qubit specified by the target in the state specified by the index.
 
+    probabilities : list of floats
+        The probability of measuring a state in a the state specified by the
+        index.
+    """
     if all(map(lambda x: x.isket, ops)):
         ops = [op * op.dag() for op in ops]
 
@@ -208,27 +208,29 @@ def measurement_statistics_observable(state, op, targets=None):
     ----------
     state : :class:`.Qobj`
         The ket or density matrix specifying the state to measure.
+
     op : :class:`.Qobj`
         The measurement operator.
-    targets : list of ints, optional
-              Specifies a list of targets "qubit" indices on which to apply
-              the measurement using :func:qutip.qip.gates.expand_operator
-              to expand op into full dimension.
 
+    targets : list of ints, optional
+        Specifies a list of targets "qubit" indices on which to apply the
+        measurement using :func:`qutip.qip.gates.expand_operator` to expand op
+        into full dimension.
 
     Returns
     -------
-    eigenvalues: List of floats
+    eigenvalues: list of float
         The list of eigenvalues of the measurement operator.
-    eigenstates_or_projectors: List of :class:`.Qobj`
+
+    eigenstates_or_projectors: list of :class:`.Qobj`
         If the state was a ket, return the eigenstates of the measurement
         operator. Otherwise return the projectors onto the eigenstates.
-    probabilities: List of floats
-        The probability of measuring the state as being in the
-        corresponding eigenstate (and the measurement result being
-        the corresponding eigenvalue).
-    """
 
+    probabilities: list of float
+        The probability of measuring the state as being in the corresponding
+        eigenstate (and the measurement result being the corresponding
+        eigenvalue).
+    """
     if targets:
         N = int(np.log2(state.shape[0]))
         op = expand_operator(op, N=N, targets=targets)
@@ -249,32 +251,31 @@ def measure_observable(state, op, targets=None):
     """
     Perform a measurement specified by an operator on the given state.
 
-    This function simulates the classic quantum measurement described
-    in many introductory texts on quantum mechanics. The measurement
-    collapses the state to one of the eigenstates of the given
-    operator and the result of the measurement is the corresponding
-    eigenvalue.
+    This function simulates the classic quantum measurement described in many
+    introductory texts on quantum mechanics. The measurement collapses the
+    state to one of the eigenstates of the given operator and the result of the
+    measurement is the corresponding eigenvalue.
 
     Parameters
     ----------
     state : :class:`.Qobj`
         The ket or density matrix specifying the state to measure.
+
     op : :class:`.Qobj`
         The measurement operator.
-    targets : list of ints, optional
-              Specifies a list of target "qubit" indices on which to apply
-              the measurement using :func:qutip.qip.gates.expand_operator
-              to expand op into full dimension.
 
+    targets : list of ints, optional
+        Specifies a list of target "qubit" indices on which to apply the
+        measurement using :func:`qutip.qip.gates.expand_operator` to expand op
+        into full dimension.
 
     Returns
     -------
     measured_value : float
         The result of the measurement (one of the eigenvalues of op).
-    state : :class:`.Qobj`
-        The new state (a ket if a ket was given, otherwise a density
-        matrix).
 
+    state : :class:`.Qobj`
+        The new state (a ket if a ket was given, otherwise a density matrix).
 
     Examples
     --------
@@ -329,39 +330,40 @@ def measure_observable(state, op, targets=None):
 
 
 def measure_povm(state, ops, targets=None):
-    """
+    r"""
     Perform a measurement specified by list of POVMs.
 
-    This function simulates a POVM measurement. The measurement
-    collapses the state to one of the resultant states of the measurement
-    and returns the index of the operator corresponding to the collapsed
-    state as well as the collapsed state.
+    This function simulates a POVM measurement. The measurement collapses the
+    state to one of the resultant states of the measurement and returns the
+    index of the operator corresponding to the collapsed state as well as the
+    collapsed state.
 
     Parameters
     ----------
     state : :class:`.Qobj`
-            The ket or density matrix specifying the state to measure.
-    ops : list of :class:.Qobj
-          list of measurement operators M_i or kets
-          Either:
-          1. specifying a POVM s.t. E_i = dagger(M_i) * M_i
-          2. projection operators if ops correspond to
-             projectors (s.t. E_i = dagger(M_i) = M_i)
-          3. kets (transformed to projectors)
+        The ket or density matrix specifying the state to measure.
+
+    ops : list of :class:`.Qobj`
+        List of measurement operators :math:`M_i` or kets.  Either:
+
+        1. specifying a POVM s.t. :math:`E_i = M_i^\dagger M_i`
+        2. projection operators if ops correspond to projectors (s.t.
+           :math:`E_i = M_i^\dagger = M_i`)
+        3. kets (transformed to projectors)
+
     targets : list of ints, optional
-              Specifies a list of target "qubit" indices on which to apply
-              the measurement using :func:`qutip.qip.gates.expand_operator`
-              to expand ops into full dimension.
+        Specifies a list of target "qubit" indices on which to apply
+        the measurement using :func:`qutip.qip.gates.expand_operator`
+        to expand ``ops`` into full dimension.
 
     Returns
     -------
     index : float
         The resultant index of the measurement.
-    state : :class:`.Qobj`
-        The new state (a ket if a ket was given, otherwise a density
-        matrix).
-    """
 
+    state : :class:`.Qobj`
+        The new state (a ket if a ket was given, otherwise a density matrix).
+    """
     collapsed_states, probabilities = measurement_statistics_povm(state,
                                                                   ops, targets)
     index = np.random.choice(range(len(collapsed_states)), p=probabilities)
@@ -370,35 +372,36 @@ def measure_povm(state, ops, targets=None):
 
 
 def measurement_statistics(state, ops, targets=None):
-    """
-    A dispatch method that provides measurement statistics
-    handling both observable style measurements
-    and projector style measurements(POVMs and PVMs).
+    r"""
+    A dispatch method that provides measurement statistics handling both
+    observable style measurements and projector style measurements(POVMs and
+    PVMs).
 
     For return signatures, please check:
-    - :func:`qutip.measurement.measurement_statistics_observable`
-      for observable measurements.
-    - :func:`qutip.measurement.measurement_statistics_povm` for povm measurements.
+
+    - :func:`~measurement_statistics_observable` for observable measurements.
+    - :func:`~measurement_statistics_povm` for POVM measurements.
 
     Parameters
     ----------
     state : :class:`.Qobj`
-            The ket or density matrix specifying the state to measure.
-    ops : :class:`.Qobj` or list of :class:`.Qobj`
-          - measurement observable (:class:.Qobj)
-          or
-          - list of measurement operators M_i or kets (list of :class:.Qobj)
-            Either:
-            1. specifying a POVM s.t. E_i = dagger(M_i) * M_i
-            2. projection operators if ops correspond to
-               projectors (s.t. E_i = dagger(M_i) = M_i)
-            3. kets (transformed to projectors)
-    targets : list of ints, optional
-              Specifies a list of target "qubit" indices on which to apply
-              the measurement using :func:qutip.qip.gates.expand_operator
-              to expand ops into full dimension.
-    """
+        The ket or density matrix specifying the state to measure.
 
+    ops : :class:`.Qobj` or list of :class:`.Qobj`
+        - measurement observable (:class:.Qobj); or
+        - list of measurement operators :math:`M_i` or kets (list of
+          :class:`.Qobj`) Either:
+
+          1. specifying a POVM s.t. :math:`E_i = M_i^\dagger * M_i`
+          2. projection operators if ops correspond to projectors (s.t.
+             :math:`E_i = M_i^\dagger = M_i`)
+          3. kets (transformed to projectors)
+
+    targets : list of ints, optional
+        Specifies a list of target "qubit" indices on which to apply the
+        measurement using :func:`qutip.qip.gates.expand_operator` to expand ops
+        into full dimension.
+    """
     if isinstance(ops, list):
         return measurement_statistics_povm(state, ops, targets)
     else:
@@ -406,34 +409,36 @@ def measurement_statistics(state, ops, targets=None):
 
 
 def measure(state, ops, targets=None):
-    """
-    A dispatch method that provides measurement results
-    handling both observable style measurements
-    and projector style measurements(POVMs and PVMs).
+    r"""
+    A dispatch method that provides measurement results handling both
+    observable style measurements and projector style measurements (POVMs and
+    PVMs).
 
     For return signatures, please check:
-    - :func:`qutip.measurement.measure_observable` for observable measurements.
-    - :func:`qutip.measurement.measure_povm` for povm measurements.
+
+    - :func:`~measure_observable` for observable measurements.
+    - :func:`~measure_povm` for POVM measurements.
 
     Parameters
     ----------
     state : :class:`.Qobj`
-            The ket or density matrix specifying the state to measure.
-    ops : :class:`.Qobj` or list of :class:`.Qobj`
-          - measurement observable (:class:`.Qobj`)
-          or
-          - list of measurement operators M_i or kets (list of :class:`.Qobj`)
-            Either:
-            1. specifying a POVM s.t. E_i = dagger(M_i) * M_i
-            2. projection operators if ops correspond to
-               projectors (s.t. E_i = dagger(M_i) = M_i)
-            3. kets (transformed to projectors)
-    targets : list of ints, optional
-              Specifies a list of target "qubit" indices on which to apply
-              the measurement using :func:qutip.qip.gates.expand_operator
-              to expand ops into full dimension.
-    """
+        The ket or density matrix specifying the state to measure.
 
+    ops : :class:`.Qobj` or list of :class:`.Qobj`
+        - measurement observable (:class:`.Qobj`); or
+        - list of measurement operators :math:`M_i` or kets (list of
+          :class:`.Qobj`) Either:
+
+          1. specifying a POVM s.t. :math:`E_i = M_i^\dagger M_i`
+          2. projection operators if ops correspond to projectors (s.t.
+             :math:`E_i = M_i^\dagger = M_i`)
+          3. kets (transformed to projectors)
+
+    targets : list of ints, optional
+        Specifies a list of target "qubit" indices on which to apply the
+        measurement using :func:`qutip.qip.gates.expand_operator` to expand ops
+        into full dimension.
+    """
     if isinstance(ops, list):
         return measure_povm(state, ops, targets)
     else:

--- a/qutip/nonmarkov/heom.py
+++ b/qutip/nonmarkov/heom.py
@@ -206,12 +206,14 @@ class HEOMSolver(object):
         """
         Creates a new stats object suitable for use with this solver
         Note: this solver expects the stats object to have sections
-            config
-            integrate
+
+        - config
+        - integrate
         """
         stats = Stats(['config', 'run'])
         stats.header = "Hierarchy Solver Stats"
         return stats
+
 
 class HSolverDL(HEOMSolver):
     """

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -648,10 +648,10 @@ def energy_degeneracy(N, m):
 
 
 def state_degeneracy(N, j):
-    """Calculate the degeneracy of the Dicke state.
+    r"""Calculate the degeneracy of the Dicke state.
 
-    Each state :math:`|j, m\\rangle` includes D(N,j) irreducible
-    representations :math:`|j, m, \\alpha\\rangle`.
+    Each state :math:`\lvert j, m\rangle` includes D(N,j) irreducible
+    representations :math:`\lvert j, m, \alpha\rangle`.
 
     Uses Decimals to calculate higher numerator and denominators numbers.
 
@@ -679,7 +679,7 @@ def state_degeneracy(N, j):
 
 
 def m_degeneracy(N, m):
-    """Calculate the number of Dicke states :math:`|j, m\\rangle` with
+    r"""Calculate the number of Dicke states :math:`\lvert j, m\rangle` with
     same energy.
 
     Parameters
@@ -707,15 +707,16 @@ def m_degeneracy(N, m):
 
 
 def ap(j, m):
-    """Calculate the coefficient `ap` by applying J_+ |j, m>.
+    r"""
+    Calculate the coefficient ``ap`` by applying :math:`J_+\lvert j,m\rangle`.
 
     The action of ap is given by:
-    :math:`J_{+}|j, m\\rangle = A_{+}(j, m)|j, m+1\\rangle`
+    :math:`J_{+}\lvert j, m\rangle = A_{+}(j, m) \lvert j, m+1\rangle`
 
     Parameters
     ----------
     j, m: float
-        The value for j and m in the dicke basis |j,m>.
+        The value for j and m in the dicke basis :math:`\lvert j, m\rangle`.
 
     Returns
     -------
@@ -727,9 +728,10 @@ def ap(j, m):
 
 
 def am(j, m):
-    """Calculate the operator `am` used later.
+    r"""Calculate the operator ``am`` used later.
 
-    The action of ap is given by: J_{-}|j, m> = A_{-}(jm)|j, m-1>
+    The action of ``ap`` is given by:
+    :math:`J_{-}\lvert j,m\rangle = A_{-}(jm)\lvert j,m-1\rangle`
 
     Parameters
     ----------
@@ -878,10 +880,10 @@ def _jspin_uncoupled(N, op=None):
 
 
 def jspin(N, op=None, basis="dicke"):
-    """
+    r"""
     Calculate the list of collective operators of the total algebra.
 
-    The Dicke basis :math:`|j,m\\rangle\\langle j,m'|` is used by
+    The Dicke basis :math:`\lvert j,m\rangle\langle j,m'\rvert` is used by
     default. Otherwise with "uncoupled" the operators are in a
     :math:`2^N` space.
 
@@ -1052,15 +1054,15 @@ def collapse_uncoupled(
 
 # State definitions in the Dicke basis with an option for basis transformation
 def dicke_basis(N, jmm1=None):
-    """
+    r"""
     Initialize the density matrix of a Dicke state for several (j, m, m1).
 
     This function can be used to build arbitrary states in the Dicke basis
-    :math:`|j, m\\rangle \\langle j, m^{\\prime}|`. We create coefficients for each
-    (j, m, m1) value in the dictionary jmm1. The mapping for the (i, k)
-    index of the density matrix to the |j, m> values is given by the
-    cythonized function `jmm1_dictionary`. A density matrix is created from
-    the given dictionary of coefficients for each (j, m, m1).
+    :math:`\lvert j, m\rangle\langle j, m'\rvert`. We create coefficients for
+    each (j, m, m1) value in the dictionary jmm1. The mapping for the (i, k)
+    index of the density matrix to the :math:`\lvert j, m\rangle` values is
+    given by the cythonized function `jmm1_dictionary`. A density matrix is
+    created from the given dictionary of coefficients for each (j, m, m1).
 
     Parameters
     ----------
@@ -1092,11 +1094,11 @@ def dicke_basis(N, jmm1=None):
 
 
 def dicke(N, j, m):
-    """
+    r"""
     Generate a Dicke state as a pure density matrix in the Dicke basis.
 
     For instance, the superradiant state given by
-    :math:`|j, m\\rangle = |1, 0\\rangle` for N = 2,
+    :math:`\lvert  j, m\rangle = \lvert 1, 0\rangle` for N = 2,
     and the state is represented as a density matrix of size (nds, nds) or
     (4, 4), with the (1, 1) element set to 1.
 
@@ -1229,7 +1231,7 @@ def _uncoupled_css(N, a, b):
     dimensional Hilbert space.
 
     The CSS states are non-entangled states given by
-    :math:`|a, b\\rangle = \\prod_i (a|1\\rangle_i + b|0\\rangle_i)`.
+    :math:`\lvert a,b\rangle = \prod_i(a\lvert1\rangle_i + b\lvert0\rangle_i)`.
 
     Parameters
     ----------
@@ -1237,10 +1239,10 @@ def _uncoupled_css(N, a, b):
         The number of two-level systems.
 
     a: complex
-        The coefficient of the :math:`|1_i\rangle` state.
+        The coefficient of the :math:`\lvert1_i\rangle` state.
 
     b: complex
-        The coefficient of the :math:`|0_i\rangle` state.
+        The coefficient of the :math:`\lvert0_i\rangle` state.
 
     Returns
     -------
@@ -1344,17 +1346,17 @@ def css(
     basis="dicke",
     coordinates="cartesian",
 ):
-    """
+    r"""
     Generate the density matrix of the Coherent Spin State (CSS).
 
     It can be defined as,
-    :math:`|CSS \\rangle = \\prod_i^N(a|1\\rangle_i + b|0\\rangle_i)`
-    with :math:`a = sin(\\frac{\\theta}{2})`,
-    :math:`b = e^{i \\phi}\\cos(\\frac{\\theta}{2})`.
+    :math:`\lvert CSS\rangle = \prod_i^N(a\lvert1\rangle_i+b\lvert0\rangle_i)`
+    with :math:`a = sin(\frac{\theta}{2})`,
+    :math:`b = e^{i \phi}\cos(\frac{\theta}{2})`.
     The default basis is that of Dicke space
-    :math:`|j, m\\rangle \\langle j, m'|`.
+    :math:`\lvert j, m\rangle \langle j, m'\rvert`.
     The default state is the symmetric CSS,
-    :math:`|CSS\\rangle = |+\\rangle`.
+    :math:`\lvert CSS\rangle = \lvert+\rangle`.
 
     Parameters
     ----------

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -342,8 +342,8 @@ def purity_dicke(rho):
 class Dicke(object):
     """The Dicke class which builds the Lindbladian and Liouvillian matrix.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from piqs import Dicke, jspin
     >>> N = 2
     >>> jx, jy, jz = jspin(N)

--- a/qutip/qip/device/optpulseprocessor.py
+++ b/qutip/qip/device/optpulseprocessor.py
@@ -102,32 +102,40 @@ class OptPulseProcessor(Processor):
 
         Examples
         --------
-        # Same parameter for all the gates
-        qc = QubitCircuit(N=1)
-        qc.add_gate("SNOT", 0)
 
-        num_tslots = 10
-        evo_time = 10
-        processor = OptPulseProcessor(N=1, drift=sigmaz(), ctrls=[sigmax()])
-        # num_tslots and evo_time are two keyword arguments
-        tlist, coeffs = processor.load_circuit(
-            qc, num_tslots=num_tslots, evo_time=evo_time)
+        Same parameter for all the gates
 
-        # Different parameters for different gates
-        qc = QubitCircuit(N=2)
-        qc.add_gate("SNOT", 0)
-        qc.add_gate("SWAP", targets=[0, 1])
-        qc.add_gate('CNOT', controls=1, targets=[0])
+        .. code-block:: python
 
-        processor = OptPulseProcessor(N=2, drift=tensor([sigmaz()]*2))
-        processor.add_control(sigmax(), cyclic_permutation=True)
-        processor.add_control(sigmay(), cyclic_permutation=True)
-        processor.add_control(tensor([sigmay(), sigmay()]))
-        setting_args = {"SNOT": {"num_tslots": 10, "evo_time": 1},
-                        "SWAP": {"num_tslots": 30, "evo_time": 3},
-                        "CNOT": {"num_tslots": 30, "evo_time": 3}}
-        tlist, coeffs = processor.load_circuit(qc, setting_args=setting_args,
-                                               merge_gates=False)
+            qc = QubitCircuit(N=1)
+            qc.add_gate("SNOT", 0)
+            num_tslots = 10
+            evo_time = 10
+            processor = OptPulseProcessor(N=1, drift=sigmaz(),
+                                          ctrls=[sigmax()])
+            # num_tslots and evo_time are two keyword arguments
+            tlist, coeffs = processor.load_circuit(
+                qc, num_tslots=num_tslots, evo_time=evo_time)
+
+        Different parameters for different gates
+
+        .. code-block:: python
+
+            qc = QubitCircuit(N=2)
+            qc.add_gate("SNOT", 0)
+            qc.add_gate("SWAP", targets=[0, 1])
+            qc.add_gate('CNOT', controls=1, targets=[0])
+
+            processor = OptPulseProcessor(N=2, drift=tensor([sigmaz()]*2))
+            processor.add_control(sigmax(), cyclic_permutation=True)
+            processor.add_control(sigmay(), cyclic_permutation=True)
+            processor.add_control(tensor([sigmay(), sigmay()]))
+            setting_args = {"SNOT": {"num_tslots": 10, "evo_time": 1},
+                            "SWAP": {"num_tslots": 30, "evo_time": 3},
+                            "CNOT": {"num_tslots": 30, "evo_time": 3}}
+            tlist, coeffs = processor.load_circuit(qc,
+                                                   setting_args=setting_args,
+                                                   merge_gates=False)
 
         Parameters
         ----------
@@ -149,10 +157,11 @@ class OptPulseProcessor(Processor):
             It is a dictionary containing keyword arguments
             for different gates.
 
-            E.g:
-            setting_args = {"SNOT": {"num_tslots": 10, "evo_time": 1},
-                            "SWAP": {"num_tslots": 30, "evo_time": 3},
-                            "CNOT": {"num_tslots": 30, "evo_time": 3}}
+            E.g: ::
+
+                setting_args = {"SNOT": {"num_tslots": 10, "evo_time": 1},
+                                "SWAP": {"num_tslots": 30, "evo_time": 3},
+                                "CNOT": {"num_tslots": 30, "evo_time": 3}}
 
         verbose: boolean, optional
             If true, the information for each decomposed gate
@@ -173,8 +182,8 @@ class OptPulseProcessor(Processor):
 
         Notes
         -----
-        len(tlist)-1=coeffs.shape[1] since tlist gives the beginning and the
-        end of the pulses
+        ``len(tlist) - 1 = coeffs.shape[1]`` since tlist gives the beginning
+        and the end of the pulses.
         """
         if setting_args is None:
             setting_args = {}

--- a/qutip/qip/device/optpulseprocessor.py
+++ b/qutip/qip/device/optpulseprocessor.py
@@ -103,7 +103,7 @@ class OptPulseProcessor(Processor):
         Examples
         --------
 
-        Same parameter for all the gates
+        Same parameter for all the gates:
 
         .. code-block:: python
 
@@ -117,7 +117,7 @@ class OptPulseProcessor(Processor):
             tlist, coeffs = processor.load_circuit(
                 qc, num_tslots=num_tslots, evo_time=evo_time)
 
-        Different parameters for different gates
+        Different parameters for different gates:
 
         .. code-block:: python
 
@@ -157,7 +157,7 @@ class OptPulseProcessor(Processor):
             It is a dictionary containing keyword arguments
             for different gates.
 
-            E.g: ::
+            E.g.: ::
 
                 setting_args = {"SNOT": {"num_tslots": 10, "evo_time": 1},
                                 "SWAP": {"num_tslots": 30, "evo_time": 3},

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -57,12 +57,10 @@ __all__ = ['Processor']
 class Processor(object):
     """
     A simulator of a quantum device based on the QuTiP solver
-    :func:`qutip.mesolve`.
-    It is defined by the available driving Hamiltonian and
-    the decoherence time for each component systems.
-    The processor can simulate the evolution under the given
-    control pulses. Noisy evolution is supported by
-    :class:`.Noise` and can be added to the processor.
+    :func:`qutip.mesolve`.  It is defined by the available driving Hamiltonian
+    and the decoherence time for each component systems.  The processor can
+    simulate the evolution under the given control pulses. Noisy evolution is
+    supported by :class:`.Noise` and can be added to the processor.
 
     Parameters
     ----------
@@ -84,17 +82,17 @@ class Processor(object):
 
     spline_kind: str, optional
         Type of the coefficient interpolation. Default is "step_func"
-        Note that they have different requirement for the length of `coeff'.
+        Note that they have different requirement for the length of ``coeff``.
 
-        -"step_func":
-        The coefficient will be treated as a step function.
-        E.g. ``tlist=[0,1,2]`` and ``coeff=[3,2]``, means that the coefficient
-        is 3 in t=[0,1) and 2 in t=[2,3). It requires
-        ``len(coeff)=len(tlist)-1`` or ``len(coeff)=len(tlist)``, but
-        in the second case the last element of `coeff` has no effect.
+        - "step_func":
+          The coefficient will be treated as a step function.  E.g.
+          ``tlist=[0,1,2]`` and ``coeff=[3,2]``, means that the coefficient is
+          3 in t=[0,1) and 2 in t=[2,3). It requires
+          ``len(coeff)=len(tlist)-1`` or ``len(coeff)=len(tlist)``, but in the
+          second case the last element of `coeff` has no effect.
 
-        -"cubic": Use cubic interpolation for the coefficient. It requires
-        ``len(coeff)=len(tlist)``
+        - "cubic": Use cubic interpolation for the coefficient. It requires
+          ``len(coeff)=len(tlist)``
 
     Attributes
     ----------

--- a/qutip/qip/pulse.py
+++ b/qutip/qip/pulse.py
@@ -370,8 +370,8 @@ class Pulse():
 
     def get_noisy_qobjevo(self, dims):
         """
-        Get the `QobjEvo` representation of the noisy evolution. The result
-        can be used directly as input for the qutip solvers.
+        Get the :obj:`.QobjEvo` representation of the noisy evolution. The
+        result can be used directly as input for the qutip solvers.
 
         Parameters
         ----------
@@ -383,7 +383,7 @@ class Pulse():
         Returns
         -------
         noisy_evo: :class:`qutip.QobjEvo`
-            A `QobjEvo` representing the ideal evolution and coherent noise.
+            A ``QobjEvo`` representing the ideal evolution and coherent noise.
         c_ops: list of :class:`qutip.QobjEvo`
             A list of (time-dependent) lindbald operators.
         """
@@ -401,14 +401,14 @@ class Pulse():
 
     def get_full_tlist(self, tol=1.0e-10):
         """
-        Return the full tlist of the pulses and noise.
-        It means that if different `tlist`s are present, they will be merged
-        to one with all time points stored in a sorted array.
+        Return the full tlist of the pulses and noise.  It means that if
+        different ``tlist`` are present, they will be merged to one with all
+        time points stored in a sorted array.
 
         Returns
         -------
         full_tlist: array-like 1d
-            The full time sequence for the nosiy evolution.
+            The full time sequence for the noisy evolution.
         """
         # TODO add test
         all_tlists = []

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1588,11 +1588,10 @@ class Qobj(object):
         elem : complex
             Complex valued matrix element.
 
-        Note
-        ----
+        Notes
+        -----
         It is slightly more computationally efficient to use a ket
         vector for the 'bra' input.
-
         """
         if not self.isoper:
             raise TypeError("Can only get matrix elements for an operator.")

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -188,6 +188,7 @@ class StateArgs:
     def __call__(self):
         return self.dyn_args
 
+
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # object for each time dependent element of the QobjEvo
 # qobj : the Qobj of element ([*Qobj*, f])
@@ -195,6 +196,18 @@ class StateArgs:
 # coeff : The coeff as a string, array or function as provided by the user.
 # type : flag for the type of coeff
 class EvoElement:
+    """
+    Internal type used to represent the time-dependent parts of a
+    :class:`~QobjEvo`.
+
+    Availables "types" are
+
+    1. function
+    2. string
+    3. ``np.ndarray``
+    4. :class:`.Cubic_Spline`
+    """
+
     def __init__(self, qobj, get_coeff, coeff, type):
         self.qobj = qobj
         self.get_coeff = get_coeff
@@ -217,21 +230,23 @@ class EvoElement:
 
 
 class QobjEvo:
-    """A class for representing time-dependent quantum objects,
-    such as quantum operators and states.
+    """
+    A class for representing time-dependent quantum objects, such as quantum
+    operators and states.
 
-    The QobjEvo class is a representation of time-dependent Qutip quantum
-    objects (Qobj). This class implements math operations :
-        +,- : QobjEvo, Qobj
-        * : Qobj, C-number
-        / : C-number
-    and some common linear operator/state operations. The QobjEvo
-    are constructed from a nested list of Qobj with their time-dependent
-    coefficients. The time-dependent coefficients are either a funciton, a
-    string or a numpy array.
+    Basic math operations are defined:
 
-    For function format, the function signature must be f(t, args).
-    *Examples*
+    - ``+``, ``-`` : :class:`~QobjEvo`, :class:`~Qobj`, scalars.
+    - ``*``: :class:`~Qobj`, C number
+    - ``/`` : C number
+
+    **Time-dependence formats**
+
+    For function format, the function signature must be
+    ``f(t: float, args: dict) -> complex``, for example
+
+    .. code-block:: python
+
         def f1_t(t, args):
             return np.exp(-1j * t * args["w1"])
 
@@ -240,207 +255,147 @@ class QobjEvo:
 
         H = QobjEvo([H0, [H1, f1_t], [H2, f2_t]], args={"w1":1., "w2":2.})
 
-    For string based coeffients, the string must be a compilable python code
+    For string-based coeffients, the string must be a compilable python code
     resulting in a complex. The following symbols are defined:
-        sin cos tan asin acos atan pi
-        sinh cosh tanh asinh acosh atanh
-        exp log log10 erf zerf sqrt
-        real imag conj abs norm arg proj
-        numpy as np, and scipy.special as spe.
-    *Examples*
+
+    .. code-block::
+
+        pi   exp   log   log10
+        erf  zerf  norm  proj
+        real imag conj abs arg
+        sin  sinh  asin  asinh
+        cos  cosh  acos  acosh
+        tan  tanh  atan  atanh
+        numpy as np
+        scipy.special as spe
+
+    A couple more simple examples:
+
+    .. code-block:: python
+
         H = QobjEvo([H0, [H1, 'exp(-1j*w1*t)'], [H2, 'cos(w2*t)']],
                     args={"w1":1.,"w2":2.})
 
-    For numpy array format, the array must be an 1d of dtype float or complex.
-    A list of times (float64) at which the coeffients must be given (tlist).
-    The coeffients array must have the same len as the tlist.
-    The time of the tlist do not need to be equidistant, but must be sorted.
-    By default, a cubic spline interpolation will be used for the coefficient
-    at time t.
-    If the coefficients are to be treated as step function, use the arguments
-    args = {"_step_func_coeff": True}
-    *Examples*
+    For numpy array format, the array must be an 1d of dtype ``np.float64`` or
+    ``np.complex128``.  A list of times (``np.float64``) at which the
+    coeffients must be given as ``tlist``.  The coeffients array must have the
+    same length as the tlist.  The times of the tlist do not need to be
+    equidistant, but must be sorted.  By default, a cubic spline interpolation
+    will be used for the coefficient at time t.  If the coefficients are to be
+    treated as step functions, use the arguments
+    ``args = {"_step_func_coeff": True}``.  Examples of array-format usage are:
+
+    .. code-block:: python
+
         tlist = np.logspace(-5,0,100)
         H = QobjEvo([H0, [H1, np.exp(-1j*tlist)], [H2, np.cos(2.*tlist)]],
                     tlist=tlist)
 
-    args is a dict of (name:object). The name must be a valid variables string.
-    Some solvers support arguments that update at each call:
-    sesolve, mesolve, mcsolve:
-        state can be obtained with:
-            "state_vec":psi0, args["state_vec"] = state as 1D np.ndarray
-            "state_mat":psi0, args["state_mat"] = state as 2D np.ndarray
-            "state":psi0, args["state"] = state as Qobj
+    Mixing time formats is allowed.  It is not possible to create a single
+    ``QobjEvo`` that contains different ``tlist`` values, however.
 
-            This Qobj is the initial value.
+    **Passing arguments**
 
-        expectation values:
-            "expect_op_n":0, args["expect_op_n"] = expect(e_ops[int(n)], state)
-            expect is <phi|O|psi> or tr(state * O) depending on state dimensions
+    ``args`` is a dict of (name: object). The name must be a valid Python
+    identifier string, and in general the object can be any type that is
+    supported by the code to be compiled in the string.
 
-    mcsolve:
-        collapse can be obtained with:
-            "collapse":list => args[name] == list of collapse
-            each collapse will be appended to the list as (time, which c_ops)
+    There are some "magic" names that can be specified, whose objects will be
+    overwritten when used within :func:`.sesolve`, :func:`.mesolve` and
+    :func:`.mcsolve`.  This allows access to the solvers' internal states, and
+    they are updated at every call.  The initial values of these dictionary
+    elements is unimportant.  The magic names available are:
 
-    Mixing the formats is possible, but not recommended.
-    Mixing tlist will cause problem.
+    - ``"state"``: the current state as a :class:`~Qobj`
+    - ``"state_vec"``: the current state as a column-stacked 1D ``np.ndarray``
+    - ``"state_mat"``: the current state as a 2D ``np.ndarray``
+    - ``"expect_op_<n>"``: the current expectation value of the element
+      ``e_ops[n]``, which is an argument to the solvers.  Replace ``<n>`` with
+      an integer literal, e.g. ``"expect_op_0"``.  This will be either real- or
+      complex-valued, depending on whether the state and operator are both
+      Hermitian or not.
+    - ``"collapse"``: (:func:`.mcsolve` only) a list of the collapses that have
+      occurred during the evolution.  Each element of the list is a 2-tuple
+      ``(time: float, which: int)``, where ``time`` is the time this collapse
+      happened, and ``which`` is an integer indexing the ``c_ops`` argument to
+      :func:`.mcsolve`.
 
     Parameters
     ----------
-    QobjEvo(Q_object=[], args={}, tlist=None)
+    Q_object : list, :class:`~Qobj` or :class:`~QobjEvo`
+        The time-dependent description of the quantum object.  This is of the
+        same format as the first parameter to the general ODE solvers; in
+        general, it is a list of ``[Qobj, time_dependence]`` pairs that are
+        summed to make the whole object.  The ``time_dependence`` can be any of
+        the formats discussed in the previous section.  If a particular term
+        has no time-dependence, then you should just give the ``Qobj`` instead
+        of the 2-element list.
 
-    Q_object : array_like
-        Data for vector/matrix representation of the quantum object.
+    args : dict, optional
+        Mapping of ``{str: object}``, discussed in greater detail above.  The
+        strings can be any valid Python identifier, and the objects are of the
+        consumable types.  See the previous section for details on the "magic"
+        names used to access solver internals.
 
-    args : dictionary that contain the arguments for
+    tlist : array_like, optional
+        List of the times any numpy-array coefficients describe.  This is used
+        only in at least one of the time dependences in ``Q_object`` is given
+        in Numpy-array format.  The times must be sorted, but need not be
+        equidistant.  Values inbetween will be interpolated.
 
-    tlist : array_like
-        List of times at which the numpy-array coefficients are applied. Times
-        must be equidistant and start from 0.
 
     Attributes
     ----------
-    cte : Qobj
-        Constant part of the QobjEvo
+    cte : :class:`~Qobj`
+        Constant part of the QobjEvo.
 
-    ops : list of EvoElement
-        List of Qobj and the coefficients.
-        [(Qobj, coefficient as a function, original coefficient,
-            type, local arguments ), ... ]
-        type :
-            1: function
-            2: string
-            3: np.array
-            4: Cubic_Spline
+    ops : list of :class:`.EvoElement`
+        Internal representation of the time-dependence structure of the
+        elements.
 
-    args : map
-        arguments of the coefficients
+    args : dict
+        The current value of the ``args`` dictionary passed into the
+        constructor.
 
     dynamics_args : list
-        arguments that change during evolution
+        Names of the dynamic arguments that the solvers will generate.  These
+        are the magic names that were found in the ``args`` parameter.
 
     tlist : array_like
         List of times at which the numpy-array coefficients are applied.
 
-    compiled : string
-        Has the cython version of the QobjEvo been created
+    compiled : str
+        A string representing the properties of the low-level Cython class
+        backing this object (may be empty).
 
-    compiled_qobjevo : cy_qobj (CQobjCte or CQobjEvoTd)
-        Cython version of the QobjEvo
+    compiled_qobjevo : ``CQobjCte`` or ``CQobjEvoTd``
+        Cython version of the QobjEvo.
 
-    coeff_get : callable object
-        object called to obtain a list of coefficient at t
+    coeff_get : callable
+        Object called to obtain a list of all the coefficients at a particular
+        time.
 
     coeff_files : list
-        runtime created files to delete with the instance
+        Runtime created files to delete with the instance.
 
     dummy_cte : bool
-        is self.cte a empty Qobj
+        Is self.cte an empty Qobj
 
     const : bool
-        Indicates if quantum object is Constant
+        Indicates if quantum object is constant
 
-    type : string
-        information about the type of coefficient
-            "string", "func", "array",
-            "spline", "mixed_callable", "mixed_compilable"
+    type : {"cte", "string", "func", "array", "spline", "mixed_callable", \
+"mixed_compilable"}
+        Information about the type of coefficients used in the entire object.
 
     num_obj : int
-        number of Qobj in the QobjEvo : len(ops) + (1 if not dummy_cte)
+        Number of :obj:`~Qobj` in the QobjEvo.
 
     use_cython : bool
-        flag to compile string to cython or python
+        Flag to compile string to Cython or Python
 
     safePickle : bool
-        flag to not share pointers between thread
-
-
-    Methods
-    -------
-    copy() :
-        Create copy of Qobj
-
-    arguments(new_args):
-        Update the args of the object
-
-    Math:
-        +/- QobjEvo, Qobj, scalar:
-            Addition is possible between QobjEvo and with Qobj or scalar
-        -:
-            Negation operator
-        * Qobj, scalar:
-            Product is possible with Qobj or scalar
-        / scalar:
-            It is possible to divide by scalar only
-    conj()
-        Return the conjugate of quantum object.
-
-    dag()
-        Return the adjoint (dagger) of quantum object.
-
-    trans()
-        Return the transpose of quantum object.
-
-    _cdc()
-        Return self.dag() * self.
-
-    permute(order)
-        Returns composite qobj with indices reordered.
-
-    apply(f, *args, **kw_args)
-        Apply the function f to every Qobj. f(Qobj) -> Qobj
-        Return a modified QobjEvo and let the original one untouched
-
-    apply_decorator(decorator, *args, str_mod=None,
-                    inplace_np=False, **kw_args):
-        Apply the decorator to each function of the ops.
-        The *args and **kw_args are passed to the decorator.
-        new_coeff_function = decorator(coeff_function, *args, **kw_args)
-        str_mod : list of 2 elements
-            replace the string : str_mod[0] + original_string + str_mod[1]
-            *exemple: str_mod = ["exp(",")"]
-        inplace_np:
-            Change the numpy array instead of applying the decorator to the
-            function reading the array. Some decorators create incorrect array.
-            Transformations f'(t) = f(g(t)) create a missmatch between the
-            array and the associated time list.
-
-    tidyup(atol=1e-12)
-        Removes small elements from quantum object.
-
-    compress():
-        Merge ops which are based on the same quantum object and coeff type.
-
-    compile(code=False, matched=False, dense=False, omp=0):
-        Create the associated cython object for faster usage.
-        code: return the code generated for compilation of the strings.
-        matched: the compiled object use sparse matrix with matching indices.
-                    (experimental, no real advantage)
-        dense: the compiled object use dense matrix.
-        omp: (int) number of thread: the compiled object use spmvpy_openmp.
-
-    __call__(t, data=False, state=None, args={}):
-        Return the Qobj at time t.
-        *Faster after compilation
-
-    mul_mat(t, mat):
-        Product of this at t time with the dense matrix mat.
-        *Faster after compilation
-
-    mul_vec(t, psi):
-        Apply the quantum object (if operator, no check) to psi.
-        More generaly, return the product of the object at t with psi.
-        *Faster after compilation
-
-    expect(t, psi, herm=False):
-        Calculates the expectation value for the quantum object (if operator,
-            no check) and state psi.
-        Return only the real part if herm.
-        *Faster after compilation
-
-    to_list():
-        Return the time-dependent quantum object as a list
+        Flag to not share pointers between thread.
     """
 
     def __init__(self, Q_object=[], args={}, copy=True,
@@ -651,6 +606,9 @@ class QobjEvo:
                 pass
 
     def __call__(self, t, data=False, state=None, args={}):
+        """
+        Return a single :obj:`~Qobj` at the given time ``t``.
+        """
         try:
             t = float(t)
         except Exception as e:
@@ -749,6 +707,7 @@ class QobjEvo:
             raise TypeError("state must be a Qobj or np.ndarray")
 
     def copy(self):
+        """Return a copy of this object."""
         new = QobjEvo(self.cte.copy())
         new.const = self.const
         new.args = self.args.copy()
@@ -800,6 +759,9 @@ class QobjEvo:
                                        new_coeff, op.type))
 
     def arguments(self, new_args):
+        """
+        Update the scoped variables that were passed as ``args`` to new values.
+        """
         if not isinstance(new_args, dict):
             raise TypeError("The new args must be in a dict")
         # remove dynamics_args that are to be refreshed
@@ -833,6 +795,10 @@ class QobjEvo:
                 self.coeff_get.set_args(self.args, self.dynamics_args)
 
     def to_list(self):
+        """
+        Return this operator in the list-like form used to initialised it, like
+        can be passed to :func:`~mesolve`.
+        """
         list_qobj = []
         if not self.dummy_cte:
             list_qobj.append(self.cte)
@@ -1021,6 +987,7 @@ class QobjEvo:
 
     # Transformations
     def trans(self):
+        """Return the matrix transpose."""
         res = self.copy()
         res.cte = res.cte.trans()
         for op in res.ops:
@@ -1028,6 +995,7 @@ class QobjEvo:
         return res
 
     def conj(self):
+        """Return the matrix elementwise conjugation."""
         res = self.copy()
         res.cte = res.cte.conj()
         for op in res.ops:
@@ -1036,6 +1004,7 @@ class QobjEvo:
         return res
 
     def dag(self):
+        """Return the matrix conjugate-transpose (dagger)."""
         res = self.copy()
         res.cte = res.cte.dag()
         for op in res.ops:
@@ -1044,7 +1013,7 @@ class QobjEvo:
         return res
 
     def _cdc(self):
-        """return a.dag * a """
+        """Return ``a.dag * a``."""
         if not self.num_obj == 1:
             res = self.dag()
             res *= self
@@ -1058,6 +1027,7 @@ class QobjEvo:
 
     # Unitary function of Qobj
     def tidyup(self, atol=1e-12):
+        """Removes small elements from this quantum object inplace."""
         self.cte = self.cte.tidyup(atol)
         for op in self.ops:
             op.qobj = op.qobj.tidyup(atol)
@@ -1152,6 +1122,13 @@ class QobjEvo:
         self.ops = new_ops
 
     def compress(self):
+        """
+        Merge together elements that share the same time-dependence, to reduce
+        the number of matrix multiplications and additions that need to be done
+        to evaluate this object.
+
+        Modifies the object inplace.
+        """
         self.tidyup()
         sets, fsets = self._compress_make_set()
         N_sets = len(sets)
@@ -1215,14 +1192,29 @@ class QobjEvo:
         self.num_obj = (len(self.ops) if self.dummy_cte else len(self.ops) + 1)
 
     def permute(self, order):
+        """
+        Permute the tensor structure of the underlying matrices into a new
+        format.
+
+        See Also
+        --------
+        Qobj.permute : the same operation on constant quantum objects.
+        """
         res = self.copy()
         res.cte = res.cte.permute(order)
         for op in res.ops:
             op.qobj = op.qobj.permute(order)
         return res
 
-    # function to apply custom transformations
     def apply(self, function, *args, **kw_args):
+        """
+        Apply the linear function ``function`` to every ``Qobj`` included in
+        this time-dependent object, and return a new ``QobjEvo`` with the
+        result.
+
+        Any additional arguments or keyword arguments will be appended to every
+        function call.
+        """
         self.compiled = ""
         res = self.copy()
         cte_res = function(res.cte, *args, **kw_args)
@@ -1233,17 +1225,34 @@ class QobjEvo:
             op.qobj = function(op.qobj, *args, **kw_args)
         return res
 
-    def apply_decorator(self, function, *args, **kw_args):
-        if "str_mod" in kw_args:
-            str_mod = kw_args["str_mod"]
-            del kw_args["str_mod"]
-        else:
-            str_mod = None
-        if "inplace_np" in kw_args:
-            inplace_np = kw_args["inplace_np"]
-            del kw_args["inplace_np"]
-        else:
-            inplace_np = None
+    def apply_decorator(self, function, *args,
+                        str_mod=None, inplace_np=False, **kw_args):
+        """
+        Apply the given function to every time-dependent coefficient in the
+        quantum object, and return a new object with the result.
+
+        Any additional arguments and keyword arguments will be appended to the
+        function calls.
+
+        Parameters
+        ----------
+        function : callable
+            ``(time_dependence, *args, **kwargs) -> time_dependence``.  Called
+            on each time-dependent coefficient to produce a new coefficient.
+            The additional arguments and keyword arguments are the ones given
+            to this function.
+
+        str_mod : list
+            A 2-element list of strings, that will additionally wrap any string
+            time-dependences.  An existing time-dependence string ``x`` will
+            become ``str_mod[0] + x + str_mod[1]``.
+
+        inplace_np : bool, default False
+            Whether this function should modify Numpy arrays inplace, or be
+            used like a regular decorator.  Some decorators create incorrect
+            arrays as some transformations ``f'(t) = f(g(t))`` create a
+            mismatch between the array and the associated time list.
+        """
         res = self.copy()
         for op in res.ops:
             op.get_coeff = function(op.get_coeff, *args, **kw_args)
@@ -1356,7 +1365,29 @@ class QobjEvo:
         self.ops = new_ops
         return self
 
-    def expect(self, t, state, herm=0):
+    def expect(self, t, state, herm=False):
+        """
+        Calculate the expectation value of this operator on the given
+        (time-independent) state at a particular time.
+
+        This is more efficient than ``expect(QobjEvo(t), state)``.
+
+        Parameters
+        ----------
+        t : float
+            The time to evaluate this operator at.
+
+        state : Qobj or np.ndarray
+            The state to take the expectation value around.
+
+        herm : bool, default False
+            Whether this operator and the state are both Hermitian.  If True,
+            only the real part of the result will be returned.
+
+        See Also
+        --------
+        expect : General-purpose expectation values.
+        """
         if not isinstance(t, (int, float)):
             raise TypeError("The time need to be a real scalar")
         if isinstance(state, Qobj):
@@ -1397,6 +1428,22 @@ class QobjEvo:
             return exp
 
     def mul_vec(self, t, vec):
+        """
+        Multiply this object evaluated at time `t` by a vector.
+
+        Parameters
+        ----------
+        t : float
+            The time to evaluate this object at.
+
+        vec : Qobj or np.ndarray
+            The state-vector to multiply this object by.
+
+        Returns
+        -------
+        vec: Qobj or np.ndarray
+            The vector result in the same type as the input.
+        """
         was_Qobj = False
         if not isinstance(t, (int, float)):
             raise TypeError("the time need to be a real scalar")
@@ -1425,6 +1472,23 @@ class QobjEvo:
             return out
 
     def mul_mat(self, t, mat):
+        """
+        Multiply this object evaluated at time `t` by a matrix (from the
+        right).
+
+        Parameters
+        ----------
+        t : float
+            The time to evaluate this object at.
+
+        mat : Qobj or np.ndarray
+            The matrix that is multiplied by this object.
+
+        Returns
+        -------
+        mat: Qobj or np.ndarray
+            The matrix result in the same type as the input.
+        """
         was_Qobj = False
         if not isinstance(t, (int, float)):
             raise TypeError("the time need to be a real scalar")
@@ -1453,6 +1517,35 @@ class QobjEvo:
             return out
 
     def compile(self, code=False, matched=False, dense=False, omp=0):
+        """
+        Create an associated Cython object for faster usage.  This function is
+        called automatically by the solvers.
+
+        Parameters
+        ----------
+        code : bool, default False
+            Return the code string generated by compilation of any strings.
+
+        matched : bool, default False
+            If True, the underlying sparse matrices used to represent each
+            element of the type will have their structures unified.  This may
+            include adding explicit zeros to sparse matrices, but can be faster
+            in some cases due to not having to deal with repeated structural
+            mismatches.
+
+        dense : bool, default False
+            Whether to swap to using dense matrices to back the data.
+
+        omp : int, optional
+            The number of OpenMP threads to use when doing matrix
+            multiplications, if QuTiP was compiled with OpenMP.
+
+        Returns
+        -------
+        compiled_str : str
+            (Only if `code` was set to True).  The code-generated string of
+            compiled calling code.
+        """
         self.tidyup()
         Code = None
         if self.compiled:

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -240,7 +240,28 @@ class QobjEvo:
     - ``*``: :class:`~Qobj`, C number
     - ``/`` : C number
 
+    This object is constructed by passing a list of :obj:`~Qobj` instances,
+    each of which *may* have an associated scalar time dependence.  The list is
+    summed to produce the final result.  In other words, if an instance of this
+    class is :math:`Q(t)`, then it is constructed from a set of constant
+    :obj:`~Qobj` :math:`\\{Q_k\\}` and time-dependent scalars :math:`f_k(t)` by
+
+    .. math::
+
+        Q(t) = \\sum_k f_k(t) Q_k
+
+    If a scalar :math:`f_k(t)` is not passed with a given :obj:`~Qobj`, then
+    that term is assumed to be constant.  The next section contains more detail
+    on the allowed forms of the constants, and gives several examples for how
+    to build instances of this class.
+
     **Time-dependence formats**
+
+    There are three major formats for specifying a time-dependent scalar:
+
+    - Python function
+    - string
+    - array
 
     For function format, the function signature must be
     ``f(t: float, args: dict) -> complex``, for example

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -141,14 +141,13 @@ def rand_herm(N, density=0.75, dims=None, pos_def=False, seed=None):
     oper : qobj
         NxN Hermitian quantum operator.
 
-    Note
-    ----
+    Notes
+    -----
     If given a list/ndarray as input 'N', this function returns a
     random Hermitian object with eigenvalues given in the list/ndarray.
     This is accomplished via complex Jacobi rotations.  While this method
     is ~50% faster than the corresponding (real only) Matlab code, it should
     not be repeatedly used for generating matrices larger than ~1000x1000.
-
     """
     if seed is not None:
         np.random.seed(seed=seed)

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -56,64 +56,62 @@ from qutip.cy.openmp.utilities import check_use_openmp, openmp_components
 def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
             progress_bar=None, _safe_mode=True):
     """
-    Schrodinger equation evolution of a state vector or unitary matrix
-    for a given Hamiltonian.
+    Schrodinger equation evolution of a state vector or unitary matrix for a
+    given Hamiltonian.
 
-    Evolve the state vector (`psi0`) using a given
-    Hamiltonian (`H`), by integrating the set of ordinary differential
-    equations that define the system. Alternatively evolve a unitary matrix in
-    solving the Schrodinger operator equation.
+    Evolve the state vector (``psi0``) using a given Hamiltonian (``H``), by
+    integrating the set of ordinary differential equations that define the
+    system. Alternatively evolve a unitary matrix in solving the Schrodinger
+    operator equation.
 
     The output is either the state vector or unitary matrix at arbitrary points
-    in time (`tlist`), or the expectation values of the supplied operators
-    (`e_ops`). If e_ops is a callback function, it is invoked for each
-    time in `tlist` with time and the state as arguments, and the function
-    does not use any return values. e_ops cannot be used in conjunction
+    in time (``tlist``), or the expectation values of the supplied operators
+    (``e_ops``). If ``e_ops`` is a callback function, it is invoked for each
+    time in ``tlist`` with time and the state as arguments, and the function
+    does not use any return values. ``e_ops`` cannot be used in conjunction
     with solving the Schrodinger operator equation
 
     Parameters
     ----------
 
-    H : :class:`qutip.qobj`, :class:`qutip.qobjevo`, *list*, *callable*
-        system Hamiltonian as a Qobj, list of Qobj and coefficient, QobjEvo,
-        or a callback function for time-dependent Hamiltonians.
-        list format and options can be found in QobjEvo's description.
+    H : :class:`~Qobj`, :class:`~QobjEvo`, list, or callable
+        System Hamiltonian as a :obj:`~Qobj , list of :obj:`Qobj` and
+        coefficient, :obj:`~QObjEvo`, or a callback function for time-dependent
+        Hamiltonians.  List format and options can be found in QobjEvo's
+        description.
 
-    psi0 : :class:`qutip.qobj`
-        initial state vector (ket)
-        or initial unitary operator `psi0 = U`
+    psi0 : :class:`~Qobj`
+        Initial state vector (ket) or initial unitary operator ``psi0 = U``.
 
-    tlist : *list* / *array*
-        list of times for :math:`t`.
+    tlist : array_like of float
+        List of times for :math:`t`.
 
-    e_ops : None / list of :class:`qutip.qobj` / callback function
-        single operator or list of operators for which to evaluate
-        expectation values.
-        For list operator evolution, the overlapse is computed:
-            tr(e_ops[i].dag()*op(t))
+    e_ops : list of :class:`~Qobj` or callback function, optional
+        Single operator or list of operators for which to evaluate expectation
+        values.  For operator evolution, the overlap is computed: ::
 
-    args : None / *dictionary*
-        dictionary of parameters for time-dependent Hamiltonians
+            (e_ops[i].dag() * op(t)).tr()
 
-    options : None / :class:`qutip.Qdeoptions`
-        with options for the ODE solver.
+    args : dict, optional
+        Dictionary of scope parameters for time-dependent Hamiltonians.
 
-    progress_bar : None / BaseProgressBar
-        Optional instance of BaseProgressBar, or a subclass thereof, for
-        showing the progress of the simulation.
+    options : :obj:`~solver.Options`, optional
+        Options for the ODE solver.
+
+    progress_bar : :obj:`~BaseProgressBar`, optional
+        Optional instance of :obj:`~BaseProgressBar`, or a subclass thereof,
+        for showing the progress of the simulation.
 
     Returns
     -------
 
-    output: :class:`qutip.solver`
-
-        An instance of the class :class:`qutip.solver`, which contains either
-        an *array* of expectation values for the times specified by `tlist`, or
-        an *array* or state vectors corresponding to the
-        times in `tlist` [if `e_ops` is an empty list], or
-        nothing if a callback function was given inplace of operators for
-        which to calculate the expectation values.
-
+    output: :class:`~solver.Result`
+        An instance of the class :class:`~solver.Result`, which contains either
+        an array of expectation values for the times specified by ``tlist``, or
+        an array or state vectors corresponding to the times in ``tlist`` (if
+        ``e_ops`` is an empty list), or nothing if a callback function was
+        given inplace of operators for which to calculate the expectation
+        values.
     """
     if e_ops is None:
         e_ops = []
@@ -140,11 +138,7 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
     if options.rhs_reuse and not isinstance(H, SolverSystem):
         # TODO: deprecate when going to class based solver.
         if "sesolve" in solver_safe:
-            # print(" ")
             H = solver_safe["sesolve"]
-        else:
-            pass
-            # raise Exception("Could not find the Hamiltonian to reuse.")
 
     if args is None:
         args = {}

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -56,7 +56,7 @@ from qutip.cy.openmp.utilities import check_use_openmp, openmp_components
 def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
             progress_bar=None, _safe_mode=True):
     """
-    Schrodinger equation evolution of a state vector or unitary matrix for a
+    Schrödinger equation evolution of a state vector or unitary matrix for a
     given Hamiltonian.
 
     Evolve the state vector (``psi0``) using a given Hamiltonian (``H``), by

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -495,7 +495,7 @@ def _format_time(t, tt=None, ttt=None):
     return time_str
 
 
-class Stats(object):
+class Stats:
     """
     Statistical information on the solver performance
     Statistics can be grouped into sections.
@@ -524,23 +524,6 @@ class Stats(object):
     total_time : float
         Time in seconds for the solver to complete processing
         Can be None, meaning that total timing percentages will be reported
-
-    Methods
-    -------
-    add_section
-        Add another section
-
-    add_count
-        Add some stat that is an integer count
-
-    add_timing
-        Add some timing statistics
-
-    add_message
-        Add some text type for output in the report
-
-    report:
-        Output the statistics report to console or file.
     """
 
     def __init__(self, section_names=None):
@@ -584,7 +567,7 @@ class Stats(object):
 
         Returns
         -------
-        section : `class` : _StatsSection
+        section : :class:`_StatsSection`
             The new section
         """
         sect = _StatsSection(name, self)
@@ -607,7 +590,7 @@ class Stats(object):
         value : int
             Initial value of the count, or added to an existing count
 
-        section: string or `class` : _StatsSection
+        section : string or :class:`_StatsSection`
             Section which to add the count to.
             If None given, the default (first) section will be used
         """

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -521,7 +521,9 @@ shape = [3, 3], type = oper, isHerm = True
 # projection operator
 #
 def projection(N, n, m, offset=None):
-    """The projection operator that projects state :math:`|m>` on state :math:`|n>`.
+    r"""
+    The projection operator that projects state :math:`\lvert m\rangle` on
+    state :math:`\lvert n\rangle`.
 
     Parameters
     ----------
@@ -539,7 +541,6 @@ def projection(N, n, m, offset=None):
     -------
     oper : qobj
          Requested projection operator.
-
     """
     ket1 = basis(N, n, offset=offset)
     ket2 = basis(N, m, offset=offset)
@@ -551,8 +552,8 @@ def projection(N, n, m, offset=None):
 # composite qubit states
 #
 def qstate(string):
-    """Creates a tensor product for a set of qubits in either
-    the 'up' :math:`|0>` or 'down' :math:`|1>` state.
+    r"""Creates a tensor product for a set of qubits in either
+    the 'up' :math:`\lvert0\rangle` or 'down' :math:`\lvert1\rangle` state.
 
     Parameters
     ----------
@@ -582,7 +583,6 @@ def qstate(string):
      [ 1.]
      [ 0.]
      [ 0.]]
-
     """
     n = len(string)
     if n != (string.count('u') + string.count('d')):
@@ -712,9 +712,11 @@ def bra(seq, dim=2):
         Each element defines state of the respective particle.
         (e.g. [1,1,0,1] or a string "1101").
         For qubits it is also possible to use the following conventions:
+
         - 'g'/'e' (ground and excited state)
         - 'u'/'d' (spin up and down)
         - 'H'/'V' (horizontal and vertical polarization)
+
         Note: for dimension > 9 you need to use a list.
 
 
@@ -1088,8 +1090,8 @@ def zero_ket(N, dims=None):
 
 
 def spin_state(j, m, type='ket'):
-    """Generates the spin state |j, m>, i.e.  the eigenstate
-    of the spin-j Sz operator with eigenvalue m.
+    r"""Generates the spin state :math:`\lvert j, m\rangle`, i.e. the
+    eigenstate of the spin-j Sz operator with eigenvalue m.
 
     Parameters
     ----------
@@ -1106,7 +1108,6 @@ def spin_state(j, m, type='ket'):
     -------
     state : qobj
         Qobj quantum object for spin state
-
     """
     J = 2 * j + 1
 
@@ -1121,7 +1122,7 @@ def spin_state(j, m, type='ket'):
 
 
 def spin_coherent(j, theta, phi, type='ket'):
-    """Generate the coherent spin state |theta, phi>.
+    r"""Generate the coherent spin state :math:`\lvert \theta, \phi\rangle`.
 
     Parameters
     ----------
@@ -1141,7 +1142,6 @@ def spin_coherent(j, theta, phi, type='ket'):
     -------
     state : qobj
         Qobj quantum object for spin coherent state
-
     """
     Sp = jmat(j, '+')
     Sm = jmat(j, '-')
@@ -1159,19 +1159,26 @@ def spin_coherent(j, theta, phi, type='ket'):
 
 
 def bell_state(state='00'):
-    """
-    Returns the Bell state:
+    r"""
+    Returns the selected Bell state:
 
-        |B00> = 1 / sqrt(2)*[|0>|0>+|1>|1>]
-        |B01> = 1 / sqrt(2)*[|0>|0>-|1>|1>]
-        |B10> = 1 / sqrt(2)*[|0>|1>+|1>|0>]
-        |B11> = 1 / sqrt(2)*[|0>|1>-|1>|0>]
+    .. math::
+
+        \begin{aligned}
+        \lvert B_{00}\rangle &=
+            \frac1{\sqrt2}(\lvert00\rangle+\lvert11\rangle)\\
+        \lvert B_{01}\rangle &=
+            \frac1{\sqrt2}(\lvert00\rangle-\lvert11\rangle)\\
+        \lvert B_{10}\rangle &=
+            \frac1{\sqrt2}(\lvert01\rangle+\lvert10\rangle)\\
+        \lvert B_{11}\rangle &=
+            \frac1{\sqrt2}(\lvert01\rangle-\lvert10\rangle)\\
+        \end{aligned}
 
     Returns
     -------
     Bell_state : qobj
         Bell state
-
     """
     if state == '00':
         Bell_state = tensor(
@@ -1190,30 +1197,32 @@ def bell_state(state='00'):
 
 
 def singlet_state():
-    """
+    r"""
     Returns the two particle singlet-state:
 
-        |S>=1/sqrt(2)*[|0>|1>-|1>|0>]
+    .. math::
+
+        \lvert S\rangle = \frac1{\sqrt2}(\lvert01\rangle-\lvert10\rangle)
 
     that is identical to the fourth bell state.
 
     Returns
     -------
     Bell_state : qobj
-        |B11> Bell state
-
+        :math:`\lvert B_{11}\rangle` Bell state
     """
     return bell_state('11')
 
 
 def triplet_states():
-    """
-    Returns the two particle triplet-states:
+    r"""
+    Returns a list of the two particle triplet-states:
 
-        |T>= |1>|1>
-           = 1 / sqrt(2)*[|0>|1>-|1>|0>]
-           = |0>|0>
-    that is identical to the fourth bell state.
+    .. math::
+
+        \lvert T_1\rangle = \lvert11\rangle
+        \lvert T_2\rangle = \frac1{\sqrt2}(\lvert01\rangle - \lvert10\rangle)
+        \lvert T_3\rangle = \lvert00\rangle
 
     Returns
     -------

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -97,50 +97,62 @@ def _default_steadystate_args():
 
 
 def steadystate(A, c_op_list=[], method='direct', solver=None, **kwargs):
-    """Calculates the steady state for quantum evolution subject to the
-    supplied Hamiltonian or Liouvillian operator and (if given a Hamiltonian) a
-    list of collapse operators.
+    """
+    Calculates the steady state for quantum evolution subject to the supplied
+    Hamiltonian or Liouvillian operator and (if given a Hamiltonian) a list of
+    collapse operators.
 
     If the user passes a Hamiltonian then it, along with the list of collapse
     operators, will be converted into a Liouvillian operator in Lindblad form.
 
     Parameters
     ----------
-    A : qobj
+    A : :obj:`~Qobj`
         A Hamiltonian or Liouvillian operator.
 
     c_op_list : list
         A list of collapse operators.
 
-    solver : str {None, 'scipy', 'mkl'}
-        Selects the sparse solver to use.  Default is auto-select
-        based on the availability of the MKL library.
+    solver : {'scipy', 'mkl'}, optional
+        Selects the sparse solver to use.  Default is to auto-select based on
+        the availability of the MKL library.
 
-    method : str {'direct', 'eigen', 'iterative-gmres',
-                  'iterative-lgmres', 'iterative-bicgstab', 'svd', 'power',
-                  'power-gmres', 'power-lgmres', 'power-bicgstab'}
+    method : str, default 'direct'
+        The allowed methods are
+
+        - 'direct'
+        - 'eigen'
+        - 'iterative-gmres'
+        - 'iterative-lgmres'
+        - 'iterative-bicgstab'
+        - 'svd'
+        - 'power'
+        - 'power-gmres'
+        - 'power-lgmres'
+        - 'power-bicgstab'
+
         Method for solving the underlying linear equation. Direct LU solver
-        'direct' (default), sparse eigenvalue problem 'eigen',
-        iterative GMRES method 'iterative-gmres', iterative LGMRES method
-        'iterative-lgmres', iterative BICGSTAB method 'iterative-bicgstab',
-        SVD 'svd' (dense), or inverse-power method 'power'. The iterative
-        power methods 'power-gmres', 'power-lgmres', 'power-bicgstab' use
-        the same solvers as their direct counterparts.
+        'direct' (default), sparse eigenvalue problem 'eigen', iterative GMRES
+        method 'iterative-gmres', iterative LGMRES method 'iterative-lgmres',
+        iterative BICGSTAB method 'iterative-bicgstab', SVD 'svd' (dense), or
+        inverse-power method 'power'. The iterative power methods
+        'power-gmres', 'power-lgmres', 'power-bicgstab' use the same solvers as
+        their direct counterparts.
 
-    return_info : bool, optional, default = False
-        Return a dictionary of solver-specific infomation about the
-        solution and how it was obtained.
+    return_info : bool, default False
+        Return a dictionary of solver-specific infomation about the solution
+        and how it was obtained.
 
-    sparse : bool, optional, default = True
+    sparse : bool, default True
         Solve for the steady state using sparse algorithms. If set to False,
         the underlying Liouvillian operator will be converted into a dense
         matrix. Use only for 'smaller' systems.
 
-    use_rcm : bool, optional, default = False
-        Use reverse Cuthill-Mckee reordering to minimize fill-in in the
-        LU factorization of the Liouvillian.
+    use_rcm : bool, default False
+        Use reverse Cuthill-Mckee reordering to minimize fill-in in the LU
+        factorization of the Liouvillian.
 
-    use_wbm : bool, optional, default = False
+    use_wbm : bool, default False
         Use Weighted Bipartite Matching reordering to make the Liouvillian
         diagonally dominant.  This is useful for iterative preconditioners
         only, and is set to ``True`` by default when finding a preconditioner.
@@ -150,41 +162,41 @@ def steadystate(A, c_op_list=[], method='direct', solver=None, **kwargs):
         to the linear solvers.  This is set to the average abs value of the
         Liouvillian elements if not specified by the user.
 
-    max_iter_refine : int {10}
+    max_iter_refine : int, default 10
         MKL ONLY. Max. number of iterative refinements to perform.
 
-    scaling_vectors : bool {True, False}
+    scaling_vectors : bool
         MKL ONLY.  Scale matrix to unit norm columns and rows.
 
-    weighted_matching : bool {True, False}
+    weighted_matching : bool
         MKL ONLY.  Use weighted matching to better condition diagonal.
 
     x0 : ndarray, optional
         ITERATIVE ONLY. Initial guess for solution vector.
 
-    maxiter : int, optional, default=1000
+    maxiter : int, default 1000
         ITERATIVE ONLY. Maximum number of iterations to perform.
 
-    tol : float, optional, default=1e-12
+    tol : float, default 1e-12
         ITERATIVE ONLY. Tolerance used for terminating solver.
 
-    mtol : float, optional, default=None
-        ITERATIVE 'power' methods ONLY. Tolerance for lu solve method.
-        If None given then `max(0.1*tol, 1e-15)` is used
+    mtol : float, optional
+        ITERATIVE 'power' methods ONLY. Tolerance for lu solve method.  If None
+        given then ``max(0.1*tol, 1e-15)`` is used.
 
-    matol : float, optional, default=1e-15
+    matol : float, default 1e-15
         ITERATIVE ONLY. Absolute tolerance for lu solve method.
 
-    permc_spec : str, optional, default='COLAMD'
+    permc_spec : str, optional
         ITERATIVE ONLY. Column ordering used internally by superLU for the
-        'direct' LU decomposition method. Options include 'COLAMD' and
-        'NATURAL'. If using RCM then this is set to 'NATURAL' automatically
+        'direct' LU decomposition method. Options include 'COLAMD' (default)
+        and 'NATURAL'. If using RCM then this is set to 'NATURAL' automatically
         unless explicitly specified.
 
-    use_precond : bool optional, default = False
+    use_precond : bool, default False
         ITERATIVE ONLY. Use an incomplete sparse LU decomposition as a
-        preconditioner for the 'iterative' GMRES and BICG solvers.
-        Speeds up convergence time by orders of magnitude in many cases.
+        preconditioner for the 'iterative' GMRES and BICG solvers.  Speeds up
+        convergence time by orders of magnitude in many cases.
 
     M : {sparse matrix, dense matrix, LinearOperator}, optional
         ITERATIVE ONLY. Preconditioner for A. The preconditioner should
@@ -193,27 +205,27 @@ def steadystate(A, c_op_list=[], method='direct', solver=None, **kwargs):
         If no preconditioner is given and ``use_precond = True``, then one
         is generated automatically.
 
-    fill_factor : float, optional, default = 100
+    fill_factor : float, default 100
         ITERATIVE ONLY. Specifies the fill ratio upper bound (>=1) of the iLU
         preconditioner.  Lower values save memory at the cost of longer
         execution times and a possible singular factorization.
 
-    drop_tol : float, optional, default = 1e-4
+    drop_tol : float, default 1e-4
         ITERATIVE ONLY. Sets the threshold for the magnitude of preconditioner
         elements that should be dropped.  Can be reduced for a courser
         factorization at the cost of an increased number of iterations, and a
         possible singular factorization.
 
-    diag_pivot_thresh : float, optional, default = None
+    diag_pivot_thresh : float, optional
         ITERATIVE ONLY. Sets the threshold between [0,1] for which diagonal
         elements are considered acceptable pivot points when using a
         preconditioner.  A value of zero forces the pivot to be the diagonal
         element.
 
-    ILU_MILU : str, optional, default = 'smilu_2'
-        ITERATIVE ONLY. Selects the incomplete LU decomposition method
-        algoithm used in creating the preconditoner. Should only be used by
-        advanced users.
+    ILU_MILU : str, default 'smilu_2'
+        ITERATIVE ONLY. Selects the incomplete LU decomposition method algoithm
+        used in creating the preconditoner. Should only be used by advanced
+        users.
 
     Returns
     -------
@@ -225,7 +237,6 @@ def steadystate(A, c_op_list=[], method='direct', solver=None, **kwargs):
     Notes
     -----
     The SVD method works only for dense operators (i.e. small systems).
-
     """
     if solver is None:
         solver = 'scipy'

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -74,14 +74,14 @@ def plot_wigner_sphere(fig, ax, wigner, reflections):
 
     Parameters
     ----------
-        fig
-            An instance of matplotlib.pyplot.figure.
-        ax
-            An axes instance in fig.
-        wigner : list of float
-            the wigner transformation at `steps` different theta and phi.
-        reflections : bool
-            If the reflections of the sphere should be plotted as well.
+    fig : :obj:`matplotlib.figure.Figure`
+        An instance of :obj:`~matplotlib.figure.Figure`.
+    ax : :obj:`matplotlib.axes.Axes`
+        An axes instance in the given figure.
+    wigner : list of float
+        The wigner transformation at `steps` different theta and phi.
+    reflections : bool
+        If the reflections of the sphere should be plotted as well.
 
     Notes
     ------
@@ -1316,18 +1316,9 @@ def plot_qubism(ket, theme='light', how='pairs',
                 grid_iteration=1, legend_iteration=0,
                 fig=None, ax=None, figsize=(6, 6)):
     """
-    Qubism plot for pure states of many qudits.
-    Works best for spin chains, especially with even number of particles
-    of the same dimension.
-    Allows to see entanglement between first 2*k particles and the rest.
-
-    More information:
-        
-        J. Rodriguez-Laguna, P. Migdal,
-        M. Ibanez Berganza, M. Lewenstein, G. Sierra,
-        "Qubism: self-similar visualization of many-body wavefunctions",
-        New J. Phys. 14 053028 (2012), arXiv:1112.3560,
-        http://dx.doi.org/10.1088/1367-2630/14/5/053028 (open access)
+    Qubism plot for pure states of many qudits.  Works best for spin chains,
+    especially with even number of particles of the same dimension.  Allows to
+    see entanglement between first 2k particles and the rest.
 
     Parameters
     ----------
@@ -1339,23 +1330,21 @@ def plot_qubism(ket, theme='light', how='pairs',
         See: complex_array_to_rgb.
 
     how : 'pairs' (default), 'pairs_skewed' or 'before_after'
-        Type of Qubism plotting.
-        Options:
-            
-            'pairs' - typical coordinates,
-            'pairs_skewed' - for ferromagnetic/antriferromagnetic plots,
-            'before_after' - related to Schmidt plot (see also: plot_schmidt).
+        Type of Qubism plotting.  Options:
+
+        - 'pairs' - typical coordinates,
+        - 'pairs_skewed' - for ferromagnetic/antriferromagnetic plots,
+        - 'before_after' - related to Schmidt plot (see also: plot_schmidt).
 
     grid_iteration : int (default 1)
         Helper lines to be drawn on plot.
         Show tiles for 2*grid_iteration particles vs all others.
 
     legend_iteration : int (default 0) or 'grid_iteration' or 'all'
-        Show labels for first 2*legend_iteration particles.
-        Option 'grid_iteration' sets the same number of particles
-            as for grid_iteration.
-        Option 'all' makes label for all particles.
-        Typically it should be 0, 1, 2 or perhaps 3.
+        Show labels for first ``2*legend_iteration`` particles.  Option
+        'grid_iteration' sets the same number of particles as for
+        grid_iteration.  Option 'all' makes label for all particles.  Typically
+        it should be 0, 1, 2 or perhaps 3.
 
     fig : a matplotlib figure instance
         The figure canvas on which the plot will be drawn.
@@ -1373,6 +1362,17 @@ def plot_qubism(ket, theme='light', how='pairs',
         A tuple of the matplotlib figure and axes instances used to produce
         the figure.
 
+    Notes
+    -----
+    See also [1]_.
+
+    References
+    ----------
+    .. [1] J. Rodriguez-Laguna, P. Migdal, M. Ibanez Berganza, M. Lewenstein
+       and G. Sierra, *Qubism: self-similar visualization of many-body
+       wavefunctions*, `New J. Phys. 14 053028
+       <http://dx.doi.org/10.1088/1367-2630/14/5/053028>`_, arXiv:1112.3560
+       (2012), open access.
     """
 
     if not isket(ket):

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -305,8 +305,8 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
             _x = x + 1
             _y = y + 1
             if np.real(W[x, y]) > 0.0:
-                _blob(_x - 0.5, height - _y + 0.5, abs(W[x,
-                      y]), w_max, min(1, abs(W[x, y]) / w_max), cmap=cmap, ax=ax)
+                _blob(_x - 0.5, height - _y + 0.5, abs(W[x, y]), w_max,
+                      min(1, abs(W[x, y]) / w_max), cmap=cmap, ax=ax)
             else:
                 _blob(_x - 0.5, height - _y + 0.5, -abs(W[
                       x, y]), w_max, min(1, abs(W[x, y]) / w_max), cmap=cmap, ax=ax)
@@ -316,18 +316,25 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
     cax, kw = mpl.colorbar.make_axes(ax, shrink=0.75, pad=.1)
     mpl.colorbar.ColorbarBase(cax, norm=norm, cmap=cmap)
 
+    xtics = 0.5 + np.arange(width)
     # x axis
-    ax.xaxis.set_major_locator(plt.IndexLocator(1, 0.5))
-
+    ax.xaxis.set_major_locator(plt.FixedLocator(xtics))
     if xlabels:
+        nxlabels = len(xlabels)
+        if nxlabels != len(xtics):
+            raise ValueError(f"got {nxlabels} xlabels but needed {len(xtics)}")
         ax.set_xticklabels(xlabels)
         if label_top:
             ax.xaxis.tick_top()
     ax.tick_params(axis='x', labelsize=14)
 
     # y axis
-    ax.yaxis.set_major_locator(plt.IndexLocator(1, 0.5))
+    ytics = 0.5 + np.arange(height)
+    ax.yaxis.set_major_locator(plt.FixedLocator(ytics))
     if ylabels:
+        nylabels = len(ylabels)
+        if nylabels != len(ytics):
+            raise ValueError(f"got {nylabels} ylabels but needed {len(ytics)}")
         ax.set_yticklabels(list(reversed(ylabels)))
     ax.tick_params(axis='y', labelsize=14)
 
@@ -469,14 +476,22 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         ax.set_title(title)
 
     # x axis
-    ax.axes.w_xaxis.set_major_locator(plt.IndexLocator(1, -0.5))
+    xtics = -0.5 + np.arange(M.shape[0])
+    ax.axes.w_xaxis.set_major_locator(plt.FixedLocator(xtics))
     if xlabels:
+        nxlabels = len(xlabels)
+        if nxlabels != len(xtics):
+            raise ValueError(f"got {nxlabels} xlabels but needed {len(xtics)}")
         ax.set_xticklabels(xlabels)
     ax.tick_params(axis='x', labelsize=14)
 
     # y axis
-    ax.axes.w_yaxis.set_major_locator(plt.IndexLocator(1, -0.5))
+    ytics = -0.5 + np.arange(M.shape[1])
+    ax.axes.w_yaxis.set_major_locator(plt.FixedLocator(ytics))
     if ylabels:
+        nylabels = len(ylabels)
+        if nylabels != len(ytics):
+            raise ValueError(f"got {nylabels} ylabels but needed {len(ytics)}")
         ax.set_yticklabels(ylabels)
     ax.tick_params(axis='y', labelsize=14)
 
@@ -582,14 +597,22 @@ def matrix_histogram_complex(M, xlabels=None, ylabels=None,
         ax.set_title(title)
 
     # x axis
-    ax.axes.w_xaxis.set_major_locator(plt.IndexLocator(1, -0.5))
+    xtics = -0.5 + np.arange(M.shape[0])
+    ax.axes.w_xaxis.set_major_locator(plt.FixedLocator(xtics))
     if xlabels:
+        nxlabels = len(xlabels)
+        if nxlabels != len(xtics):
+            raise ValueError(f"got {nxlabels} xlabels but needed {len(xtics)}")
         ax.set_xticklabels(xlabels)
     ax.tick_params(axis='x', labelsize=12)
 
     # y axis
-    ax.axes.w_yaxis.set_major_locator(plt.IndexLocator(1, -0.5))
+    ytics = -0.5 + np.arange(M.shape[1])
+    ax.axes.w_yaxis.set_major_locator(plt.FixedLocator(ytics))
     if ylabels:
+        nylabels = len(ylabels)
+        if nylabels != len(ytics):
+            raise ValueError(f"got {nylabels} ylabels but needed {len(ytics)}")
         ax.set_yticklabels(ylabels)
     ax.tick_params(axis='y', labelsize=12)
 


### PR DESCRIPTION
This isn't a complete "fix" of every piece of bad formatting in the API documentation that we're building, but it does fix every warning that Sphinx produces in both the `html` and `latexpdf` targets.

It's quite a big patch, but there's no meaningful changes, only formatting ones - I haven't attempted to actually change the meaning of any of the writing, only to reformat it.  If we want to make any changes to any of the docstrings, we can do that in separate patches.  My intent is to merge this in as the very final patch in the 4.6 release, since it's useful for doing the documentation release.

See also qutip/qutip-doc#136