### PR TITLE
Re-implement entropy_relative.

### DIFF
--- a/doc/apidoc/functions.rst
+++ b/doc/apidoc/functions.rst
@@ -99,7 +99,7 @@ Entropy Functions
 -----------------
 
 .. automodule:: qutip.entropy
-    :members: concurrence, entropy_conditional, entropy_linear, entropy_mutual, entropy_vn
+    :members: concurrence, entropy_conditional, entropy_linear, entropy_mutual, entropy_relative, entropy_vn
 
 
 Density Matrix Metrics

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -228,6 +228,7 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
     """
     Calculates the relative entropy S(rho||sigma) between two density
     matrices.
+
     Parameters
     ----------
     rho : :class:`qutip.Qobj`

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -252,6 +252,8 @@ def entropy_relative(rho, sigma, base=e, sparse=False):
     """
     if not rho.isoper or not sigma.isoper:
         raise TypeError("Inputs must be density matrices.")
+    if rho.shape != sigma.shape or rho.dims != sigma.dims:
+        raise ValueError("Inputs must have the same shape and dims.")
     if base == 2:
         log_base = log2
     elif base == e:

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -232,9 +232,11 @@ def entropy_relative(rho, sigma, base=e, sparse=False):
     Parameters
     ----------
     rho : :class:`qutip.Qobj`
-        First density matrix.
+        First density matrix (or ket which will be converted to a density
+        matrix).
     sigma : :class:`qutip.Qobj`
-        Second density matrix.
+        Second density matrix (or ket which will be converted to a density
+        matrix).
     base : {e,2}
         Base of logarithm. Defaults to e.
     sparse : bool
