### PR TITLE
Version checks for `matplotlib` [unitaryHACK]

### DIFF
--- a/doc/guide/guide-bloch.rst
+++ b/doc/guide/guide-bloch.rst
@@ -422,13 +422,13 @@ Directly Generating an Animation
 The code to directly generate an mp4 movie of the Qubit decay is as follows ::
 
    import matplotlib
-   from packaging.version import parse as parse_version  # For checking matplotlib version
+   from qutip.bloch import matplotlib_version_gte  # For checking matplotlib version
    from matplotlib import pyplot, animation
    from mpl_toolkits.mplot3d import Axes3D
 
    fig = pyplot.figure()
 
-   if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+   if matplotlib_version_gte():
       ax = Axes3D(fig,azim=-40,elev=30, auto_add_to_figure=False)
       fig.add_axes(ax)
    else:

--- a/doc/guide/guide-bloch.rst
+++ b/doc/guide/guide-bloch.rst
@@ -421,18 +421,11 @@ Directly Generating an Animation
 
 The code to directly generate an mp4 movie of the Qubit decay is as follows ::
 
-   import matplotlib
-   from qutip.bloch import matplotlib_version_gte  # For checking matplotlib version
    from matplotlib import pyplot, animation
    from mpl_toolkits.mplot3d import Axes3D
 
    fig = pyplot.figure()
-
-   if matplotlib_version_gte():
-      ax = Axes3D(fig,azim=-40,elev=30, auto_add_to_figure=False)
-      fig.add_axes(ax)
-   else:
-      ax = Axes3D(fig,azim=-40,elev=30)
+   ax = Axes3D(fig, azim=-40, elev=30)
    sphere = qutip.Bloch(axes=ax)
 
    def animate(i):

--- a/doc/guide/guide-bloch.rst
+++ b/doc/guide/guide-bloch.rst
@@ -421,11 +421,18 @@ Directly Generating an Animation
 
 The code to directly generate an mp4 movie of the Qubit decay is as follows ::
 
+   import matplotlib
+   from packaging.version import parse as parse_version  # For checking matplotlib version
    from matplotlib import pyplot, animation
    from mpl_toolkits.mplot3d import Axes3D
 
    fig = pyplot.figure()
-   ax = Axes3D(fig,azim=-40,elev=30)
+
+   if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+      ax = Axes3D(fig,azim=-40,elev=30, auto_add_to_figure=False)
+      fig.add_axes(ax)
+   else:
+      ax = Axes3D(fig,azim=-40,elev=30)
    sphere = qutip.Bloch(axes=ax)
 
    def animate(i):

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -35,8 +35,6 @@ __all__ = ['Bloch']
 
 import os
 
-import matplotlib
-
 from numpy import (ndarray, array, linspace, pi, outer, cos, sin, ones, size,
                    sqrt, real, mod, append, ceil, arange)
 
@@ -47,10 +45,20 @@ from qutip.expect import expect
 from qutip.operators import sigmax, sigmay, sigmaz
 
 try:
+    import matplotlib
     import matplotlib.pyplot as plt
     from mpl_toolkits.mplot3d import Axes3D
     from matplotlib.patches import FancyArrowPatch
     from mpl_toolkits.mplot3d import proj3d
+
+    def matplotlib_version_gte(version='3.4'):
+        """
+        Checks if matplotlib version is greater than a specific version
+        """
+        if parse_version(matplotlib.__version__) >= parse_version(version):
+            return True
+        else:
+            return False
 
     class Arrow3D(FancyArrowPatch):
         def __init__(self, xs, ys, zs, *args, **kwargs):
@@ -60,7 +68,7 @@ try:
 
         def draw(self, renderer):
             xs3d, ys3d, zs3d = self._verts3d
-            if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+            if matplotlib_version_gte():
                 xs, ys, zs = proj3d.proj_transform(xs3d, ys3d,
                                                    zs3d, self.axes.M)
             else:
@@ -457,7 +465,7 @@ class Bloch:
             self.fig = plt.figure(figsize=self.figsize)
 
         if not axes:
-            if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+            if matplotlib_version_gte():
                 self.axes = Axes3D(self.fig, azim=self.view[0],
                                    elev=self.view[1], auto_add_to_figure=False)
                 self.fig.add_axes(self.axes)
@@ -478,10 +486,8 @@ class Bloch:
             self.axes.set_zlim3d(-0.7, 0.7)
         # Manually set aspect ratio to fit a square bounding box.
         # Matplotlib did this stretching for < 3.3.0, but not above.
-        if parse_version(matplotlib.__version__) >= parse_version('3.3'):
+        if matplotlib_version_gte(version='3.3'):
             self.axes.set_box_aspect((1, 1, 1))
-        else:
-            pass
 
         self.axes.grid(False)
         self.plot_back()

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -51,10 +51,11 @@ try:
     from matplotlib.patches import FancyArrowPatch
     from mpl_toolkits.mplot3d import proj3d
 
+    # Define a custom _axes3D function based on the matplotlib version.
+    # The auto_add_to_figure keyword is new for matplotlib>=3.4.
     if parse_version(matplotlib.__version__) >= parse_version('3.4'):
-        def _axes3D(*args, **kwargs):
-            fig = args[0]
-            ax = Axes3D(*args, auto_add_to_figure=False, **kwargs)
+        def _axes3D(fig, *args, **kwargs):
+            ax = Axes3D(fig, *args, auto_add_to_figure=False, **kwargs)
             return fig.add_axes(ax)
     else:
         def _axes3D(*args, **kwargs):

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -61,9 +61,11 @@ try:
         def draw(self, renderer):
             xs3d, ys3d, zs3d = self._verts3d
             if parse_version(matplotlib.__version__) >= parse_version('3.4'):
-                xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
+                xs, ys, zs = proj3d.proj_transform(xs3d, ys3d,
+                                                   zs3d, self.axes.M)
             else:
-                xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
+                xs, ys, zs = proj3d.proj_transform(xs3d, ys3d,
+                                                   zs3d, renderer.M)
 
             self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
             FancyArrowPatch.draw(self, renderer)
@@ -456,10 +458,12 @@ class Bloch:
 
         if not axes:
             if parse_version(matplotlib.__version__) >= parse_version('3.4'):
-               self.axes = Axes3D(self.fig, azim=self.view[0], elev=self.view[1], auto_add_to_figure=False)
-               self.fig.add_axes(self.axes)
+                self.axes = Axes3D(self.fig, azim=self.view[0],
+                                   elev=self.view[1], auto_add_to_figure=False)
+                self.fig.add_axes(self.axes)
             else:
-                self.axes = Axes3D(self.fig, azim=self.view[0], elev=self.view[1])
+                self.axes = Axes3D(self.fig, azim=self.view[0],
+                                   elev=self.view[1])
 
         if self.background:
             self.axes.clear()

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -57,6 +57,8 @@ try:
 except:
     pass
 
+from packaging.version import parse as parse_version
+
 from qutip.qobj import Qobj, isket
 from qutip.states import ket2dm
 from qutip.wigner import wigner
