### PR TITLE
Fix test warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 
 script:
   - python -c "import qutip; qutip.about()"
-  - pytest --verbosity=1 --rootdir="${QUTIP_INSTALL}/tests" -c "${QUTIP_INSTALL}/tests/pytest.ini" --pyargs qutip
+  - pytest -We --verbosity=1 --rootdir="${QUTIP_INSTALL}/tests" -c "${QUTIP_INSTALL}/tests/pytest.ini" --pyargs qutip
 
 _mac_generic_setup: &mac_generic_setup
   os: osx
@@ -79,7 +79,7 @@ jobs:
         - export QUTIP_NUM_PROCESSES=2
       script:
         - python -c "import qutip; qutip.about()"
-        - pytest --verbosity=1 --cov=qutip --cov-config="${QUTIP_DOWNLOAD}/.coveragerc" --rootdir="${QUTIP_INSTALL}/tests" -c "${QUTIP_INSTALL}/tests/pytest.ini" --pyargs qutip
+        - pytest -We --verbosity=1 --cov=qutip --cov-config="${QUTIP_DOWNLOAD}/.coveragerc" --rootdir="${QUTIP_INSTALL}/tests" -c "${QUTIP_INSTALL}/tests/pytest.ini" --pyargs qutip
       after_success:
         - coveralls
 

--- a/qutip/cy/pyxbuilder.py
+++ b/qutip/cy/pyxbuilder.py
@@ -32,9 +32,19 @@
 ###############################################################################
 import sys
 import os
+import warnings
 
 import numpy as np
-import pyximport
+
+with warnings.catch_warnings():
+    # TODO: pyximport loads the imp module, which is deprecated in favour of
+    # importlib and slated for removal in Python 3.12.  Our intent is to
+    # remove all usage of pyximport in QuTiP 5.0 with new Coefficient objects,
+    # before Python 3.12 is released.
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, module="pyximport",
+    )
+    import pyximport
 
 old_get_distutils_extension = pyximport.pyximport.get_distutils_extension
 

--- a/qutip/essolve.py
+++ b/qutip/essolve.py
@@ -221,7 +221,7 @@ def ode2es(L, rho0):
 
         out = None
         for i in range(rlen):
-            qo = Qobj(np.matrix(vv[:, i]).T, dims=rho0.dims, shape=rho0.shape)
+            qo = Qobj(np.array(vv[:, i]).T, dims=rho0.dims, shape=rho0.shape)
             if out:
                 out += eseries(qo, -1.0j * w[i])
             else:

--- a/qutip/fastsparse.py
+++ b/qutip/fastsparse.py
@@ -173,7 +173,7 @@ class fast_csr_matrix(csr_matrix):
             elif other.size == 1:
                 return self._mul_scalar(other.flat[0])
         # Anything else.
-        return np.multiply(self.todense(), other)
+        return np.multiply(self.toarray(), other)
 
     def _mul_sparse_matrix(self, other):
         """
@@ -263,7 +263,7 @@ class fast_csr_matrix(csr_matrix):
                 return self._scalar_binopt(other, operator.eq)
         # Dense other.
         elif isdense(other):
-            return self.todense() == other
+            return self.toarray() == other
         # Sparse other.
         elif isspmatrix(other):
             warn("Comparing sparse matrices using == is inefficient, try using"
@@ -297,7 +297,7 @@ class fast_csr_matrix(csr_matrix):
                 return self._scalar_binopt(other, operator.ne)
         # Dense other.
         elif isdense(other):
-            return self.todense() != other
+            return self.toarray() != other
         # Sparse other.
         elif isspmatrix(other):
             #TODO sparse broadcasting
@@ -324,7 +324,7 @@ class fast_csr_matrix(csr_matrix):
                 return self._scalar_binopt(other, op)
         # Dense other.
         elif isdense(other):
-            return op(self.todense(), other)
+            return op(self.toarray(), other)
         # Sparse other.
         elif isspmatrix(other):
             #TODO sparse broadcasting

--- a/qutip/fileio.py
+++ b/qutip/fileio.py
@@ -276,11 +276,11 @@ def qload(name):
         Object retrieved from requested file.
 
     """
-    fileObject = open(name + '.qu', 'rb')  # open the file for reading
-    if sys.version_info >= (3, 0):
-        out = pickle.load(fileObject, encoding='latin1')  # return the object from the file
-    else:
-        out = pickle.load(fileObject)
+    with open(name + ".qu", "rb") as fileObject:
+        if sys.version_info >= (3, 0):
+            out = pickle.load(fileObject, encoding='latin1')
+        else:
+            out = pickle.load(fileObject)
     if isinstance(out, Qobj):  # for quantum objects
         print('Loaded Qobj object:')
         str1 = "Quantum object: " + "dims = " + str(out.dims) \

--- a/qutip/floquet.py
+++ b/qutip/floquet.py
@@ -122,7 +122,7 @@ def floquet_modes(H, T, args=None, sort=False, U=None):
     # prepare a list of kets for the floquet states
     new_dims = [U.dims[0], [1] * len(U.dims[0])]
     new_shape = [U.shape[0], 1]