@@ -253,6 +255,10 @@ def entropy_relative(rho, sigma, base=e, sparse=False):
     Section 11.3.1, pg. 511 for a detailed explanation of quantum relative
     entropy.
     """
+    if rho.isket:
+        rho = ket2dm(rho)
+    if sigma.isket:
+        sigma = ket2dm(sigma)
     if not rho.isoper or not sigma.isoper:
         raise TypeError("Inputs must be density matrices.")
     if rho.dims != sigma.dims:

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -35,7 +35,7 @@ __all__ = ['entropy_vn', 'entropy_linear', 'entropy_mutual', 'negativity',
            'concurrence', 'entropy_conditional', 'entangling_power',
            'entropy_relative']
 
-from numpy import conj, e, inf, inner, real, sort, sqrt, vdot
+from numpy import conj, e, inf, imag, inner, real, sort, sqrt
 from numpy.lib.scimath import log, log2
 from qutip.qobj import ptrace
 from qutip.states import ket2dm
@@ -276,7 +276,11 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
     # S is +inf if the kernel of sigma (i.e. svecs[svals == 0]) has non-trivial
     # intersection with the support of rho (i.e. rvecs[rvals != 0]).
     rvals, rvecs = sp_eigs(rho.data, rho.isherm, vecs=True, sparse=sparse)
+    if any(imag(rvals) >= tol):
+        raise ValueError("Input rho has non-real eigenvalues.")
     svals, svecs = sp_eigs(sigma.data, sigma.isherm, vecs=True, sparse=sparse)
+    if any(imag(svals) >= tol):
+        raise ValueError("Input sigma has non-real eigenvalues.")
     nzrvals = rvals[abs(rvals) >= tol]
     # Calculate S
     S = sum(nzrvals * log_base(nzrvals))

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -231,12 +231,15 @@ def entropy_relative(rho, sigma, base=e, sparse=False):
 
     Parameters
     ----------
-    rho : qobj
+    rho : :class:`qutip.Qobj`
         First density matrix.
-    sigma : qobj
+    sigma : :class:`qutip.Qobj`
         Second density matrix.
     base : {e,2}
-        Base of logarithm.
+        Base of logarithm. Defaults to e.
+    sparse : bool
+        Flag to use sparse solver when determining the eigenvectors
+        of the density matrices. Defaults to False.
 
     Returns
     -------

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -249,7 +249,25 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
     Returns
     -------
     rel_ent : float
-        Value of relative entropy.
+        Value of relative entropy. Guaranteed to be greater than zero
+        and should equal zero only when rho and sigma are identical.
+
+    Examples
+    --------
+
+    First we define two density matrices:
+
+    >>> rho = qutip.ket2dm(qutip.ket("00"))
+    >>> sigma = rho + qutip.ket2dm(qutip.ket("01"))
+    >>> sigma = sigma.unit()
+
+    Then we calculate their relative entropy using base 2 (i.e. ``log2``)
+    and base e (i.e. ``log``).
+
+    >>> qutip.entropy_relative(rho, sigma, base=2)
+    1.0
+    >>> qutip.entropy_relative(rho, sigma)
+    0.6931471805599453
 
     References
     ----------

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -277,11 +277,11 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
     # S is +inf if the kernel of sigma (i.e. svecs[svals == 0]) has non-trivial
     # intersection with the support of rho (i.e. rvecs[rvals != 0]).
     rvals, rvecs = sp_eigs(rho.data, rho.isherm, vecs=True, sparse=sparse)
-    if any(imag(rvals) >= tol):
+    if any(abs(imag(rvals)) >= tol):
         raise ValueError("Input rho has non-real eigenvalues.")
     rvals = real(rvals)
     svals, svecs = sp_eigs(sigma.data, sigma.isherm, vecs=True, sparse=sparse)
-    if any(imag(svals) >= tol):
+    if any(abs(imag(svals)) >= tol):
         raise ValueError("Input sigma has non-real eigenvalues.")
     svals = real(svals)
     # Calculate inner products of eigenvectors and return +inf if kernel

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -294,7 +294,7 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
     svals[abs(svals) < tol] = 1
     nzrvals = rvals[abs(rvals) >= tol]
     # Calculate S
-    S = nzrvals @ conj(log_base(nzrvals)) - rvals @ P @ log_base(svals)
+    S = nzrvals @ log_base(nzrvals) - rvals @ P @ log_base(svals)
     # the relative entropy is guaranteed to be >= 0, so we clamp the
     # calculated value to 0 to avoid small violations of the lower bound.
     return max(0, S)

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -292,7 +292,9 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
                 return inf
             if svals[j] != 0:
                 S -= rvals[i] * P_ij * log_base(svals[j])
-    return real(S)
+    # the relative entropy is guaranteed to be >= 0, so we clamp the
+    # calculated value to 0 to avoid small violations of the lower bound.
+    return max(0, real(S))
 
 
 def entropy_conditional(rho, selB, base=e, sparse=False):

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -35,7 +35,7 @@ __all__ = ['entropy_vn', 'entropy_linear', 'entropy_mutual', 'negativity',
            'concurrence', 'entropy_conditional', 'entangling_power',
            'entropy_relative']
 
-from numpy import dot, e, inf, real, sort, sqrt, vdot
+from numpy import e, inf, real, sort, sqrt, vdot
 from numpy.lib.scimath import log, log2
 from qutip.qobj import ptrace
 from qutip.states import ket2dm
@@ -288,7 +288,7 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
                     abs(rvals[i]) < tol or abs(P_ij) < tol):
                 # kernel of sigma intersects support of rho
                 return inf
-            if svals[j] != 0:
+            if svals[j] >= tol:
                 S -= rvals[i] * P_ij * log_base(svals[j])
     # the relative entropy is guaranteed to be >= 0, so we clamp the
     # calculated value to 0 to avoid small violations of the lower bound.

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -252,7 +252,7 @@ def entropy_relative(rho, sigma, base=e, sparse=False):
     """
     if not rho.isoper or not sigma.isoper:
         raise TypeError("Inputs must be density matrices.")
-    if rho.shape != sigma.shape or rho.dims != sigma.dims:
+    if rho.dims != sigma.dims:
         raise ValueError("Inputs must have the same shape and dims.")
     if base == 2:
         log_base = log2

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -278,9 +278,11 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
     rvals, rvecs = sp_eigs(rho.data, rho.isherm, vecs=True, sparse=sparse)
     if any(imag(rvals) >= tol):
         raise ValueError("Input rho has non-real eigenvalues.")
