### PR TITLE
Changes signature of rand_ket

### DIFF
--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -322,8 +322,7 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     Raises
     -------
     ValueError
-        Specify either the number of rows of operator (N) or
-        dimensions of quantum object (dims).
+        If neither `N` or `dims` are not specified.
 
     """
     if seed is not None:
@@ -373,8 +372,7 @@ def rand_ket_haar(N=None, dims=None, seed=None):
     Raises
     -------
     ValueError
-        Specify either the number of rows of operator (N) or
-        dimensions of quantum object (dims).
+        If neither `N` or `dims` are not specified.
     """
     if N is None and dims is None:
         raise ValueError('Specify either the number of rows of operator'

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -306,7 +306,7 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     Parameters
     ----------
     N : int
-        Number of rows for output quantum operator.
+        Number of rows for output quantum vector.
         If None or 0, N is deduced from dims.
     density : float
         Density between [0,1] of output ket state.
@@ -317,7 +317,7 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     Returns
     -------
     oper : qobj
-        Nx1 ket state quantum operator.
+        Nx1 ket quantum state vector.
 
     Raises
     -------

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -369,6 +369,12 @@ def rand_ket_haar(N=None, dims=None, seed=None):
     -------
     psi : Qobj
         A random state vector drawn from the Haar measure.
+
+    Raises
+    -------
+    ValueError
+        Specify either the number of rows of operator (N) or
+        dimensions of quantum object (dims).
     """
     if N is None and dims is None:
         raise ValueError('Specify either the number of rows of operator'

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -322,7 +322,7 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     Raises
     -------
     ValueError
-        If neither `N` or `dims` are not specified.
+        If neither `N` or `dims` are specified.
 
     """
     if seed is not None:
@@ -372,7 +372,7 @@ def rand_ket_haar(N=None, dims=None, seed=None):
     Raises
     -------
     ValueError
-        If neither `N` or `dims` are not specified.
+        If neither `N` or `dims` are specified.
     """
     if N is None and dims is None:
         raise ValueError('Specify either the number of rows of state vector'

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -330,7 +330,7 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
         np.random.seed(seed=seed)
     if N is None and dims is None:
         raise ValueError('Specify either the number of rows of operator'
-        '(N) or dimensions of quantum object (dims)')
+                         '(N) or dimensions of quantum object (dims)')
     elif N is not None and dims:
         _check_dims(dims, N, 1)
     elif dims:

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -325,7 +325,7 @@ def rand_ket(N=0, density=1, dims=None, seed=None):
     if N and dims:
         _check_dims(dims, N, 1)
     elif dims:
-        N = prod(dims[0])
+        N = np.prod(dims[0])
         _check_dims(dims, N, 1)
     else:
         dims = [[N],[1]]
@@ -364,7 +364,7 @@ def rand_ket_haar(N=2, dims=None, seed=None):
     if N and dims:
         _check_dims(dims, N, 1)
     elif dims:
-        N = prod(dims[0])
+        N = np.prod(dims[0])
         _check_dims(dims, N, 1)
     else:
         dims = [[N],[1]]

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -319,10 +319,19 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     oper : qobj
         Nx1 ket state quantum operator.
 
+    Raises
+    -------
+    ValueError
+        Specify either the number of rows of operator (N) or
+        dimensions of quantum object (dims).
+
     """
     if seed is not None:
         np.random.seed(seed=seed)
-    if N is not None and dims:
+    if N is None and dims is None:
+        raise ValueError('Specify either the number of rows of operator'
+        '(N) or dimensions of quantum object (dims)')
+    elif N is not None and dims:
         _check_dims(dims, N, 1)
     elif dims:
         N = np.prod(dims[0])

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -330,13 +330,13 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     if N is None and dims is None:
         raise ValueError('Specify either the number of rows of state vector'
                          '(N) or dimensions of quantum object (dims)')
-    elif N is not None and dims:
+    if N is not None and dims:
         _check_dims(dims, N, 1)
     elif dims:
         N = np.prod(dims[0])
         _check_dims(dims, N, 1)
     else:
-        dims = [[N],[1]]
+        dims = [[N], [1]]
     X = sp.rand(N, 1, density, format='csr')
     while X.nnz == 0:
         # ensure that the ket is not all zeros.
@@ -377,13 +377,13 @@ def rand_ket_haar(N=None, dims=None, seed=None):
     if N is None and dims is None:
         raise ValueError('Specify either the number of rows of state vector'
                          '(N) or dimensions of quantum object (dims)')
-    elif N and dims:
+    if N and dims:
         _check_dims(dims, N, 1)
     elif dims:
         N = np.prod(dims[0])
         _check_dims(dims, N, 1)
     else:
-        dims = [[N],[1]]
+        dims = [[N], [1]]
     psi = rand_unitary_haar(N, seed=seed) * basis(N, 0)
     psi.dims = dims
     return psi

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -322,13 +322,13 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     """
     if seed is not None:
         np.random.seed(seed=seed)
-    if N is not None and dims is not None:
+    if N is not None and dims:
         _check_dims(dims, N, 1)
     elif dims:
         N = np.prod(dims[0])
         _check_dims(dims, N, 1)
-    #else:
-        #dims = [[N],[1]]
+    else:
+        dims = [[N],[1]]
     X = sp.rand(N, 1, density, format='csr')
     while X.nnz == 0:
         # ensure that the ket is not all zeros.

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -300,7 +300,7 @@ def rand_unitary_haar(N=2, dims=None, seed=None):
     return U
 
 
-def rand_ket(N=0, density=1, dims=None, seed=None):
+def rand_ket(N=None, density=1, dims=None, seed=None):
     """Creates a random Nx1 sparse ket vector.
 
     Parameters
@@ -322,13 +322,13 @@ def rand_ket(N=0, density=1, dims=None, seed=None):
     """
     if seed is not None:
         np.random.seed(seed=seed)
-    if N and dims:
+    if N is not None and dims is not None:
         _check_dims(dims, N, 1)
     elif dims:
         N = np.prod(dims[0])
         _check_dims(dims, N, 1)
-    else:
-        dims = [[N],[1]]
+    #else:
+        #dims = [[N],[1]]
     X = sp.rand(N, 1, density, format='csr')
     while X.nnz == 0:
         # ensure that the ket is not all zeros.

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -307,7 +307,7 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     ----------
     N : int
         Number of rows for output quantum vector.
-        If None or 0, N is deduced from dims.
+        If None, N is deduced from dims.
     density : float
         Density between [0,1] of output ket state.
     dims : list
@@ -359,7 +359,7 @@ def rand_ket_haar(N=None, dims=None, seed=None):
     ----------
     N : int
         Dimension of the state vector to be returned.
-        If None or 0, N is deduced from dims.
+        If None, N is deduced from dims.
     dims : list of ints, or None
         Dimensions of the resultant quantum object.
         If None, [[N],[1]] is used.

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -328,7 +328,7 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     if seed is not None:
         np.random.seed(seed=seed)
     if N is None and dims is None:
-        raise ValueError('Specify either the number of rows of operator'
+        raise ValueError('Specify either the number of rows of state vector'
                          '(N) or dimensions of quantum object (dims)')
     elif N is not None and dims:
         _check_dims(dims, N, 1)
@@ -375,7 +375,7 @@ def rand_ket_haar(N=None, dims=None, seed=None):
         If neither `N` or `dims` are not specified.
     """
     if N is None and dims is None:
-        raise ValueError('Specify either the number of rows of operator'
+        raise ValueError('Specify either the number of rows of state vector'
                          '(N) or dimensions of quantum object (dims)')
     elif N and dims:
         _check_dims(dims, N, 1)

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -351,7 +351,7 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     return Qobj(X / X.norm(), dims=dims)
 
 
-def rand_ket_haar(N=2, dims=None, seed=None):
+def rand_ket_haar(N=None, dims=None, seed=None):
     """
     Returns a Haar random pure state of dimension ``dim`` by
     applying a Haar random unitary to a fixed pure state.
@@ -370,7 +370,10 @@ def rand_ket_haar(N=2, dims=None, seed=None):
     psi : Qobj
         A random state vector drawn from the Haar measure.
     """
-    if N and dims:
+    if N is None and dims is None:
+        raise ValueError('Specify either the number of rows of operator'
+                         '(N) or dimensions of quantum object (dims)')
+    elif N and dims:
         _check_dims(dims, N, 1)
     elif dims:
         N = np.prod(dims[0])

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -76,7 +76,7 @@ def check_func_dims(func, args, kwargs, dims):
 
 def check_func_shape(func, args, kwargs, shape):
     resdims = func(*args, **kwargs).dims
-    assert_(dims_to_tensor_shape(resdims)==shape)
+    assert_(dims_to_tensor_shape(resdims)==shape,"Checking {}; expected shape of {}, got {}.".format(func.__name__, shape, dims_to_tensor_shape(resdims)))
 
 def test_rand_vector_dims():
     FUNCS = [rand_ket, rand_ket_haar]

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -76,6 +76,7 @@ def check_func_dims(func, args, kwargs, dims):
 def check_func_N(func, args, kwargs,N):
     new_state_shape=func(*args, **kwargs).shape
     assert new_state_shape==(N,1)
+    assert new_state_shape[0]==N
 
 
 def test_rand_vector_dims():

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -75,6 +75,8 @@ def check_func_dims(func, args, kwargs, dims):
 
 
 def check_func_N(func, args, kwargs,expected_shape):
+    # Here, expected_shape is supposed to be of form N X 1. When assigning
+    # this to a tuple, value 1 cannot be used. 
     number_of_rows , column_number = expected_shape
     new_state_shape=func(*args, **kwargs).shape
     assert new_state_shape==expected_shape

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -78,12 +78,13 @@ def check_func_dims(func, args, kwargs, dims):
 def test_rand_vector_dims():
     FUNCS = [rand_ket, rand_ket_haar]
     for func in FUNCS:
-        # when neither N or dims are specified
+        # N or dims are not given
+        assert_raises(ValueError,check_func_dims,func,(),{},[])
         # both N and dims (named argument) are specified
         check_func_dims( func, (6, ), {'dims': [[2,3], [1,1]]}, [[2,3], [1,1]])
-        # only N is specified
+        # only N is specified and dims is defined via default
         check_func_dims( func, (7, ), {}, [[7], [1]])
-        # only dims is specified
+        # only dims is specified and N has to be determined
         check_func_dims( func, (), {'dims': [[2,3], [1,1]]},[[2,3], [1,1]])
 
 def test_rand_oper_dims():
@@ -97,26 +98,6 @@ def test_rand_super_dims():
     for func in FUNCS:
         check_func_dims(func, (7, ), {}, [[[7], [7]]] * 2)
         check_func_dims(func, (6, ), {'dims': [[[2, 3], [2, 3]], [[2, 3], [2, 3]]]}, [[[2, 3], [2, 3]], [[2, 3], [2, 3]]])
-
-def test_rand_ket():
-    """
-    Random Qobjs: Tests that N and dims are determined as needed.
-    """
-    # when neither N or dims are specified
-    assert_raises(ValueError,rand_ket, )
-
-    # when both N and dims are specified
-    test_both_N_dim = rand_ket(N=7,dims=[[7], [1]])
-    assert(np.shape(test_both_N_dim)==(7,1))
-
-    # when dims is specified and N has to be determined
-    test_only_dim = rand_ket(dims=[[7], [1]]).shape
-    assert((test_only_dim)==(7,1))
-
-    # when N is specified but dims has to be defined using default
-    test_only_N = rand_ket(N=7)
-    assert(np.shape(test_only_N)==(7,1))
-
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -91,5 +91,23 @@ def test_rand_super_dims():
         check_func_dims(func, (7, ), {}, [[[7], [7]]] * 2)
         check_func_dims(func, (6, ), {'dims': [[[2, 3], [2, 3]], [[2, 3], [2, 3]]]}, [[[2, 3], [2, 3]], [[2, 3], [2, 3]]])
 
+def test_rand_ket():
+    """
+    Random Qobjs: Tests that N and dims are determined as needed.
+    """
+    # when both N and dims are specified
+    test_both_N_dim = rand_ket(N=7,dims=[[7], [1]])
+    assert(np.shape(test_both_N_dim)==(7,1))
+
+    # when dims is specified and N has to be determined
+    test_only_dim = rand_ket(dims=[[7], [1]])
+    assert(np.shape(test_only_dim)==(7,1))
+
+    # when N is specified but dims has to be defined using default
+    test_only_N = rand_ket(N=7)
+    assert(np.shape(test_only_N)==(7,1))
+
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -50,7 +50,7 @@ def test_rand_unitary_haar_unitarity():
     U = rand_unitary_haar(5)
     I = qeye(5)
 
-    assert_(U * U.dag() == I)
+    assert U * U.dag() == I
 
 def test_rand_dm_ginibre_rank():
     """

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -34,7 +34,7 @@
 import scipy.sparse as sp
 import scipy.linalg as la
 import numpy as np
-from numpy.testing import assert_equal, assert_, run_module_suite
+from numpy.testing import assert_equal, assert_, run_module_suite, assert_raises
 
 from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
                                   rand_ket_haar, rand_dm_hs,
@@ -95,6 +95,9 @@ def test_rand_ket():
     """
     Random Qobjs: Tests that N and dims are determined as needed.
     """
+    # when neither N or dims are specified
+    assert_raises(ValueError,rand_ket, )
+
     # when both N and dims are specified
     test_both_N_dim = rand_ket(N=7,dims=[[7], [1]])
     assert(np.shape(test_both_N_dim)==(7,1))

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -34,6 +34,7 @@
 import scipy.sparse as sp
 import scipy.linalg as la
 import numpy as np
+from numpy.testing import run_module_suite
 from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
                                   rand_ket_haar, rand_dm_hs,
                                   rand_super, rand_unitary_haar, rand_dm_ginibre,
@@ -72,8 +73,6 @@ def check_func_dims(func, args, kwargs, dims):
     resdims = func(*args, **kwargs).dims
     assert resdims == dims
 
-
-
 def check_func_N(func, args, kwargs,expected_shape):
     # Here, expected_shape is supposed to be of form N X 1. When assigning
     # this to a tuple, value 1 cannot be used.
@@ -109,3 +108,7 @@ def test_rand_super_dims():
     for func in FUNCS:
         check_func_dims(func, (7, ), {}, [[[7], [7]]] * 2)
         check_func_dims(func, (6, ), {'dims': [[[2, 3], [2, 3]], [[2, 3], [2, 3]]]}, [[[2, 3], [2, 3]], [[2, 3], [2, 3]]])
+
+if __name__ == "__main__":
+    import pytest
+    run_module_suite()

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -74,6 +74,7 @@ def check_func_dims(func, args, kwargs, dims):
     resdims = func(*args, **kwargs).dims
     assert_(resdims == dims, "Checking {}; expected dimensions of {}, got {}.".format(func.__name__, dims, resdims))
 
+
 def test_rand_vector_dims():
     FUNCS = [rand_ket, rand_ket_haar]
     for func in FUNCS:
@@ -104,8 +105,8 @@ def test_rand_ket():
     assert(np.shape(test_both_N_dim)==(7,1))
 
     # when dims is specified and N has to be determined
-    test_only_dim = rand_ket(dims=[[7], [1]])
-    assert(np.shape(test_only_dim)==(7,1))
+    test_only_dim = rand_ket(dims=[[7], [1]]).shape
+    assert((test_only_dim)==(7,1))
 
     # when N is specified but dims has to be defined using default
     test_only_N = rand_ket(N=7)

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -84,15 +84,19 @@ def check_func_N(func, args, kwargs,expected_shape):
 def test_rand_vector_dims():
     FUNCS = [rand_ket, rand_ket_haar]
     for func in FUNCS:
-        # N or dims are not given
+
+        # N or dims are not provided
         assert pytest.raises(ValueError,check_func_dims,func,(),{},[])
         assert pytest.raises(ValueError,check_func_N,func,(),{},[])
+
         # both N and dims (named argument) are specified
         check_func_dims( func, (6, ), {'dims': [[2,3], [1,1]]}, [[2,3], [1,1]])
         check_func_N(func,(6, ),{'dims': [[2,3], [1,1]]},(6,1))
+
         # only N is specified and dims is defined via default
         check_func_dims( func, (7, ), {}, [[7], [1]])
         check_func_N( func, (7, ), {}, (7,1))
+
         # only dims is specified and N has to be determined
         check_func_dims( func, (), {'dims': [[2,3], [1,1]]},[[2,3], [1,1]])
         check_func_N( func, (), {'dims': [[2,3], [1,1]]},(6,1))

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -72,11 +72,11 @@ def check_func_dims(func, args, kwargs, dims):
     # TODO: promote this out of test_random, as it's generically useful
     #       in writing tests.
     resdims = func(*args, **kwargs).dims
-    assert resdims == dims, "Checking {}; expected dimensions of {}, got {}.".format(func.__name__, dims, resdims)
+    assert resdims == dims
 
 def check_func_N(func, args, kwargs, N):
     new_state_shape=func(*args, **kwargs).shape
-    assert new_state_shape[0]==N,"Checking {}; expected N of {}, got {}.".format(func.__name__, N, new_state_shape[0])
+    assert new_state_shape[0]==N
 
 
 def test_rand_vector_dims():

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -71,7 +71,7 @@ def check_func_dims(func, args, kwargs, dims):
     # TODO: promote this out of test_random, as it's generically useful
     #       in writing tests.
     resdims = func(*args, **kwargs).dims
-    assert_(resdims == dims, "Checking {}; epected dimensions of {}, got {}.".format(func.__name__, dims, resdims))
+    assert_(resdims == dims, "Checking {}; expected dimensions of {}, got {}.".format(func.__name__, dims, resdims))
 
 def test_rand_vector_dims():
     FUNCS = [rand_ket, rand_ket_haar]

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -41,7 +41,7 @@ from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
                                   rand_super, rand_unitary_haar, rand_dm_ginibre,
                                   rand_super_bcsz)
 from qutip.operators import qeye
-from qutip.dimensions import dims_to_tensor_shape
+from pytest import assert,
 
 def test_rand_unitary_haar_unitarity():
     """
@@ -72,7 +72,7 @@ def check_func_dims(func, args, kwargs, dims):
     # TODO: promote this out of test_random, as it's generically useful
     #       in writing tests.
     resdims = func(*args, **kwargs).dims
-    assert_(resdims == dims, "Checking {}; expected dimensions of {}, got {}.".format(func.__name__, dims, resdims))
+    assert resdims == dims, "Checking {}; expected dimensions of {}, got {}.".format(func.__name__, dims, resdims))
 
 def check_func_N(func, args, kwargs, N):
     new_state_shape=func(*args, **kwargs).shape

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -78,6 +78,11 @@ def check_func_shape(func, args, kwargs, shape):
     resdims = func(*args, **kwargs).dims
     assert_(dims_to_tensor_shape(resdims)==shape,"Checking {}; expected shape of {}, got {}.".format(func.__name__, shape, dims_to_tensor_shape(resdims)))
 
+def check_func_N(func, args, kwargs, N):
+    new_state_shape=func(*args, **kwargs).shape
+    assert_(new_state_shape[0]==N,"Checking {}; expected dimensions of {}, got {}.".format(func.__name__, N, new_state_shape[0]))
+
+
 def test_rand_vector_dims():
     FUNCS = [rand_ket, rand_ket_haar]
     for func in FUNCS:
@@ -86,12 +91,15 @@ def test_rand_vector_dims():
         # both N and dims (named argument) are specified
         check_func_dims( func, (6, ), {'dims': [[2,3], [1,1]]}, [[2,3], [1,1]])
         check_func_shape( func, (6, ), {'dims': [[2,3], [1,1]]}, (2,3,1,1))
+        check_func_N(func,(6, ),{'dims': [[2,3], [1,1]]},6)
         # only N is specified and dims is defined via default
         check_func_dims( func, (7, ), {}, [[7], [1]])
         check_func_shape( func, (7, ), {}, (7,1))
+        check_func_N( func, (7, ), {}, 7)
         # only dims is specified and N has to be determined
         check_func_dims( func, (), {'dims': [[2,3], [1,1]]},[[2,3], [1,1]])
         check_func_shape( func, (), {'dims': [[2,3], [1,1]]},(2,3,1,1))
+        check_func_N( func, (), {'dims': [[2,3], [1,1]]},6)
 
 def test_rand_oper_dims():
     FUNCS = [rand_unitary, rand_herm, rand_dm, rand_unitary_haar, rand_dm_ginibre, rand_dm_hs]

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -74,6 +74,9 @@ def check_func_dims(func, args, kwargs, dims):
     resdims = func(*args, **kwargs).dims
     assert_(resdims == dims, "Checking {}; expected dimensions of {}, got {}.".format(func.__name__, dims, resdims))
 
+def check_func_shape(func, args, kwargs, shape):
+    resdims = func(*args, **kwargs).dims
+    assert_(dims_to_tensor_shape(resdims)==shape)
 
 def test_rand_vector_dims():
     FUNCS = [rand_ket, rand_ket_haar]
@@ -82,10 +85,13 @@ def test_rand_vector_dims():
         assert_raises(ValueError,check_func_dims,func,(),{},[])
         # both N and dims (named argument) are specified
         check_func_dims( func, (6, ), {'dims': [[2,3], [1,1]]}, [[2,3], [1,1]])
+        check_func_shape( func, (6, ), {'dims': [[2,3], [1,1]]}, (2,3,1,1))
         # only N is specified and dims is defined via default
         check_func_dims( func, (7, ), {}, [[7], [1]])
+        check_func_shape( func, (7, ), {}, (7,1))
         # only dims is specified and N has to be determined
         check_func_dims( func, (), {'dims': [[2,3], [1,1]]},[[2,3], [1,1]])
+        check_func_shape( func, (), {'dims': [[2,3], [1,1]]},(2,3,1,1))
 
 def test_rand_oper_dims():
     FUNCS = [rand_unitary, rand_herm, rand_dm, rand_unitary_haar, rand_dm_ginibre, rand_dm_hs]

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -74,8 +74,6 @@ def check_func_dims(func, args, kwargs, dims):
     assert resdims == dims
 
 def check_func_N(func, args, kwargs,N):
-    # Here, expected_shape is supposed to be of form N X 1. When assigning
-    # this to a tuple, value 1 cannot be used.
     new_state_shape=func(*args, **kwargs).shape
     assert new_state_shape==(N,1)
 

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -41,7 +41,7 @@ from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
                                   rand_super, rand_unitary_haar, rand_dm_ginibre,
                                   rand_super_bcsz)
 from qutip.operators import qeye
