### PR TITLE
Enforce int types in math.factorial

### DIFF
--- a/qutip/piqs.py
+++ b/qutip/piqs.py
@@ -102,6 +102,18 @@ __all__ = [
     "Pim",
 ]
 
+
+def _ensure_int(x):
+    """
+    Ensure that a floating-point value `x` is exactly an integer, and return it
+    as an int.
+    """
+    out = int(x)
+    if out != x:
+        raise ValueError(f"{x} is not an integral value")
+    return out
+
+
 # Functions necessary to generate the Lindbladian/Liouvillian
 def num_dicke_states(N):
     """Calculate the number of Dicke states.
@@ -641,8 +653,8 @@ def energy_degeneracy(N, m):
         The energy degeneracy
     """
     numerator = Decimal(factorial(N))
-    d1 = Decimal(factorial(N / 2 + m))
-    d2 = Decimal(factorial(N / 2 - m))
+    d1 = Decimal(factorial(_ensure_int(N / 2 + m)))
+    d2 = Decimal(factorial(_ensure_int(N / 2 - m)))
     degeneracy = numerator / (d1 * d2)
     return int(degeneracy)
 
@@ -671,8 +683,8 @@ def state_degeneracy(N, j):
     if j < 0:
         raise ValueError("j value should be >= 0")
     numerator = Decimal(factorial(N)) * Decimal(2 * j + 1)
-    denominator_1 = Decimal(factorial(N / 2 + j + 1))
-    denominator_2 = Decimal(factorial(N / 2 - j))
+    denominator_1 = Decimal(factorial(_ensure_int(N / 2 + j + 1)))
+    denominator_2 = Decimal(factorial(_ensure_int(N / 2 - j)))
     degeneracy = numerator / (denominator_1 * denominator_2)
     degeneracy = int(np.round(float(degeneracy)))
     return degeneracy


### PR DESCRIPTION
Using integer-like floats in `math.factorial` is deprecated as of Python 3.9.

Glancing over the rest of the code, I'm fairly sure `math.factorial` is only called on floats formed by (e.g.) `N / 2 + 0.5`, which is guaranteed be an integer for all odd `N` integers, but to be safe I inserted the same test that `math.factorial` will do as well.

By the way: depending on how accurate you actually want/need to be with your degeneracy calculations, a common way to deal with these binomial quantities is to work in the logarithmic space --
```python
def factln(x):
    return scipy.special.gammaln(x + 1)

def energy_degeneracy(N, m):
    return int(np.exp(Decimal(factln(N) - factln(N/2 + m) - factln(N/2 - m))))
```
This is pretty much guaranteed to be faster, but a little less precise; double-precision floats have ~15 decimal digits of precision compared to the `Decimal` default of 28.  You have to be careful that the `np.exp` call doesn't overflow (unless you can use the number in logarithmic space as well), but you can just use a single `Decimal` instance like I did if it really matters to you to have huuuuge numbers output.  I suspect it doesn't, since you multiply it by a float right after, which will overflow to `inf`.

Timings:
```python
from math import factorial
from decimal import Decimal
import numpy as np
from scipy.special import gammaln

def degeneracy_all_decimal(N, m):
    return int(Decimal(factorial(N)) / (Decimal(factorial(int(N/2+m))) * Decimal(factorial(int(N/2-m)))))

def degeneracy_log_then_decimal(N, m):
    return int(np.exp(Decimal(gammaln(N+1) - gammaln(N/2+m+1) - gammaln(N/2-m+1))))

def degeneracy_log(N, m):
    return int(np.exp(gammaln(N+1) - gammaln(N/2+m+1) - gammaln(N/2-m+1)))
```
```python
In [3]: %timeit degeneracy_all_decimal(1000, 0)
   ...: %timeit degeneracy_log_then_decimal(1000, 0)
   ...: %timeit degeneracy_log(1000, 0)
831 µs ± 1.91 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
31.9 µs ± 190 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
4.63 µs ± 86.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```