@@ -372,7 +374,11 @@ def sphereplot(theta, phi, values, fig=None, ax=None, save=False):
     """
     if fig is None or ax is None:
         fig = plt.figure()
-        ax = Axes3D(fig)
+        if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+            ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
+            fig.add_axes(ax)
+        else:
+            ax = Axes3D(fig, azim=-35, elev=35)
 
     thetam, phim = np.meshgrid(theta, phi)
     xx = sin(thetam) * cos(phim)
@@ -468,7 +474,11 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
 
     if ax is None:
         fig = plt.figure()
-        ax = Axes3D(fig, azim=-35, elev=35)
+        if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+            ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
+            fig.add_axes(ax)
+        else:
+            ax = Axes3D(fig, azim=-35, elev=35)
 
     ax.bar3d(xpos, ypos, zpos, dx, dy, dz, color=colors)
 
@@ -589,7 +599,11 @@ def matrix_histogram_complex(M, xlabels=None, ylabels=None,
 
     if ax is None:
         fig = plt.figure()
-        ax = Axes3D(fig, azim=-35, elev=35)
+        if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+            ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
+            fig.add_axes(ax)
+        else:
+            ax = Axes3D(fig, azim=-35, elev=35)
 
     ax.bar3d(xpos, ypos, zpos, dx, dy, dz, color=colors)
 
@@ -1138,7 +1152,11 @@ def plot_spin_distribution_3d(P, THETA, PHI,
 
     if fig is None or ax is None:
         fig = plt.figure(figsize=figsize)
-        ax = Axes3D(fig, azim=-35, elev=35)
+        if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+            ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
+            fig.add_axes(ax)
+        else:
+            ax = Axes3D(fig, azim=-35, elev=35)
 
     xx = sin(THETA) * cos(PHI)
     yy = sin(THETA) * sin(PHI)

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -55,14 +55,14 @@ try:
     from matplotlib import cm
     from mpl_toolkits.mplot3d import Axes3D
 
-    def matplotlib_version_gte(version='3.4'):
-        """
-        Checks if matplotlib version is greater than a specific version
-        """
-        if parse_version(mpl.__version__) >= parse_version(version):
-            return True
-        else:
-            return False
+    if parse_version(mpl.__version__) >= parse_version('3.4'):
+        def _axes3D(*args, **kwargs):
+            fig = args[0]
+            ax = Axes3D(*args, auto_add_to_figure=False, **kwargs)
+            return fig.add_axes(ax)
+    else:
+        def _axes3D(*args, **kwargs):
+            return Axes3D(*args, **kwargs)
 except:
     pass
 
@@ -383,11 +383,7 @@ def sphereplot(theta, phi, values, fig=None, ax=None, save=False):
     """
     if fig is None or ax is None:
         fig = plt.figure()
-        if matplotlib_version_gte():
-            ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
-            fig.add_axes(ax)
-        else:
-            ax = Axes3D(fig, azim=-35, elev=35)
+        ax = _axes3D(fig, azim=-35, elev=35)
 
     thetam, phim = np.meshgrid(theta, phi)
     xx = sin(thetam) * cos(phim)
@@ -483,11 +479,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
 
     if ax is None:
         fig = plt.figure()
-        if matplotlib_version_gte():
-            ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
-            fig.add_axes(ax)
-        else:
-            ax = Axes3D(fig, azim=-35, elev=35)
+        ax = _axes3D(fig, azim=-35, elev=35)
 
     ax.bar3d(xpos, ypos, zpos, dx, dy, dz, color=colors)
 
