### PR TITLE
Scipy<1.5 and mkl eigenh problem solved

### DIFF
--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -63,10 +63,16 @@ else:
     os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
 
 import platform
+import scipy
+import mkl
+from packaging import version
 from qutip.utilities import _blas_info
-qutip.settings.eigh_unsafe = (_blas_info() == "OPENBLAS" and
-                              platform.system() == 'Darwin')
-del platform, _blas_info
+qutip.settings.eigh_unsafe = ((_blas_info() == "OPENBLAS" and
+                              platform.system() == 'Darwin') or 
+                              (version.parse(scipy.__version__) < version.parse("1.5") 
+                              and (_blas_info() == 'INTEL MKL') )
+                              )
+del platform, _blas_info, scipy
 # -----------------------------------------------------------------------------
 # setup the cython environment
 #

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -67,12 +67,13 @@ import scipy
 import mkl
 from packaging import version
 from qutip.utilities import _blas_info
+is_old_scipy = version.parse(scipy.__version__) < version.parse("1.5")
 qutip.settings.eigh_unsafe = ((_blas_info() == "OPENBLAS" and
-                              platform.system() == 'Darwin') or 
-                              (version.parse(scipy.__version__) < version.parse("1.5") 
-                              and (_blas_info() == 'INTEL MKL') )
+                              platform.system() == 'Darwin') or
+                              (is_old_scipy
+                              and (_blas_info() == 'INTEL MKL'))
                               )
-del platform, _blas_info, scipy
+del platform, _blas_info, scipy, version, is_old_scipy
 # -----------------------------------------------------------------------------
 # setup the cython environment
 #

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -64,7 +64,6 @@ else:
 
 import platform
 import scipy
-import mkl
 from packaging import version
 from qutip.utilities import _blas_info
 is_old_scipy = version.parse(scipy.__version__) < version.parse("1.5")

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -64,15 +64,24 @@ else:
 
 import platform
 import scipy
-from packaging import version
+from packaging import version as pac_version
 from qutip.utilities import _blas_info
-is_old_scipy = version.parse(scipy.__version__) < version.parse("1.5")
-qutip.settings.eigh_unsafe = ((_blas_info() == "OPENBLAS" and
-                              platform.system() == 'Darwin') or
+
+is_old_scipy = pac_version.parse(scipy.__version__) < pac_version.parse("1.5")
+qutip.settings.eigh_unsafe = (
+                              # macOS OpenBLAS eigh is unstable, see #1288
+                              (_blas_info() == "OPENBLAS" and
+                               platform.system() == 'Darwin')
+                              or
+                              # The combination of
+                              # scipy<1.5 and MKL causes wrong results
+                              # when calling eigh for big matrices.
+                              # See #1495, #1491 and #1498.
                               (is_old_scipy
-                              and (_blas_info() == 'INTEL MKL'))
-                              )
-del platform, _blas_info, scipy, version, is_old_scipy
+                               and (_blas_info() == 'INTEL MKL'))
+                               )
+
+del platform, _blas_info, scipy, pac_version, is_old_scipy
 # -----------------------------------------------------------------------------
 # setup the cython environment
 #

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -69,16 +69,16 @@ from qutip.utilities import _blas_info
 
 is_old_scipy = pac_version.parse(scipy.__version__) < pac_version.parse("1.5")
 qutip.settings.eigh_unsafe = (
-                              # macOS OpenBLAS eigh is unstable, see #1288
-                              (_blas_info() == "OPENBLAS" and
-                               platform.system() == 'Darwin')
-                              or
-                              # The combination of
-                              # scipy<1.5 and MKL causes wrong results
-                              # when calling eigh for big matrices.
-                              # See #1495, #1491 and #1498.
-                              (is_old_scipy
-                               and (_blas_info() == 'INTEL MKL'))
+        # macOS OpenBLAS eigh is unstable, see #1288
+        (_blas_info() == "OPENBLAS" and
+         platform.system() == 'Darwin')
+        or
+        # The combination of
+        # scipy<1.5 and MKL causes wrong results
+        # when calling eigh for big matrices.
+        # See #1495, #1491 and #1498.
+        (is_old_scipy and
+         (_blas_info() == 'INTEL MKL'))
                                )
 
 del platform, _blas_info, scipy, pac_version, is_old_scipy

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -69,17 +69,12 @@ from qutip.utilities import _blas_info
 
 is_old_scipy = pac_version.parse(scipy.__version__) < pac_version.parse("1.5")
 qutip.settings.eigh_unsafe = (
-        # macOS OpenBLAS eigh is unstable, see #1288
-        (_blas_info() == "OPENBLAS" and
-         platform.system() == 'Darwin')
-        or
-        # The combination of
-        # scipy<1.5 and MKL causes wrong results
-        # when calling eigh for big matrices.
-        # See #1495, #1491 and #1498.
-        (is_old_scipy and
-         (_blas_info() == 'INTEL MKL'))
-                               )
+    # macOS OpenBLAS eigh is unstable, see #1288
+    (_blas_info() == "OPENBLAS" and platform.system() == 'Darwin')
+    # The combination of scipy<1.5 and MKL causes wrong results when calling
+    # eigh for big matrices.  See #1495, #1491 and #1498.
+    or (is_old_scipy and (_blas_info() == 'INTEL MKL'))
+)
 
 del platform, _blas_info, scipy, pac_version, is_old_scipy
 # -----------------------------------------------------------------------------

--- a/qutip/tests/test_sp_eigs.py
+++ b/qutip/tests/test_sp_eigs.py
@@ -241,7 +241,7 @@ def test_BigDenseValsOnly():
     have had instabilitus with MKL backend and
     certain libraries.
     """
-    H = rand_herm(2000, density=1e-3)
+    H = rand_herm(2000, density=1e-2)
     spvals = H.eigenenergies()
     np.testing.assert_allclose(H.tr(), spvals.sum(), atol=1e-12)
 

--- a/qutip/tests/test_sp_eigs.py
+++ b/qutip/tests/test_sp_eigs.py
@@ -233,5 +233,16 @@ def test_DenseValsOnly():
     spvals = U.eigenenergies(sparse=False, sort='high', eigvals=4)
     assert_equal(len(spvals), 4)
 
+def test_BigDenseValsOnly():
+    """
+    This checks eigenvalue calculation for
+    large dense matrices, which historically
+    have had instabilitus with MKL backend and
+    certain libraries.
+    """
+    H = rand_herm(2000)
+    spvals = H.eigenenergies(sparse=False)
+    np.testing.assert_allclose(H.tr(), spvals.sum())
+
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_sp_eigs.py
+++ b/qutip/tests/test_sp_eigs.py
@@ -240,9 +240,13 @@ def test_BigDenseValsOnly():
     historically have had instabilities with certain OS and BLAS combinations
     (see e.g. #1288 and #1495).
     """
