### PR TITLE
Adds hyperlinks to docstrings of Qobj and Qobjevo class

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1101,7 +1101,7 @@ class Qobj(object):
         Returns
         -------
         data : array
-            Array of complex data from quantum object's :obj:`.data` attribute.
+            Array of complex data from quantum object's `data` attribute.
         """
         if squeeze:
             return self.data.toarray(order=order).squeeze()
@@ -1541,8 +1541,7 @@ class Qobj(object):
 
         Raises
         ------
-        ValueError : Must be a Hermitian operator to remove negative
-        eigenvalues
+        ValueError : Must be a Hermitian operator
             When input operator is not Hermitian.
 
         ValueError : Method not recognized
@@ -1737,7 +1736,7 @@ class Qobj(object):
             Array of eigenvalues for operator.
 
         eigvecs : array
-            Array of quantum operators representing the oprator eigenkets.
+            Array of quantum operators representing the operator eigenkets.
             Order of eigenkets is determined by order of eigenvalues.
 
         Notes
@@ -1868,7 +1867,7 @@ class Qobj(object):
         return out
 
     def extract_states(self, states_inds, normalize=False):
-        """:obj:`.Qobj` with states in ``states_inds`` only.
+        """:obj:`.Qobj` with states in `states_inds` only.
 
         Parameters
         ----------
@@ -1886,12 +1885,12 @@ class Qobj(object):
         -------
         q : :obj:`.Qobj`
             A new instance of :obj:`.Qobj` that contains only the states
-            corresponding to the indices in ``states_inds``.
+            corresponding to the indices in `states_inds`.
 
         Raises
         -------
         TypeError : Can only eliminate states from operators or state vectors
-            If input is not ket, bra or an operator.
+            If input is not :obj:`.ket`, :obj:`.bra` or an :obj:`.operators`.
 
         Notes
         -----
@@ -1911,7 +1910,7 @@ class Qobj(object):
         return q.unit() if normalize else q
 
     def eliminate_states(self, states_inds, normalize=False):
-        """Creates a new quantum object with states in ``states_inds`` eliminated.
+        """Creates a new quantum object with states in `states_inds` eliminated.
 
         Parameters
         ----------
@@ -1929,7 +1928,7 @@ class Qobj(object):
         -------
         :obj:`.Qobj`
             A new instance of :obj:`.Qobj` that contains only the states
-            corresponding to indices that are **not** in ``states_inds``.
+            corresponding to indices that are **not** in `states_inds`.
 
         Notes
         -----
@@ -2172,8 +2171,7 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError : Unrecognized format for specification of time-dependent
-        Qobj
+        TypeError : Unrecognized format for specification of time-dep Qobj
             When type of `qobj_list` cannot be recognized - :obj:`.Qobj` or
             list etc.
 
@@ -2345,7 +2343,7 @@ def dims(inpt):
     Raises
     -------
     TypeError : Input is not a quantum object
-        When input cannot be identified as :obj:`.Qobj`. 
+        When input cannot be identified as :obj:`.Qobj`.
 
     Notes
     -----

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -100,15 +100,16 @@ class Qobj(object):
     inpt : array_like
         Data for vector/matrix representation of the quantum object.
     dims : list
-        Dimensions of object used for tensor products.
+        Dimensions of object used for :obj:`.tensor` products via :obj:`.dims`.
     shape : list
-        Shape of underlying data structure (matrix shape).
+        Shape of underlying data structure (matrix shape) via
+        :obj:`.dims_to_tensor_shape`.
     copy : bool
         Flag specifying whether :class:`Qobj` should get a copy of the
         input data, or use the original.
     fast : bool
         Flag for fast :class:`Qobj` creation when running ODE solvers like
-        :func:`qutip.mesolve` and :func:`qutip.mcsolve`.
+        :func:`~qutip.mesolve` and :func:`~qutip.mcsolve`.
         This parameter is used internally only.
 
 
@@ -117,26 +118,26 @@ class Qobj(object):
     data : array_like
         Sparse matrix characterizing the quantum object.
     dims : list
-        List of dimensions keeping track of the tensor structure.
+        List of dimensions keeping track of the :obj:`.tensor` structure.
     shape : list
         Shape of the underlying `data` array.
     type : str
         Type of quantum object: :func:`~qutip.states.bra`,
-        :func:`~qutip.states.ket`, 'oper' (:func:`~qutip.qobj.isoper`),
-        'operator-ket' (:func:`~qutip.qobj.isoperket`),
-        'operator-bra' (:func:`~qutip.qobj.isoperbra`), or 'super'
-        (:func:`~qutip.qobj.issuper`).
+        :func:`~qutip.states.ket`, 'oper' (:obj:`.isoper`),
+        'operator-ket' (:obj:`.isoperket`),
+        'operator-bra' (:obj:`.isoperbra`), or 'super'
+        (:obj:`.issuper`).
     superrep : str
         Representation used if ``type`` is 'super'
-        (:func:`~qutip.qobj.issuper`). One of 'super'
+        (:obj:`.issuper`). One of 'super'
         (:func:`~qutip.superoperator.liouvillian` form) or 'choi'
         (Choi matrix with tr = dimension via :mod:`~qutip.superop_reps`).
     isherm : bool
         Indicates if quantum object represents Hermitian operator via
-        :func:`~qutip.qobj.isherm`.
+        :obj:`.isherm`.
     isunitary : bool
-        Indictaes if quantum object represents unitary operator via
-        :func:`~qutip.qobj.check_isunitary`.
+        Indicates if quantum object represents unitary operator via
+        :meth:`check_isunitary`.
     iscp : bool
         Indicates if the quantum object represents a map, and if that map is
         completely positive (CP).

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -104,10 +104,11 @@ class Qobj(object):
     shape : list
         Shape of underlying data structure (matrix shape).
     copy : bool
-        Flag specifying whether Qobj should get a copy of the
+        Flag specifying whether :class:`Qobj` should get a copy of the
         input data, or use the original.
     fast : bool
-        Flag for fast qobj creation when running ode solvers.
+        Flag for fast :class:`Qobj` creation when running ODE solvers like
+        :func:`qutip.mesolve` and :func:`qutip.mcsolve`.
         This parameter is used internally only.
 
 
@@ -885,7 +886,7 @@ class Qobj(object):
         return s
 
     def dag(self):
-        """Adjoint operator of quantum object.
+        """Adjoint operator of quantum object (:class:`Qobj`).
         """
         out = Qobj()
         out.data = zcsr_adjoint(self.data)
@@ -912,7 +913,7 @@ class Qobj(object):
         return J_dual
 
     def conj(self):
-        """Conjugate operator of quantum object.
+        """Conjugate operator of quantum object (:class:`Qobj`).
         """
         out = Qobj()
         out.data = self.data.conj()
@@ -920,7 +921,7 @@ class Qobj(object):
         return out
 
     def norm(self, norm=None, sparse=False, tol=0, maxiter=100000):
-        """Norm of a quantum object.
+        """Norm of a quantum object (:class:`Qobj`).
 
         Default norm is L2-norm for kets and trace-norm for operators.
         Other ket and operator norms may be specified using the `norm` and
@@ -1051,7 +1052,7 @@ class Qobj(object):
         Returns
         -------
         data : array
-            Array of complex data from quantum objects `data` attribute.
+            Array of complex data from quantum object's ``data`` attribute.
         """
         if squeeze:
             return self.data.toarray(order=order).squeeze()
@@ -1065,7 +1066,7 @@ class Qobj(object):
         return self.full()
 
     def diag(self):
-        """Diagonal elements of quantum object.
+        """Diagonal elements of quantum object (:class:`Qobj`).
 
         Returns
         -------
@@ -1120,7 +1121,7 @@ class Qobj(object):
         return out.tidyup() if settings.auto_tidyup else out
 
     def check_herm(self):
-        """Check if the quantum object is hermitian.
+        """Check if the quantum object (:class:`Qobj`) is hermitian.
 
         Returns
         -------
@@ -1522,7 +1523,7 @@ class Qobj(object):
         Parameters
         -----------
         bra : :class:`qutip.Qobj`
-            Quantum object of type 'bra' or 'ket'
+            Quantum object of type 'bra' 
 
         ket : :class:`qutip.Qobj`
             Quantum object of type 'ket'.
@@ -1778,7 +1779,7 @@ class Qobj(object):
         return out
 
     def extract_states(self, states_inds, normalize=False):
-        """Qobj with states in state_inds only.
+        """:class:`Qobj` with states in ``states_inds`` only.
 
         Parameters
         ----------
@@ -1796,7 +1797,7 @@ class Qobj(object):
         -------
         q : :class:`qutip.Qobj`
             A new instance of :class:`qutip.Qobj` that contains only the states
-            corresponding to the indices in `state_inds`.
+            corresponding to the indices in `states_inds`.
 
         Notes
         -----
@@ -1816,7 +1817,7 @@ class Qobj(object):
         return q.unit() if normalize else q
 
     def eliminate_states(self, states_inds, normalize=False):
-        """Creates a new quantum object with states in state_inds eliminated.
+        """Creates a new quantum object with states in ``states_inds`` eliminated.
 
         Parameters
         ----------
@@ -1824,7 +1825,7 @@ class Qobj(object):
             The states that should be removed.
 
         normalize : True / False
