### PR TITLE
Fix tlist QobJEvo with constant c_ops in mesolve

### DIFF
--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -293,7 +293,17 @@ def _mesolve_QobjEvo(H, c_ops, tlist, args, opt):
     else:
         L_td = H_td
     for op in c_ops:
-        op_td = QobjEvo(op, args, tlist=tlist)
+        # We want to avoid passing tlist where it isn't necessary, to allow a
+        # Hamiltonian/Liouvillian which already _has_ time-dependence not equal
+        # to the mesolve evaluation times to be used in conjunction with
+        # time-independent c_ops.  If we _always_ pass it, it may appear to
+        # QobjEvo that there is a tlist mismatch, even though it is not used.
+        if isinstance(op, Qobj):
+            op_td = QobjEvo(op)
+        elif isinstance(op, QobjEvo):
+            op_td = QobjEvo(op, args)
+        else:
+            op_td = QobjEvo(op, args, tlist=tlist)
         if not issuper(op_td.cte):
             op_td = lindblad_dissipator(op_td)
         L_td += op_td


### PR DESCRIPTION
Previously, passing a Hamiltonian to `mesolve` which used "array" time dependence with a tlist not equal to `mesolve`'s would fail if any constant collapse operators were present.  This was because `mesolve` was a little over-zealous in promoting `c_ops` to time-dependent `QobjEvo` using the `mesolve` time list.  This would cause an unnecessary failure if the Hamiltonian was a `QobjEvo` specified previously with a different tlist.

Fix #1560

#### Changelog
- Specialise exception types in ``QobjEvo`` failure paths
- Fix ``tlist`` ``QobjEvo`` with constant collapse operators in ``mesolve``