-    H = rand_herm(2000, density=1e-2)
+    dimension = 2000
+    # Allow an average absolute tolerance for each eigenvalue; we expect
+    # uncertainty in the sum to add in quadrature.
+    tol = 1e-12 * np.sqrt(dimension)
+    H = rand_herm(dimension, density=1e-2)
     spvals = H.eigenenergies()
-    assert abs(H.tr() - spvals.sum()) < 1e-12
+    assert abs(H.tr() - spvals.sum()) < tol
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_sp_eigs.py
+++ b/qutip/tests/test_sp_eigs.py
@@ -233,6 +233,7 @@ def test_DenseValsOnly():
     spvals = U.eigenenergies(sparse=False, sort='high', eigvals=4)
     assert_equal(len(spvals), 4)
 
+
 def test_BigDenseValsOnly():
     """
     This checks eigenvalue calculation for
@@ -240,9 +241,10 @@ def test_BigDenseValsOnly():
     have had instabilitus with MKL backend and
     certain libraries.
     """
-    H = rand_herm(2000)
-    spvals = H.eigenenergies(sparse=False)
-    np.testing.assert_allclose(H.tr(), spvals.sum())
+    H = rand_herm(2000, density=1e-3)
+    spvals = H.eigenenergies()
+    np.testing.assert_allclose(H.tr(), spvals.sum(), atol=1e-12)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_sp_eigs.py
+++ b/qutip/tests/test_sp_eigs.py
@@ -236,14 +236,13 @@ def test_DenseValsOnly():
 
 def test_BigDenseValsOnly():
     """
-    This checks eigenvalue calculation for
-    large dense matrices, which historically
-    have had instabilitus with MKL backend and
-    certain libraries.
+    This checks eigenvalue calculation for large dense matrices, which
+    historically have had instabilities with certain OS and BLAS combinations
+    (see e.g. #1288 and #1495).
     """
     H = rand_herm(2000, density=1e-2)
     spvals = H.eigenenergies()
-    np.testing.assert_allclose(H.tr(), spvals.sum(), atol=1e-12)
+    assert abs(H.tr() - spvals.sum()) < 1e-12
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -79,6 +79,8 @@ class TestSuperopReps:
 
         # Assert both that the result is close to expected, and has the right
         # type.
+        
+
         assert (test_supe - superoperator).norm() < 1e-5
         assert choi_matrix.type == "super" and choi_matrix.superrep == "choi"
         assert chi_matrix.type == "super" and chi_matrix.superrep == "chi"
@@ -367,4 +369,5 @@ def test_chi_known():
         [0, 0, 0, 0],
         [0, 0, 0, 0]
     ])
+
 

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -84,7 +84,7 @@ class TestSuperopReps:
         assert choi_matrix.type == "super" and choi_matrix.superrep == "choi"
         assert chi_matrix.type == "super" and chi_matrix.superrep == "chi"
         assert test_supe.type == "super" and test_supe.superrep == "super" 
- 
+
 def test_SuperChoiSuper():
     """
     Superoperator: Converting superoperator to Choi matrix and back.

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -43,8 +43,7 @@ from numpy import abs, pi, asarray, kron
 from numpy.linalg import norm
 from numpy.testing import assert_, assert_almost_equal, run_module_suite, assert_equal
 
-import pytest
-
+from unittest import expectedFailure
 
 from qutip.qobj import Qobj
 from qutip.states import basis
@@ -59,31 +58,11 @@ from qutip.superoperator import operator_to_vector, vector_to_operator, sprepost
 tol = 1e-9
 
 
-
-class TestSuperopReps:
+class TestSuperopReps(object):
     """
     A test class for the QuTiP function for applying superoperators to
     subsystems.
     """
-    @pytest.mark.parametrize('dimension', [2, 4, 8])
-    def test_SuperChoiChiSuper(self, dimension):
-        """
-        Superoperator: Converting two-qubit superoperator through
-        Choi and chi representations goes back to right superoperator.
-        """
-        superoperator = super_tensor(rand_super(dimension), rand_super(dimension))
-
-        choi_matrix = to_choi(superoperator)
-        chi_matrix = to_chi(choi_matrix)
-        test_supe = to_super(chi_matrix)
-
-        # Assert both that the result is close to expected, and has the right
-        # type.
-
-        assert (test_supe - superoperator).norm() < 1e-5
-        assert choi_matrix.type == "super" and choi_matrix.superrep == "choi"
-        assert chi_matrix.type == "super" and chi_matrix.superrep == "chi"
-        assert test_supe.type == "super" and test_supe.superrep == "super" 
 
     def test_SuperChoiSuper(self):
         """
@@ -242,7 +221,7 @@ class TestSuperopReps:
         # nor even HP.
         S = sprepost(a, a)
         case(S, False, False, False)
-
+        
         # Check that unitaries are CPTP and HP.
         case(identity(2), True, True, True)
         case(sigmax(), True, True, True)
@@ -367,3 +346,6 @@ class TestSuperopReps:
             [0, 0, 0, 0],
             [0, 0, 0, 0]
         ])
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -85,285 +85,285 @@ class TestSuperopReps:
         assert chi_matrix.type == "super" and chi_matrix.superrep == "chi"
         assert test_supe.type == "super" and test_supe.superrep == "super" 
 
-def test_SuperChoiSuper():
-    """
-    Superoperator: Converting superoperator to Choi matrix and back.
-    """
-    superoperator = rand_super()
+    def test_SuperChoiSuper(self):
+        """
+        Superoperator: Converting superoperator to Choi matrix and back.
+        """
+        superoperator = rand_super()
 
-    choi_matrix = to_choi(superoperator)
-    test_supe = to_super(choi_matrix)
+        choi_matrix = to_choi(superoperator)
+        test_supe = to_super(choi_matrix)
 
-    # Assert both that the result is close to expected, and has the right
-    # type.
-    assert_((test_supe - superoperator).norm() < tol)
-    assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
-    assert_(test_supe.type == "super" and test_supe.superrep == "super")
+        # Assert both that the result is close to expected, and has the right
+        # type.
+        assert_((test_supe - superoperator).norm() < tol)
+        assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
+        assert_(test_supe.type == "super" and test_supe.superrep == "super")
 
-def test_SuperChoiChiSuper():
-    """
-    Superoperator: Converting two-qubit superoperator through
-    Choi and chi representations goes back to right superoperator.
-    """
-    superoperator = super_tensor(rand_super(2), rand_super(2))
+    def test_SuperChoiChiSuper(self):
+        """
+        Superoperator: Converting two-qubit superoperator through
+        Choi and chi representations goes back to right superoperator.
+        """
+        superoperator = super_tensor(rand_super(2), rand_super(2))
 
-    choi_matrix = to_choi(superoperator)
-    chi_matrix = to_chi(choi_matrix)
-    test_supe = to_super(chi_matrix)
+        choi_matrix = to_choi(superoperator)
+        chi_matrix = to_chi(choi_matrix)
+        test_supe = to_super(chi_matrix)
 