-            Weather or not the new Qobj instance should be normalized (default
+            Weather or not the new :class:`Qobj` instance should be normalized (default
             is False). For Qobjs that represents density matrices or state
             vectors normalized should probably be set to True, but for Qobjs
             that represents operators in for example an Hamiltonian, normalize
@@ -1832,9 +1833,9 @@ class Qobj(object):
 
         Returns
         -------
-        q : :class:`qutip.Qobj`
-            A new instance of :class:`qutip.Qobj` that contains only the states
-            corresponding to indices that are **not** in `state_inds`.
+        q : :class:`Qobj`
+            A new instance of :class:`Qobj` that contains only the states
+            corresponding to indices that are **not** in ``states_inds``.
 
         Notes
         -----
@@ -1964,7 +1965,7 @@ class Qobj(object):
 
     def check_isunitary(self):
         """
-        Checks whether :class:`QobjEvo`  is a unitary matrix
+        Checks whether :class:`Qobj` is a unitary matrix
         """
         if self.isoper:
             eye_data = fast_identity(self.shape[0])
@@ -2062,11 +2063,11 @@ class Qobj(object):
             The time for which to evaluate the time-dependent Qobj instance.
         args : dictionary
             A dictionary with parameter values required to evaluate the
-            time-dependent Qobj intance.
+            time-dependent Qobj instance.
 
         Returns
         -------
-        output : :class:`qutip.Qobj`
+        output : :class:`Qobj`
             A Qobj instance that represents the value of qobj_list at time t.
 
         """

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1523,7 +1523,7 @@ class Qobj(object):
         Parameters
         -----------
         bra : :class:`qutip.Qobj`
-            Quantum object of type 'bra' 
+            Quantum object of type 'bra'
 
         ket : :class:`qutip.Qobj`
             Quantum object of type 'ket'.
@@ -1825,11 +1825,11 @@ class Qobj(object):
             The states that should be removed.
 
         normalize : True / False
-            Weather or not the new :class:`Qobj` instance should be normalized (default
-            is False). For Qobjs that represents density matrices or state
-            vectors normalized should probably be set to True, but for Qobjs
-            that represents operators in for example an Hamiltonian, normalize
-            should be False.
+            Weather or not the new :class:`Qobj` instance should be normalized
+            (default is False). For Qobjs that represents density matrices or
+            state vectors normalized should probably be set to True, but for
+            Qobjs that represents operators in for example an Hamiltonian,
+            normalize should be False.
 
         Returns
         -------

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -134,7 +134,8 @@ class Qobj(object):
         Indicates if quantum object represents Hermitian operator via
         :func:`~qutip.qobj.isherm`.
     isunitary : bool
-        Indictaes if quantum object represents unitary operator via :func:`~qutip.qobj.check_isunitary`.
+        Indictaes if quantum object represents unitary operator via
+        :func:`~qutip.qobj.check_isunitary`.
     iscp : bool
         Indicates if the quantum object represents a map, and if that map is
         completely positive (CP).

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1250,7 +1250,7 @@ class Qobj(object):
 
         Notes
         -----
-        Uses the Q.expm() method.
+        Uses the Q.:attr:`expm()` method.
 
         """
         if self.dims[0][0] == self.dims[1][0]:

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -314,7 +314,13 @@ class Qobj(object):
         self._type = None
 
     def copy(self):
-        """Create identical copy"""
+        """Create identical copy
+        Returns
+        -------
+        :class:`Qobj`
+            The requested copy of an operator or a quantum state as a
+            quantum object.
+        """
         return Qobj(inpt=self)
 
     def get_data(self):

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1028,8 +1028,13 @@ class Qobj(object):
 
         Returns
         -------
-        P : :class:`Qobj`
+        P : :obj:`.Qobj`
             Projection operator.
+
+        Raises
+        -------
+        TypeError
+            Projector can only be formed from a bra or ket.
         """
         if self.isket:
             _out = zcsr_proj(self.data, 1)
@@ -1142,10 +1147,12 @@ class Qobj(object):
         Raises
         ------
         TypeError
-            Invalid operand for matrix exponential.
+            Invalid operand for matrix exponential - when dimensions do not
+            match.
 
         ValueError
-            Method must be 'dense' or 'sparse'.
+            Method must be 'dense' or 'sparse' - when available method is not
+            chosen.
 
         """
         if self.dims[0][0] != self.dims[1][0]:
@@ -1158,7 +1165,7 @@ class Qobj(object):
             F = sp_expm(self.data, sparse=True)
 
         else:
-            raise ValueError("method must be 'dense' or 'sparse'.")
+            raise ValueError("Method must be 'dense' or 'sparse'.")
 
         out = Qobj(F, dims=self.dims)
         return out.tidyup() if settings.auto_tidyup else out
@@ -1190,13 +1197,13 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`qutip.Qobj`
+        oper : :obj:`.Qobj`
             Matrix square root of operator.
 
         Raises
         ------
         TypeError
-            Invalid operand for matrix square root.
+            Invalid operand for matrix square root - when input is not square.
 
         Notes
         -----
@@ -1234,7 +1241,7 @@ class Qobj(object):
         Raises
         ------
         TypeError
-            Invalid operand for matrix square root.
+            Invalid operand for matrix square root - when input is not square.
 
         Notes
         -----
@@ -1259,7 +1266,7 @@ class Qobj(object):
         Raises
         ------
         TypeError
-            Invalid operand for matrix square root.
+            Invalid operand for matrix square root - when input is not square.
 
         Notes
         -----
@@ -1284,7 +1291,7 @@ class Qobj(object):
         Raises
         ------
         TypeError
-            Invalid operand for matrix inverse.
+            Invalid operand for matrix inverse - when input is not square.
         """
         if self.shape[0] != self.shape[1]:
             raise TypeError('Invalid operand for matrix inverse')
@@ -1447,9 +1454,11 @@ class Qobj(object):
         Raises
         ------
         TypeError
-            Invalid size of ket list for basis transformation.
+            Invalid size of ket list for basis transformation - when input
+            is a list or array and the dimensions do not match.
 
-            Invalid operand for basis transformation.
+            Invalid operand for basis transformation - when input is not a
+            proper quantum object or operator.
 
         Notes
         -----
@@ -1531,9 +1540,11 @@ class Qobj(object):
         Raises
         ------
         ValueError
-            Must be a Hermitian operator to remove negative eigenvalues.
+            Must be a Hermitian operator to remove negative eigenvalues - when
+            operator is not Hermitian.
 
-            Method not recognized.
+            Method not recognized - if method other than 'clip' or 'sgs' is
+            specified.
 
         """
         if not self.isherm:
@@ -1598,9 +1609,11 @@ class Qobj(object):
         Raises
         -------
         TypeError
-            Can only get matrix elements for an operator.
+            Can only get matrix elements for an operator - when input
+            is not a valid operator.
 
-            Can only calculate matrix elements for bra  and ket vectors.
+            Can only calculate matrix elements for bra  and ket vectors -
+            when input is not a valid ket or bra vector.
 
         Notes
         -----
@@ -1844,7 +1857,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`Qobj`
+        oper : :obj:`.Qobj`
             Transpose of input operator.
 
         """
@@ -2159,7 +2172,7 @@ class Qobj(object):
         Raises
         ------
         TypeError
-            Unrecognized format for specification of time-dependent Qobj
+            Unrecognized format for specification of time-dependent Qobj.
 
         """
 
@@ -2231,7 +2244,7 @@ def dag(A):
     Notes
     -----
     This function is for legacy compatibility only. It is recommended to use
-    the :obj:`.dag()` Qobj method.
+    the :obj:`.Qobj.dag()` Qobj method.
 
     """
     if not isinstance(A, Qobj):
@@ -2245,14 +2258,14 @@ def ptrace(Q, sel):
 
     Parameters
     ----------
-    Q : :class:`qutip.Qobj`
+    Q : :obj:`.Qobj`
         Composite quantum object.
     sel : int/list
         An ``int`` or ``list`` of components to keep after partial trace.
 
     Returns
     -------
-    oper : :class:`qutip.Qobj`
+    oper : :obj:`.Qobj`
         Quantum object representing partial trace with selected components
         remaining.
 
@@ -2264,7 +2277,7 @@ def ptrace(Q, sel):
     Notes
     -----
     This function is for legacy compatibility only. It is recommended to use
-    the ``ptrace()`` Qobj method.
+    the :obj:`.Qobj.ptrace()` Qobj method.
 
     """
     if not isinstance(Q, Qobj):
@@ -2317,7 +2330,7 @@ def dims(inpt):
 
     Parameters
     ----------
-    inpt : :class:`qutip.Qobj`
+    inpt : :obj:`.Qobj`
         Input quantum object.
 
     Returns
@@ -2332,7 +2345,7 @@ def dims(inpt):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `Qobj.dims`
+    This function is for legacy compatibility only. Using the :obj:`.Qobj.dims`
     attribute is recommended.
 
     """
@@ -2347,7 +2360,7 @@ def shape(inpt):
 
     Parameters
     ----------
-    inpt : :class:`qutip.Qobj`
+    inpt : :obj:`.Qobj`
         Input quantum object.
 
     Returns
@@ -2357,7 +2370,7 @@ def shape(inpt):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `Qobj.shape`
+    This function is for legacy compatibility only. Using the :obj:`.Qobj.shape`
     attribute is recommended.
 
     """
@@ -2373,7 +2386,7 @@ def isket(Q):
 
     Parameters
     ----------
-    Q : :class:`qutip.Qobj`
+    Q : :obj:`.Qobj`
         Quantum object
 
     Returns
@@ -2389,7 +2402,7 @@ def isket(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `Qobj.isket`
+    This function is for legacy compatibility only. Using the :obj:`.Qobj.isket`
     attribute is recommended.
 
     """
@@ -2401,7 +2414,7 @@ def isbra(Q):
 
     Parameters
     ----------
-    Q : :class:`qutip.Qobj`
+    Q : :obj:`.Qobj`
         Quantum object
 
     Returns
@@ -2417,7 +2430,7 @@ def isbra(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `Qobj.isbra`
+    This function is for legacy compatibility only. Using the `:obj:`.Qobj.isbra`
     attribute is recommended.
 
     """
@@ -2430,7 +2443,7 @@ def isoperket(Q):
 
     Parameters
     ----------
-    Q : :class:`qutip.Qobj`
+    Q : :obj:`.Qobj`
         Quantum object
 
     Returns
@@ -2440,7 +2453,7 @@ def isoperket(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `Qobj.isoperket`
+    This function is for legacy compatibility only. Using the `:obj:`.Qobj.isoperket`
     attribute is recommended.
 
     """
@@ -2453,7 +2466,7 @@ def isoperbra(Q):
 
     Parameters
     ----------
-    Q : :class:`qutip.Qobj`
+    Q : :obj:`.Qobj`
         Quantum object
 
     Returns
@@ -2463,7 +2476,7 @@ def isoperbra(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `Qobj.isoperbra`
+    This function is for legacy compatibility only. Using the :obj:`.Qobj.isoperbra`
     attribute is recommended.
 
     """
@@ -2475,7 +2488,7 @@ def isoper(Q):
 
     Parameters
     ----------
-    Q : :class:`qutip.Qobj`
+    Q : :obj:`.Qobj`
         Quantum object
 
     Returns
@@ -2491,7 +2504,7 @@ def isoper(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `Qobj.isoper`
+    This function is for legacy compatibility only. Using the :obj:`.Qobj.isoper`
     attribute is recommended.
 
     """
@@ -2503,7 +2516,7 @@ def issuper(Q):
 
     Parameters
     ----------
-    Q : :class:`qutip.Qobj`
+    Q : :obj:`.Qobj`
         Quantum object
 
     Returns
@@ -2513,7 +2526,7 @@ def issuper(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `Qobj.issuper`
+    This function is for legacy compatibility only. Using the :obj:`.Qobj.issuper`
     attribute is recommended.
 
     """
@@ -2525,12 +2538,12 @@ def isequal(A, B, tol=None):
 
     Parameters
     ----------
-    A : :class:`qutip.Qobj`
+    A : :obj:`.Qobj`
         Qobj one
-    B : :class:`qutip.Qobj`
+    B : :obj:`.Qobj`
         Qobj two
     tol : float
-        Tolerence for equality to be valid
+        Tolerance for equality to be valid
 
     Returns
     -------
@@ -2566,7 +2579,7 @@ def isherm(Q):
 
     Parameters
     ----------
-    Q : :class:`qutip.Qobj`
+    Q : :obj:`.Qobj`
         Quantum object
 
     Returns
@@ -2582,7 +2595,7 @@ def isherm(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `Qobj.isherm`
+    This function is for legacy compatibility only. Using the :obj:`.Qobj.isherm`
     attribute is recommended.
 
     """

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -156,62 +156,6 @@ class Qobj(object):
         Indicates if the quantum object represents an operator in row vector
         form.
 
-    Methods
-    -------
-    copy()
-        Create copy of Qobj
-    conj()
-        Conjugate of quantum object.
-    cosm()
-        Cosine of quantum object.
-    dag()
-        Adjoint (dagger) of quantum object.
-    dnorm()
-        Diamond norm of quantum operator.
-    dual_chan()
-        Dual channel of quantum object representing a CP map.
-    eigenenergies(sparse=False, sort='low', eigvals=0, tol=0, maxiter=100000)
-        Returns eigenenergies (eigenvalues) of a quantum object.
-    eigenstates(sparse=False, sort='low', eigvals=0, tol=0, maxiter=100000)
-        Returns eigenenergies and eigenstates of quantum object.
-    :meth:`Qobj.expm`
-        Matrix exponential of quantum object.
-    full(order='C')
-        Returns dense array of quantum object `data` attribute.
-    groundstate(sparse=False, tol=0, maxiter=100000)
-        Returns eigenvalue and eigenket for the groundstate of a quantum
-        object.
-    inv()
-        Return a Qobj corresponding to the matrix inverse of the operator.
-    matrix_element(bra, ket)
-        Returns the matrix element of operator between `bra` and `ket` vectors.
-    norm(norm='tr', sparse=False, tol=0, maxiter=100000)
-        Returns norm of a ket or an operator.
-    permute(order)
-        Returns composite qobj with indices reordered.
-    proj()
-        Computes the projector for a ket or bra vector.
-    ptrace(sel)
-        Returns quantum object for selected dimensions after performing
-        partial trace.
-    sinm()
-        Sine of quantum object.
-    sqrtm()
-        Matrix square root of quantum object.
-    tidyup(atol=1e-12)
-        Removes small elements from quantum object.
-    tr()
-        Trace of quantum object.
-    trans()
-        Transpose of quantum object.
-    transform(inpt, inverse=False)
-        Performs a basis transformation defined by `inpt` matrix.
-    trunc_neg(method='clip')
-        Removes negative eigenvalues and returns a new Qobj that is
-        a valid density operator.
-    unit(norm='tr', sparse=False, tol=0, maxiter=100000)
-        Returns normalized quantum object.
-
     """
     __array_priority__ = 100  # sets Qobj priority above numpy arrays
     # Disable ufuncs from acting directly on Qobj. This is necessary because we

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -2001,7 +2001,7 @@ class Qobj(object):
         Returns
         -------
         isunitary : bool
-        Returns the new value of isunitary property.
+            Returns the new value of isunitary property.
         """
         if self.isoper:
             eye_data = fast_identity(self.shape[0])

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -174,7 +174,7 @@ class Qobj(object):
         Returns eigenenergies (eigenvalues) of a quantum object.
     eigenstates(sparse=False, sort='low', eigvals=0, tol=0, maxiter=100000)
         Returns eigenenergies and eigenstates of quantum object.
-    expm()
+    :meth:`Qobj.expm`
         Matrix exponential of quantum object.
     full(order='C')
         Returns dense array of quantum object `data` attribute.
@@ -2020,7 +2020,7 @@ class Qobj(object):
 
     def check_isunitary(self):
         """
-        Checks whether qobj is a unitary matrix
+        Checks whether :class:`QobjEvo` is a unitary matrix
         """
         if self.isoper:
             eye_data = fast_identity(self.shape[0])

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -127,8 +127,9 @@ class Qobj(object):
         'operator-bra' (:func:`~qutip.qobj.isoperbra`), or 'super'
         (:func:`~qutip.qobj.issuper`).
     superrep : str
-        Representation used if ``type`` is 'super'(:func:`~qutip.qobj.issuper`).
-        One of 'super'(:func:`~qutip.superoperator.liouvillian` form) or 'choi'
+        Representation used if ``type`` is 'super'
+        (:func:`~qutip.qobj.issuper`). One of 'super'
+        (:func:`~qutip.superoperator.liouvillian` form) or 'choi'
         (Choi matrix with tr = dimension via :mod:`~qutip.superop_reps`).
     isherm : bool
         Indicates if quantum object represents Hermitian operator via

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1216,14 +1216,12 @@ class Qobj(object):
             raise TypeError('Invalid operand for matrix square root')
 
     def cosm(self):
-        """Cosine of a quantum operator.
-
-        Operator must be square.
+        """Cosine of a square quantum operator.
 
         Returns
         -------
         oper : :class:`qutip.Qobj`
-            Matrix cosine of operator.
+            Matrix cosine of an operator.
 
         Raises
         ------

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1071,7 +1071,7 @@ class Qobj(object):
         Raises
         -------
         TypeError
-            Purity is defined on a densoty matrix or state.
+            Purity is defined on a density matrix or state.
 
         """
         rho = self
@@ -1366,7 +1366,7 @@ class Qobj(object):
 
         Notes
         -----
-        This function is identical to the :obj:`.ptrace` function
+        This function is identical to the :func:`~qutip.ptrace` function
         that has been deprecated.
 
         """
@@ -2214,7 +2214,7 @@ def qobj_list_evaluate(qobj_list, t, args):
     """
     Deprecated: See Qobj.evaluate
     """
-    warnings.warn("Deprecated: Use Qobj.evaluate", DeprecationWarning)
+    warnings.warn("Deprecated: Use :obj:`.Qobj.evaluate`", DeprecationWarning)
     return Qobj.evaluate(qobj_list, t, args)
 
 
@@ -2345,7 +2345,7 @@ def dims(inpt):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the :obj:`.Qobj.dims`
+    This function is for legacy compatibility only. Using the :obj:`.Qobj.dims()`
     attribute is recommended.
 
     """
@@ -2430,7 +2430,7 @@ def isbra(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `:obj:`.Qobj.isbra`
+    This function is for legacy compatibility only. Using the :obj:`.Qobj.isbra`
     attribute is recommended.
 
     """
@@ -2453,7 +2453,7 @@ def isoperket(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the `:obj:`.Qobj.isoperket`
+    This function is for legacy compatibility only. Using the :obj:`.Qobj.isoperket()`
     attribute is recommended.
 
     """

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -107,9 +107,8 @@ class Qobj(object):
         Flag specifying whether :obj:`.Qobj` should get a copy of the
         input data, or use the original.
     fast : bool
-        Flag for fast :obj:`.Qobj` creation when running ODE solvers (
-        :obj:`~qutip.mesolve`, :obj:`~qutip.mcsolve`). This parameter
-        is used internally only.
+        Flag for fast :obj:`.Qobj` creation when running ODE solvers. This
+        parameter is used internally only.
 
 
     Attributes
@@ -983,11 +982,11 @@ class Qobj(object):
 
         Raises
         -------
-        ValueError : For matrices, norm must be 'tr', 'fro', 'one', or 'max'.
-            When norm chosen is not from default types.
+        ValueError : For matrices, norm must be 'tr', 'fro', 'one', or 'max'
+            When norm chosen is not from default methods.
 
-        ValueError : For vectors, norm must be 'l2', or 'max'.
-            When norm chosen is not from default types.
+        ValueError : For vectors, norm must be 'l2', or 'max'
+            When norm chosen is not from default methods.
 
 
         Notes
@@ -1147,11 +1146,11 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError : Invalid operand for matrix exponential.
-            when dimensions do not match i.e. input is not a square operator.
+        TypeError : Invalid operand for matrix exponential
+            When dimensions do not match i.e. input is not a square operator.
 
-        ValueError : Method must be 'dense' or 'sparse'.
-            when available deafult method is not chosen.
+        ValueError : Method must be 'dense' or 'sparse'
+            When available deafult method is not chosen.
 
         """
         if self.dims[0][0] != self.dims[1][0]:
@@ -1201,8 +1200,8 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError : Invalid operand for matrix square root.
-            when input is not a square operator.
+        TypeError : Invalid operand for matrix square root
+            When input is not a square operator.
 
         Notes
         -----
@@ -1264,8 +1263,8 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError : Invalid operand for matrix square root.
-            when input is not square.
+        TypeError : Invalid operand for matrix square root
+            When input is not a square operator.
 
         Notes
         -----
@@ -1289,8 +1288,8 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError : Invalid operand for matrix inverse.
-            when input is not square.
+        TypeError : Invalid operand for matrix inverse
+            When input is not square.
         """
         if self.shape[0] != self.shape[1]:
             raise TypeError('Invalid operand for matrix inverse')
@@ -1365,7 +1364,7 @@ class Qobj(object):
 
         Notes
         -----
-        This function is identical to the :func:`~qutip.ptrace` function
+        This function is identical to the :obj:`~qutip.qobj.ptrace` function
         that has been deprecated.
 
         """
@@ -1452,11 +1451,11 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError : Invalid size of ket list for basis transformation.
-            when input is a list or array and the dimensions do not match.
+        TypeError : Invalid size of ket list for basis transformation
+            When input is a list or array and the dimensions do not match.
 
-        TypeError : Invalid operand for basis transformation.
-            when input is not a proper quantum object or operator.
+        TypeError : Invalid operand for basis transformation
+            When input is not a proper quantum object or operator.
 
         Notes
         -----
@@ -1537,9 +1536,9 @@ class Qobj(object):
         Raises
         ------
         ValueError : Must be a Hermitian operator to remove negative eigenvalues
-            when operator is not Hermitian.
+            When input operator is not Hermitian.
 
-        ValueError : Method not recognized.
+        ValueError : Method not recognized
             If method other than 'clip' or 'sgs' is specified.
 
         """
@@ -1604,16 +1603,16 @@ class Qobj(object):
 
         Raises
         -------
-        TypeError : Can only get matrix elements for an operator.
-            when input is not a valid operator.
+        TypeError : Can only get matrix elements for an operator
+            When input is not a valid operator.
 
-        TypeError : Can only calculate matrix elements for bra  and ket vectors.
-            when input is not a valid ket or bra vector.
+        TypeError : Can only calculate matrix elements for bra  and ket vectors
+            When input is not a valid ket or bra vector.
 
         Notes
         -----
         It is slightly more computationally efficient to use a `ket`
-        vector for the 'bra' input.
+        vector for the `bra` input.
         """
         if not self.isoper:
             raise TypeError("Can only get matrix elements for an operator.")
@@ -2207,9 +2206,9 @@ class Qobj(object):
 #
 def qobj_list_evaluate(qobj_list, t, args):
     """
-    Deprecated: See Qobj.evaluate
+    Deprecated: See :obj:`.Qobj.evaluate`
     """
-    warnings.warn("Deprecated: Use :obj:`.Qobj.evaluate`", DeprecationWarning)
+    warnings.warn("Deprecated: Use Qobj.evaluate", DeprecationWarning)
     return Qobj.evaluate(qobj_list, t, args)
 
 

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1275,7 +1275,7 @@ class Qobj(object):
 
         Notes
         -----
-        Uses the Q.expm() method.
+        Uses the Q. :meth:`expm()` method.
 
         """
         if self.dims[0][0] == self.dims[1][0]:

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -95,8 +95,6 @@ class Qobj(object):
     operator/state operations.  The Qobj constructor optionally takes a
     dimension ``list`` and/or shape ``list`` as arguments.
 
-.._qobj_parameters:
-
     Parameters
     ----------
     inpt : array_like
@@ -2022,7 +2020,7 @@ class Qobj(object):
 
     def check_isunitary(self):
         """
-        Checks whether :class:`QobjEvo` is a unitary matrix
+        Checks whether :class:`QobjEvo`  is a unitary matrix
         """
         if self.isoper:
             eye_data = fast_identity(self.shape[0])

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -104,11 +104,11 @@ class Qobj(object):
     shape : list
         Shape of underlying data structure (matrix shape)
     copy : bool
-        Flag specifying whether :class:`Qobj` should get a copy of the
+        Flag specifying whether :obj:`.Qobj` should get a copy of the
         input data, or use the original.
     fast : bool
-        Flag for fast :class:`Qobj` creation when running ODE solvers (
-        :func:`~qutip.mesolve`, :func:`~qutip.mcsolve`). This parameter
+        Flag for fast :obj:`.Qobj` creation when running ODE solvers (
+        :obj:`.~qutip.mesolve`, :obj:`.qutip.mcsolve`). This parameter
         is used internally only.
 
 
@@ -897,7 +897,7 @@ class Qobj(object):
         return s
 
     def dag(self):
-        """Adjoint operator of :class:`Qobj`.
+        """Adjoint operator of quantum object.
 
         Returns
         -------
@@ -950,7 +950,7 @@ class Qobj(object):
         return out
 
     def norm(self, norm=None, sparse=False, tol=0, maxiter=100000):
-        """Norm of a quantum object (:class:`Qobj`).
+        """Norm of a quantum object.
 
         Default norm is L2-norm for kets and trace-norm for operators.
         Other ket and operator norms may be specified using the `norm` and
@@ -959,8 +959,7 @@ class Qobj(object):
         Parameters
         ----------
         norm : str
-            Which norm to use for ket/bra vectors: L2
-            (:obj:`.sp_L2_norm`), max norm 'max',
+            Which norm to use for ket/bra vectors: L2, max norm 'max',
             or for operators: trace 'tr', Frobius 'fro', one 'one', or max
             'max'.
 
@@ -1023,12 +1022,12 @@ class Qobj(object):
 
         Parameters
         ----------
-        Q : :class:`qutip.Qobj`
-            Input bra or ket vector
+        Q : :class:`Qobj`
+            Input :obj:`.bra` or :obj:`.ket` vector
 
         Returns
         -------
-        P : :class:`qutip.Qobj`
+        P : :class:`Qobj`
             Projection operator.
         """
         if self.isket:
@@ -1119,13 +1118,11 @@ class Qobj(object):
             return np.real(out)
 
     def expm(self, method='dense'):
-        """Matrix exponential of quantum operator.
-
-        Input operator must be square.
+        """Matrix exponential of a square quantum operator.
 
         Parameters
         ----------
-        method : str {'dense', 'sparse'}
+        method : ``str`` {'dense', 'sparse'}
             Use set method to use to calculate the matrix exponentiation. The
             available choices includes 'dense' and 'sparse'.  Since the
             exponential of a matrix is nearly always dense, method='dense'
@@ -1239,13 +1236,13 @@ class Qobj(object):
             raise TypeError('Invalid operand for matrix square root')
 
     def sinm(self):
-        """Sine of a quantum operator.
+        """Sine of a square quantum operator.
 
         Operator must be square.
 
         Returns
         -------
-        oper : :class:`qutip.Qobj`
+        oper : :class:`Qobj`
             Matrix sine of operator.
 
         Raises
@@ -1255,7 +1252,7 @@ class Qobj(object):
 
         Notes
         -----
-        Uses the Q. :meth:`expm()` method.
+        Uses the Q. :obj:`.expm()` method.
 
         """
         if self.dims[0][0] == self.dims[1][0]:
@@ -1264,7 +1261,7 @@ class Qobj(object):
             raise TypeError('Invalid operand for matrix square root')
 
     def inv(self, sparse=False):
-        """Matrix inverse of a quantum operator
+        """Matrix inverse of a square quantum operator.
 
         Operator must be square.
 
@@ -1291,7 +1288,7 @@ class Qobj(object):
              tol=0, maxiter=100000):
         """Operator or state normalized to unity.
 
-        Uses norm from Qobj.norm().
+        Uses norm from :obj:`.Qobj.norm()`.
 
         Parameters
         ----------
@@ -1308,7 +1305,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`qutip.Qobj`
+        oper : :class:`Qobj`
             Normalized quantum object if not in-place,
             else None.
 
@@ -1340,13 +1337,13 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`qutip.Qobj`
+        oper : :class:`Qobj`
             Quantum object representing partial trace with selected components
             remaining.
 
         Notes
         -----
-        This function is identical to the :func:`qutip.qobj.ptrace` function
+        This function is identical to the :obj:`.ptrace` function
         that has been deprecated.
 
         """
@@ -1372,7 +1369,7 @@ class Qobj(object):
 
         Returns
         -------
-        P : :class:`qutip.Qobj`
+        P : :class:`Qobj`
             Permuted quantum object.
 
         """
@@ -1392,7 +1389,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`qutip.Qobj`
+        oper : :class:`Qobj`
             Quantum object with small elements removed.
 
         """
@@ -1428,7 +1425,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`qutip.Qobj`
+        oper : :class:`Qobj`
             Operator in new basis.
 
         Notes
@@ -1505,8 +1502,8 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`qutip.Qobj`
-            A valid density operator.
+        oper : :class:`Qobj`
+            A valid density operator as a quantum object.
 
         """
         if not self.isherm:
@@ -1557,11 +1554,11 @@ class Qobj(object):
 
         Parameters
         -----------
-        bra : :class:`qutip.Qobj`
-            Quantum object of type 'bra'
+        bra : :class:`Qobj`
+            Quantum object of type :obj:`.bra`
 
-        ket : :class:`qutip.Qobj`
-            Quantum object of type 'ket'.
+        ket : :class:`Qobj`
+            Quantum object of type :obj:`.ket`.
 
         Returns
         -------
@@ -1570,7 +1567,7 @@ class Qobj(object):
 
         Notes
         -----
-        It is slightly more computationally efficient to use a ket
+        It is slightly more computationally efficient to use a `ket`
         vector for the 'bra' input.
         """
         if not self.isoper:
@@ -1597,7 +1594,7 @@ class Qobj(object):
         Parameters
         -----------
         other : :class:`qutip.Qobj`
-            Quantum object for a state vector of type 'ket', 'bra' or density
+            Quantum object for a state vector of type :obj:`.ket`, :obj:`.bra` or density
             matrix.
 
         Returns
@@ -1804,7 +1801,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`qutip.Qobj`
+        oper : :class:`Qobj`
             Transpose of input operator.
 
         """
@@ -1814,7 +1811,7 @@ class Qobj(object):
         return out
 
     def extract_states(self, states_inds, normalize=False):
-        """:class:`Qobj` with states in ``states_inds`` only.
+        """:obj:`.Qobj` with states in ``states_inds`` only.
 
         Parameters
         ----------
@@ -1824,9 +1821,9 @@ class Qobj(object):
         normalize : True / False
             Weather or not the new :class:`Qobj` instance should be normalized
             (default is False). For Qobjs that represents density matrices or
-            state vectors normalized should probably be set to True, but for
+            state vectors normalized should probably be set to ``True``, but for
             Qobjs that represents operators in for example an Hamiltonian,
-            normalize should be False.
+            normalize should be ``False``.
 
         Returns
         -------
@@ -2097,18 +2094,18 @@ class Qobj(object):
         Parameters
         ----------
         qobj_list : list
-            A nested list of Qobj instances and corresponding time-dependent
+            A nested list of :obj:`.Qobj` instances and corresponding time-dependent
             coefficients.
         t : float
-            The time for which to evaluate the time-dependent :class:`Qobj`
+            The time for which to evaluate the time-dependent :obj:`.Qobj`
             instance.
         args : dictionary
             A dictionary with parameter values required to evaluate the
-            time-dependent :class:`Qobj` instance.
+            time-dependent :obj:`.Qobj` instance.
 
         Returns
         -------
-        output : :class:`Qobj`
+        output : :obj:`.Qobj`
             A Qobj instance that represents the value of qobj_list at time t.
 
         """

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -121,15 +121,20 @@ class Qobj(object):
     shape : list
         Shape of the underlying `data` array.
     type : str
-        Type of quantum object: 'bra', 'ket', 'oper', 'operator-ket',
-        'operator-bra', or 'super'.
+        Type of quantum object: :func:`~qutip.states.bra`,
+        :func:`~qutip.states.ket`, 'oper' (:func:`~qutip.qobj.isoper`),
+        'operator-ket' (:func:`~qutip.qobj.isoperket`),
+        'operator-bra' (:func:`~qutip.qobj.isoperbra`), or 'super'
+        (:func:`~qutip.qobj.issuper`).
     superrep : str
-        Representation used if `type` is 'super'. One of 'super'
-        (Liouville form) or 'choi' (Choi matrix with tr = dimension).
+        Representation used if ``type`` is 'super' (:func:`~qutip.qobj.issuper`).
+        One of 'super' (:func:`~qutip.superoperator.liouvillian` form) or 'choi'
+        (Choi matrix with tr = dimension via :mod:`~qutip.superop_reps`).
     isherm : bool
-        Indicates if quantum object represents Hermitian operator.
+        Indicates if quantum object represents Hermitian operator via
+        :func:`~qutip.qobj.isherm`.
     isunitary : bool
-        Indictaes if quantum object represents unitary operator.
+        Indictaes if quantum object represents unitary operator via :func:`~qutip.qobj.check_isunitary`.
     iscp : bool
         Indicates if the quantum object represents a map, and if that map is
         completely positive (CP).
@@ -1787,7 +1792,7 @@ class Qobj(object):
             The states that should be kept.
 
         normalize : True / False
-            Weather or not the new Qobj instance should be normalized (default
+            Weather or not the new :class:`Qobj` instance should be normalized (default
             is False). For Qobjs that represents density matrices or state
             vectors normalized should probably be set to True, but for Qobjs
             that represents operators in for example an Hamiltonian, normalize
@@ -1797,7 +1802,7 @@ class Qobj(object):
         -------
         q : :class:`qutip.Qobj`
             A new instance of :class:`qutip.Qobj` that contains only the states
-            corresponding to the indices in `states_inds`.
+            corresponding to the indices in ``states_inds``.
 
         Notes
         -----
@@ -2060,10 +2065,11 @@ class Qobj(object):
             A nested list of Qobj instances and corresponding time-dependent
             coefficients.
         t : float
-            The time for which to evaluate the time-dependent Qobj instance.
+            The time for which to evaluate the time-dependent :class:`Qobj`
+            instance.
         args : dictionary
             A dictionary with parameter values required to evaluate the
-            time-dependent Qobj instance.
+            time-dependent :class:`Qobj` instance.
 
         Returns
         -------

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -108,7 +108,7 @@ class Qobj(object):
         input data, or use the original.
     fast : bool
         Flag for fast :obj:`.Qobj` creation when running ODE solvers (
-        :obj:`.~qutip.mesolve`, :obj:`.qutip.mcsolve`). This parameter
+        :obj:`~qutip.mesolve`, :obj:`~qutip.mcsolve`). This parameter
         is used internally only.
 
 
@@ -121,18 +121,18 @@ class Qobj(object):
     shape : list
         Shape of the underlying `data` array.
     type : str
-        Type of quantum object: :func:`~qutip.states.bra`,
-        :func:`~qutip.states.ket`, 'oper', 'operator-ket', 'operator-bra',
+        Type of quantum object: :obj:`~qutip.states.bra`,
+        :obj:`~qutip.states.ket`, 'oper', 'operator-ket', 'operator-bra',
         or 'super'.
     superrep : str
         Representation used if ``type`` is 'super'. One of 'super'
-        (:func:`~qutip.superoperator.liouvillian` form) or 'choi'
-        (Choi matrix with tr = dimension via :mod:`~qutip.superop_reps`).
+        (:obj:`~qutip.superoperator.liouvillian` form) or 'choi'
+        (Choi matrix with tr = dimension via :obj:`~qutip.superop_reps`).
     isherm : bool
         :obj:`.isherm` indicates if quantum object represents Hermitian
         operator.
     isunitary : bool
-        :meth:`check_isunitary` indicates if quantum object represents unitary
+        :obj:`.check_isunitary` indicates if quantum object represents unitary
         operator.
     iscp : bool
         Indicates if the quantum object represents a map, and if that map is
@@ -314,10 +314,11 @@ class Qobj(object):
         self._type = None
 
     def copy(self):
-        """Create identical copy
+        """Create identical copy of quantum object.
+
         Returns
         -------
-        :class:`Qobj`
+        :obj:`.Qobj`
             The requested copy of an operator or a quantum state as a
             quantum object.
         """
@@ -901,7 +902,7 @@ class Qobj(object):
 
         Returns
         -------
-        dag : :class:`Qobj`
+        dag : :obj:`.Qobj`
             The requested adjoint of an operator or a quantum state as a
             quantum object.
         """
@@ -940,7 +941,7 @@ class Qobj(object):
 
         Returns
         -------
-        conj : :class:`Qobj`
+        conj : :obj:`.Qobj`
             The requested conjugate of an operator or a quantum state as a
             quantum object.
         """
@@ -952,15 +953,15 @@ class Qobj(object):
     def norm(self, norm=None, sparse=False, tol=0, maxiter=100000):
         """Norm of a quantum object.
 
-        Default norm is L2-norm for kets and trace-norm for operators.
-        Other ket and operator norms may be specified using the `norm` and
+        Default norm is `L2-norm` for kets and `trace-norm` for operators.
+        Other ket and operator norms may be specified using the :obj:`.norm` and
         argument.
 
         Parameters
         ----------
         norm : str
             Which norm to use for ket/bra vectors: L2, max norm 'max',
-            or for operators: trace 'tr', Frobius 'fro', one 'one', or max
+            or for operators: trace `tr', Frobius 'fro', one 'one', or max
             'max'.
 
         sparse : bool
@@ -1022,7 +1023,7 @@ class Qobj(object):
 
         Parameters
         ----------
-        Q : :class:`Qobj`
+        Q : :obj:`.Qobj`
             Input :obj:`.bra` or :obj:`.ket` vector
 
         Returns
@@ -1062,6 +1063,11 @@ class Qobj(object):
             For a pure state, the purity is 1.
             For a mixed state of dimension `d`, 1/d<=purity<1.
 
+        Raises
+        -------
+        TypeError
+            Purity is defined on a densoty matrix or state.
+
         """
         rho = self
         if (rho.type == "super"):
@@ -1080,15 +1086,15 @@ class Qobj(object):
 
         Parameters
         ----------
-        order : str {'C', 'F'}
+        order : ``str {'C', 'F'}``
             Return array in C (default) or Fortran ordering.
-        squeeze : bool {False, True}
+        squeeze : ``bool {False, True}``
             Squeeze output array.
 
         Returns
         -------
         data : array
-            Array of complex data from quantum object's ``data`` attribute.
+            Array of complex data from quantum object's :obj:`.data` attribute.
         """
         if squeeze:
             return self.data.toarray(order=order).squeeze()
@@ -1122,25 +1128,28 @@ class Qobj(object):
 
         Parameters
         ----------
-        method : ``str`` {'dense', 'sparse'}
+        method : ``str {'dense', 'sparse'}``
             Use set method to use to calculate the matrix exponentiation. The
             available choices includes 'dense' and 'sparse'.  Since the
             exponential of a matrix is nearly always dense, method='dense'
-            is set as default.s
+            is set as default.
 
         Returns
         -------
-        oper : :class:`qutip.Qobj`
+        oper : :obj:`.Qobj`
             Exponentiated quantum operator.
 
         Raises
         ------
         TypeError
-            Quantum operator is not square.
+            Invalid operand for matrix exponential.
+
+        ValueError
+            Method must be 'dense' or 'sparse'.
 
         """
         if self.dims[0][0] != self.dims[1][0]:
-            raise TypeError('Invalid operand for matrix exponential')
+            raise TypeError('Invalid operand for matrix exponential.')
 
         if method == 'dense':
             F = sp_expm(self.data, sparse=False)
@@ -1160,7 +1169,7 @@ class Qobj(object):
         Returns
         -------
         isherm : bool
-            Returns the new value of isherm property.
+            Returns the new value of :obj:`.isherm` property.
         """
         self._isherm = None
         return self.isherm
@@ -1187,7 +1196,7 @@ class Qobj(object):
         Raises
         ------
         TypeError
-            Quantum object is not square.
+            Invalid operand for matrix square root.
 
         Notes
         -----
@@ -1215,25 +1224,27 @@ class Qobj(object):
     def cosm(self):
         """Cosine of a square quantum operator.
 
+        Operator must be square.
+
         Returns
         -------
-        oper : :class:`qutip.Qobj`
+        oper : :obj:`.Qobj`
             Matrix cosine of an operator.
 
         Raises
         ------
         TypeError
-            Quantum object is not square.
+            Invalid operand for matrix square root.
 
         Notes
         -----
-        Uses the Q. :attr:`expm()` method.
+        Uses the Q. :obj:`.expm()` method.
 
         """
         if self.dims[0][0] == self.dims[1][0]:
             return 0.5 * ((1j * self).expm() + (-1j * self).expm())
         else:
-            raise TypeError('Invalid operand for matrix square root')
+            raise TypeError('Invalid operand for matrix square root.')
 
     def sinm(self):
         """Sine of a square quantum operator.
@@ -1248,7 +1259,7 @@ class Qobj(object):
         Raises
         ------
         TypeError
-            Quantum object is not square.
+            Invalid operand for matrix square root.
 
         Notes
         -----
@@ -1267,13 +1278,13 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`qutip.Qobj`
+        oper : :obj:`.Qobj`
             Matrix inverse of operator.
 
         Raises
         ------
         TypeError
-            Quantum object is not square.
+            Invalid operand for matrix inverse.
         """
         if self.shape[0] != self.shape[1]:
             raise TypeError('Invalid operand for matrix inverse')
@@ -1295,7 +1306,7 @@ class Qobj(object):
         inplace : bool
             Do an in-place normalization
         norm : str
-            Requested norm for states / operators.
+            Requested :obj:`.norm` for states / operators.
         sparse : bool
             Use sparse eigensolver for trace norm. Does not affect other norms.
         tol : float
@@ -1305,9 +1316,14 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`Qobj`
+        oper : :obj:`.Qobj`
             Normalized quantum object if not in-place,
             else None.
+
+        Raises
+        -------
+        Exception
+            Inplace kwarg must be bool.
 
         """
         if inplace:
@@ -1337,7 +1353,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`Qobj`
+        oper : :obj:`.Qobj`
             Quantum object representing partial trace with selected components
             remaining.
 
@@ -1369,7 +1385,7 @@ class Qobj(object):
 
         Returns
         -------
-        P : :class:`Qobj`
+        P : :obj:`.Qobj`
             Permuted quantum object.
 
         """
@@ -1385,11 +1401,11 @@ class Qobj(object):
         ----------
         atol : float
             Absolute tolerance used by tidyup. Default is set
-            via qutip global settings parameters.
+            via qutip global settings parameters in :obj:`.Options`.
 
         Returns
         -------
-        oper : :class:`Qobj`
+        oper : :obj:`.Qobj`
             Quantum object with small elements removed.
 
         """
@@ -1425,8 +1441,15 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`Qobj`
+        oper : :obj:`.Qobj`
             Operator in new basis.
+
+        Raises
+        ------
+        TypeError
+            Invalid size of ket list for basis transformation.
+
+            Invalid operand for basis transformation.
 
         Notes
         -----
@@ -1502,8 +1525,15 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`Qobj`
+        oper : :obj:`.Qobj`
             A valid density operator as a quantum object.
+
+        Raises
+        ------
+        ValueError
+            Must be a Hermitian operator to remove negative eigenvalues.
+
+            Method not recognized.
 
         """
         if not self.isherm:
@@ -1554,16 +1584,23 @@ class Qobj(object):
 
         Parameters
         -----------
-        bra : :class:`Qobj`
+        bra : :obj:`.Qobj`
             Quantum object of type :obj:`.bra`
 
-        ket : :class:`Qobj`
+        ket : :obj:`.Qobj`
             Quantum object of type :obj:`.ket`.
 
         Returns
         -------
         elem : complex
             Complex valued matrix element.
+
+        Raises
+        -------
+        TypeError
+            Can only get matrix elements for an operator.
+
+            Can only calculate matrix elements for bra  and ket vectors.
 
         Notes
         -----
@@ -1593,7 +1630,7 @@ class Qobj(object):
 
         Parameters
         -----------
-        other : :class:`qutip.Qobj`
+        other : :obj:`.Qobj`
             Quantum object for a state vector of type :obj:`.ket`, :obj:`.bra` or density
             matrix.
 
@@ -1664,7 +1701,7 @@ class Qobj(object):
             Use sparse Eigensolver
 
         sort : str
-            Sort eigenvalues (and vectors) 'low' to high, or 'high' to low.
+            Sort eigenvalues (and vectors) 'low' to 'high', or 'high' to 'low'.
 
         eigvals : int
             Number of requested eigenvalues. Default is all eigenvalues.
@@ -1771,8 +1808,14 @@ class Qobj(object):
         -------
         eigval : float
             Eigenvalue for the ground state of quantum operator.
-        eigvec : :class:`qutip.Qobj`
+        eigvec : :obj:`.Qobj`
             Eigenket for the ground state of quantum operator.
+
+        Raises
+        -------
+        WARNING
+            Ground state may be degenerate. Use Q. :obj:`.eigenstates()`.
+
 
         Notes
         -----
@@ -1827,9 +1870,14 @@ class Qobj(object):
 
         Returns
         -------
-        q : :class:`qutip.Qobj`
-            A new instance of :class:`qutip.Qobj` that contains only the states
+        q : :obj:`.Qobj`
+            A new instance of :obj:`.Qobj` that contains only the states
             corresponding to the indices in ``states_inds``.
+
+        Raises
+        -------
+        TypeError
+            Can only eliminate states from operators or state vectors.
 
         Notes
         -----
@@ -1857,7 +1905,7 @@ class Qobj(object):
             The states that should be removed.
 
         normalize : True / False
-            Weather or not the new :class:`Qobj` instance should be normalized
+            Whether or not the new :obj:`.Qobj` instance should be normalized
             (default is False). For Qobjs that represents density matrices or
             state vectors normalized should probably be set to True, but for
             Qobjs that represents operators in for example an Hamiltonian,
@@ -1865,8 +1913,8 @@ class Qobj(object):
 
         Returns
         -------
-        q : :class:`Qobj`
-            A new instance of :class:`Qobj` that contains only the states
+        q : :obj:`.Qobj`
+            A new instance of :obj:`.Qobj` that contains only the states
             corresponding to indices that are **not** in ``states_inds``.
 
         Notes
@@ -1885,8 +1933,8 @@ class Qobj(object):
 
         Parameters
         ----------
-        B : :class:`qutip.Qobj` or None
-            If B is not None, the diamond distance d(A, B) = dnorm(A - B)
+        B : :obj:`.Qobj` or None
+            If B is not None, the diamond distance `d(A, B) = dnorm(A - B)`
             between this operator and B is returned instead of the diamond
             norm.
 
@@ -1997,12 +2045,12 @@ class Qobj(object):
 
     def check_isunitary(self):
         """
-        Checks whether :class:`Qobj` is a unitary matrix
+        Checks whether quantum object is a unitary.
 
         Returns
         -------
         isunitary : bool
-            Returns the new value of isunitary property.
+            Returns the new value of :obj:`.isunitary` property.
         """
         if self.isoper:
             eye_data = fast_identity(self.shape[0])
@@ -2108,6 +2156,11 @@ class Qobj(object):
         output : :obj:`.Qobj`
             A Qobj instance that represents the value of qobj_list at time t.
 
+        Raises
+        ------
+        TypeError
+            Unrecognized format for specification of time-dependent Qobj
+
         """
 
         q_sum = 0
@@ -2162,18 +2215,23 @@ def dag(A):
 
     Parameters
     ----------
-    A : :class:`qutip.Qobj`
+    A : :obj:`.Qobj`
         Input quantum object.
 
     Returns
     -------
-    oper : :class:`qutip.Qobj`
+    oper : :obj:`.Qobj`
         Adjoint of input operator
+
+    Raises
+    -------
+    TypeError
+        Input is not a quantum object.
 
     Notes
     -----
     This function is for legacy compatibility only. It is recommended to use
-    the ``dag()`` Qobj method.
+    the :obj:`.dag()` Qobj method.
 
     """
     if not isinstance(A, Qobj):
@@ -2197,6 +2255,11 @@ def ptrace(Q, sel):
     oper : :class:`qutip.Qobj`
         Quantum object representing partial trace with selected components
         remaining.
+
+    Raises
+    -------
+    TypeError
+        Input is not a quantum object.
 
     Notes
     -----
@@ -2261,6 +2324,11 @@ def dims(inpt):
     -------
     dims : list
         A ``list`` of the quantum objects dimensions.
+
+    Raises
+    -------
+    TypeError
+        Input is not a quantum object.
 
     Notes
     -----

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -100,7 +100,7 @@ class Qobj(object):
     inpt : array_like
         Data for vector/matrix representation of the quantum object.
     dims : list
-        Dimensions of object used for :obj:`.tensor` products via :obj:`.dims`.
+        Dimensions of object (:obj:`.dims`) used for :obj:`.tensor` products .
     shape : list
         Shape of underlying data structure (matrix shape) via
         :obj:`.dims_to_tensor_shape`.
@@ -108,9 +108,9 @@ class Qobj(object):
         Flag specifying whether :class:`Qobj` should get a copy of the
         input data, or use the original.
     fast : bool
-        Flag for fast :class:`Qobj` creation when running ODE solvers like
-        :func:`~qutip.mesolve` and :func:`~qutip.mcsolve`.
-        This parameter is used internally only.
+        Flag for fast :class:`Qobj` creation when running ODE solvers (
+        :func:`~qutip.mesolve`, :func:`~qutip.mcsolve`). This parameter
+        is used internally only.
 
 
     Attributes
@@ -123,21 +123,18 @@ class Qobj(object):
         Shape of the underlying `data` array.
     type : str
         Type of quantum object: :func:`~qutip.states.bra`,
-        :func:`~qutip.states.ket`, 'oper' (:obj:`.isoper`),
-        'operator-ket' (:obj:`.isoperket`),
-        'operator-bra' (:obj:`.isoperbra`), or 'super'
-        (:obj:`.issuper`).
+        :func:`~qutip.states.ket`, 'oper', 'operator-ket', 'operator-bra',
+        or 'super'.
     superrep : str
-        Representation used if ``type`` is 'super'
-        (:obj:`.issuper`). One of 'super'
+        Representation used if ``type`` is 'super'. One of 'super'
         (:func:`~qutip.superoperator.liouvillian` form) or 'choi'
         (Choi matrix with tr = dimension via :mod:`~qutip.superop_reps`).
     isherm : bool
-        Indicates if quantum object represents Hermitian operator via
-        :obj:`.isherm`.
+        :obj:`.isherm` indicates if quantum object represents Hermitian
+        operator.
     isunitary : bool
-        Indicates if quantum object represents unitary operator via
-        :meth:`check_isunitary`.
+        :meth:`check_isunitary` indicates if quantum object represents unitary
+        operator.
     iscp : bool
         Indicates if the quantum object represents a map, and if that map is
         completely positive (CP).
@@ -151,19 +148,20 @@ class Qobj(object):
         Indicates if the quantum object represents a map that is completely
         positive and trace preserving (CPTP).
     isket : bool
-        Indicates if the quantum object represents a ket.
+        :obj:`.isket` indicates if the quantum object represents a ket.
     isbra : bool
-        Indicates if the quantum object represents a bra.
+        :obj:`.isbra` indicates if the quantum object represents a bra.
     isoper : bool
-        Indicates if the quantum object represents an operator.
+        :obj:`.isoper` indicates if the quantum object represents an operator.
     issuper : bool
-        Indicates if the quantum object represents a superoperator.
+        :obj:`.issuper` indicates if the quantum object represents a
+        superoperator.
     isoperket : bool
-        Indicates if the quantum object represents an operator in column vector
-        form.
+        :obj:`.isoperket` indicates if the quantum object represents an operator
+        in column vector form.
     isoperbra : bool
-        Indicates if the quantum object represents an operator in row vector
-        form.
+        :obj:`.isoperbra` indicates if the quantum object represents an operator
+        in row vector form.
 
     """
     __array_priority__ = 100  # sets Qobj priority above numpy arrays
@@ -894,7 +892,13 @@ class Qobj(object):
         return s
 
     def dag(self):
-        """Adjoint operator of quantum object (:class:`Qobj`).
+        """Adjoint operator of :class:`Qobj`.
+
+        Returns
+        -------
+        dag : :class:`Qobj`
+            The requested adjoint of an operator or a quantum state as a
+            quantum object.
         """
         out = Qobj()
         out.data = zcsr_adjoint(self.data)
@@ -906,6 +910,12 @@ class Qobj(object):
     def dual_chan(self):
         """Dual channel of quantum object representing a completely positive
         map.
+
+        Raises
+        -------
+        ValueError
+            Dual channels are only implemented for CP maps.
+
         """
         # Uses the technique of Johnston and Kribs (arXiv:1102.0948), which
         # is only valid for completely positive maps.
@@ -921,7 +931,13 @@ class Qobj(object):
         return J_dual
 
     def conj(self):
-        """Conjugate operator of quantum object (:class:`Qobj`).
+        """Conjugate operator of quantum object.
+
+        Returns
+        -------
+        conj : :class:`Qobj`
+            The requested conjugate of an operator or a quantum state as a
+            quantum object.
         """
         out = Qobj()
         out.data = self.data.conj()
@@ -938,7 +954,8 @@ class Qobj(object):
         Parameters
         ----------
         norm : str
-            Which norm to use for ket/bra vectors: L2 'l2', max norm 'max',
+            Which norm to use for ket/bra vectors: L2
+            (:obj:`.sp_L2_norm`), max norm 'max',
             or for operators: trace 'tr', Frobius 'fro', one 'one', or max
             'max'.
 
@@ -958,6 +975,13 @@ class Qobj(object):
         -------
         norm : float
             The requested norm of the operator or state quantum object.
+
+        Raises
+        -------
+        ValueError
+            For matrices, norm must be 'tr', 'fro', 'one', or 'max'.
+
+            For vectors, norm must be 'l2', or 'max'.
 
 
         Notes
@@ -1074,7 +1098,7 @@ class Qobj(object):
         return self.full()
 
     def diag(self):
-        """Diagonal elements of quantum object (:class:`Qobj`).
+        """Diagonal elements of quantum object.
 
         Returns
         -------
@@ -1129,7 +1153,7 @@ class Qobj(object):
         return out.tidyup() if settings.auto_tidyup else out
 
     def check_herm(self):
-        """Check if the quantum object (:class:`Qobj`) is hermitian.
+        """Check if the quantum object is hermitian.
 
         Returns
         -------

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -127,8 +127,8 @@ class Qobj(object):
         'operator-bra' (:func:`~qutip.qobj.isoperbra`), or 'super'
         (:func:`~qutip.qobj.issuper`).
     superrep : str
-        Representation used if ``type`` is 'super' (:func:`~qutip.qobj.issuper`).
-        One of 'super' (:func:`~qutip.superoperator.liouvillian` form) or 'choi'
+        Representation used if ``type`` is 'super'(:func:`~qutip.qobj.issuper`).
+        One of 'super'(:func:`~qutip.superoperator.liouvillian` form) or 'choi'
         (Choi matrix with tr = dimension via :mod:`~qutip.superop_reps`).
     isherm : bool
         Indicates if quantum object represents Hermitian operator via
@@ -1793,11 +1793,11 @@ class Qobj(object):
             The states that should be kept.
 
         normalize : True / False
-            Weather or not the new :class:`Qobj` instance should be normalized (default
-            is False). For Qobjs that represents density matrices or state
-            vectors normalized should probably be set to True, but for Qobjs
-            that represents operators in for example an Hamiltonian, normalize
-            should be False.
+            Weather or not the new :class:`Qobj` instance should be normalized
+            (default is False). For Qobjs that represents density matrices or
+            state vectors normalized should probably be set to True, but for
+            Qobjs that represents operators in for example an Hamiltonian,
+            normalize should be False.
 
         Returns
         -------

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -95,6 +95,8 @@ class Qobj(object):
     operator/state operations.  The Qobj constructor optionally takes a
     dimension ``list`` and/or shape ``list`` as arguments.
 
+.._qobj_parameters:
+
     Parameters
     ----------
     inpt : array_like

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -1250,7 +1250,7 @@ class Qobj(object):
 
         Notes
         -----
-        Uses the Q.:attr:`expm()` method.
+        Uses the Q. :attr:`expm()` method.
 
         """
         if self.dims[0][0] == self.dims[1][0]:

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -155,11 +155,11 @@ class Qobj(object):
         :obj:`.issuper` indicates if the quantum object represents a
         superoperator.
     isoperket : bool
-        :obj:`.isoperket` indicates if the quantum object represents an operator
-        in column vector form.
+        :obj:`.isoperket` indicates if the quantum object represents an
+        operator in column vector form.
     isoperbra : bool
-        :obj:`.isoperbra` indicates if the quantum object represents an operator
-        in row vector form.
+        :obj:`.isoperbra` indicates if the quantum object represents an
+        operator in row vector form.
 
     """
     __array_priority__ = 100  # sets Qobj priority above numpy arrays
@@ -953,8 +953,8 @@ class Qobj(object):
         """Norm of a quantum object.
 
         Default norm is `L2-norm` for kets and `trace-norm` for operators.
-        Other ket and operator norms may be specified using the :obj:`.norm` and
-        argument.
+        Other ket and operator norms may be specified using the :obj:`.norm`
+        and argument.
 
         Parameters
         ----------
@@ -1535,8 +1535,8 @@ class Qobj(object):
 
         Raises
         ------
-        ValueError : Must be a Hermitian operator to remove negative eigenvalues
-            When input operator is not Hermitian.
+        ValueError : Must be a Hermitian operator to remove negative
+        eigenvalues When input operator is not Hermitian.
 
         ValueError : Method not recognized
             If method other than 'clip' or 'sgs' is specified.
@@ -1638,8 +1638,8 @@ class Qobj(object):
         Parameters
         -----------
         other : :obj:`.Qobj`
-            Quantum object for a state vector of type :obj:`.ket`, :obj:`.bra` or density
-            matrix.
+            Quantum object for a state vector of type :obj:`.ket`, :obj:`.bra`
+            or density matrix.
 
         Returns
         -------
@@ -1871,8 +1871,8 @@ class Qobj(object):
         normalize : True / False
             Weather or not the new :class:`Qobj` instance should be normalized
             (default is False). For Qobjs that represents density matrices or
-            state vectors normalized should probably be set to ``True``, but for
-            Qobjs that represents operators in for example an Hamiltonian,
+            state vectors normalized should probably be set to ``True``, but
+            for Qobjs that represents operators in for example an Hamiltonian,
             normalize should be ``False``.
 
         Returns
@@ -2149,8 +2149,8 @@ class Qobj(object):
         Parameters
         ----------
         qobj_list : list
-            A nested list of :obj:`.Qobj` instances and corresponding time-dependent
-            coefficients.
+            A nested list of :obj:`.Qobj` instances and corresponding
+            time-dependent coefficients.
         t : float
             The time for which to evaluate the time-dependent :obj:`.Qobj`
             instance.
@@ -2339,8 +2339,8 @@ def dims(inpt):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the :obj:`.Qobj.dims()`
-    attribute is recommended.
+    This function is for legacy compatibility only. Using the
+    :obj:`.Qobj.dims()` attribute is recommended.
 
     """
     if isinstance(inpt, Qobj):
@@ -2364,8 +2364,8 @@ def shape(inpt):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the :obj:`.Qobj.shape`
-    attribute is recommended.
+    This function is for legacy compatibility only. Using the
+    :obj:`.Qobj.shape` attribute is recommended.
 
     """
     if isinstance(inpt, Qobj):
@@ -2396,8 +2396,8 @@ def isket(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the :obj:`.Qobj.isket`
-    attribute is recommended.
+    This function is for legacy compatibility only. Using the
+    :obj:`.Qobj.isket` attribute is recommended.
 
     """
     return True if isinstance(Q, Qobj) and Q.isket else False
@@ -2424,8 +2424,8 @@ def isbra(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the :obj:`.Qobj.isbra`
-    attribute is recommended.
+    This function is for legacy compatibility only. Using the
+    :obj:`.Qobj.isbra` attribute is recommended.
 
     """
     return True if isinstance(Q, Qobj) and Q.isbra else False
@@ -2447,8 +2447,8 @@ def isoperket(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the :obj:`.Qobj.isoperket()`
-    attribute is recommended.
+    This function is for legacy compatibility only. Using the
+    :obj:`.Qobj.isoperket()` attribute is recommended.
 
     """
     return True if isinstance(Q, Qobj) and Q.isoperket else False
@@ -2470,8 +2470,8 @@ def isoperbra(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the :obj:`.Qobj.isoperbra`
-    attribute is recommended.
+    This function is for legacy compatibility only. Using the
+    :obj:`.Qobj.isoperbra` attribute is recommended.
 
     """
     return True if isinstance(Q, Qobj) and Q.isoperbra else False
@@ -2498,8 +2498,8 @@ def isoper(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the :obj:`.Qobj.isoper`
-    attribute is recommended.
+    This function is for legacy compatibility only. Using the
+    :obj:`.Qobj.isoper` attribute is recommended.
 
     """
     return True if isinstance(Q, Qobj) and Q.isoper else False
@@ -2520,8 +2520,8 @@ def issuper(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the :obj:`.Qobj.issuper`
-    attribute is recommended.
+    This function is for legacy compatibility only. Using the
+    :obj:`.Qobj.issuper` attribute is recommended.
 
     """
     return True if isinstance(Q, Qobj) and Q.issuper else False
@@ -2589,8 +2589,8 @@ def isherm(Q):
 
     Notes
     -----
-    This function is for legacy compatibility only. Using the :obj:`.Qobj.isherm`
-    attribute is recommended.
+    This function is for legacy compatibility only. Using the
+    :obj:`.Qobj.isherm` attribute is recommended.
 
     """
     return True if isinstance(Q, Qobj) and Q.isherm else False

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -131,7 +131,7 @@ class Qobj(object):
         :obj:`.isherm` indicates if quantum object represents Hermitian
         operator.
     isunitary : bool
-        :obj:`.check_isunitary` indicates if quantum object represents unitary
+        `isunitary` indicates if quantum object represents unitary
         operator.
     iscp : bool
         Indicates if the quantum object represents a map, and if that map is
@@ -901,7 +901,7 @@ class Qobj(object):
 
         Returns
         -------
-        dag : :obj:`.Qobj`
+        :obj:`.Qobj`
             The requested adjoint of an operator or a quantum state as a
             quantum object.
         """
@@ -918,8 +918,8 @@ class Qobj(object):
 
         Raises
         -------
-        ValueError
-            Dual channels are only implemented for CP maps.
+        ValueError : Dual channels are only implemented for CP maps.
+            If the input is not a completely positive map.
 
         """
         # Uses the technique of Johnston and Kribs (arXiv:1102.0948), which
@@ -940,7 +940,7 @@ class Qobj(object):
 
         Returns
         -------
-        conj : :obj:`.Qobj`
+        :obj:`.Qobj`
             The requested conjugate of an operator or a quantum state as a
             quantum object.
         """
@@ -959,9 +959,11 @@ class Qobj(object):
         Parameters
         ----------
         norm : str
-            Which norm to use for ket/bra vectors: L2, max norm 'max',
-            or for operators: trace 'tr', Frobius 'fro', one 'one', or max
-            'max'.
+            Norm to use for :obj:`.ket` or :obj:`.bra` vectors: L2,
+            max norm 'max',
+
+            Norm for :obj:`.operators` : trace 'tr', Frobius 'fro', one 'one',
+            or max 'max'.
 
         sparse : bool
             Use sparse eigenvalue solver for trace norm.  Other norms are not
@@ -977,16 +979,16 @@ class Qobj(object):
 
         Returns
         -------
-        norm : float
+        float
             The requested norm of the operator or state quantum object.
 
         Raises
         -------
         ValueError : For matrices, norm must be 'tr', 'fro', 'one', or 'max'
-            When norm chosen is not from default methods.
+            When norm chosen is not from default methods of operators.
 
         ValueError : For vectors, norm must be 'l2', or 'max'
-            When norm chosen is not from default methods.
+            When norm chosen is not from default methods of bra/kets.
 
 
         Notes
@@ -1028,13 +1030,13 @@ class Qobj(object):
 
         Returns
         -------
-        P : :obj:`.Qobj`
-            Projection operator.
+        :obj:`.Qobj`
+            Projection operator of a state vector.
 
         Raises
         -------
-        TypeError
-            Projector can only be formed from a bra or ket.
+        TypeError : Projector can only be formed from a bra or ket
+            If the input is not a ket or bra.
         """
         if self.isket:
             _out = zcsr_proj(self.data, 1)
@@ -1052,7 +1054,7 @@ class Qobj(object):
 
         Returns
         -------
-        trace : float
+        float
             Returns the trace of the quantum object.
 
         """
@@ -1070,8 +1072,8 @@ class Qobj(object):
 
         Raises
         -------
-        TypeError
-            Purity is defined on a density matrix or state.
+        TypeError : Purity is defined on a density matrix or state
+            If the input is a superoperator.
 
         """
         rho = self
@@ -1091,9 +1093,9 @@ class Qobj(object):
 
         Parameters
         ----------
-        order : ``str {'C', 'F'}``
+        order : str {'C', 'F'}
             Return array in C (default) or Fortran ordering.
-        squeeze : ``bool {False, True}``
+        squeeze : bool {False, True}
             Squeeze output array.
 
         Returns
@@ -1117,8 +1119,8 @@ class Qobj(object):
 
         Returns
         -------
-        diags : array
-            Returns array of ``real`` values if operators is Hermitian,
+        array
+            Returns array of ``real`` values if operator is Hermitian,
             otherwise ``complex`` values are returned.
 
         """
@@ -1133,7 +1135,7 @@ class Qobj(object):
 
         Parameters
         ----------
-        method : ``str {'dense', 'sparse'}``
+        method : str {'dense', 'sparse'}
             Use set method to use to calculate the matrix exponentiation. The
             available choices includes 'dense' and 'sparse'.  Since the
             exponential of a matrix is nearly always dense, method='dense'
@@ -1141,7 +1143,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :obj:`.Qobj`
+        :obj:`.Qobj`
             Exponentiated quantum operator.
 
         Raises
@@ -1195,13 +1197,14 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :obj:`.Qobj`
+        :obj:`.Qobj`
             Matrix square root of operator.
 
         Raises
         ------
         TypeError : Invalid operand for matrix square root
-            When input is not a square operator.
+            When input is not a square operator i.e. rows and columns are not
+            equal in size.
 
         Notes
         -----
@@ -1233,13 +1236,14 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :obj:`.Qobj`
+        :obj:`.Qobj`
             Matrix cosine of an operator.
 
         Raises
         ------
         TypeError : Invalid operand for matrix square root.
-            when input is not square.
+            When input is not a square operator, number of rows and columns
+            do not match.
 
         Notes
         -----
@@ -1258,13 +1262,14 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :class:`Qobj`
+        :class:`Qobj`
             Matrix sine of operator.
 
         Raises
         ------
         TypeError : Invalid operand for matrix square root
-            When input is not a square operator.
+            When input is not a square operator, number of rows and columns
+            do not match.
 
         Notes
         -----
@@ -1283,13 +1288,14 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :obj:`.Qobj`
+        :obj:`.Qobj`
             Matrix inverse of operator.
 
         Raises
         ------
         TypeError : Invalid operand for matrix inverse
-            When input is not square.
+            When input is not square, number of rows and columns
+            do not match.
         """
         if self.shape[0] != self.shape[1]:
             raise TypeError('Invalid operand for matrix inverse')
@@ -1327,8 +1333,8 @@ class Qobj(object):
 
         Raises
         -------
-        Exception
-            Inplace kwarg must be bool.
+        Exception : inplace kwarg must be bool
+            Inplace must be True or False.
 
         """
         if inplace:
@@ -1358,7 +1364,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :obj:`.Qobj`
+        :obj:`.Qobj`
             Quantum object representing partial trace with selected components
             remaining.
 
@@ -1390,7 +1396,7 @@ class Qobj(object):
 
         Returns
         -------
-        P : :obj:`.Qobj`
+        q : :obj:`.Qobj`
             Permuted quantum object.
 
         """
@@ -1410,7 +1416,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :obj:`.Qobj`
+        :obj:`.Qobj`
             Quantum object with small elements removed.
 
         """
@@ -1446,7 +1452,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :obj:`.Qobj`
+        :obj:`.Qobj`
             Operator in new basis.
 
         Raises
@@ -1455,7 +1461,7 @@ class Qobj(object):
             When input is a list or array and the dimensions do not match.
 
         TypeError : Invalid operand for basis transformation
-            When input is not a proper quantum object or operator.
+            When input is not a proper quantum object, array or operator.
 
         Notes
         -----
@@ -1530,13 +1536,14 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :obj:`.Qobj`
+        :obj:`.Qobj`
             A valid density operator as a quantum object.
 
         Raises
         ------
         ValueError : Must be a Hermitian operator to remove negative
-        eigenvalues When input operator is not Hermitian.
+        eigenvalues
+            When input operator is not Hermitian.
 
         ValueError : Method not recognized
             If method other than 'clip' or 'sgs' is specified.
@@ -1598,7 +1605,7 @@ class Qobj(object):
 
         Returns
         -------
-        elem : complex
+        complex
             Complex valued matrix element.
 
         Raises
@@ -1643,7 +1650,7 @@ class Qobj(object):
 
         Returns
         -------
-        overlap : complex
+        complex
             Complex valued overlap.
 
         Raises
@@ -1771,7 +1778,7 @@ class Qobj(object):
         sparse : bool
             Use sparse Eigensolver
         sort : str
-            Sort eigenvalues 'low' to high, or 'high' to low.
+            Sort eigenvalues 'low' to 'high', or 'high' to 'low'.
         eigvals : int
             Number of requested eigenvalues. Default is all eigenvalues.
         tol : float
@@ -1820,8 +1827,8 @@ class Qobj(object):
 
         Raises
         -------
-        WARNING
-            Ground state may be degenerate. Use Q. :obj:`.eigenstates()`.
+        WARNING : Ground state may be degenerate.
+            Use Q. :obj:`.eigenstates()`
 
 
         Notes
@@ -1851,7 +1858,7 @@ class Qobj(object):
 
         Returns
         -------
-        oper : :obj:`.Qobj`
+        :obj:`.Qobj`
             Transpose of input operator.
 
         """
@@ -1883,8 +1890,8 @@ class Qobj(object):
 
         Raises
         -------
-        TypeError
-            Can only eliminate states from operators or state vectors.
+        TypeError : Can only eliminate states from operators or state vectors
+            If input is not ket, bra or an operator.
 
         Notes
         -----
@@ -1920,7 +1927,7 @@ class Qobj(object):
 
         Returns
         -------
-        q : :obj:`.Qobj`
+        :obj:`.Qobj`
             A new instance of :obj:`.Qobj` that contains only the states
             corresponding to indices that are **not** in ``states_inds``.
 
@@ -1947,7 +1954,7 @@ class Qobj(object):
 
         Returns
         -------
-        d : float
+        float
             Either the diamond norm of this operator, or the diamond distance
             from this operator to B.
 
@@ -2057,7 +2064,7 @@ class Qobj(object):
         Returns
         -------
         isunitary : bool
-            Returns the new value of :obj:`.isunitary` property.
+            Returns the new value of `isunitary` property.
         """
         if self.isoper:
             eye_data = fast_identity(self.shape[0])
@@ -2160,13 +2167,15 @@ class Qobj(object):
 
         Returns
         -------
-        output : :obj:`.Qobj`
+        :obj:`.Qobj`
             A Qobj instance that represents the value of qobj_list at time t.
 
         Raises
         ------
-        TypeError
-            Unrecognized format for specification of time-dependent Qobj.
+        TypeError : Unrecognized format for specification of time-dependent
+        Qobj
+            When type of `qobj_list` cannot be recognized - :obj:`.Qobj` or
+            list etc.
 
         """
 
@@ -2227,13 +2236,14 @@ def dag(A):
 
     Returns
     -------
-    oper : :obj:`.Qobj`
+    :obj:`.Qobj`
         Adjoint of input operator
 
     Raises
     -------
-    TypeError
-        Input is not a quantum object.
+    TypeError : Input is not a quantum object
+        When input cannot be identified as :obj:`.Qobj`.
+
 
     Notes
     -----
@@ -2265,8 +2275,8 @@ def ptrace(Q, sel):
 
     Raises
     -------
-    TypeError
-        Input is not a quantum object.
+    TypeError : Input is not a quantum object
+        When input cannot be identified as :obj:`.Qobj`.
 
     Notes
     -----
@@ -2334,8 +2344,8 @@ def dims(inpt):
 
     Raises
     -------
-    TypeError
-        Input is not a quantum object.
+    TypeError : Input is not a quantum object
+        When input cannot be identified as :obj:`.Qobj`. 
 
     Notes
     -----

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -102,8 +102,7 @@ class Qobj(object):
     dims : list
         Dimensions of object (:obj:`.dims`) used for :obj:`.tensor` products .
     shape : list
-        Shape of underlying data structure (matrix shape) via
-        :obj:`.dims_to_tensor_shape`.
+        Shape of underlying data structure (matrix shape)
     copy : bool
         Flag specifying whether :class:`Qobj` should get a copy of the
         input data, or use the original.
@@ -1998,6 +1997,11 @@ class Qobj(object):
     def check_isunitary(self):
         """
         Checks whether :class:`Qobj` is a unitary matrix
+
+        Returns
+        -------
+        isunitary : bool
+        Returns the new value of isunitary property.
         """
         if self.isoper:
             eye_data = fast_identity(self.shape[0])

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -983,10 +983,11 @@ class Qobj(object):
 
         Raises
         -------
-        ValueError
-            For matrices, norm must be 'tr', 'fro', 'one', or 'max'.
+        ValueError : For matrices, norm must be 'tr', 'fro', 'one', or 'max'.
+            When norm chosen is not from default types.
 
-            For vectors, norm must be 'l2', or 'max'.
+        ValueError : For vectors, norm must be 'l2', or 'max'.
+            When norm chosen is not from default types.
 
 
         Notes
@@ -1146,13 +1147,11 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError
-            Invalid operand for matrix exponential - when dimensions do not
-            match.
+        TypeError : Invalid operand for matrix exponential.
+            when dimensions do not match i.e. input is not a square operator.
 
-        ValueError
-            Method must be 'dense' or 'sparse' - when available method is not
-            chosen.
+        ValueError : Method must be 'dense' or 'sparse'.
+            when available deafult method is not chosen.
 
         """
         if self.dims[0][0] != self.dims[1][0]:
@@ -1202,8 +1201,8 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError
-            Invalid operand for matrix square root - when input is not square.
+        TypeError : Invalid operand for matrix square root.
+            when input is not a square operator.
 
         Notes
         -----
@@ -1240,8 +1239,8 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError
-            Invalid operand for matrix square root - when input is not square.
+        TypeError : Invalid operand for matrix square root.
+            when input is not square.
 
         Notes
         -----
@@ -1265,8 +1264,8 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError
-            Invalid operand for matrix square root - when input is not square.
+        TypeError : Invalid operand for matrix square root.
+            when input is not square.
 
         Notes
         -----
@@ -1290,8 +1289,8 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError
-            Invalid operand for matrix inverse - when input is not square.
+        TypeError : Invalid operand for matrix inverse.
+            when input is not square.
         """
         if self.shape[0] != self.shape[1]:
             raise TypeError('Invalid operand for matrix inverse')
@@ -1453,17 +1452,15 @@ class Qobj(object):
 
         Raises
         ------
-        TypeError
-            Invalid size of ket list for basis transformation - when input
-            is a list or array and the dimensions do not match.
+        TypeError : Invalid size of ket list for basis transformation.
+            when input is a list or array and the dimensions do not match.
 
-            Invalid operand for basis transformation - when input is not a
-            proper quantum object or operator.
+        TypeError : Invalid operand for basis transformation.
+            when input is not a proper quantum object or operator.
 
         Notes
         -----
         This function is still in development.
-
 
         """
         if isinstance(inpt, list) or (isinstance(inpt, np.ndarray) and
@@ -1539,12 +1536,11 @@ class Qobj(object):
 
         Raises
         ------
-        ValueError
-            Must be a Hermitian operator to remove negative eigenvalues - when
-            operator is not Hermitian.
+        ValueError : Must be a Hermitian operator to remove negative eigenvalues
+            when operator is not Hermitian.
 
-            Method not recognized - if method other than 'clip' or 'sgs' is
-            specified.
+        ValueError : Method not recognized.
+            If method other than 'clip' or 'sgs' is specified.
 
         """
         if not self.isherm:
@@ -1608,11 +1604,10 @@ class Qobj(object):
 
         Raises
         -------
-        TypeError
-            Can only get matrix elements for an operator - when input
-            is not a valid operator.
+        TypeError : Can only get matrix elements for an operator.
+            when input is not a valid operator.
 
-            Can only calculate matrix elements for bra  and ket vectors -
+        TypeError : Can only calculate matrix elements for bra  and ket vectors.
             when input is not a valid ket or bra vector.
 
         Notes

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -960,7 +960,7 @@ class Qobj(object):
         ----------
         norm : str
             Which norm to use for ket/bra vectors: L2, max norm 'max',
-            or for operators: trace `tr', Frobius 'fro', one 'one', or max
+            or for operators: trace 'tr', Frobius 'fro', one 'one', or max
             'max'.
 
         sparse : bool

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -313,7 +313,7 @@ class QobjEvo:
                     tlist=tlist)
 
     Mixing time formats is allowed.  It is not possible to create a single
-    :class:`~QobjEvo` that contains different ``tlist`` values, however.
+    :class:`QobjEvo` that contains different ``tlist`` values, however.
 
     **Passing arguments**
 
@@ -346,10 +346,10 @@ class QobjEvo:
     Q_object : list, :class:`~Qobj` or :class:`~QobjEvo`
         The time-dependent description of the quantum object.  This is of the
         same format as the first parameter to the general ODE solvers; in
-        general, it is a list of ``[:class:`~Qobj`, time_dependence]`` pairs that are
+        general, it is a list of ``[:class:`Qobj`, time_dependence]`` pairs that are
         summed to make the whole object.  The ``time_dependence`` can be any of
         the formats discussed in the previous section.  If a particular term
-        has no time-dependence, then you should just give the :class:`~Qobj` instead
+        has no time-dependence, then you should just give the :class:`Qobj` instead
         of the 2-element list.
 
     args : dict, optional
@@ -360,7 +360,7 @@ class QobjEvo:
 
     tlist : array_like, optional
         List of the times any numpy-array coefficients describe.  This is used
-        only in at least one of the time dependences in :attr:`~Q_object` is given
+        only in at least one of the time dependences in :attr:`Q_object` is given
         in Numpy-array format.  The times must be sorted, but need not be
         equidistant.  Values inbetween will be interpolated.
 
@@ -390,7 +390,7 @@ class QobjEvo:
         backing this object (may be empty).
 
     compiled_qobjevo : :class:`~CQobjCte` or :class:`~CQobjEvoTd`
-        Cython version of the QobjEvo.
+        Cython version of the :class:`QobjEvo`.
 
     coeff_get : callable
         Object called to obtain a list of all the coefficients at a particular
@@ -400,7 +400,7 @@ class QobjEvo:
         Runtime created files to delete with the instance.
 
     dummy_cte : bool
-        Is self.cte an empty Qobj
+        Is self.cte an empty :obj:`Qobj`
 
     const : bool
         Indicates if quantum object is constant
@@ -410,7 +410,7 @@ class QobjEvo:
         Information about the type of coefficients used in the entire object.
 
     num_obj : int
-        Number of :obj:`~Qobj` in the QobjEvo.
+        Number of :obj:`~Qobj` in the :class:`QobjEvo`.
 
     use_cython : bool
         Flag to compile string to Cython or Python
@@ -1229,8 +1229,8 @@ class QobjEvo:
 
     def apply(self, function, *args, **kw_args):
         """
-        Apply the linear function ``function`` to every ``Qobj`` included in
-        this time-dependent object, and return a new ``QobjEvo`` with the
+        Apply the linear function ``function`` to every :class:`Qobj` included in
+        this time-dependent object, and return a new :class:`QobjEvo` with the
         result.
 
         Any additional arguments or keyword arguments will be appended to every
@@ -1398,7 +1398,7 @@ class QobjEvo:
         t : float
             The time to evaluate this operator at.
 
-        state : Qobj or np.ndarray
+        state : :class:`Qobj` or np.ndarray
             The state to take the expectation value around.
 
         herm : bool, default False
@@ -1457,12 +1457,12 @@ class QobjEvo:
         t : float
             The time to evaluate this object at.
 
-        vec : Qobj or np.ndarray
+        vec : :class:`Qobj` or np.ndarray
             The state-vector to multiply this object by.
 
         Returns
         -------
-        vec: Qobj or np.ndarray
+        vec: :class:`Qobj` or np.ndarray
             The vector result in the same type as the input.
         """
         was_Qobj = False

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -198,14 +198,14 @@ class StateArgs:
 class EvoElement:
     """
     Internal type used to represent the time-dependent parts of a
-    :class:`~QobjEvo`.
+    :obj:`.QobjEvo`.
 
     Availables "types" are
 
     1. function
     2. string
     3. ``np.ndarray``
-    4. :class:`.Cubic_Spline`
+    4. :obj:`.Cubic_Spline`
     """
 
     def __init__(self, qobj, get_coeff, coeff, type):
@@ -236,11 +236,11 @@ class QobjEvo:
 
     Basic math operations are defined:
 
-    - ``+``, ``-`` : :class:`~QobjEvo`, :class:`~Qobj`, scalars.
-    - ``*``: :class:`~Qobj`, C number
+    - ``+``, ``-`` : :obj:`.QobjEvo`, :obj:`.Qobj`, scalars.
+    - ``*``: :obj:`.Qobj`, C number
     - ``/`` : C number
 
-    This object is constructed by passing a list of :obj:`~Qobj` instances,
+    This object is constructed by passing a list of :obj:`.Qobj` instances,
     each of which *may* have an associated scalar time dependence.  The list is
     summed to produce the final result.  In other words, if an instance of this
     class is :math:`Q(t)`, then it is constructed from a set of constant
@@ -313,7 +313,7 @@ class QobjEvo:
                     tlist=tlist)
 
     Mixing time formats is allowed.  It is not possible to create a single
