### PR TITLE
Re-add contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing to QuTiP Development
+
+You are most welcome to contribute to QuTiP development by forking this repository and sending pull requests, or filing bug reports at the [issues page](https://github.com/qutip/qutip/issues).
+You can also help out with users' questions, or discuss proposed changes in the [QuTiP discussion group](https://groups.google.com/g/qutip).
+All code contributions are acknowledged in the [contributors](http://qutip.org/docs/latest/contributors.html) section in the documentation.
+
+For more information, including technical advice, please see the ["contributing to QuTiP development" section of the documentation](http://qutip.org/docs/latest/development/contributing.html).


### PR DESCRIPTION
This file has been added and removed a few times, but GitHub likes it if
we have it.  The main contributing guidelines remain in the actual
documentation, so this just replicates the readme and points to the main
version.

I think the UnitaryHack guidelines say we should have it, too.