-    # Assert both that the result is close to expected, and has the right
-    # type.
-    assert_((test_supe - superoperator).norm() < tol)
-    assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
-    assert_(chi_matrix.type == "super" and chi_matrix.superrep == "chi")
-    assert_(test_supe.type == "super" and test_supe.superrep == "super")
+        # Assert both that the result is close to expected, and has the right
+        # type.
+        assert_((test_supe - superoperator).norm() < tol)
+        assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
+        assert_(chi_matrix.type == "super" and chi_matrix.superrep == "chi")
+        assert_(test_supe.type == "super" and test_supe.superrep == "super")
 
-def test_ChoiKrausChoi():
-    """
-    Superoperator: Convert superoperator to Choi matrix and back.
-    """
-    superoperator = rand_super()
-    choi_matrix = to_choi(superoperator)
-    kraus_ops = to_kraus(choi_matrix)
-    test_choi = kraus_to_choi(kraus_ops)
+    def test_ChoiKrausChoi(self):
+        """
+        Superoperator: Convert superoperator to Choi matrix and back.
+        """
+        superoperator = rand_super()
+        choi_matrix = to_choi(superoperator)
+        kraus_ops = to_kraus(choi_matrix)
+        test_choi = kraus_to_choi(kraus_ops)
 
-    # Assert both that the result is close to expected, and has the right
-    # type.
-    assert_((test_choi - choi_matrix).norm() < tol)
-    assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
-    assert_(test_choi.type == "super" and test_choi.superrep == "choi")
+        # Assert both that the result is close to expected, and has the right
+        # type.
+        assert_((test_choi - choi_matrix).norm() < tol)
+        assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
+        assert_(test_choi.type == "super" and test_choi.superrep == "choi")
 
-def test_NonSquareKrausSuperChoi():
-    """
-    Superoperator: Convert non-square Kraus operator to Super + Choi matrix and back.
-    """
-    zero = asarray([[1], [0]], dtype=complex)
-    one = asarray([[0], [1]], dtype=complex)
-    zero_log = kron(kron(zero, zero), zero)
-    one_log = kron(kron(one, one), one)
-    # non-square Kraus operator (isometry)
-    kraus = Qobj(zero_log @ zero.T + one_log @ one.T)
-    super = sprepost(kraus, kraus.dag())
-    choi = to_choi(super)
-    op1 = to_kraus(super)
-    op2 = to_kraus(choi)
-    op3 = to_super(choi)
-    assert_(choi.type == "super" and choi.superrep == "choi")
-    assert_(super.type == "super" and super.superrep == "super")
-    assert_((op1[0] - kraus).norm() < 1e-8)
-    assert_((op2[0] - kraus).norm() < 1e-8)
-    assert_((op3 - super).norm() < 1e-8)
+    def test_NonSquareKrausSuperChoi(self):
+        """
+        Superoperator: Convert non-square Kraus operator to Super + Choi matrix and back.
+        """
+        zero = asarray([[1], [0]], dtype=complex)
+        one = asarray([[0], [1]], dtype=complex)
+        zero_log = kron(kron(zero, zero), zero)
+        one_log = kron(kron(one, one), one)
+        # non-square Kraus operator (isometry)
+        kraus = Qobj(zero_log @ zero.T + one_log @ one.T)
+        super = sprepost(kraus, kraus.dag())
+        choi = to_choi(super)
+        op1 = to_kraus(super)
+        op2 = to_kraus(choi)
+        op3 = to_super(choi)
+        assert_(choi.type == "super" and choi.superrep == "choi")
+        assert_(super.type == "super" and super.superrep == "super")
+        assert_((op1[0] - kraus).norm() < 1e-8)
+        assert_((op2[0] - kraus).norm() < 1e-8)
+        assert_((op3 - super).norm() < 1e-8)
 
-def test_NeglectSmallKraus():
-    """
-    Superoperator: Convert Kraus to Choi matrix and back. Neglect tiny Kraus operators.
-    """
-    zero = asarray([[1], [0]], dtype=complex)
-    one = asarray([[0], [1]], dtype=complex)
-    zero_log = kron(kron(zero, zero), zero)
-    one_log = kron(kron(one, one), one)
-    # non-square Kraus operator (isometry)
-    kraus = Qobj(zero_log @ zero.T + one_log @ one.T)
-    super = sprepost(kraus, kraus.dag())
-    # 1 non-zero Kraus operator the rest are zero
-    sixteen_kraus_ops = to_kraus(super, tol=0.0)
-    # default is tol=1e-9
-    one_kraus_op = to_kraus(super)
-    assert_(len(sixteen_kraus_ops) == 16 and len(one_kraus_op) == 1)
-    assert_((one_kraus_op[0] - kraus).norm() < tol)
+    def test_NeglectSmallKraus(self):
+        """
+        Superoperator: Convert Kraus to Choi matrix and back. Neglect tiny Kraus operators.
+        """
+        zero = asarray([[1], [0]], dtype=complex)
+        one = asarray([[0], [1]], dtype=complex)
+        zero_log = kron(kron(zero, zero), zero)
+        one_log = kron(kron(one, one), one)
+        # non-square Kraus operator (isometry)
+        kraus = Qobj(zero_log @ zero.T + one_log @ one.T)
+        super = sprepost(kraus, kraus.dag())
+        # 1 non-zero Kraus operator the rest are zero
+        sixteen_kraus_ops = to_kraus(super, tol=0.0)
+        # default is tol=1e-9
+        one_kraus_op = to_kraus(super)
+        assert_(len(sixteen_kraus_ops) == 16 and len(one_kraus_op) == 1)
+        assert_((one_kraus_op[0] - kraus).norm() < tol)
 
-def test_SuperPreservesSelf():
-    """
-    Superoperator: to_super(q) returns q if q is already a
-    supermatrix.
-    """
-    superop = rand_super()
-    assert_(superop is to_super(superop))
+    def test_SuperPreservesSelf(self):
+        """
+        Superoperator: to_super(q) returns q if q is already a
+        supermatrix.
+        """
+        superop = rand_super()
+        assert_(superop is to_super(superop))
 
-def test_ChoiPreservesSelf():
-    """
-    Superoperator: to_choi(q) returns q if q is already Choi.
-    """
-    superop = rand_super()
-    choi = to_choi(superop)
-    assert_(choi is to_choi(choi))
+    def test_ChoiPreservesSelf(self):
+        """
+        Superoperator: to_choi(q) returns q if q is already Choi.
+        """
+        superop = rand_super()
+        choi = to_choi(superop)
+        assert_(choi is to_choi(choi))
 
-def test_random_iscptp():
-    """
-    Superoperator: Randomly generated superoperators are
-    correctly reported as CPTP and HP.
-    """
-    superop = rand_super()
-    assert_(superop.iscptp)
-    assert_(superop.ishp)
+    def test_random_iscptp(self):
+        """
+        Superoperator: Randomly generated superoperators are
+        correctly reported as CPTP and HP.
+        """
+        superop = rand_super()
+        assert_(superop.iscptp)
+        assert_(superop.ishp)
 