-    :class:`QobjEvo` that contains different ``tlist`` values, however.
+    :obj:`.QobjEvo` that contains different ``tlist`` values, however.
 
     **Passing arguments**
 
@@ -322,12 +322,12 @@ class QobjEvo:
     supported by the code to be compiled in the string.
 
     There are some "magic" names that can be specified, whose objects will be
-    overwritten when used within :func:`.sesolve`, :func:`.mesolve` and
-    :func:`.mcsolve`.  This allows access to the solvers' internal states, and
+    overwritten when used within :func:`.sesolve`, :obj:`.mesolve` and
+    :obj:`.mcsolve`.  This allows access to the solvers' internal states, and
     they are updated at every call.  The initial values of these dictionary
     elements is unimportant.  The magic names available are:
 
-    - ``"state"``: the current state as a :class:`~Qobj`
+    - ``"state"``: the current state as a :obj:`.Qobj`
     - ``"state_vec"``: the current state as a column-stacked 1D ``np.ndarray``
     - ``"state_mat"``: the current state as a 2D ``np.ndarray``
     - ``"expect_op_<n>"``: the current expectation value of the element
@@ -335,21 +335,21 @@ class QobjEvo:
       an integer literal, e.g. ``"expect_op_0"``.  This will be either real- or
       complex-valued, depending on whether the state and operator are both
       Hermitian or not.