@@ -608,11 +600,7 @@ def matrix_histogram_complex(M, xlabels=None, ylabels=None,
 
     if ax is None:
         fig = plt.figure()
-        if matplotlib_version_gte():
-            ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
-            fig.add_axes(ax)
-        else:
-            ax = Axes3D(fig, azim=-35, elev=35)
+        ax = _axes3D(fig, azim=-35, elev=35)
 
     ax.bar3d(xpos, ypos, zpos, dx, dy, dz, color=colors)
 
@@ -1161,11 +1149,7 @@ def plot_spin_distribution_3d(P, THETA, PHI,
 
     if fig is None or ax is None:
         fig = plt.figure(figsize=figsize)
-        if matplotlib_version_gte():
-            ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
-            fig.add_axes(ax)
-        else:
-            ax = Axes3D(fig, azim=-35, elev=35)
+        ax = _axes3D(fig, azim=-35, elev=35)
 
     xx = sin(THETA) * cos(PHI)
     yy = sin(THETA) * sin(PHI)

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -55,10 +55,11 @@ try:
     from matplotlib import cm
     from mpl_toolkits.mplot3d import Axes3D
 
+    # Define a custom _axes3D function based on the matplotlib version.
+    # The auto_add_to_figure keyword is new for matplotlib>=3.4.
     if parse_version(mpl.__version__) >= parse_version('3.4'):
-        def _axes3D(*args, **kwargs):
-            fig = args[0]
-            ax = Axes3D(*args, auto_add_to_figure=False, **kwargs)
+        def _axes3D(fig, *args, **kwargs):
+            ax = Axes3D(fig, *args, auto_add_to_figure=False, **kwargs)
             return fig.add_axes(ax)
     else:
         def _axes3D(*args, **kwargs):

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -49,6 +49,19 @@ import itertools as it
 import numpy as np
 from numpy import pi, array, sin, cos, angle, log2, sqrt
 
+from packaging.version import parse as parse_version
+
+from qutip.qobj import Qobj, isket
+from qutip.states import ket2dm
+from qutip.wigner import wigner
+from qutip.tensor import tensor
+from qutip.matplotlib_utilities import complex_phase_cmap
+from qutip.superoperator import vector_to_operator
+from qutip.superop_reps import to_super, _super_to_superpauli, _isqubitdims, _pauli_basis
+from qutip.tensor import flatten
+
+from qutip import settings
+
 try:
     import matplotlib.pyplot as plt
     import matplotlib as mpl
@@ -66,19 +79,6 @@ try:
             return Axes3D(*args, **kwargs)
 except:
     pass
-
-from packaging.version import parse as parse_version
-
-from qutip.qobj import Qobj, isket
-from qutip.states import ket2dm
-from qutip.wigner import wigner
-from qutip.tensor import tensor
-from qutip.matplotlib_utilities import complex_phase_cmap
-from qutip.superoperator import vector_to_operator
-from qutip.superop_reps import to_super, _super_to_superpauli, _isqubitdims, _pauli_basis
-from qutip.tensor import flatten
-
-from qutip import settings
 
 
 def plot_wigner_sphere(fig, ax, wigner, reflections):

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -54,6 +54,15 @@ try:
     import matplotlib as mpl
     from matplotlib import cm
     from mpl_toolkits.mplot3d import Axes3D
+
+    def matplotlib_version_gte(version='3.4'):
+        """
+        Checks if matplotlib version is greater than a specific version
+        """
+        if parse_version(mpl.__version__) >= parse_version(version):
+            return True
+        else:
+            return False
 except:
     pass
 
@@ -374,7 +383,7 @@ def sphereplot(theta, phi, values, fig=None, ax=None, save=False):
     """
     if fig is None or ax is None:
         fig = plt.figure()
-        if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+        if matplotlib_version_gte():
             ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
             fig.add_axes(ax)
         else:
@@ -474,7 +483,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
 
     if ax is None:
         fig = plt.figure()
-        if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+        if matplotlib_version_gte():
             ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
             fig.add_axes(ax)
         else:
@@ -599,7 +608,7 @@ def matrix_histogram_complex(M, xlabels=None, ylabels=None,
 
     if ax is None:
         fig = plt.figure()
-        if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+        if matplotlib_version_gte():
             ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
             fig.add_axes(ax)
         else:
@@ -1152,7 +1161,7 @@ def plot_spin_distribution_3d(P, THETA, PHI,
 
     if fig is None or ax is None:
         fig = plt.figure(figsize=figsize)
-        if parse_version(matplotlib.__version__) >= parse_version('3.4'):
+        if matplotlib_version_gte():
             ax = Axes3D(fig, azim=-35, elev=35, auto_add_to_figure=False)
             fig.add_axes(ax)
         else:

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -384,7 +384,7 @@ def sphereplot(theta, phi, values, fig=None, ax=None, save=False):
     """
     if fig is None or ax is None:
         fig = plt.figure()
-        ax = _axes3D(fig, azim=-35, elev=35)
+        ax = _axes3D(fig)
 
     thetam, phim = np.meshgrid(theta, phi)
     xx = sin(thetam) * cos(phim)


### PR DESCRIPTION
**Description**
This PR attempts to add version checks for resolving deprecation warnings for `matplotlib` in the `bloch` and `visualization` modules. Specifically, it attempts to resolve warnings related to `matplotlib>=3.4` and `matplotlib>=3.3`.

Places where the change has been made:
- `proj3d.proj_transform`
- `Axes3D`

Thanks!

**Related issues or PRs**
Fix #1503 and #1502.

**Changelog**
Added a version checking condition to handle specific functionalities depending on the `matplotlib` version.