+    rvals = real(rvals)
     svals, svecs = sp_eigs(sigma.data, sigma.isherm, vecs=True, sparse=sparse)
     if any(imag(svals) >= tol):
         raise ValueError("Input sigma has non-real eigenvalues.")
+    svals = real(svals)
     nzrvals = rvals[abs(rvals) >= tol]
     # Calculate S
     S = sum(nzrvals * log_base(nzrvals))
@@ -295,7 +297,7 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
                 S -= rvals[i] * P[i, j] * log_base(svals[j])
     # the relative entropy is guaranteed to be >= 0, so we clamp the
     # calculated value to 0 to avoid small violations of the lower bound.
-    return max(0, real(S))
+    return max(0, S)
 
 
 def entropy_conditional(rho, selB, base=e, sparse=False):

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -35,7 +35,7 @@ __all__ = ['entropy_vn', 'entropy_linear', 'entropy_mutual', 'negativity',
            'concurrence', 'entropy_conditional', 'entangling_power',
            'entropy_relative']
 
-from numpy import e, inf, real, sort, sqrt, vdot
+from numpy import conj, e, inf, inner, real, sort, sqrt, vdot
 from numpy.lib.scimath import log, log2
 from qutip.qobj import ptrace
 from qutip.states import ket2dm
@@ -280,16 +280,15 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
     nzrvals = rvals[abs(rvals) >= tol]
     # Calculate S
     S = sum(nzrvals * log_base(nzrvals))
+    P = abs(inner(rvecs, conj(svecs))) ** 2
     for i in range(len(rvals)):
         for j in range(len(svals)):
-            ij_dot = vdot(rvecs[i], svecs[j])
-            P_ij = ij_dot * ij_dot.conjugate()
             if abs(svals[j]) < tol and not (
-                    abs(rvals[i]) < tol or abs(P_ij) < tol):
+                    abs(rvals[i]) < tol or abs(P[i, j]) < tol):
                 # kernel of sigma intersects support of rho
                 return inf
             if svals[j] >= tol:
-                S -= rvals[i] * P_ij * log_base(svals[j])
+                S -= rvals[i] * P[i, j] * log_base(svals[j])
     # the relative entropy is guaranteed to be >= 0, so we clamp the
     # calculated value to 0 to avoid small violations of the lower bound.
     return max(0, real(S))

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -35,7 +35,7 @@ __all__ = ['entropy_vn', 'entropy_linear', 'entropy_mutual', 'negativity',
            'concurrence', 'entropy_conditional', 'entangling_power',
            'entropy_relative']
 
-from numpy import dot, e, inf, real, sort, sqrt
+from numpy import dot, e, inf, real, sort, sqrt, vdot
 from numpy.lib.scimath import log, log2
 from qutip.qobj import ptrace
 from qutip.states import ket2dm
@@ -282,10 +282,8 @@ def entropy_relative(rho, sigma, base=e, sparse=False, tol=1e-12):
     S = sum(nzrvals * log_base(nzrvals))
     for i in range(len(rvals)):
         for j in range(len(svals)):