-    - ``"collapse"``: (:func:`.mcsolve` only) a list of the collapses that have
+    - ``"collapse"``: (:obj:`.mcsolve` only) a list of the collapses that have
       occurred during the evolution.  Each element of the list is a 2-tuple
       ``(time: float, which: int)``, where ``time`` is the time this collapse
       happened, and ``which`` is an integer indexing the ``c_ops`` argument to
-      :func:`.mcsolve`.
+      :obj:`.mcsolve`.
 
     Parameters
     ----------
-    Q_object : list, :class:`~Qobj` or :class:`~QobjEvo`
+    Q_object : list, :obj:`.Qobj` or :obj:`.QobjEvo`
         The time-dependent description of the quantum object.  This is of the
         same format as the first parameter to the general ODE solvers; in
-        general, it is a list of ``[:class:`Qobj`, time_dependence]`` pairs that are
+        general, it is a list of ``[:obj:`.Qobj`, time_dependence]`` pairs that are
         summed to make the whole object.  The ``time_dependence`` can be any of
         the formats discussed in the previous section.  If a particular term
-        has no time-dependence, then you should just give the :class:`Qobj` instead
+        has no time-dependence, then you should just give the :obj:`.Qobj` instead
         of the 2-element list.
 
     args : dict, optional
@@ -367,10 +367,10 @@ class QobjEvo:
 
     Attributes
     ----------
