### PR TITLE
Fix more warnings in documentation build

### DIFF
--- a/qutip/nonmarkov/memorycascade.py
+++ b/qutip/nonmarkov/memorycascade.py
@@ -167,7 +167,7 @@ class MemoryCascade:
 
     def outfieldpropagator(self, blist, tlist, tau, c1=None, c2=None,
                            notrace=False):
-        """
+        r"""
         Compute propagator for computing output field expectation values
         <O_n(tn)...O_2(t2)O_1(t1)> for times t1,t2,... and
         O_i = I, b_out, b_out^\dagger, b_loop, b_loop^\dagger
@@ -297,7 +297,7 @@ class MemoryCascade:
         return qt.vector_to_operator(E*rhovec)
 
     def outfieldcorr(self, rho0, blist, tlist, tau, c1=None, c2=None):
-        """
+        r"""
         Compute output field expectation value
         <O_n(tn)...O_2(t2)O_1(t1)> for times t1,t2,... and
         O_i = I, b_out, b_out^\dagger, b_loop, b_loop^\dagger

--- a/qutip/nonmarkov/transfertensor.py
+++ b/qutip/nonmarkov/transfertensor.py
@@ -212,7 +212,7 @@ def ttmsolve(dynmaps, rho0, times, e_ops=[], learningtimes=None, tensors=None,
 
 
 def _generatetensors(dynmaps, learningtimes=None, **kwargs):
-    """
+    r"""
     Generate the tensors :math:`T_1,\dots,T_K` from the dynamical maps
     :math:`E(t_k)`.
 

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -1226,7 +1226,7 @@ def _uncoupled_ghz(N):
 
 
 def _uncoupled_css(N, a, b):
-    """
+    r"""
     Generate the density matrix of the CSS state in the full 2^N
     dimensional Hilbert space.
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -35,10 +35,10 @@ __all__ = ['wigner', 'qfunc', 'spin_q_function',
            'spin_wigner', 'wigner_transform']
 
 import numpy as np
-from numpy import (zeros, array, arange, exp, real, conj, pi,
-                   copy, sqrt, meshgrid, size, conjugate,
-                   cos, sin)
-from scipy import polyval, fliplr
+from numpy import (
+    zeros, array, arange, exp, real, conj, pi, copy, sqrt, meshgrid, size,
+    conjugate, cos, sin, polyval, fliplr,
+)
 import scipy.sparse as sp
 import scipy.fftpack as ft
 import scipy.linalg as la


### PR DESCRIPTION
There were a few invalid escape sequences and scipy imports that somehow escaped being fixed #1493, so this fixes those.

Also, in #1480 we issued deprecation warnings for user-facing uses of `eseries`, `essolve` and `ode2es`, however we are not deprecating the correlation and spectrum methods (in QuTiP 5.0 the necessary components are just absorbed into private functions inside `correlation.py`), so these should not generate warnings.  Simon (@hodgestar) and I briefly discussed whether we needed a special warnings filter inside those functions, but we thought we didn't need it because default Python filters would prevent `DeprecationWarning` from being shown, since it is triggered by library code and not code in `__main__`.

The problem is that not everything uses the default filters; both `pytest` and the documentation build do not suppress all `DeprecationWarning` messages.  This was a particular problem in `pytest`, where approximately 68,000 warnings (!) were generated.  Since this is _not_ deprecated functionality, nor is it using deprecated functionality, so there shouldn't be any warnings.  This PR removes those as well.

The end result is that a completely clean documentation build now should generate 0 warnings.  My eventual intent is to create an automatic documentation build process, which treats warnings as errors to prevent us from breaking it in PRs.  This cannot happen until the merger of the documentation into this repository, however, because otherwise new features/feature removals could get into an impossible situation where the two PRs to `qutip` and `qutip-doc` would not be aware of each other, so would return failed CI.

Tests still generate several warnings, but that's for a different PR.