### PR TITLE
Correct typo in guide-states.rst

### DIFF
--- a/doc/guide/guide-states.rst
+++ b/doc/guide/guide-states.rst
@@ -753,7 +753,7 @@ The :func:`qutip.expect` function also accepts lists or arrays of state vectors 
 
     [ 0.+0.j  0.+1.j -1.+0.j  0.-1.j]
 
-Notice how in this last example, all of the return values are complex numbers.  This is because the :func:`qutip.expect` function looks to see whether the operator is Hermitian or not.  If the operator is Hermitian, than the output will always be real.  In the case of non-Hermitian operators, the return values may be complex.  Therefore, the :func:`qutip.expect` function will return an array of complex values for non-Hermitian operators when the input is a list/array of states or density matrices.
+Notice how in this last example, all of the return values are complex numbers.  This is because the :func:`qutip.expect` function looks to see whether the operator is Hermitian or not.  If the operator is Hermitian, then the output will always be real.  In the case of non-Hermitian operators, the return values may be complex.  Therefore, the :func:`qutip.expect` function will return an array of complex values for non-Hermitian operators when the input is a list/array of states or density matrices.
 
 Of course, the :func:`qutip.expect` function works for spin states and operators:
 


### PR DESCRIPTION
**Description**

The word "then" is mistyped in the sentence "If the operator is Hermitian, **than** the output will always be real".

**Related issues or PRs**

None.

**Changelog**

Corrected typo in Guide / Manipulating States and Operators.