-    cte : :class:`~Qobj`
+    cte : :obj:`.Qobj`
         Constant part of the QobjEvo.
 
-    ops : list of :class:`.EvoElement`
+    ops : list of :obj:`.EvoElement`
         Internal representation of the time-dependence structure of the
         elements.
 
@@ -390,7 +390,7 @@ class QobjEvo:
         backing this object (may be empty).
 
     compiled_qobjevo : :class:`~CQobjCte` or :class:`~CQobjEvoTd`
-        Cython version of the :class:`QobjEvo`.
+        Cython version of the :obj:`.QobjEvo`.
 
     coeff_get : callable
         Object called to obtain a list of all the coefficients at a particular
@@ -400,7 +400,7 @@ class QobjEvo:
         Runtime created files to delete with the instance.
 
     dummy_cte : bool
-        Is self.cte an empty :obj:`Qobj`
+        Is self.cte an empty :obj:`.Qobj`
 
     const : bool
         Indicates if quantum object is constant
@@ -410,13 +410,28 @@ class QobjEvo:
         Information about the type of coefficients used in the entire object.
 
     num_obj : int
-        Number of :obj:`~Qobj` in the :class:`QobjEvo`.
+        Number of :obj:`.Qobj` in the :obj:`.QobjEvo`.
 
     use_cython : bool
         Flag to compile string to Cython or Python
 
     safePickle : bool
         Flag to not share pointers between thread.