-from pytest import assert,
+import pytest
 
 def test_rand_unitary_haar_unitarity():
     """
@@ -72,18 +72,18 @@ def check_func_dims(func, args, kwargs, dims):
     # TODO: promote this out of test_random, as it's generically useful
     #       in writing tests.
     resdims = func(*args, **kwargs).dims
-    assert resdims == dims, "Checking {}; expected dimensions of {}, got {}.".format(func.__name__, dims, resdims))
+    assert resdims == dims, "Checking {}; expected dimensions of {}, got {}.".format(func.__name__, dims, resdims)
 
 def check_func_N(func, args, kwargs, N):
     new_state_shape=func(*args, **kwargs).shape
-    assert_(new_state_shape[0]==N,"Checking {}; expected N of {}, got {}.".format(func.__name__, N, new_state_shape[0]))
+    assert new_state_shape[0]==N,"Checking {}; expected N of {}, got {}.".format(func.__name__, N, new_state_shape[0])
 
 
 def test_rand_vector_dims():
     FUNCS = [rand_ket, rand_ket_haar]
     for func in FUNCS:
         # N or dims are not given
-        assert_raises(ValueError,check_func_dims,func,(),{},[])
+        assert pytest.raises(ValueError,check_func_dims,func,(),{},[])
         # both N and dims (named argument) are specified
         check_func_dims( func, (6, ), {'dims': [[2,3], [1,1]]}, [[2,3], [1,1]])
         check_func_N(func,(6, ),{'dims': [[2,3], [1,1]]},6)

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -70,7 +70,8 @@ def check_func_dims(func, args, kwargs, dims):
     # TODO: promote this out of test_random, as it's generically useful
     #       in writing tests.
     resdims = func(*args, **kwargs).dims
-    assert resdims == dims
+    assert resdims == dims, message = "Calculated value of dims (left) does \
+    not match with expected value (right)."
 
 def check_func_N(func, args, kwargs, N):
     new_state_shape=func(*args, **kwargs).shape

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -103,7 +103,3 @@ def test_rand_super_dims():
     for func in FUNCS:
         check_func_dims(func, (7, ), {}, [[[7], [7]]] * 2)
         check_func_dims(func, (6, ), {'dims': [[[2, 3], [2, 3]], [[2, 3], [2, 3]]]}, [[[2, 3], [2, 3]], [[2, 3], [2, 3]]])
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -76,7 +76,7 @@ def check_func_dims(func, args, kwargs, dims):
 
 def check_func_N(func, args, kwargs,expected_shape):
     # Here, expected_shape is supposed to be of form N X 1. When assigning
-    # this to a tuple, value 1 cannot be used. 
+    # this to a tuple, value 1 cannot be used.
     number_of_rows , column_number = expected_shape
     new_state_shape=func(*args, **kwargs).shape
     assert new_state_shape==expected_shape
@@ -87,6 +87,7 @@ def test_rand_vector_dims():
     for func in FUNCS:
         # N or dims are not given
         assert pytest.raises(ValueError,check_func_dims,func,(),{},[])
+        assert pytest.raises(ValueError,check_func_N,func,(),{},[])
         # both N and dims (named argument) are specified
         check_func_dims( func, (6, ), {'dims': [[2,3], [1,1]]}, [[2,3], [1,1]])
         check_func_N(func,(6, ),{'dims': [[2,3], [1,1]]},(6,1))

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -80,7 +80,7 @@ def check_func_shape(func, args, kwargs, shape):
 
 def check_func_N(func, args, kwargs, N):
     new_state_shape=func(*args, **kwargs).shape
-    assert_(new_state_shape[0]==N,"Checking {}; expected dimensions of {}, got {}.".format(func.__name__, N, new_state_shape[0]))
+    assert_(new_state_shape[0]==N,"Checking {}; expected N of {}, got {}.".format(func.__name__, N, new_state_shape[0]))
 
 
 def test_rand_vector_dims():

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -72,9 +72,12 @@ def check_func_dims(func, args, kwargs, dims):
     resdims = func(*args, **kwargs).dims
     assert resdims == dims
 
-def check_func_N(func, args, kwargs, N):
+
+
+def check_func_N(func, args, kwargs,expected_shape):
+    number_of_rows , column_number = expected_shape
     new_state_shape=func(*args, **kwargs).shape
-    assert new_state_shape[0]==N
+    assert new_state_shape==expected_shape
 
 
 def test_rand_vector_dims():
@@ -84,13 +87,13 @@ def test_rand_vector_dims():
         assert pytest.raises(ValueError,check_func_dims,func,(),{},[])
         # both N and dims (named argument) are specified
         check_func_dims( func, (6, ), {'dims': [[2,3], [1,1]]}, [[2,3], [1,1]])
-        check_func_N(func,(6, ),{'dims': [[2,3], [1,1]]},6)
+        check_func_N(func,(6, ),{'dims': [[2,3], [1,1]]},(6,1))
         # only N is specified and dims is defined via default
         check_func_dims( func, (7, ), {}, [[7], [1]])
-        check_func_N( func, (7, ), {}, 7)
+        check_func_N( func, (7, ), {}, (7,1))
         # only dims is specified and N has to be determined
         check_func_dims( func, (), {'dims': [[2,3], [1,1]]},[[2,3], [1,1]])
-        check_func_N( func, (), {'dims': [[2,3], [1,1]]},6)
+        check_func_N( func, (), {'dims': [[2,3], [1,1]]},(6,1))
 
 def test_rand_oper_dims():
     FUNCS = [rand_unitary, rand_herm, rand_dm, rand_unitary_haar, rand_dm_ginibre, rand_dm_hs]

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -41,6 +41,7 @@ from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
                                   rand_super, rand_unitary_haar, rand_dm_ginibre,
                                   rand_super_bcsz)
 from qutip.operators import qeye
+from qutip.dimensions import dims_to_tensor_shape
 
 def test_rand_unitary_haar_unitarity():
     """

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -34,8 +34,6 @@
 import scipy.sparse as sp
 import scipy.linalg as la
 import numpy as np