-            P_ij = (
-                dot(rvecs[i], svecs[j].conjugate()) *
-                dot(svecs[j], rvecs[i].conjugate())
-            )
+            ij_dot = vdot(rvecs[i], svecs[j])
+            P_ij = ij_dot * ij_dot.conjugate()
             if abs(svals[j]) < tol and not (
                     abs(rvals[i]) < tol or abs(P_ij) < tol):
                 # kernel of sigma intersects support of rho

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -250,7 +250,7 @@ def entropy_relative(rho, sigma, base=e, sparse=False):
     Section 11.3.1, pg. 511 for a detailed explanation of quantum relative
     entropy.
     """
-    if rho.type != 'oper' or sigma.type != 'oper':
+    if not rho.isoper or not sigma.isoper:
         raise TypeError("Inputs must be density matrices.")
     if base == 2:
         log_base = log2

--- a/qutip/tests/test_entropy.py
+++ b/qutip/tests/test_entropy.py
@@ -91,32 +91,35 @@ class TestMutualInformation:
 
 class TestRelativeEntropy:
     def test_rho_or_sigma_not_oper(self):
-        rho = qutip.ket("00")
-        sigma = qutip.ket("01")
+        rho = qutip.bra("00")
+        sigma = qutip.bra("01")
         with pytest.raises(TypeError) as exc:
-            qutip.entropy_relative(qutip.ket2dm(rho), sigma)
+            qutip.entropy_relative(rho.dag(), sigma)
         assert str(exc.value) == "Inputs must be density matrices."
         with pytest.raises(TypeError) as exc:
-            qutip.entropy_relative(rho, qutip.ket2dm(sigma))
+            qutip.entropy_relative(rho, sigma.dag())
+        assert str(exc.value) == "Inputs must be density matrices."
+        with pytest.raises(TypeError) as exc:
+            qutip.entropy_relative(rho, sigma)
         assert str(exc.value) == "Inputs must be density matrices."
 
     def test_rho_and_sigma_have_different_shape_and_dims(self):
-        rho = qutip.ket2dm(qutip.ket("00"))
-        sigma = qutip.ket2dm(qutip.ket("0"))
+        rho = qutip.ket("00")
+        sigma = qutip.ket("0")
         with pytest.raises(ValueError) as exc:
             qutip.entropy_relative(rho, sigma)
         assert str(exc.value) == "Inputs must have the same shape and dims."
 
     def test_base_not_2_or_e(self):
-        rho = qutip.ket2dm(qutip.ket("00"))
-        sigma = qutip.ket2dm(qutip.ket("01"))
+        rho = qutip.ket("00")
+        sigma = qutip.ket("01")
         with pytest.raises(ValueError) as exc:
             qutip.entropy_relative(rho, sigma, base=3)
         assert str(exc.value) == "Base must be 2 or e."
 
     def test_infinite_relative_entropy(self):
-        rho = qutip.ket2dm(qutip.ket("00"))
-        sigma = qutip.ket2dm(qutip.ket("01"))
+        rho = qutip.ket("00")
+        sigma = qutip.ket("01")
         assert qutip.entropy_relative(rho, sigma) == np.inf
 
     def test_base_2_or_e(self):

--- a/qutip/tests/test_entropy.py
+++ b/qutip/tests/test_entropy.py
@@ -100,6 +100,13 @@ class TestRelativeEntropy:
             qutip.entropy_relative(rho, qutip.ket2dm(sigma))
         assert str(exc.value) == "Inputs must be density matrices."
 
+    def test_rho_and_sigma_have_different_shape_and_dims(self):
+        rho = qutip.ket2dm(qutip.ket("00"))
+        sigma = qutip.ket2dm(qutip.ket("0"))
+        with pytest.raises(ValueError) as exc:
+            qutip.entropy_relative(rho, sigma)
+        assert str(exc.value) == "Inputs must have the same shape and dims."
+
     def test_base_not_2_or_e(self):
         rho = qutip.ket2dm(qutip.ket("00"))
         sigma = qutip.ket2dm(qutip.ket("01"))

--- a/qutip/tests/test_entropy.py
+++ b/qutip/tests/test_entropy.py
@@ -135,6 +135,13 @@ class TestRelativeEntropy:
         )
         assert qutip.entropy_relative(rho, sigma, base=2) == pytest.approx(1)
 
+    def test_pure_vs_maximally_mixed_state(self):
+        rho = qutip.ket("00")
+        sigma = sum(
+            qutip.ket2dm(qutip.ket(psi)) for psi in ["00", "01", "10", "11"]
+        ).unit()
+        assert qutip.entropy_relative(rho, sigma, base=2) == pytest.approx(2)
+
     @pytest.mark.repeat(20)
     def test_random_dm_with_self(self):
         rho = qutip.rand_dm(8, pure=False)

--- a/qutip/tests/test_entropy.py
+++ b/qutip/tests/test_entropy.py
@@ -177,7 +177,13 @@ class TestRelativeEntropy:
             qutip.entropy_relative(rho + 1j, sigma)
         assert str(exc.value) == "Input rho has non-real eigenvalues."
         with pytest.raises(ValueError) as exc:
+            qutip.entropy_relative(rho - 1j, sigma)
+        assert str(exc.value) == "Input rho has non-real eigenvalues."
+        with pytest.raises(ValueError) as exc:
             qutip.entropy_relative(rho, sigma + 1j)
+        assert str(exc.value) == "Input sigma has non-real eigenvalues."
+        with pytest.raises(ValueError) as exc:
+            qutip.entropy_relative(rho, sigma - 1j)
         assert str(exc.value) == "Input sigma has non-real eigenvalues."
 
     @pytest.mark.repeat(20)

--- a/qutip/tests/test_entropy.py
+++ b/qutip/tests/test_entropy.py
@@ -132,8 +132,15 @@ class TestRelativeEntropy:
         assert str(exc.value) == "Inputs must be density matrices."
 
     def test_rho_and_sigma_have_different_shape_and_dims(self):
+        # test different shape and dims
         rho = qutip.ket("00")
         sigma = qutip.ket("0")
+        with pytest.raises(ValueError) as exc:
+            qutip.entropy_relative(rho, sigma)
+        assert str(exc.value) == "Inputs must have the same shape and dims."
+        # test same shape, difference dims
+        rho = qutip.basis([2, 3], [0, 0])
+        sigma = qutip.basis([3, 2], [0, 0])
         with pytest.raises(ValueError) as exc:
             qutip.entropy_relative(rho, sigma)
         assert str(exc.value) == "Inputs must have the same shape and dims."

--- a/qutip/tests/test_entropy.py
+++ b/qutip/tests/test_entropy.py
@@ -170,6 +170,16 @@ class TestRelativeEntropy:
         ).unit()
         assert qutip.entropy_relative(rho, sigma, base=2) == pytest.approx(2)
 
+    def test_density_matrices_with_non_real_eigenvalues(self):
+        rho = qutip.ket2dm(qutip.ket("00"))
+        sigma = qutip.ket2dm(qutip.ket("01"))
+        with pytest.raises(ValueError) as exc:
+            qutip.entropy_relative(rho + 1j, sigma)
+        assert str(exc.value) == "Input rho has non-real eigenvalues."
+        with pytest.raises(ValueError) as exc:
+            qutip.entropy_relative(rho, sigma + 1j)
+        assert str(exc.value) == "Input sigma has non-real eigenvalues."
+
     @pytest.mark.repeat(20)
     def test_random_dm_with_self(self):
         rho = qutip.rand_dm(8, pure=False)

--- a/qutip/tests/test_entropy.py
+++ b/qutip/tests/test_entropy.py
@@ -127,7 +127,7 @@ class TestRelativeEntropy:
         sigma = rho + qutip.ket2dm(qutip.ket("01"))
         sigma = sigma.unit()
         assert (
-            qutip.entropy_relative(rho, sigma) == pytest.approx(0.69314718)
+            qutip.entropy_relative(rho, sigma) == pytest.approx(np.log(2))
         )
         assert (
             qutip.entropy_relative(rho, sigma, base=np.e)


### PR DESCRIPTION
**Description**
Re-implement entropy_relative.

This function was implemented in March 2012, but then removed a month later. After some digging, it appears that the reason the function was removed is that it assumed the eigenvectors of the density matrices were identical (and in the same order).

After some reading of Nielsen & Chuang, I have re-implemented it to address the issue.

**Still todo**
 - [x] Update the documentation.
 - [ ] Add an example to an example notebook.
 - [x] Add some tests for specific cases where we know what the answer should be.
 - [x] Stretch goal: Vectorize the calculation of P_ij and the rest of the loop as much as we can (but let's make sure the answers are correct first).

**Changelog**
Re-implement entropy_relative which returns the quantum relative entropy between two density matrices.