+
+    Raises
+    -------
+    Exception : The Qobj must not already be a function.
+        When `op_type` is not a :obj:`.Qobj` type in `Q_object` list.
+
+    TypeError : Qobj not compatible.
+        After a failed compatibility check of Qobj :obj:`.dims` and
+        :obj:`.shape`.
+
+    TypeError : Incorrect Q_object specification.
+        Checks if `op_type` is a :obj:`.Qobj`.
+
+    TypeError : Time list does not match.
+        Checks compatibility of `tlist` with `op_type`. 
     """
 
     def __init__(self, Q_object=[], args={}, copy=True,
@@ -782,6 +797,11 @@ class QobjEvo:
     def arguments(self, new_args):
         """
         Update the scoped variables that were passed as ``args`` to new values.
+
+        Raises
+        -------
+        TypeError
+            The new args must be in a dict.
         """
         if not isinstance(new_args, dict):
             raise TypeError("The new args must be in a dict")
@@ -818,7 +838,12 @@ class QobjEvo:
     def to_list(self):
         """
         Return this operator in the list-like form used to initialised it, like
-        can be passed to :func:`~mesolve`.
+        can be passed to :obj:`.mesolve`.
+
+        Raises
+        -------
+        Exception
+            tlist are not compatible.
         """
         list_qobj = []
         if not self.dummy_cte:
@@ -1214,12 +1239,12 @@ class QobjEvo:
 
     def permute(self, order):
         """