-    kets_order = [Qobj(np.matrix(evecs[:, o]).T,
+    kets_order = [Qobj(np.array(evecs[:, o]).T,
                        dims=new_dims, shape=new_shape) for o in order]
 
     return kets_order, e_quasi[order]

--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -448,7 +448,7 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
         op = vector_to_operator(S_dual * vec_eye)
         # The 2-norm was not implemented for sparse matrices as of the time
         # of this writing. Thus, we must yet again go dense.
-        return la.norm(op.data.todense(), 2)
+        return la.norm(op.full(), 2)
 
     # If we're still here, we need to actually solve the problem.
 

--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -47,7 +47,7 @@ from decimal import Decimal
 
 import numpy as np
 from scipy.integrate import odeint
-from scipy.sparse.linalg import eigsh
+from scipy.linalg import eigvalsh
 from scipy.special import entr
 from scipy.sparse import dok_matrix, block_diag, lil_matrix
 from qutip.solver import Options, Result
@@ -291,7 +291,7 @@ def dicke_function_trace(f, rho):
     for i, block in enumerate(blocks):
         dj = state_degeneracies[i]
         normalized_block = block / dj
-        eigenvals_block = eigsh(normalized_block, return_eigenvectors=False)
+        eigenvals_block = eigvalsh(normalized_block)
         for val in eigenvals_block:
             eigenvals_degeneracy.append(val)
             deg.append(dj)

--- a/qutip/qip/operations/__init__.py
+++ b/qutip/qip/operations/__init__.py
@@ -33,7 +33,7 @@
 from qutip.qip.operations.gates import (
     rx, ry, rz, x_gate, y_gate, z_gate, s_gate, t_gate,
     cy_gate, cz_gate, cs_gate, ct_gate, sqrtnot, snot,
-    phasegate, qrot, cphase, cnot,
+    phasegate, qrot, cphase, cnot, qasmu_gate,
     csign, berkeley, swapalpha, swap, iswap, sqrtswap,
     sqrtiswap, fredkin, molmer_sorensen,
     toffoli, rotation, controlled_gate,

--- a/qutip/qip/qasm.py
+++ b/qutip/qip/qasm.py
@@ -7,10 +7,10 @@ import warnings
 from math import pi
 import numpy as np
 
-from qutip.qip import gate_sequence_product
 from qutip.qip.circuit import QubitCircuit
-from qutip.qip.operations.gates import controlled_gate, qasmu_gate, rz, snot
-
+from qutip.qip.operations import (
+    controlled_gate, qasmu_gate, rz, snot, gate_sequence_product,
+)
 
 __all__ = ["read_qasm", "save_qasm", "print_qasm", "circuit_to_qasm_str"]
 

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -699,7 +699,7 @@ class Qobj(object):
         """
         out = self.data[ind]
         if sp.issparse(out):
-            return np.asarray(out.todense())
+            return out.toarray()
         else:
             return out
 

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -528,8 +528,7 @@ def rand_kraus_map(N, dims=None, seed=None):
         _check_dims(dims, N, N)
 
     # Random unitary (Stinespring Dilation)
-    big_unitary = rand_unitary(N ** 3, seed=seed).data.todense()
-    orthog_cols = np.array(big_unitary[:, :N])
+    orthog_cols = rand_unitary(N ** 3, seed=seed).full()[:, :N]
     oper_list = np.reshape(orthog_cols, (N ** 2, N, N))
     return list(map(lambda x: Qobj(inpt=x, dims=dims), oper_list))
 

--- a/qutip/semidefinite.py
+++ b/qutip/semidefinite.py
@@ -169,7 +169,7 @@ def initialize_constraints_on_dnorm_problem(dim):
     # we need to swap the order in Rho0 and Rho1. This is not straightforward,
     # as CVXPY requires that the constant be the first argument. To solve this,
     # We conjugate by SWAP.
-    W = qudit_swap(dim).data.todense()
+    W = qudit_swap(dim).full()
     W = Complex(re=W.real, im=W.imag)
     Rho0 = conj(W, kron(np.eye(dim), rho0))
     Rho1 = conj(W, kron(np.eye(dim), rho1))

--- a/qutip/sparse.py
+++ b/qutip/sparse.py
@@ -406,7 +406,7 @@ def sp_eigs(data, isherm, vecs=True, sparse=False, sort='low',
         evals, evecs = _sp_eigs(data, isherm, vecs, N, eigvals, num_large,
                                 num_small, tol, maxiter)
     else:
-        evals, evecs = _dense_eigs(data.todense(), isherm, vecs, N, eigvals,
+        evals, evecs = _dense_eigs(data.toarray(), isherm, vecs, N, eigvals,
                                    num_large, num_small)
 
     if sort == 'high':  # flip arrays to largest values first

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -472,8 +472,8 @@ def _steadystate_direct_sparse(L, ss_args):
 
 def _steadystate_direct_dense(L, ss_args):
     """
-    Direct solver that use numpy dense matrices. Suitable for
-    small system, with a few states.
+    Direct solver that uses numpy arrays. Suitable for small systems with few
+    states.
     """
     if settings.debug:
         logger.debug('Starting direct dense solver.')
@@ -483,14 +483,14 @@ def _steadystate_direct_dense(L, ss_args):
     b = np.zeros(n ** 2)
     b[0] = ss_args['weight']
 
-    L = L.data.todense()
+    L = L.full()
     L[0, :] = np.diag(ss_args['weight']*np.ones(n)).reshape((1, n ** 2))
     _dense_start = time.time()
     v = np.linalg.solve(L, b)
     _dense_end = time.time()
     ss_args['info']['solution_time'] = _dense_end-_dense_start
     if ss_args['return_info']:
-        ss_args['info']['residual_norm'] = la.norm(b - L*v, np.inf)
+        ss_args['info']['residual_norm'] = la.norm(b - L@v, np.inf)
     data = vec2mat(v)
     data = 0.5 * (data + data.conj().T)
 

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -39,24 +39,23 @@ collapse operators.
 __all__ = ['steadystate', 'steady', 'build_preconditioner',
            'pseudo_inverse']
 
-import warnings
+import functools
 import time
-import scipy
+import warnings
+
+from packaging.version import parse as _parse_version
 import numpy as np
 from numpy.linalg import svd
-from scipy import prod
+import scipy
 import scipy.sparse as sp
 import scipy.linalg as la
-from scipy.sparse.linalg import (use_solver, splu, spilu, spsolve, eigs,
-                                 LinearOperator, gmres, lgmres, bicgstab)
+from scipy.sparse.linalg import (
+    use_solver, splu, spilu, eigs, LinearOperator, gmres, lgmres, bicgstab,
+)
 from qutip.qobj import Qobj, issuper, isoper
 
 from qutip.superoperator import liouvillian, vec2mat, spre
-from qutip.sparse import sp_permute, sp_bandwidth, sp_reshape, sp_profile
-
-from qutip.superoperator import liouvillian, vec2mat
-from qutip.sparse import (sp_permute, sp_bandwidth, sp_reshape,
-                          sp_profile)
+from qutip.sparse import sp_permute, sp_bandwidth, sp_profile
 from qutip.cy.spmath import zcsr_kron
 from qutip.graph import weighted_bipartite_matching
 from qutip import (mat2vec, tensor, identity, operator_to_vector)
@@ -70,6 +69,36 @@ logger.setLevel('DEBUG')
 # Load MKL spsolve if avaiable
 if settings.has_mkl:
     from qutip._mkl.spsolve import (mkl_splu, mkl_spsolve)
+
+
+def _eat_kwargs(function, names):
+    """
+    Return a wrapped version of `function` that simply removes any keyword
+    arguments with one of the given names.
+    """
+    @functools.wraps(function)
+    def out(*args, **kwargs):
+        for name in names:
+            if name in kwargs:
+                del kwargs[name]
+        return function(*args, **kwargs)
+    return out
+
+
+# From SciPy 1.4 onwards we need to pass the `callback_type='legacy'` argument
+# to gmres to maintain the same behaviour we used to have.  Since this should
+# be the default behaviour, we use that in the main code and just "eat" the
+# argument if passed to a lower version of SciPy that doesn't know about it.
+# Similarly, SciPy < 1.1 does not recognise the `atol` keyword.
+#
+# Respective checks can be removed when SciPy version requirements are raised.
+
+if _parse_version(scipy.__version__) < _parse_version("1.1"):
+    gmres = _eat_kwargs(gmres, ['atol', 'callback_type'])
+    lgmres = _eat_kwargs(lgmres, ['atol'])
+    bicgstab = _eat_kwargs(bicgstab, ['atol'])
+elif _parse_version(scipy.__version__) < _parse_version("1.4"):
+    gmres = _eat_kwargs(gmres, ['callback_type'])
 
 
 def _empty_info_dict():
@@ -628,50 +657,23 @@ def _steadystate_iterative(L, ss_args):
 
     # Select iterative solver type
     _iter_start = time.time()
-    # FIXME: These atol keyword except checks can be removed once scipy 1.1
-    # is a minimum requirement
-    extra = {"callback_type": 'legacy'} if scipy.__version__ >= "1.4" else {}
     if ss_args['method'] == 'iterative-gmres':
-        try:
-            v, check = gmres(L, b, tol=ss_args['tol'], atol=ss_args['matol'],
-                             M=ss_args['M'], x0=ss_args['x0'],
-                             restart=ss_args['restart'],
-                             maxiter=ss_args['maxiter'],
-                             callback=_iter_count, **extra)
-        except TypeError as e:
-            if "unexpected keyword argument 'atol'" in str(e):
-                v, check = gmres(L, b, tol=ss_args['tol'],
-                                 M=ss_args['M'], x0=ss_args['x0'],
-                                 restart=ss_args['restart'],
-                                 maxiter=ss_args['maxiter'],
-                                 callback=_iter_count)
-
+        v, check = gmres(L, b, tol=ss_args['tol'], atol=ss_args['matol'],
+                         M=ss_args['M'], x0=ss_args['x0'],
+                         restart=ss_args['restart'],
+                         maxiter=ss_args['maxiter'],
+                         callback=_iter_count, callback_type='legacy')
     elif ss_args['method'] == 'iterative-lgmres':
-        try:
-            v, check = lgmres(L, b, tol=ss_args['tol'], atol=ss_args['matol'],
-                              M=ss_args['M'], x0=ss_args['x0'],
-                              maxiter=ss_args['maxiter'],
-                              callback=_iter_count)
-        except TypeError as e:
-            if "unexpected keyword argument 'atol'" in str(e):
-                v, check = lgmres(L, b, tol=ss_args['tol'],
-                                  M=ss_args['M'], x0=ss_args['x0'],
-                                  maxiter=ss_args['maxiter'],
-                                  callback=_iter_count)
-
+        v, check = lgmres(L, b, tol=ss_args['tol'], atol=ss_args['matol'],
+                          M=ss_args['M'], x0=ss_args['x0'],
+                          maxiter=ss_args['maxiter'],
+                          callback=_iter_count)
     elif ss_args['method'] == 'iterative-bicgstab':
-        try:
-            v, check = bicgstab(L, b, tol=ss_args['tol'],
-                                atol=ss_args['matol'],
-                                M=ss_args['M'], x0=ss_args['x0'],
-                                maxiter=ss_args['maxiter'],
-                                callback=_iter_count)
-        except TypeError as e:
-            if "unexpected keyword argument 'atol'" in str(e):
-                v, check = bicgstab(L, b, tol=ss_args['tol'],
-                                    M=ss_args['M'], x0=ss_args['x0'],
-                                    maxiter=ss_args['maxiter'],
-                                    callback=_iter_count)
+        v, check = bicgstab(L, b, tol=ss_args['tol'],
+                            atol=ss_args['matol'],
+                            M=ss_args['M'], x0=ss_args['x0'],
+                            maxiter=ss_args['maxiter'],
+                            callback=_iter_count)
     else:
         raise Exception("Invalid iterative solver method.")
     _iter_end = time.time()
@@ -875,52 +877,26 @@ def _steadystate_power(L, ss_args):
                 logger.debug('Fill factor: %f' % ((L_nnz+U_nnz)/orig_nnz))
 
     it = 0
-    # FIXME: These atol keyword except checks can be removed once scipy 1.1
-    # is a minimum requirement
     while (la.norm(L * v, np.inf) > tol) and (it < maxiter):
         check = 0
         if ss_args['method'] == 'power':
             v = lu.solve(v)
         elif ss_args['method'] == 'power-gmres':
-            try:
-                v, check = gmres(L, v, tol=mtol, atol=ss_args['matol'],
-                                 M=ss_args['M'], x0=ss_args['x0'],
-                                 restart=ss_args['restart'],
-                                 maxiter=ss_args['maxiter'],
-                                 callback=_iter_count)
-            except TypeError as e:
-                if "unexpected keyword argument 'atol'" in str(e):
-                    v, check = gmres(L, v, tol=mtol,
-                                     M=ss_args['M'], x0=ss_args['x0'],
-                                     restart=ss_args['restart'],
-                                     maxiter=ss_args['maxiter'],
-                                     callback=_iter_count)
-
+            v, check = gmres(L, v, tol=mtol, atol=ss_args['matol'],
+                             M=ss_args['M'], x0=ss_args['x0'],
+                             restart=ss_args['restart'],
+                             maxiter=ss_args['maxiter'],
+                             callback=_iter_count, callback_type='legacy')
         elif ss_args['method'] == 'power-lgmres':
-            try:
-                v, check = lgmres(L, v, tol=mtol, atol=ss_args['matol'],
-                                  M=ss_args['M'], x0=ss_args['x0'],
-                                  maxiter=ss_args['maxiter'],
-                                  callback=_iter_count)
-            except TypeError as e:
-                if "unexpected keyword argument 'atol'" in str(e):
-                    v, check = lgmres(L, v, tol=mtol,
-                                      M=ss_args['M'], x0=ss_args['x0'],
-                                      maxiter=ss_args['maxiter'],
-                                      callback=_iter_count)
-
+            v, check = lgmres(L, v, tol=mtol, atol=ss_args['matol'],
+                              M=ss_args['M'], x0=ss_args['x0'],
+                              maxiter=ss_args['maxiter'],
+                              callback=_iter_count)
         elif ss_args['method'] == 'power-bicgstab':
-            try:
-                v, check = bicgstab(L, v, tol=mtol, atol=ss_args['matol'],
-                                    M=ss_args['M'], x0=ss_args['x0'],
-                                    maxiter=ss_args['maxiter'],
-                                    callback=_iter_count)
-            except TypeError as e:
-                if "unexpected keyword argument 'atol'" in str(e):
-                    v, check = bicgstab(L, v, tol=mtol,
-                                        M=ss_args['M'], x0=ss_args['x0'],
-                                        maxiter=ss_args['maxiter'],
-                                        callback=_iter_count)
+            v, check = bicgstab(L, v, tol=mtol, atol=ss_args['matol'],
+                                M=ss_args['M'], x0=ss_args['x0'],
+                                maxiter=ss_args['maxiter'],
+                                callback=_iter_count)
         else:
             raise Exception("Invalid iterative solver method.")
         if check > 0:

--- a/qutip/subsystem_apply.py
+++ b/qutip/subsystem_apply.py
@@ -161,7 +161,7 @@ def _one_subsystem_apply(state, channel, idx):
 
     blk_sz = state.shape[0] // n_blks
     # Apply channel to top subsystem of each block in matrix
-    full_data_matrix = state.data.todense()
+    full_data_matrix = state.full()
 
     if isreal(full_data_matrix).all():
         full_data_matrix = full_data_matrix.astype(complex)
@@ -221,14 +221,12 @@ def _top_apply_S(block, channel):
     n_v =  int(sqrt(channel.shape[0]))
     n_h =  int(sqrt(channel.shape[1]))
     column = _block_col(block, n_v, n_h)
-    chan_mat = channel.data.todense()
+    chan_mat = channel.full()
     temp_col = zeros(shape(column)).astype(complex)
-    # print chan_mat.shape
     for row_idx in range(len(chan_mat)):
         row = chan_mat[row_idx]
-        # print [scal[0,0]*mat for (scal,mat) in zip(transpose(row),column)]
-        temp_col[row_idx] = sum([s[0, 0] * mat
-                                 for (s, mat) in zip(transpose(row), column)])
+        temp_col[row_idx] = sum([s * mat
+                                 for s, mat in zip(row, column)])
     return _block_stack(temp_col, n_v, n_h)
 
 
@@ -277,7 +275,6 @@ def _subsystem_apply_reference(state, channel, mask):
         return full_oper * state * full_oper.dag()
     else:
         # Go to Choi, then Kraus
-        # chan_mat = array(channel.data.todense())
         choi_matrix = super_to_choi(channel)
         vals, vecs = eig(choi_matrix.full())
         vecs = list(map(array, zip(*vecs)))

--- a/qutip/tests/test_device.py
+++ b/qutip/tests/test_device.py
@@ -31,7 +31,6 @@
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-import warnings
 import numpy as np
 import pytest
 import qutip
@@ -70,7 +69,7 @@ single_gate_tests = [
 
 
 device_lists = [
-    pytest.param(DispersiveCavityQED, {"g":0.1}, id = "DispersiveCavityQED"),
+    pytest.param(DispersiveCavityQED, {"g": 0.02}, id="DispersiveCavityQED"),
     pytest.param(LinearSpinChain, {}, id = "LinearSpinChain"),
     pytest.param(CircularSpinChain, {}, id = "CircularSpinChain"),
 ]
@@ -112,8 +111,7 @@ def test_numerical_evolution(
     circuit = qutip.qip.circuit.QubitCircuit(num_qubits)
     for gate in gates:
         circuit.add_gate(gate)
-    with warnings.catch_warnings(record=True):
-        device = device_class(num_qubits, **kwargs)
+    device = device_class(num_qubits, **kwargs)
     device.load_circuit(circuit)
 
     state = qutip.rand_ket(2**num_qubits)
@@ -152,15 +150,15 @@ circuit2.add_gate("SQRTISWAP", targets=[0, 2])  # supported only by SpinChain
 
 
 @pytest.mark.parametrize(("circuit", "device_class", "kwargs"), [
-    pytest.param(circuit, DispersiveCavityQED, {"g":0.1}, id = "DispersiveCavityQED"),
+    pytest.param(circuit, DispersiveCavityQED, {"g": 0.02},
+                 id="DispersiveCavityQED"),
     pytest.param(circuit2, LinearSpinChain, {}, id = "LinearSpinChain"),
     pytest.param(circuit2, CircularSpinChain, {}, id = "CircularSpinChain"),
 ])
 @pytest.mark.parametrize(("schedule_mode"), ["ASAP", "ALAP", None])
 def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
     num_qubits = circuit.N
-    with warnings.catch_warnings(record=True):
-        device = device_class(circuit.N, **kwargs)
+    device = device_class(circuit.N, **kwargs)
     device.load_circuit(circuit, schedule_mode=schedule_mode)
 
     state = qutip.rand_ket(2**num_qubits)

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -1518,9 +1518,9 @@ class TestPim:
         """
         N = 2
         ensemble = Pim(N, emission=1)
-        test_matrix = ensemble.coefficient_matrix().todense()
+        test_matrix = ensemble.coefficient_matrix().toarray()
         ensemble2 = Dicke(N, emission=1)
-        test_matrix2 = ensemble.coefficient_matrix().todense()
+        test_matrix2 = ensemble.coefficient_matrix().toarray()
         true_matrix = [
             [-2, 0, 0, 0],
             [1, -1, 0, 0],

--- a/qutip/tests/test_qasm.py
+++ b/qutip/tests/test_qasm.py
@@ -73,7 +73,8 @@ def check_measurement_defn(gate, gate_name, targets, classical_store):
 def test_qasm_addcircuit():
     filename = "test_add.qasm"
     filepath = Path(__file__).parent / 'qasm_files' / filename
-    qc = read_qasm(filepath)
+    with pytest.warns(UserWarning, match="not preserved in QubitCircuit"):
+        qc = read_qasm(filepath)
     assert qc.N == 2
     assert qc.num_cbits == 2
     check_gate_defn(qc.gates[0], "X", [1])
@@ -100,7 +101,8 @@ def test_custom_gates():
 def test_qasm_teleportation():
     filename = "teleportation.qasm"
     filepath = Path(__file__).parent / 'qasm_files' / filename
-    teleportation = read_qasm(filepath)
+    with pytest.warns(UserWarning, match="not preserved in QubitCircuit"):
+        teleportation = read_qasm(filepath)
     final_measurement = Measurement("start", targets=[2])
     initial_measurement = Measurement("start", targets=[0])
 

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -76,8 +76,8 @@ def test_QobjData():
     q1 = Qobj(data1)
     # check if data is a csr_matrix if originally array
     assert sp.isspmatrix_csr(q1.data)
-    # check if dense ouput is equal to original data
-    assert np.all(q1.data.todense() - np.matrix(data1) == 0)
+    # check if dense ouput is exactly equal to original data
+    assert np.all(q1.full() == data1)
 
     data2 = _random_not_singular(N)
     data2 = sp.csr_matrix(data2)
@@ -89,13 +89,6 @@ def test_QobjData():
     q3 = Qobj(data3)
     # check if data is a csr_matrix if originally int
     assert sp.isspmatrix_csr(q3.data)
-
-    data4 = _random_not_singular(N)
-    data4 = np.matrix(data4)
-    q4 = Qobj(data4)
-    # check if data is a csr_matrix if originally csr_matrix
-    assert sp.isspmatrix_csr(q4.data)
-    assert np.all(q4.data.todense() - np.matrix(data4) == 0)
 
 
 def test_QobjType():
@@ -285,8 +278,8 @@ def test_QobjAddition():
     x2 = 5 + q
 
     data = data + np.eye(5) * 5
-    assert np.all(x1.data.todense() - np.matrix(data) == 0)
-    assert np.all(x2.data.todense() - np.matrix(data) == 0)
+    assert np.all(x1.full() == data)
+    assert np.all(x2.full() == data)
 
     data = np.random.random((5, 5))
     q = Qobj(data)
@@ -294,8 +287,8 @@ def test_QobjAddition():
     x4 = data + q
 
     data = 2.0 * data
-    assert np.all(x3.data.todense() - np.matrix(data) == 0)
-    assert np.all(x4.data.todense() - np.matrix(data) == 0)
+    assert np.all(x3.full() == data)
+    assert np.all(x4.full() == data)
 
 
 def test_QobjSubtraction():
@@ -309,12 +302,12 @@ def test_QobjSubtraction():
     q3 = q1 - q2
     data3 = data1 - data2
 
-    assert np.all(q3.data.todense() - np.matrix(data3) == 0)
+    assert np.all(q3.full() == data3)
 
     q4 = q2 - q1
     data4 = data2 - data1
 
-    assert np.all(q4.data.todense() - np.matrix(data4) == 0)
+    assert np.all(q4.full() == data4)
 
 
 def test_QobjMultiplication():
@@ -339,7 +332,7 @@ def test_QobjDivision():
     q = Qobj(data)
     randN = 10 * np.random.random()
     q = q / randN
-    assert np.allclose(q.data.todense(), np.matrix(data) / randN)
+    assert np.allclose(q.full(), data / randN)
 
 
 def test_QobjPower():
@@ -348,10 +341,10 @@ def test_QobjPower():
     q = Qobj(data)
 
     q2 = q ** 2
-    assert (q2.data.todense() - np.matrix(data)**2 < 1e-12).all()
+    assert (q2.full() - np.linalg.matrix_power(data, 2) < 1e-12).all()
 
     q3 = q ** 3
-    assert (q3.data.todense() - np.matrix(data)**3 < 1e-12).all()
+    assert (q3.full() - np.linalg.matrix_power(data, 3) < 1e-12).all()
 
 
 def test_QobjNeg():
@@ -359,7 +352,7 @@ def test_QobjNeg():
     data = _random_not_singular(5)
     q = Qobj(data)
     x = -q
-    assert np.all(x.data.todense() + np.matrix(data) == 0)
+    assert np.all(x.full() + data == 0)
     assert q.isherm == x.isherm
     assert q.type == x.type
 
@@ -465,7 +458,7 @@ def test_QobjConjugate():
     data = _random_not_singular(5)
     A = Qobj(data)
     B = A.conj()
-    assert np.all(B.data.todense() - np.matrix(data.conj()) == 0)
+    assert np.all(B.full() == data.conj())
     assert A.isherm == B.isherm
     assert A.type == B.type
     assert A.superrep == B.superrep
@@ -476,7 +469,7 @@ def test_QobjDagger():
     data = _random_not_singular(5)
     A = Qobj(data)
     B = A.dag()
-    assert np.all(B.data.todense() - np.matrix(data.conj().T) == 0)
+    assert np.all(B.full() == data.conj().T)
     assert A.isherm == B.isherm
     assert A.type == B.type
     assert A.superrep == B.superrep
@@ -526,7 +519,7 @@ def test_QobjExpm():
     data = _random_not_singular(15)
     A = Qobj(data)
     B = A.expm()
-    assert (B.data.todense() - np.matrix(la.expm(data)) < 1e-10).all()
+    assert (B.full() - la.expm(data) < 1e-10).all()
 
 
 def test_QobjExpmExplicitlySparse():
@@ -534,7 +527,7 @@ def test_QobjExpmExplicitlySparse():
     data = _random_not_singular(15)
     A = Qobj(data)
     B = A.expm(method='sparse')
-    assert (B.data.todense() - np.matrix(la.expm(data)) < 1e-10).all()
+    assert (B.full() - la.expm(data) < 1e-10).all()
 
 
 def test_QobjExpmZeroOper():
@@ -860,8 +853,8 @@ def trunc_neg_case(qobj, method, expected=None):
     assert all(energy > -1e-8 for energy in pos_qobj.eigenenergies())
     assert np.allclose(pos_qobj.tr(), 1)
     if expected is not None:
-        test_array = pos_qobj.data.todense()
-        exp_array = expected.data.todense()
+        test_array = pos_qobj.full()
+        exp_array = expected.full()
         assert np.allclose(test_array, exp_array)
 
 

--- a/qutip/tests/test_rand.py
+++ b/qutip/tests/test_rand.py
@@ -148,7 +148,7 @@ class TestRand:
         for i in range(5):
             A = Q[i].data.tocsc()
             for j in range(10):
-                assert_(np.abs(np.sum(A.getcol(j).todense().real)-1.0) < 1e-15)
+                assert_(np.abs(np.sum(A.getcol(j).toarray().real)-1.0) < 1e-15)
 
     def testRandStochasticLeftSeed(self):
         "Random: Stochastic - left with seed"
@@ -166,7 +166,7 @@ class TestRand:
         for i in range(5):
             A = Q[i].data
             for j in range(10):
-                assert_(np.abs(np.sum(A.getrow(j).todense().real)-1.0) < 1e-15)
+                assert_(np.abs(np.sum(A.getrow(j).toarray().real)-1.0) < 1e-15)
 
     def testRandStochasticRightSeed(self):
         "Random: Stochastic - right with seed"

--- a/qutip/tests/test_subsys_apply.py
+++ b/qutip/tests/test_subsys_apply.py
@@ -60,15 +60,15 @@ class TestSubsysApply(object):
         analytic_result = single_op * rho_3 * single_op.dag()
         naive_result = subsystem_apply(rho_3, single_op, [True],
                                        reference=True)
-        naive_diff = (analytic_result - naive_result).data.todense()
+        naive_diff = (analytic_result - naive_result).full()
         naive_diff_norm = norm(naive_diff)
         assert_(naive_diff_norm < tol,
                 msg="SimpleSingle: naive_diff_norm {} "
                     "is beyond tolerance {}".format(
                         naive_diff_norm, tol))
-                                       
+
         efficient_result = subsystem_apply(rho_3, single_op, [True])
-        efficient_diff = (efficient_result - analytic_result).data.todense()
+        efficient_diff = (efficient_result - analytic_result).full()
         efficient_diff_norm = norm(efficient_diff)
         assert_(efficient_diff_norm < tol,
                 msg="SimpleSingle: efficient_diff_norm {} "
@@ -82,12 +82,10 @@ class TestSubsysApply(object):
         tol = 1e-12
         rho_3 = rand_dm(3)
         superop = kraus_to_super(rand_kraus_map(3))
-        analytic_result = vec2mat(superop.data.todense() *
-                                  mat2vec(rho_3.data.todense()))
-
+        analytic_result = vec2mat(superop.full() @ mat2vec(rho_3.full()))
         naive_result = subsystem_apply(rho_3, superop, [True],
                                        reference=True)
-        naive_diff = (analytic_result - naive_result).data.todense()
+        naive_diff = (analytic_result - naive_result).full()
         naive_diff_norm = norm(naive_diff)
         assert_(naive_diff_norm < tol,
                 msg="SimpleSuper: naive_diff_norm {} "
@@ -95,7 +93,7 @@ class TestSubsysApply(object):
                         naive_diff_norm, tol))
 
         efficient_result = subsystem_apply(rho_3, superop, [True])
-        efficient_diff = (efficient_result - analytic_result).data.todense()
+        efficient_diff = (efficient_result - analytic_result).full()
         efficient_diff_norm = norm(efficient_diff)
         assert_(efficient_diff_norm < tol,
                 msg="SimpleSuper: efficient_diff_norm {} "
@@ -119,7 +117,7 @@ class TestSubsysApply(object):
         naive_result = subsystem_apply(rho_input, single_op,
                                        [False, True, False, True, False],
                                        reference=True)
-        naive_diff = (analytic_result - naive_result).data.todense()
+        naive_diff = (analytic_result - naive_result).full()
         naive_diff_norm = norm(naive_diff)
         assert_(naive_diff_norm < tol,
                 msg="ComplexSingle: naive_diff_norm {} "
@@ -128,7 +126,7 @@ class TestSubsysApply(object):
 
         efficient_result = subsystem_apply(rho_input, single_op,
                                            [False, True, False, True, False])
-        efficient_diff = (efficient_result - analytic_result).data.todense()
+        efficient_diff = (efficient_result - analytic_result).full()
         efficient_diff_norm = norm(efficient_diff)
         assert_(efficient_diff_norm < tol,
                 msg="ComplexSingle: efficient_diff_norm {} "
@@ -144,18 +142,18 @@ class TestSubsysApply(object):
         rho_list = list(map(rand_dm, [2, 3, 2, 3, 2]))
         rho_input = tensor(rho_list)
         superop = kraus_to_super(rand_kraus_map(3))
-        
+
         analytic_result = rho_list
-        analytic_result[1] = Qobj(vec2mat(superop.data.todense() *
-                                  mat2vec(analytic_result[1].data.todense())))
-        analytic_result[3] = Qobj(vec2mat(superop.data.todense() *
-                                  mat2vec(analytic_result[3].data.todense())))
+        analytic_result[1] = Qobj(
+            vec2mat(superop.full() @ mat2vec(analytic_result[1].full())))
+        analytic_result[3] = Qobj(
+            vec2mat(superop.full() @ mat2vec(analytic_result[3].full())))
         analytic_result = tensor(analytic_result)
 
         naive_result = subsystem_apply(rho_input, superop,
                                        [False, True, False, True, False],
                                        reference=True)
-        naive_diff = (analytic_result - naive_result).data.todense()
+        naive_diff = (analytic_result - naive_result).full()
         naive_diff_norm = norm(naive_diff)
         assert_(naive_diff_norm < tol,
                 msg="ComplexSuper: naive_diff_norm {} "
@@ -164,7 +162,7 @@ class TestSubsysApply(object):
 
         efficient_result = subsystem_apply(rho_input, superop,
                                            [False, True, False, True, False])
-        efficient_diff = (efficient_result - analytic_result).data.todense()
+        efficient_diff = (efficient_result - analytic_result).full()
         efficient_diff_norm = norm(efficient_diff)
         assert_(efficient_diff_norm < tol,
                 msg="ComplexSuper: efficient_diff_norm {} "

--- a/qutip/tests/test_superop_reps.py
+++ b/qutip/tests/test_superop_reps.py
@@ -262,7 +262,7 @@ class TestSuperopReps(object):
         """
         def case(map):
             A, B = to_stinespring(map)
-            assert_(norm((A - B).data.todense()) < thresh)
+            assert_(norm((A - B).full()) < thresh)
 
         for idx in range(4):
             case(rand_super_bcsz(7))

--- a/qutip/tests/test_superoper.py
+++ b/qutip/tests/test_superoper.py
@@ -218,7 +218,7 @@ class TestSuper_td:
     A test class for the QuTiP superoperator functions.
     """
 
-    def __init__(self):
+    def setup_method(self):
         N = 3
         self.t1 = QobjEvo([qeye(N)*(1.+0.1j),[create(N)*(1.-0.1j),f]])
         self.t2 = QobjEvo([destroy(N)*(1.-0.2j)])

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -294,7 +294,7 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
 
     height, width = W.shape
 
-    w_max = 1.25 * max(abs(np.diag(np.matrix(W))))
+    w_max = 1.25 * max(abs(np.diag(np.array(W))))
     if w_max <= 0.0:
         w_max = 1.0
 


### PR DESCRIPTION
This PR fixes every warning reported in `pytest`, and then makes `pytest` treat warnings as errors to hopefully make sure we stick to this state of affairs.  (Or at least it fixes all the ones that appear on my particular machine...)

The reason this is desirable is that it means we cannot ignore deprecation warnings in dependencies or even in our own code.  It also helps us not let certain parts of the codebase get lost in the sands of time, or at least compels us to do something about potential problems before they actually become catastrophic.  This is _somewhat_ of a trial, though I hope we can stick to it; warnings usually indicate that something's wrong.

Tests can still test run code that generates warnings, but you now have to mark it explicitly in `pytest`.  This doesn't mean you should just "blank out" warnings by filtering them away.  You should first consider if what you're doing is the right way to do it (fix the warning), and then only if it absolutely is and you're testing something that is _supposed_ to warn, then you can use `pytest.warns` to _assert_ that it warns.

Of note: a `warnings.catch_warnings` block _inside_ a test (i.e. in test code, not module code) does not work when `pytest` is treating warnings as errors.

There are a few classes of fixes in this PR:

- filtering "expected" warnings from `pyximport` (hoping to remove QuTiP's dependence on this in 5.0 anyway)
- removal of the old `np.matrix` type in favour of `ndarray`, with some changes to accommodate the different arithmetic semantics
- convert an `__init__` method in a test into just class attributes to allow `pytest` to collect it
- bug fixes for behaviour that was raising warnings we hadn't been paying attention to

I'll be mightily surprised if all 5 CI runs pass immediately with warnings enabled; I haven't tested MKL on my laptop, and a quick glance at old logs suggests that SciPy 1.4 might be issuing a few more.