-from numpy.testing import assert_equal, assert_, run_module_suite, assert_raises
-
 from qutip.random_objects import (rand_ket, rand_dm, rand_herm, rand_unitary,
                                   rand_ket_haar, rand_dm_hs,
                                   rand_super, rand_unitary_haar, rand_dm_ginibre,

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -74,10 +74,6 @@ def check_func_dims(func, args, kwargs, dims):
     resdims = func(*args, **kwargs).dims
     assert_(resdims == dims, "Checking {}; expected dimensions of {}, got {}.".format(func.__name__, dims, resdims))
 
-def check_func_shape(func, args, kwargs, shape):
-    resdims = func(*args, **kwargs).dims
-    assert_(dims_to_tensor_shape(resdims)==shape,"Checking {}; expected shape of {}, got {}.".format(func.__name__, shape, dims_to_tensor_shape(resdims)))
-
 def check_func_N(func, args, kwargs, N):
     new_state_shape=func(*args, **kwargs).shape
     assert_(new_state_shape[0]==N,"Checking {}; expected N of {}, got {}.".format(func.__name__, N, new_state_shape[0]))
@@ -90,15 +86,12 @@ def test_rand_vector_dims():
         assert_raises(ValueError,check_func_dims,func,(),{},[])
         # both N and dims (named argument) are specified
         check_func_dims( func, (6, ), {'dims': [[2,3], [1,1]]}, [[2,3], [1,1]])
-        check_func_shape( func, (6, ), {'dims': [[2,3], [1,1]]}, (2,3,1,1))
         check_func_N(func,(6, ),{'dims': [[2,3], [1,1]]},6)
         # only N is specified and dims is defined via default
         check_func_dims( func, (7, ), {}, [[7], [1]])
-        check_func_shape( func, (7, ), {}, (7,1))
         check_func_N( func, (7, ), {}, 7)
         # only dims is specified and N has to be determined
         check_func_dims( func, (), {'dims': [[2,3], [1,1]]},[[2,3], [1,1]])
-        check_func_shape( func, (), {'dims': [[2,3], [1,1]]},(2,3,1,1))
         check_func_N( func, (), {'dims': [[2,3], [1,1]]},6)
 
 def test_rand_oper_dims():

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -78,8 +78,13 @@ def check_func_dims(func, args, kwargs, dims):
 def test_rand_vector_dims():
     FUNCS = [rand_ket, rand_ket_haar]
     for func in FUNCS:
-        check_func_dims( func, (7, ), {}, [[7], [1]])
+        # when neither N or dims are specified
+        # both N and dims (named argument) are specified
         check_func_dims( func, (6, ), {'dims': [[2,3], [1,1]]}, [[2,3], [1,1]])
+        # only N is specified
+        check_func_dims( func, (7, ), {}, [[7], [1]])
+        # only dims is specified
+        check_func_dims( func, (), {'dims': [[2,3], [1,1]]},[[2,3], [1,1]])
 
 def test_rand_oper_dims():
     FUNCS = [rand_unitary, rand_herm, rand_dm, rand_unitary_haar, rand_dm_ginibre, rand_dm_hs]

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -73,12 +73,11 @@ def check_func_dims(func, args, kwargs, dims):
     resdims = func(*args, **kwargs).dims
     assert resdims == dims
 
-def check_func_N(func, args, kwargs,expected_shape):
+def check_func_N(func, args, kwargs,N):
     # Here, expected_shape is supposed to be of form N X 1. When assigning
     # this to a tuple, value 1 cannot be used.
-    number_of_rows , column_number = expected_shape
     new_state_shape=func(*args, **kwargs).shape
-    assert new_state_shape==expected_shape
+    assert new_state_shape==(N,1)
 
 
 def test_rand_vector_dims():
@@ -91,15 +90,15 @@ def test_rand_vector_dims():
 
         # both N and dims (named argument) are specified
         check_func_dims( func, (6, ), {'dims': [[2,3], [1,1]]}, [[2,3], [1,1]])
-        check_func_N(func,(6, ),{'dims': [[2,3], [1,1]]},(6,1))
+        check_func_N(func,(6, ),{'dims': [[2,3], [1,1]]},6)
 
         # only N is specified and dims is defined via default
         check_func_dims( func, (7, ), {}, [[7], [1]])
-        check_func_N( func, (7, ), {}, (7,1))
+        check_func_N( func, (7, ),{},7)
 
         # only dims is specified and N has to be determined
         check_func_dims( func, (), {'dims': [[2,3], [1,1]]},[[2,3], [1,1]])
-        check_func_N( func, (), {'dims': [[2,3], [1,1]]},(6,1))
+        check_func_N( func, (), {'dims': [[2,3], [1,1]]},6)
 
 def test_rand_oper_dims():
     FUNCS = [rand_unitary, rand_herm, rand_dm, rand_unitary_haar, rand_dm_ginibre, rand_dm_hs]

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -70,8 +70,7 @@ def check_func_dims(func, args, kwargs, dims):
     # TODO: promote this out of test_random, as it's generically useful
     #       in writing tests.
     resdims = func(*args, **kwargs).dims
-    assert resdims == dims, message = "Calculated value of dims (left) does \
-    not match with expected value (right)."
+    assert resdims == dims
 
 def check_func_N(func, args, kwargs, N):
     new_state_shape=func(*args, **kwargs).shape

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -59,14 +59,14 @@ def test_rand_dm_ginibre_rank():
     rho = rand_dm_ginibre(5, rank=3)
 
     rank = sum([abs(E) >= 1e-10 for E in rho.eigenenergies()])
-    assert_(rank == 3)
+    assert rank == 3
 
 def test_rand_super_bcsz_cptp():
     """
     Random Qobjs: Tests that BCSZ-random superoperators are CPTP.
     """
     S = rand_super_bcsz(5)
-    assert_(S.iscptp)
+    assert S.iscptp
 
 def check_func_dims(func, args, kwargs, dims):
     # TODO: promote this out of test_random, as it's generically useful


### PR DESCRIPTION
**Description**
Fixes #1504 and changes signature of `rand_ket` as [requested](https://github.com/qutip/qutip/issues/1504#issuecomment-823455134). 

Added tests to check behavior of `rand_ket` by checking shape of output when -  both N and dims are specified,  only dims is specified and finally only N is specified. 

**Changelog**
Fixes typo in random objects and changes signature of rand_ket