-        Permute the tensor structure of the underlying matrices into a new
+        Permute the :obj:`.tensor` structure of the underlying matrices into a new
         format.
 
         See Also
         --------
-        Qobj.permute : the same operation on constant quantum objects.
+        :obj:`.permute` : the same operation on constant quantum objects.
         """
         res = self.copy()
         res.cte = res.cte.permute(order)
@@ -1229,12 +1254,17 @@ class QobjEvo:
 
     def apply(self, function, *args, **kw_args):
         """
-        Apply the linear function ``function`` to every :class:`Qobj` included in
-        this time-dependent object, and return a new :class:`QobjEvo` with the
+        Apply the linear function ``function`` to every :obj:`.Qobj` included in
+        this time-dependent object, and return a new :obj:`.QobjEvo` with the
         result.
 
         Any additional arguments or keyword arguments will be appended to every
         function call.
+
+        Raises
+        -------
+        TypeError
+            The function must return a Qobj.
         """
         self.compiled = ""
         res = self.copy()
@@ -1398,19 +1428,32 @@ class QobjEvo:
         t : float
             The time to evaluate this operator at.
 
-        state : :class:`Qobj` or np.ndarray
+        state : :obj:`.Qobj` or ``np.ndarray``
             The state to take the expectation value around.
 
         herm : bool, default False
             Whether this operator and the state are both Hermitian.  If True,
             only the real part of the result will be returned.
 
+        Raises
+        --------
+        TypeError
+            The time needs to be a real scalar.
+
+            The vector must be an array or Qobj.
+
+        Exception
+            Dimensions do not fit.
+
+            The shapes do not match.
+
+
         See Also
         --------
-        expect : General-purpose expectation values.
+        :obj:`.expect` : General-purpose expectation values.
         """
         if not isinstance(t, (int, float)):
-            raise TypeError("The time need to be a real scalar")
+            raise TypeError("The time needs to be a real scalar")
         if isinstance(state, Qobj):
             if self.cte.dims[1] == state.dims[0]:
                 vec = state.full().ravel("F")
@@ -1457,17 +1500,31 @@ class QobjEvo:
         t : float
             The time to evaluate this object at.
 
-        vec : :class:`Qobj` or np.ndarray
+        vec : :obj:`.Qobj` or ``np.ndarray``
             The state-vector to multiply this object by.
 
         Returns
         -------
-        vec: :class:`Qobj` or np.ndarray
+        vec: :obj:`.Qobj` or ``np.ndarray``
             The vector result in the same type as the input.
+
+        Raises
+        --------
+        TypeError
+            The time needs to be a real scalar.
+
+            The vector must be an array or Qobj.
+
+        Exception
+            Dimensions do not fit.
+
+            The vector must be 1d.
+
+            The lengths do not match.
         """
         was_Qobj = False
         if not isinstance(t, (int, float)):
-            raise TypeError("the time need to be a real scalar")
+            raise TypeError("the time needs to be a real scalar")
         if isinstance(vec, Qobj):
             if self.cte.dims[1] != vec.dims[0]:
                 raise Exception("Dimensions do not fit")
@@ -1479,7 +1536,7 @@ class QobjEvo:
         if vec.ndim != 1:
             raise Exception("The vector must be 1d")
         if vec.shape[0] != self.cte.shape[1]:
-            raise Exception("The length do not match")
+            raise Exception("The lengths do not match")
 
         if self.compiled:
             out = self.compiled_qobjevo.mul_vec(t, vec)
@@ -1502,17 +1559,31 @@ class QobjEvo:
         t : float
             The time to evaluate this object at.
 
-        mat : Qobj or np.ndarray
+        mat : :obj:`.Qobj` or ``np.ndarray``
             The matrix that is multiplied by this object.
 
         Returns
         -------
-        mat: Qobj or np.ndarray
+        mat: :obj:`.Qobj` or ``np.ndarray``
             The matrix result in the same type as the input.
+
+        Raises
+        --------
+        TypeError
+            The time needs to be a real scalar.
+
+            The vector must be an array or Qobj.
+
+        Exception
+            Dimensions do not fit.
+
+            The vector must be 2d.
+
+            The lengths do not match.
         """
         was_Qobj = False
         if not isinstance(t, (int, float)):
-            raise TypeError("the time need to be a real scalar")
+            raise TypeError("the time needs to be a real scalar")
         if isinstance(mat, Qobj):
             if self.cte.dims[1] != mat.dims[0]:
                 raise Exception("Dimensions do not fit")
@@ -1524,7 +1595,7 @@ class QobjEvo:
         if mat.ndim != 2:
             raise Exception("The matrice must be 2d")
         if mat.shape[0] != self.cte.shape[1]:
-            raise Exception("The length do not match")
+            raise Exception("The lengths do not match")
 
         if self.compiled:
             out = self.compiled_qobjevo.mul_mat(t, mat)

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -1235,8 +1235,8 @@ class QobjEvo:
 
     def permute(self, order):
         """
-        Permute the :obj:`.tensor` structure of the underlying matrices into a new
-        format.
+        Permute the :obj:`.tensor` structure of the underlying matrices into a
+        new format.
 
         See Also
         --------
@@ -1250,9 +1250,9 @@ class QobjEvo:
 
     def apply(self, function, *args, **kw_args):
         """
-        Apply the linear function ``function`` to every :obj:`.Qobj` included in
-        this time-dependent object, and return a new :obj:`.QobjEvo` with the
-        result.
+        Apply the linear function ``function`` to every :obj:`.Qobj` included
+        in this time-dependent object, and return a new :obj:`.QobjEvo` with
+        the result.
 
         Any additional arguments or keyword arguments will be appended to every
         function call.

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -368,7 +368,7 @@ class QobjEvo:
     Attributes
     ----------
     cte : :obj:`.Qobj`
-        Constant part of the QobjEvo.
+        Constant part of the :obj:`.QobjEvo`.
 
     ops : list of :obj:`.EvoElement`
         Internal representation of the time-dependence structure of the
@@ -389,7 +389,7 @@ class QobjEvo:
         A string representing the properties of the low-level Cython class
         backing this object (may be empty).
 
-    compiled_qobjevo : :class:`~CQobjCte` or :class:`~CQobjEvoTd`
+    compiled_qobjevo : :obj:`.CQobjCte` or :obj:`.CQobjEvoTd`
         Cython version of the :obj:`.QobjEvo`.
 
     coeff_get : callable
@@ -400,7 +400,7 @@ class QobjEvo:
         Runtime created files to delete with the instance.
 
     dummy_cte : bool
-        Is self.cte an empty :obj:`.Qobj`
+        Is `self.cte` an empty :obj:`.Qobj`
 
     const : bool
         Indicates if quantum object is constant
@@ -418,6 +418,7 @@ class QobjEvo:
     safePickle : bool
         Flag to not share pointers between thread.
 
+
     Raises
     -------
     Exception : The Qobj must not already be a function.
@@ -431,7 +432,7 @@ class QobjEvo:
         Checks if `op_type` is a :obj:`.Qobj`.
 
     TypeError : Time list does not match.
-        Checks compatibility of `tlist` with `op_type`. 
+        Checks compatibility of `tlist` with `op_type`.
     """
 
     def __init__(self, Q_object=[], args={}, copy=True,
@@ -839,11 +840,6 @@ class QobjEvo:
         """
         Return this operator in the list-like form used to initialised it, like
         can be passed to :obj:`.mesolve`.
-
-        Raises
-        -------
-        Exception
-            tlist are not compatible.
         """
         list_qobj = []
         if not self.dummy_cte:
@@ -1264,7 +1260,7 @@ class QobjEvo:
         Raises
         -------
         TypeError
-            The function must return a Qobj.
+            The function must return a :obj:`.Qobj`.
         """
         self.compiled = ""
         res = self.copy()
@@ -1437,15 +1433,17 @@ class QobjEvo:
 
         Raises
         --------
-        TypeError
-            The time needs to be a real scalar.
+        TypeError : The time needs to be a real scalar.
+            Input time `t` must be either ``int`` or ``float``
 
-            The vector must be an array or Qobj.
+        TypeError : The vector must be an array or :obj:`.Qobj`.
+            When input state is neither a quantum object or an array.
 
-        Exception
-            Dimensions do not fit.
+        Exception : Dimensions do not fit.
+            When input is a :obj:`.Qobj` and :obj:`.dims` check fails.
 
-            The shapes do not match.
+        Exception : The shapes do not match.
+            Shape of vector created from input must agree with expected value.
 
 
         See Also
@@ -1510,17 +1508,20 @@ class QobjEvo:
 
         Raises
         --------
-        TypeError
-            The time needs to be a real scalar.
+        TypeError : The time needs to be a real scalar.
+            Input time `t` must be either ``int`` or ``float``
 
-            The vector must be an array or Qobj.
+        TypeError : The vector must be an array or :obj:`.Qobj`.
+            When input vector is neither a quantum object or an array.
 
-        Exception
-            Dimensions do not fit.
+        Exception : Dimensions do not fit.
+            When input is a :obj:`.Qobj` and :obj:`.dims` check fails.
 
-            The vector must be 1d.
+        Exception : The vector must be 1d.
+            1-dimensional vector.
 
-            The lengths do not match.
+        Exception : The lengths do not match.
+            Shape of vector created from input must agree with expected value.
         """
         was_Qobj = False
         if not isinstance(t, (int, float)):
@@ -1569,17 +1570,20 @@ class QobjEvo:
 
         Raises
         --------
-        TypeError
-            The time needs to be a real scalar.
+        TypeError : The time needs to be a real scalar.
+            Input time `t` must be either ``int`` or ``float``
 
-            The vector must be an array or Qobj.
+        TypeError : The matrix must be an array or :obj:`.Qobj`.
+            When input matrix is neither a quantum object or an array.
 
-        Exception
-            Dimensions do not fit.
+        Exception : Dimensions do not fit.
+            When input is a :obj:`.Qobj` and :obj:`.dims` check fails.
 
-            The vector must be 2d.
+        Exception : The matrix must be 2d.
+            2-dimensional matrix.
 
-            The lengths do not match.
+        Exception : The lengths do not match.
+            Shape of vector created from input must agree with expected value.
         """
         was_Qobj = False
         if not isinstance(t, (int, float)):
@@ -1593,7 +1597,7 @@ class QobjEvo:
         if not isinstance(mat, np.ndarray):
             raise TypeError("The vector must be an array or Qobj")
         if mat.ndim != 2:
-            raise Exception("The matrice must be 2d")
+            raise Exception("The matrix must be 2d")
         if mat.shape[0] != self.cte.shape[1]:
             raise Exception("The lengths do not match")
 

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -313,7 +313,7 @@ class QobjEvo:
                     tlist=tlist)
 
     Mixing time formats is allowed.  It is not possible to create a single
-    ``QobjEvo`` that contains different ``tlist`` values, however.
+    :class:`~QobjEvo` that contains different ``tlist`` values, however.
 
     **Passing arguments**
 
@@ -346,10 +346,10 @@ class QobjEvo:
     Q_object : list, :class:`~Qobj` or :class:`~QobjEvo`
         The time-dependent description of the quantum object.  This is of the
         same format as the first parameter to the general ODE solvers; in
-        general, it is a list of ``[Qobj, time_dependence]`` pairs that are
+        general, it is a list of ``[:class:`~Qobj`, time_dependence]`` pairs that are
         summed to make the whole object.  The ``time_dependence`` can be any of
         the formats discussed in the previous section.  If a particular term
-        has no time-dependence, then you should just give the ``Qobj`` instead
+        has no time-dependence, then you should just give the :class:`~Qobj` instead
         of the 2-element list.
 
     args : dict, optional
@@ -360,7 +360,7 @@ class QobjEvo:
 
     tlist : array_like, optional
         List of the times any numpy-array coefficients describe.  This is used
-        only in at least one of the time dependences in ``Q_object`` is given
+        only in at least one of the time dependences in :attr:`~Q_object` is given
         in Numpy-array format.  The times must be sorted, but need not be
         equidistant.  Values inbetween will be interpolated.
 
@@ -389,7 +389,7 @@ class QobjEvo:
         A string representing the properties of the low-level Cython class
         backing this object (may be empty).
 
-    compiled_qobjevo : ``CQobjCte`` or ``CQobjEvoTd``
+    compiled_qobjevo : :class:`~CQobjCte` or :class:`~CQobjEvoTd`
         Cython version of the QobjEvo.
 
     coeff_get : callable

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -346,7 +346,7 @@ class QobjEvo:
     Q_object : list, :obj:`.Qobj` or :obj:`.QobjEvo`
         The time-dependent description of the quantum object.  This is of the
         same format as the first parameter to the general ODE solvers; in
-        general, it is a list of ``[:obj:`.Qobj`, time_dependence]`` pairs that are
+        general, it is a list of ``[Qobj, time_dependence]`` pairs that are
         summed to make the whole object.  The ``time_dependence`` can be any of
         the formats discussed in the previous section.  If a particular term
         has no time-dependence, then you should just give the :obj:`.Qobj` instead
@@ -360,7 +360,7 @@ class QobjEvo:
 
     tlist : array_like, optional
         List of the times any numpy-array coefficients describe.  This is used
-        only in at least one of the time dependences in :attr:`Q_object` is given
+        only in at least one of the time dependences in :obj:`.Q_object` is given
         in Numpy-array format.  The times must be sorted, but need not be
         equidistant.  Values inbetween will be interpolated.
 
@@ -421,17 +421,17 @@ class QobjEvo:
 
     Raises
     -------
-    Exception : The Qobj must not already be a function.
+    Exception : The Qobj must not already be a function
         When `op_type` is not a :obj:`.Qobj` type in `Q_object` list.
 
-    TypeError : Qobj not compatible.
+    TypeError : Qobj not compatible
         After a failed compatibility check of Qobj :obj:`.dims` and
         :obj:`.shape`.
 
-    TypeError : Incorrect Q_object specification.
+    TypeError : Incorrect Q_object specification
         Checks if `op_type` is a :obj:`.Qobj`.
 
-    TypeError : Time list does not match.
+    TypeError : Time list does not match
         Checks compatibility of `tlist` with `op_type`.
     """
 
@@ -1240,7 +1240,7 @@ class QobjEvo:
 
         See Also
         --------
-        :obj:`.permute` : the same operation on constant quantum objects.
+        :obj:`Qobj.permute` : the same operation on constant quantum objects.
         """
         res = self.copy()
         res.cte = res.cte.permute(order)
@@ -1433,22 +1433,22 @@ class QobjEvo:
 
         Raises
         --------
-        TypeError : The time needs to be a real scalar.
+        TypeError : The time needs to be a real scalar
             Input time `t` must be either ``int`` or ``float``
 
-        TypeError : The vector must be an array or :obj:`.Qobj`.
+        TypeError : The vector must be an array or :obj:`.Qobj`
             When input state is neither a quantum object or an array.
 
-        Exception : Dimensions do not fit.
+        Exception : Dimensions do not fit
             When input is a :obj:`.Qobj` and :obj:`.dims` check fails.
 
-        Exception : The shapes do not match.
+        Exception : The shapes do not match
             Shape of vector created from input must agree with expected value.
 
 
         See Also
         --------
-        :obj:`.expect` : General-purpose expectation values.
+        :obj:`qutip.expect` : General-purpose expectation values.
         """
         if not isinstance(t, (int, float)):
             raise TypeError("The time needs to be a real scalar")
@@ -1508,19 +1508,19 @@ class QobjEvo:
 
         Raises
         --------
-        TypeError : The time needs to be a real scalar.
+        TypeError : The time needs to be a real scalar
             Input time `t` must be either ``int`` or ``float``
 
-        TypeError : The vector must be an array or :obj:`.Qobj`.
+        TypeError : The vector must be an array or :obj:`.Qobj`
             When input vector is neither a quantum object or an array.
 
-        Exception : Dimensions do not fit.
+        Exception : Dimensions do not fit
             When input is a :obj:`.Qobj` and :obj:`.dims` check fails.
 
-        Exception : The vector must be 1d.
+        Exception : The vector must be 1d
             1-dimensional vector.
 
-        Exception : The lengths do not match.
+        Exception : The lengths do not match
             Shape of vector created from input must agree with expected value.
         """
         was_Qobj = False
@@ -1570,16 +1570,16 @@ class QobjEvo:
 
         Raises
         --------
-        TypeError : The time needs to be a real scalar.
+        TypeError : The time needs to be a real scalar
             Input time `t` must be either ``int`` or ``float``
 
-        TypeError : The matrix must be an array or :obj:`.Qobj`.
+        TypeError : The matrix must be an array or :obj:`.Qobj`
             When input matrix is neither a quantum object or an array.
 
-        Exception : Dimensions do not fit.
+        Exception : Dimensions do not fit
             When input is a :obj:`.Qobj` and :obj:`.dims` check fails.
 
-        Exception : The matrix must be 2d.
+        Exception : The matrix must be 2d
             2-dimensional matrix.
 
         Exception : The lengths do not match.

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -801,8 +801,8 @@ class QobjEvo:
 
         Raises
         -------
-        TypeError
-            The new args must be in a dict.
+        TypeError : The new args must be in a dict
+            When input arguments are not in a dictionary.
         """
         if not isinstance(new_args, dict):
             raise TypeError("The new args must be in a dict")
@@ -1259,8 +1259,9 @@ class QobjEvo:
 
         Raises
         -------
-        TypeError
-            The function must return a :obj:`.Qobj`.
+        TypeError : The function must return a :obj:`.Qobj`
+            After function acts on the quantum object, the output must be a
+            quantum object. 
         """
         self.compiled = ""
         res = self.copy()

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -389,7 +389,7 @@ class QobjEvo:
         A string representing the properties of the low-level Cython class
         backing this object (may be empty).
 
-    compiled_qobjevo : :obj:`.CQobjCte` or :obj:`.CQobjEvoTd`
+    compiled_qobjevo : `CQobjCte` or `CQobjEvoTd`
         Cython version of the :obj:`.QobjEvo`.
 
     coeff_get : callable
@@ -1261,7 +1261,7 @@ class QobjEvo:
         -------
         TypeError : The function must return a :obj:`.Qobj`
             After function acts on the quantum object, the output must be a
-            quantum object. 
+            quantum object.
         """
         self.compiled = ""
         res = self.copy()


### PR DESCRIPTION
**Description**
Adds hyperlinks for functions, classes, attributes etc. wherever possible. 

- Deleted methods table. See [this comment](https://github.com/qutip/qutip/pull/1499#issuecomment-822679427). 
- Every function, class etc is linked by default method of ``:obj:`.some_func` ``
- Functions not in API doc are referenced as  'func_not_in_API'. 
- Added `TypeError` and `ValueError` etc. in docstrings when an error of either type is raised by a function. Most of these might not be needed as [this link](https://numpydoc.readthedocs.io/en/latest/format.html#raises) advises to provide information about only the obvious errors. I read the link after making the changes. If needed, the new additions can be removed from the docstrings. 

**Related issues or PRs**
[One of the fixes for issue 71 in documentation](https://github.com/qutip/qutip-doc/issues/71). 

**Changelog**
Add hyperlinks in documentation and errors in docstrings of functions in qobj and qobevo