### PR TITLE
Fix Bloch sphere distortion

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -461,6 +461,9 @@ class Bloch:
             self.axes.set_xlim3d(-0.7, 0.7)
             self.axes.set_ylim3d(-0.7, 0.7)
             self.axes.set_zlim3d(-0.7, 0.7)
+        # Manually set aspect ratio to fit a square bounding box.
+        # Matplotlib did this stretching for < 3.3.0, but not above.
+        self.axes.set_box_aspect((1, 1, 1))
 
         self.axes.grid(False)
         self.plot_back()


### PR DESCRIPTION
Matplotlib stopped to stretch the plot to fit it in a square box from 3.3.0. We do it manually. See https://matplotlib.org/3.3.0/users/whats_new.html#d-axes-improvements

**Description**
To reproduce 
```python
import numpy as np
from qutip import Bloch

b = Bloch()
xp = [np.cos(th) for th in np.linspace(0, 2*np.pi, 20)]
yp = [np.sin(th) for th in np.linspace(0, 2*np.pi, 20)]
zp = np.zeros(20)
pnts = [xp, yp, zp]
b.add_points(pnts)
b.show()
```
before:
![image](https://user-images.githubusercontent.com/12125783/114322977-61172700-9b23-11eb-947d-682ae24a697f.png)

after:
![image](https://user-images.githubusercontent.com/12125783/114322944-4349c200-9b23-11eb-92e7-7ce43996961a.png)


**Related issues or PRs**
fix #1385

**Changelog**
Fix Bloch sphere distortion