-def test_known_iscptp():
-    """
-    Superoperator: ishp, iscp, istp and iscptp known cases.
-    """
-    def case(qobj, shouldhp, shouldcp, shouldtp):
-        hp = qobj.ishp
-        cp = qobj.iscp
-        tp = qobj.istp
-        cptp = qobj.iscptp
+    def test_known_iscptp(self):
+        """
+        Superoperator: ishp, iscp, istp and iscptp known cases.
+        """
+        def case(qobj, shouldhp, shouldcp, shouldtp):
+            hp = qobj.ishp
+            cp = qobj.iscp
+            tp = qobj.istp
+            cptp = qobj.iscptp
 
-        shouldcptp = shouldcp and shouldtp
+            shouldcptp = shouldcp and shouldtp
 
-        if (
-            hp == shouldhp and
-            cp == shouldcp and
-            tp == shouldtp and
-            cptp == shouldcptp
-        ):
-            return
+            if (
+                hp == shouldhp and
+                cp == shouldcp and
+                tp == shouldtp and
+                cptp == shouldcptp
+            ):
+                return
 
-        fails = []
-        if hp != shouldhp:
-            fails.append(("ishp", shouldhp, hp))
-        if tp != shouldtp:
-            fails.append(("istp", shouldtp, tp))
-        if cp != shouldcp:
-            fails.append(("iscp", shouldcp, cp))
-        if cptp != shouldcptp:
-            fails.append(("iscptp", shouldcptp, cptp))
+            fails = []
+            if hp != shouldhp:
+                fails.append(("ishp", shouldhp, hp))
+            if tp != shouldtp:
+                fails.append(("istp", shouldtp, tp))
+            if cp != shouldcp:
+                fails.append(("iscp", shouldcp, cp))
+            if cptp != shouldcptp:
+                fails.append(("iscptp", shouldcptp, cptp))
 
-        raise AssertionError("Expected {}.".format(" and ".join([
-            "{} == {} (got {})".format(fail, expected, got)
-            for fail, expected, got in fails
-        ])))
+            raise AssertionError("Expected {}.".format(" and ".join([
+                "{} == {} (got {})".format(fail, expected, got)
+                for fail, expected, got in fails
+            ])))
 
-    # Conjugation by a creation operator should
-    # have be CP (and hence HP), but not TP.
-    a = create(2).dag()
-    S = sprepost(a, a.dag())
-    case(S, True, True, False)
+        # Conjugation by a creation operator should
+        # have be CP (and hence HP), but not TP.
+        a = create(2).dag()
+        S = sprepost(a, a.dag())
+        case(S, True, True, False)
 
-    # A single off-diagonal element should not be CP,
-    # nor even HP.
-    S = sprepost(a, a)
-    case(S, False, False, False)
+        # A single off-diagonal element should not be CP,
+        # nor even HP.
+        S = sprepost(a, a)
+        case(S, False, False, False)
 
-    # Check that unitaries are CPTP and HP.
-    case(identity(2), True, True, True)
-    case(sigmax(), True, True, True)
+        # Check that unitaries are CPTP and HP.
+        case(identity(2), True, True, True)
+        case(sigmax(), True, True, True)
 
-    # Check that unitaries on bipartite systems are CPTP and HP.
-    case(tensor(sigmax(), identity(2)), True, True, True)
+        # Check that unitaries on bipartite systems are CPTP and HP.
+        case(tensor(sigmax(), identity(2)), True, True, True)
 
-    # Check that a linear combination of bipartitie unitaries is CPTP and HP.
-    S = (
-        to_super(tensor(sigmax(), identity(2))) + to_super(tensor(identity(2), sigmay()))
-    ) / 2
-    case(S, True, True, True)
+        # Check that a linear combination of bipartitie unitaries is CPTP and HP.
+        S = (
+            to_super(tensor(sigmax(), identity(2))) + to_super(tensor(identity(2), sigmay()))
+        ) / 2
+        case(S, True, True, True)
 
-    # The partial transpose map, whose Choi matrix is SWAP, is TP
-    # and HP but not CP (one negative eigenvalue).
-    W = Qobj(swap(), type='super', superrep='choi')
-    case(W, True, False, True)
+        # The partial transpose map, whose Choi matrix is SWAP, is TP
+        # and HP but not CP (one negative eigenvalue).
+        W = Qobj(swap(), type='super', superrep='choi')
+        case(W, True, False, True)
 
-    # Subnormalized maps (representing erasure channels, for instance)
-    # can be CP but not TP.
-    subnorm_map = Qobj(identity(4) * 0.9, type='super', superrep='super')
-    case(subnorm_map, True, True, False)
+        # Subnormalized maps (representing erasure channels, for instance)
+        # can be CP but not TP.
+        subnorm_map = Qobj(identity(4) * 0.9, type='super', superrep='super')
+        case(subnorm_map, True, True, False)
 
-    # Check that things which aren't even operators aren't identified as
-    # CPTP.
-    case(basis(2), False, False, False)
+        # Check that things which aren't even operators aren't identified as
+        # CPTP.
+        case(basis(2), False, False, False)
 
-def test_choi_tr():
-    """
-    Superoperator: Trace returned by to_choi matches docstring.
-    """
-    for dims in range(2, 5):
-        assert_(abs(to_choi(identity(dims)).tr() - dims) <= tol)
+    def test_choi_tr(self):
+        """
+        Superoperator: Trace returned by to_choi matches docstring.
+        """
+        for dims in range(2, 5):
+            assert_(abs(to_choi(identity(dims)).tr() - dims) <= tol)
 
-def test_stinespring_cp( thresh=1e-10):
-    """
-    Stinespring: A and B match for CP maps.
-    """
-    def case(map):
-        A, B = to_stinespring(map)
-        assert_(norm((A - B).data.todense()) < thresh)
+    def test_stinespring_cp(self, thresh=1e-10):
+        """
+        Stinespring: A and B match for CP maps.
+        """
+        def case(map):
+            A, B = to_stinespring(map)
+            assert_(norm((A - B).data.todense()) < thresh)
 
-    for idx in range(4):
-        case(rand_super_bcsz(7))
+        for idx in range(4):
+            case(rand_super_bcsz(7))
 
-def test_stinespring_agrees( thresh=1e-10):
-    """
-    Stinespring: Partial Tr over pair agrees w/ supermatrix.
-    """
-    def case(map, state):
-        S = to_super(map)
-        A, B = to_stinespring(map)
+    def test_stinespring_agrees(self, thresh=1e-10):
+        """
+        Stinespring: Partial Tr over pair agrees w/ supermatrix.
+        """
+        def case(map, state):
+            S = to_super(map)
+            A, B = to_stinespring(map)
 
