### PR TITLE
Add [full] target to get all optional dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,10 @@ semidefinite =
 tests =
     pytest>=5.2
     pytest-rerunfailures
+; This uses ConfigParser's string interpolation to include all the above
+; dependencies into one single target, convenient for testing full builds.
+full =
+    %(graphics)s
+    %(runtime_compilation)s
+    %(semidefinite)s
+    %(tests)s


### PR DESCRIPTION
This makes a `qutip[full]` target for pip, to make it easier to install qutip and all its optional dependencies.