-        q1 = vector_to_operator(
-            S * operator_to_vector(state)
-        )
-        # FIXME: problem if Kraus index is implicitly
-        #        ptraced!
-        q2 = (A * state * B.dag()).ptrace((0,))
+            q1 = vector_to_operator(
+                S * operator_to_vector(state)
+            )
+            # FIXME: problem if Kraus index is implicitly
+            #        ptraced!
+            q2 = (A * state * B.dag()).ptrace((0,))
 
-        assert_((q1 - q2).norm('tr') <= thresh)
+            assert_((q1 - q2).norm('tr') <= thresh)
 
-    for idx in range(4):
-        case(rand_super_bcsz(2), rand_dm_ginibre(2))
+        for idx in range(4):
+            case(rand_super_bcsz(2), rand_dm_ginibre(2))
 
-def test_stinespring_dims():
-    """
-    Stinespring: Check that dims of channels are preserved.
-    """
-    # FIXME: not the most general test, since this assumes a map
-    #        from square matrices to square matrices on the same space.
-    chan = super_tensor(to_super(sigmax()), to_super(qeye(3)))
-    A, B = to_stinespring(chan)
-    assert_equal(A.dims, [[2, 3, 1], [2, 3]])
-    assert_equal(B.dims, [[2, 3, 1], [2, 3]])
+    def test_stinespring_dims(self):
+        """
+        Stinespring: Check that dims of channels are preserved.
+        """
+        # FIXME: not the most general test, since this assumes a map
+        #        from square matrices to square matrices on the same space.
+        chan = super_tensor(to_super(sigmax()), to_super(qeye(3)))
+        A, B = to_stinespring(chan)
+        assert_equal(A.dims, [[2, 3, 1], [2, 3]])
+        assert_equal(B.dims, [[2, 3, 1], [2, 3]])
 
-def test_chi_choi_roundtrip():
-    def case(qobj):
-        qobj = to_chi(qobj)
-        rt_qobj = to_chi(to_choi(qobj))
+    def test_chi_choi_roundtrip(self):
+        def case(qobj):
+            qobj = to_chi(qobj)
+            rt_qobj = to_chi(to_choi(qobj))
 
-        assert_almost_equal(rt_qobj.data.toarray(), qobj.data.toarray())
-        assert_equal(rt_qobj.type, qobj.type)
-        assert_equal(rt_qobj.dims, qobj.dims)
+            assert_almost_equal(rt_qobj.data.toarray(), qobj.data.toarray())
+            assert_equal(rt_qobj.type, qobj.type)
+            assert_equal(rt_qobj.dims, qobj.dims)
 
-    for N in (2, 4, 8):
-        case(rand_super_bcsz(N))
+        for N in (2, 4, 8):
+            case(rand_super_bcsz(N))
 
-def test_chi_known():
-    """
-    Superoperator: Chi-matrix for known cases is correct.
-    """
-    def case(S, chi_expected, silent=True):
-        chi_actual = to_chi(S)
-        chiq = Qobj(chi_expected, dims=[[[2], [2]], [[2], [2]]], superrep='chi')
-        if not silent:
-            print(chi_actual)
-            print(chi_expected)
-        assert_almost_equal((chi_actual - chiq).norm('tr'), 0)
+    def test_chi_known(self):
+        """
+        Superoperator: Chi-matrix for known cases is correct.
+        """
+        def case(S, chi_expected, silent=True):
+            chi_actual = to_chi(S)
+            chiq = Qobj(chi_expected, dims=[[[2], [2]], [[2], [2]]], superrep='chi')
+            if not silent:
+                print(chi_actual)
+                print(chi_expected)
+            assert_almost_equal((chi_actual - chiq).norm('tr'), 0)
 
-    case(sigmax(), [
-        [0, 0, 0, 0],
-        [0, 4, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0]
-    ])
-    case(to_super(sigmax()), [
-        [0, 0, 0, 0],
-        [0, 4, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0]
-    ])
-    case(qeye(2), [
-        [4, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0]
-    ])
-    case((-1j * sigmax() * pi / 4).expm(), [
-        [2, 2j, 0, 0],
-        [-2j, 2, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0]
-    ])
+        case(sigmax(), [
+            [0, 0, 0, 0],
+            [0, 4, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ])
+        case(to_super(sigmax()), [
+            [0, 0, 0, 0],
+            [0, 4, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ])
+        case(qeye(2), [
+            [4, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ])
+        case((-1j * sigmax() * pi / 4).expm(), [
+            [2, 2j, 0, 0],
+            [-2j, 2, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ])

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -79,14 +79,12 @@ class TestSuperopReps:
 
         # Assert both that the result is close to expected, and has the right
         # type.
-        
 
         assert (test_supe - superoperator).norm() < 1e-5
         assert choi_matrix.type == "super" and choi_matrix.superrep == "choi"
         assert chi_matrix.type == "super" and chi_matrix.superrep == "chi"
         assert test_supe.type == "super" and test_supe.superrep == "super" 
-
-    
+ 
 def test_SuperChoiSuper():
     """
     Superoperator: Converting superoperator to Choi matrix and back.
@@ -244,7 +242,7 @@ def test_known_iscptp():
     # nor even HP.
     S = sprepost(a, a)
     case(S, False, False, False)
-    
+
     # Check that unitaries are CPTP and HP.
     case(identity(2), True, True, True)
     case(sigmax(), True, True, True)
@@ -369,5 +367,3 @@ def test_chi_known():
         [0, 0, 0, 0],
         [0, 0, 0, 0]
     ])
-
-

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -43,7 +43,8 @@ from numpy import abs, pi, asarray, kron
 from numpy.linalg import norm
 from numpy.testing import assert_, assert_almost_equal, run_module_suite, assert_equal
 
-from unittest import expectedFailure
+import pytest
+
 
 from qutip.qobj import Qobj
 from qutip.states import basis
@@ -58,33 +59,19 @@ from qutip.superoperator import operator_to_vector, vector_to_operator, sprepost
 tol = 1e-9
 
 
-class TestSuperopReps(object):
+
+class TestSuperopReps:
     """
     A test class for the QuTiP function for applying superoperators to
     subsystems.
     """
-
-    def test_SuperChoiSuper(self):
-        """
-        Superoperator: Converting superoperator to Choi matrix and back.
-        """
-        superoperator = rand_super()
-
-        choi_matrix = to_choi(superoperator)
-        test_supe = to_super(choi_matrix)
-
-        # Assert both that the result is close to expected, and has the right
-        # type.
-        assert_((test_supe - superoperator).norm() < tol)
-        assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
-        assert_(test_supe.type == "super" and test_supe.superrep == "super")
-
-    def test_SuperChoiChiSuper(self):
+    @pytest.mark.parametrize('dimension', [2, 4, 8])
+    def test_SuperChoiChiSuper(self, dimension):
         """
         Superoperator: Converting two-qubit superoperator through
         Choi and chi representations goes back to right superoperator.
         """
-        superoperator = super_tensor(rand_super(2), rand_super(2))
+        superoperator = super_tensor(rand_super(dimension), rand_super(dimension))
 
         choi_matrix = to_choi(superoperator)
         chi_matrix = to_chi(choi_matrix)
@@ -92,261 +79,292 @@ class TestSuperopReps(object):
 
         # Assert both that the result is close to expected, and has the right
         # type.
-        assert_((test_supe - superoperator).norm() < tol)
-        assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
-        assert_(chi_matrix.type == "super" and chi_matrix.superrep == "chi")
-        assert_(test_supe.type == "super" and test_supe.superrep == "super")
+        assert (test_supe - superoperator).norm() < 1e-5
+        assert choi_matrix.type == "super" and choi_matrix.superrep == "choi"
+        assert chi_matrix.type == "super" and chi_matrix.superrep == "chi"
+        assert test_supe.type == "super" and test_supe.superrep == "super" 
 
-    def test_ChoiKrausChoi(self):
-        """
-        Superoperator: Convert superoperator to Choi matrix and back.
-        """
-        superoperator = rand_super()
-        choi_matrix = to_choi(superoperator)
-        kraus_ops = to_kraus(choi_matrix)
-        test_choi = kraus_to_choi(kraus_ops)
+    
+def test_SuperChoiSuper():
+    """
+    Superoperator: Converting superoperator to Choi matrix and back.
+    """
+    superoperator = rand_super()
 
-        # Assert both that the result is close to expected, and has the right
-        # type.
-        assert_((test_choi - choi_matrix).norm() < tol)
-        assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
-        assert_(test_choi.type == "super" and test_choi.superrep == "choi")
+    choi_matrix = to_choi(superoperator)
+    test_supe = to_super(choi_matrix)
 
-    def test_NonSquareKrausSuperChoi(self):
-        """
-        Superoperator: Convert non-square Kraus operator to Super + Choi matrix and back.
-        """
-        zero = asarray([[1], [0]], dtype=complex)
-        one = asarray([[0], [1]], dtype=complex)
-        zero_log = kron(kron(zero, zero), zero)
-        one_log = kron(kron(one, one), one)
-        # non-square Kraus operator (isometry)
-        kraus = Qobj(zero_log @ zero.T + one_log @ one.T)
-        super = sprepost(kraus, kraus.dag())
-        choi = to_choi(super)
-        op1 = to_kraus(super)
-        op2 = to_kraus(choi)
-        op3 = to_super(choi)
-        assert_(choi.type == "super" and choi.superrep == "choi")
-        assert_(super.type == "super" and super.superrep == "super")
-        assert_((op1[0] - kraus).norm() < 1e-8)
-        assert_((op2[0] - kraus).norm() < 1e-8)
-        assert_((op3 - super).norm() < 1e-8)
+    # Assert both that the result is close to expected, and has the right
+    # type.
+    assert_((test_supe - superoperator).norm() < tol)
+    assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
+    assert_(test_supe.type == "super" and test_supe.superrep == "super")
 
-    def test_NeglectSmallKraus(self):
-        """
-        Superoperator: Convert Kraus to Choi matrix and back. Neglect tiny Kraus operators.
-        """
-        zero = asarray([[1], [0]], dtype=complex)
-        one = asarray([[0], [1]], dtype=complex)
-        zero_log = kron(kron(zero, zero), zero)
-        one_log = kron(kron(one, one), one)
-        # non-square Kraus operator (isometry)
-        kraus = Qobj(zero_log @ zero.T + one_log @ one.T)
-        super = sprepost(kraus, kraus.dag())
-        # 1 non-zero Kraus operator the rest are zero
-        sixteen_kraus_ops = to_kraus(super, tol=0.0)
-        # default is tol=1e-9
-        one_kraus_op = to_kraus(super)
-        assert_(len(sixteen_kraus_ops) == 16 and len(one_kraus_op) == 1)
-        assert_((one_kraus_op[0] - kraus).norm() < tol)
+def test_SuperChoiChiSuper():
+    """
+    Superoperator: Converting two-qubit superoperator through
+    Choi and chi representations goes back to right superoperator.
+    """
+    superoperator = super_tensor(rand_super(2), rand_super(2))
 
-    def test_SuperPreservesSelf(self):
-        """
-        Superoperator: to_super(q) returns q if q is already a
-        supermatrix.
-        """
-        superop = rand_super()
-        assert_(superop is to_super(superop))
+    choi_matrix = to_choi(superoperator)
+    chi_matrix = to_chi(choi_matrix)
+    test_supe = to_super(chi_matrix)
 
-    def test_ChoiPreservesSelf(self):
-        """
-        Superoperator: to_choi(q) returns q if q is already Choi.
-        """
-        superop = rand_super()
-        choi = to_choi(superop)
-        assert_(choi is to_choi(choi))
+    # Assert both that the result is close to expected, and has the right
+    # type.
+    assert_((test_supe - superoperator).norm() < tol)
+    assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
+    assert_(chi_matrix.type == "super" and chi_matrix.superrep == "chi")
+    assert_(test_supe.type == "super" and test_supe.superrep == "super")
 
-    def test_random_iscptp(self):
-        """
-        Superoperator: Randomly generated superoperators are
-        correctly reported as CPTP and HP.
-        """
-        superop = rand_super()
-        assert_(superop.iscptp)
-        assert_(superop.ishp)
+def test_ChoiKrausChoi():
+    """
+    Superoperator: Convert superoperator to Choi matrix and back.
+    """
+    superoperator = rand_super()
+    choi_matrix = to_choi(superoperator)
+    kraus_ops = to_kraus(choi_matrix)
+    test_choi = kraus_to_choi(kraus_ops)
 
-    def test_known_iscptp(self):
-        """
-        Superoperator: ishp, iscp, istp and iscptp known cases.
-        """
-        def case(qobj, shouldhp, shouldcp, shouldtp):
-            hp = qobj.ishp
-            cp = qobj.iscp
-            tp = qobj.istp
-            cptp = qobj.iscptp
+    # Assert both that the result is close to expected, and has the right
+    # type.
+    assert_((test_choi - choi_matrix).norm() < tol)
+    assert_(choi_matrix.type == "super" and choi_matrix.superrep == "choi")
+    assert_(test_choi.type == "super" and test_choi.superrep == "choi")
 
-            shouldcptp = shouldcp and shouldtp
+def test_NonSquareKrausSuperChoi():
+    """
+    Superoperator: Convert non-square Kraus operator to Super + Choi matrix and back.
+    """
+    zero = asarray([[1], [0]], dtype=complex)
+    one = asarray([[0], [1]], dtype=complex)
+    zero_log = kron(kron(zero, zero), zero)
+    one_log = kron(kron(one, one), one)
+    # non-square Kraus operator (isometry)
+    kraus = Qobj(zero_log @ zero.T + one_log @ one.T)
+    super = sprepost(kraus, kraus.dag())
+    choi = to_choi(super)
+    op1 = to_kraus(super)
+    op2 = to_kraus(choi)
+    op3 = to_super(choi)
+    assert_(choi.type == "super" and choi.superrep == "choi")
+    assert_(super.type == "super" and super.superrep == "super")
+    assert_((op1[0] - kraus).norm() < 1e-8)
+    assert_((op2[0] - kraus).norm() < 1e-8)
+    assert_((op3 - super).norm() < 1e-8)
 
-            if (
-                hp == shouldhp and
-                cp == shouldcp and
-                tp == shouldtp and
-                cptp == shouldcptp
-            ):
-                return
+def test_NeglectSmallKraus():
+    """
+    Superoperator: Convert Kraus to Choi matrix and back. Neglect tiny Kraus operators.
+    """
+    zero = asarray([[1], [0]], dtype=complex)
+    one = asarray([[0], [1]], dtype=complex)
+    zero_log = kron(kron(zero, zero), zero)
+    one_log = kron(kron(one, one), one)
+    # non-square Kraus operator (isometry)
+    kraus = Qobj(zero_log @ zero.T + one_log @ one.T)
+    super = sprepost(kraus, kraus.dag())
+    # 1 non-zero Kraus operator the rest are zero
+    sixteen_kraus_ops = to_kraus(super, tol=0.0)
+    # default is tol=1e-9
+    one_kraus_op = to_kraus(super)
+    assert_(len(sixteen_kraus_ops) == 16 and len(one_kraus_op) == 1)
+    assert_((one_kraus_op[0] - kraus).norm() < tol)
 
-            fails = []
-            if hp != shouldhp:
-                fails.append(("ishp", shouldhp, hp))
-            if tp != shouldtp:
-                fails.append(("istp", shouldtp, tp))
-            if cp != shouldcp:
-                fails.append(("iscp", shouldcp, cp))
-            if cptp != shouldcptp:
-                fails.append(("iscptp", shouldcptp, cptp))
+def test_SuperPreservesSelf():
+    """
+    Superoperator: to_super(q) returns q if q is already a
+    supermatrix.
+    """
+    superop = rand_super()
+    assert_(superop is to_super(superop))
 
-            raise AssertionError("Expected {}.".format(" and ".join([
-                "{} == {} (got {})".format(fail, expected, got)
-                for fail, expected, got in fails
-            ])))
+def test_ChoiPreservesSelf():
+    """
+    Superoperator: to_choi(q) returns q if q is already Choi.
+    """
+    superop = rand_super()
+    choi = to_choi(superop)
+    assert_(choi is to_choi(choi))
 
-        # Conjugation by a creation operator should
-        # have be CP (and hence HP), but not TP.
-        a = create(2).dag()
-        S = sprepost(a, a.dag())
-        case(S, True, True, False)
+def test_random_iscptp():
+    """
+    Superoperator: Randomly generated superoperators are
+    correctly reported as CPTP and HP.
+    """
+    superop = rand_super()
+    assert_(superop.iscptp)
+    assert_(superop.ishp)
 
-        # A single off-diagonal element should not be CP,
-        # nor even HP.
-        S = sprepost(a, a)
-        case(S, False, False, False)
-        
-        # Check that unitaries are CPTP and HP.
-        case(identity(2), True, True, True)
-        case(sigmax(), True, True, True)
+def test_known_iscptp():
+    """
+    Superoperator: ishp, iscp, istp and iscptp known cases.
+    """
+    def case(qobj, shouldhp, shouldcp, shouldtp):
+        hp = qobj.ishp
+        cp = qobj.iscp
+        tp = qobj.istp
+        cptp = qobj.iscptp
 
-        # Check that unitaries on bipartite systems are CPTP and HP.
-        case(tensor(sigmax(), identity(2)), True, True, True)
+        shouldcptp = shouldcp and shouldtp
 
-        # Check that a linear combination of bipartitie unitaries is CPTP and HP.
-        S = (
-            to_super(tensor(sigmax(), identity(2))) + to_super(tensor(identity(2), sigmay()))
-        ) / 2
-        case(S, True, True, True)
+        if (
+            hp == shouldhp and
+            cp == shouldcp and
+            tp == shouldtp and
+            cptp == shouldcptp
+        ):
+            return
 
-        # The partial transpose map, whose Choi matrix is SWAP, is TP
-        # and HP but not CP (one negative eigenvalue).
-        W = Qobj(swap(), type='super', superrep='choi')
-        case(W, True, False, True)
+        fails = []
+        if hp != shouldhp:
+            fails.append(("ishp", shouldhp, hp))
+        if tp != shouldtp:
+            fails.append(("istp", shouldtp, tp))
+        if cp != shouldcp:
+            fails.append(("iscp", shouldcp, cp))
+        if cptp != shouldcptp:
+            fails.append(("iscptp", shouldcptp, cptp))
 
-        # Subnormalized maps (representing erasure channels, for instance)
-        # can be CP but not TP.
-        subnorm_map = Qobj(identity(4) * 0.9, type='super', superrep='super')
-        case(subnorm_map, True, True, False)
+        raise AssertionError("Expected {}.".format(" and ".join([
+            "{} == {} (got {})".format(fail, expected, got)
+            for fail, expected, got in fails
+        ])))
 
-        # Check that things which aren't even operators aren't identified as
-        # CPTP.
-        case(basis(2), False, False, False)
+    # Conjugation by a creation operator should
+    # have be CP (and hence HP), but not TP.
+    a = create(2).dag()
+    S = sprepost(a, a.dag())
+    case(S, True, True, False)
 
-    def test_choi_tr(self):
-        """
-        Superoperator: Trace returned by to_choi matches docstring.
-        """
-        for dims in range(2, 5):
-            assert_(abs(to_choi(identity(dims)).tr() - dims) <= tol)
+    # A single off-diagonal element should not be CP,
+    # nor even HP.
+    S = sprepost(a, a)
+    case(S, False, False, False)
+    
+    # Check that unitaries are CPTP and HP.
+    case(identity(2), True, True, True)
+    case(sigmax(), True, True, True)
 
-    def test_stinespring_cp(self, thresh=1e-10):
-        """
-        Stinespring: A and B match for CP maps.
-        """
-        def case(map):
-            A, B = to_stinespring(map)
-            assert_(norm((A - B).data.todense()) < thresh)
+    # Check that unitaries on bipartite systems are CPTP and HP.
+    case(tensor(sigmax(), identity(2)), True, True, True)
 
-        for idx in range(4):
-            case(rand_super_bcsz(7))
+    # Check that a linear combination of bipartitie unitaries is CPTP and HP.
+    S = (
+        to_super(tensor(sigmax(), identity(2))) + to_super(tensor(identity(2), sigmay()))
+    ) / 2
+    case(S, True, True, True)
 
-    def test_stinespring_agrees(self, thresh=1e-10):
-        """
-        Stinespring: Partial Tr over pair agrees w/ supermatrix.
-        """
-        def case(map, state):
-            S = to_super(map)
-            A, B = to_stinespring(map)
+    # The partial transpose map, whose Choi matrix is SWAP, is TP
+    # and HP but not CP (one negative eigenvalue).
+    W = Qobj(swap(), type='super', superrep='choi')
+    case(W, True, False, True)
 
-            q1 = vector_to_operator(
-                S * operator_to_vector(state)
-            )
-            # FIXME: problem if Kraus index is implicitly
-            #        ptraced!
-            q2 = (A * state * B.dag()).ptrace((0,))
+    # Subnormalized maps (representing erasure channels, for instance)
+    # can be CP but not TP.
+    subnorm_map = Qobj(identity(4) * 0.9, type='super', superrep='super')
+    case(subnorm_map, True, True, False)
 
-            assert_((q1 - q2).norm('tr') <= thresh)
+    # Check that things which aren't even operators aren't identified as
+    # CPTP.
+    case(basis(2), False, False, False)
 
-        for idx in range(4):
-            case(rand_super_bcsz(2), rand_dm_ginibre(2))
+def test_choi_tr():
+    """
+    Superoperator: Trace returned by to_choi matches docstring.
+    """
+    for dims in range(2, 5):
+        assert_(abs(to_choi(identity(dims)).tr() - dims) <= tol)
 
-    def test_stinespring_dims(self):
-        """
-        Stinespring: Check that dims of channels are preserved.
-        """
-        # FIXME: not the most general test, since this assumes a map
-        #        from square matrices to square matrices on the same space.
-        chan = super_tensor(to_super(sigmax()), to_super(qeye(3)))
-        A, B = to_stinespring(chan)
-        assert_equal(A.dims, [[2, 3, 1], [2, 3]])
-        assert_equal(B.dims, [[2, 3, 1], [2, 3]])
+def test_stinespring_cp( thresh=1e-10):
+    """
+    Stinespring: A and B match for CP maps.
+    """
+    def case(map):
+        A, B = to_stinespring(map)
+        assert_(norm((A - B).data.todense()) < thresh)
 
-    def test_chi_choi_roundtrip(self):
-        def case(qobj):
-            qobj = to_chi(qobj)
-            rt_qobj = to_chi(to_choi(qobj))
+    for idx in range(4):
+        case(rand_super_bcsz(7))
 
-            assert_almost_equal(rt_qobj.data.toarray(), qobj.data.toarray())
-            assert_equal(rt_qobj.type, qobj.type)
-            assert_equal(rt_qobj.dims, qobj.dims)
+def test_stinespring_agrees( thresh=1e-10):
+    """
+    Stinespring: Partial Tr over pair agrees w/ supermatrix.
+    """
+    def case(map, state):
+        S = to_super(map)
+        A, B = to_stinespring(map)
 
-        for N in (2, 4, 8):
-            case(rand_super_bcsz(N))
+        q1 = vector_to_operator(
+            S * operator_to_vector(state)
+        )
+        # FIXME: problem if Kraus index is implicitly
+        #        ptraced!
+        q2 = (A * state * B.dag()).ptrace((0,))
 
-    def test_chi_known(self):
-        """
-        Superoperator: Chi-matrix for known cases is correct.
-        """
-        def case(S, chi_expected, silent=True):
-            chi_actual = to_chi(S)
-            chiq = Qobj(chi_expected, dims=[[[2], [2]], [[2], [2]]], superrep='chi')
-            if not silent:
-                print(chi_actual)
-                print(chi_expected)
-            assert_almost_equal((chi_actual - chiq).norm('tr'), 0)
+        assert_((q1 - q2).norm('tr') <= thresh)
 
-        case(sigmax(), [
-            [0, 0, 0, 0],
-            [0, 4, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 0]
-        ])
-        case(to_super(sigmax()), [
-            [0, 0, 0, 0],
-            [0, 4, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 0]
-        ])
-        case(qeye(2), [
-            [4, 0, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 0]
-        ])
-        case((-1j * sigmax() * pi / 4).expm(), [
-            [2, 2j, 0, 0],
-            [-2j, 2, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 0]
-        ])
+    for idx in range(4):
+        case(rand_super_bcsz(2), rand_dm_ginibre(2))
 
-if __name__ == "__main__":
-    run_module_suite()
+def test_stinespring_dims():
+    """
+    Stinespring: Check that dims of channels are preserved.
+    """
+    # FIXME: not the most general test, since this assumes a map
+    #        from square matrices to square matrices on the same space.
+    chan = super_tensor(to_super(sigmax()), to_super(qeye(3)))
+    A, B = to_stinespring(chan)
+    assert_equal(A.dims, [[2, 3, 1], [2, 3]])
+    assert_equal(B.dims, [[2, 3, 1], [2, 3]])
+
+def test_chi_choi_roundtrip():
+    def case(qobj):
+        qobj = to_chi(qobj)
+        rt_qobj = to_chi(to_choi(qobj))
+
+        assert_almost_equal(rt_qobj.data.toarray(), qobj.data.toarray())
+        assert_equal(rt_qobj.type, qobj.type)
+        assert_equal(rt_qobj.dims, qobj.dims)
+
+    for N in (2, 4, 8):
+        case(rand_super_bcsz(N))
+
+def test_chi_known():
+    """
+    Superoperator: Chi-matrix for known cases is correct.
+    """
+    def case(S, chi_expected, silent=True):
+        chi_actual = to_chi(S)
+        chiq = Qobj(chi_expected, dims=[[[2], [2]], [[2], [2]]], superrep='chi')
+        if not silent:
+            print(chi_actual)
+            print(chi_expected)
+        assert_almost_equal((chi_actual - chiq).norm('tr'), 0)
+
+    case(sigmax(), [
+        [0, 0, 0, 0],
+        [0, 4, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0]
+    ])
+    case(to_super(sigmax()), [
+        [0, 0, 0, 0],
+        [0, 4, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0]
+    ])
+    case(qeye(2), [
+        [4, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0]
+    ])
+    case((-1j * sigmax() * pi / 4).expm(), [
+        [2, 2j, 0, 0],
+        [-2j, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0]
+    ])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cython>=0.21
 numpy>=1.12
 scipy>=1.0
+packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ zip_safe = False
 install_requires =
     numpy>=1.16.6
     scipy>=1.0
+    packaging
+
 setup_requires =
     numpy>=1.16.6,<1.20
     scipy>=1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ setup_requires =
     numpy>=1.16.6,<1.20
     scipy>=1.0
     cython>=0.29.20
+    packaging
 
 [options.packages.find]
 include = qutip*

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     numpy>=1.16.6
     scipy>=1.0
     packaging
-
 setup_requires =
     numpy>=1.16.6,<1.20
     scipy>=1.0


### PR DESCRIPTION
**Description**
Setting eigh_unsafe on sipy<1.5 and  MKL

**Related issues or PRs**
#1495

**Changelog**
- Changed init to set eigh not safe in case scipy<1.5 and mkl backend
- Added the correct pytest breaking test from issue #1491 to check the solution