### PR TITLE
matrix_histogram updated - imporved the styling options

### DIFF
--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -577,7 +577,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
 
     options : dict
         A dictionary containing extra options for the plot.
-        The names (keys) and values of the options are 
+        The names (keys) and values of the options are
         described below:
 
         'zticks' : list of numbers

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -504,16 +504,9 @@ def _update_zaxis(ax, z_min, z_max, zticks):
     updates the z-axis
     """
     ax.axes.w_zaxis.set_major_locator(plt.IndexLocator(1, 0.5))
-    # ax.set_zlim3d([min(z_min, 0), z_max])
-    if z_min > 0 and z_max > 0:
-        ax.set_zlim3d([0, z_max])
-    elif z_min < 0 and z_max < 0:
-        ax.set_zlim3d([0, z_min])
-    else:
-        ax.set_zlim3d([z_min, z_max])
-
-    if zticks:
+    if isinstance(zticks, list):
         ax.set_zticks(zticks)
+    ax.set_zlim3d([min(z_min, 0), z_max])
 
 
 def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -479,24 +479,24 @@ def _stick_to_planes(stick, azim, ax, M, spacing):
     if stick is True:
         azim = azim % 360
         if 0 <= azim <= 90:
-            ax.set_ylim(1-0.55,)
-            ax.set_xlim(1-0.55,)
+            ax.set_ylim(1 - .5,)
+            ax.set_xlim(1 - .5,)
         elif 90 < azim <= 180:
-            ax.set_ylim(1-0.55,)
-            ax.set_xlim(0, M.shape[0]+(.5-spacing))
+            ax.set_ylim(1 - .5,)
+            ax.set_xlim(0, M.shape[0]+(.5 - spacing))
         elif 180 < azim <= 270:
-            ax.set_ylim(0, M.shape[1]+(.5-spacing))
-            ax.set_xlim(0, M.shape[0]+(.5-spacing))
+            ax.set_ylim(0, M.shape[1]+(.5 - spacing))
+            ax.set_xlim(0, M.shape[0]+(.5 - spacing))
         elif 270 < azim < 360:
-            ax.set_ylim(0, M.shape[1]+(.5-spacing))
-            ax.set_xlim(1-0.55,)
+            ax.set_ylim(0, M.shape[1]+(.5 - spacing))
+            ax.set_xlim(1 - .5,)
 
 
 def _update_yaxis(spacing, M, ax, ylabels):
     """
     updates the y-axis
     """
-    ytics = [x+(1-(spacing/2)) for x in range(M.shape[1])]
+    ytics = [x+(1 - (spacing / 2)) for x in range(M.shape[1])]
     ax.axes.w_yaxis.set_major_locator(plt.FixedLocator(ytics))
     if ylabels:
         nylabels = len(ylabels)
@@ -504,17 +504,17 @@ def _update_yaxis(spacing, M, ax, ylabels):
             raise ValueError(f"got {nylabels} ylabels but needed {len(ytics)}")
         ax.set_yticklabels(ylabels)
     else:
-        ax.set_yticklabels([str(y+1) for y in range(M.shape[1])])
+        ax.set_yticklabels([str(y + 1) for y in range(M.shape[1])])
         ax.set_yticklabels([str(i) for i in range(M.shape[1])])
     ax.tick_params(axis='y', labelsize=14)
-    ax.set_yticks([y+(1-(spacing/2)) for y in range(M.shape[1])])
+    ax.set_yticks([y+(1 - (spacing / 2)) for y in range(M.shape[1])])
 
 
 def _update_xaxis(spacing, M, ax, xlabels):
     """
     updates the x-axis
     """
-    xtics = [x+(1-(spacing/2)) for x in range(M.shape[1])]
+    xtics = [x+(1 - (spacing / 2)) for x in range(M.shape[1])]
     ax.axes.w_xaxis.set_major_locator(plt.FixedLocator(xtics))
     if xlabels:
         nxlabels = len(xlabels)
@@ -522,10 +522,10 @@ def _update_xaxis(spacing, M, ax, xlabels):
             raise ValueError(f"got {nxlabels} xlabels but needed {len(xtics)}")
         ax.set_xticklabels(xlabels)
     else:
-        ax.set_xticklabels([str(x+1) for x in range(M.shape[0])])
+        ax.set_xticklabels([str(x + 1) for x in range(M.shape[0])])
         ax.set_xticklabels([str(i) for i in range(M.shape[0])])
     ax.tick_params(axis='x', labelsize=14)
-    ax.set_xticks([x+(1-(spacing/2)) for x in range(M.shape[0])])
+    ax.set_xticks([x+(1 - (spacing / 2)) for x in range(M.shape[0])])
 
 
 def _update_zaxis(ax, z_min, z_max, zticks):
@@ -544,7 +544,8 @@ def _update_zaxis(ax, z_min, z_max, zticks):
     if zticks:
         ax.set_zticks(zticks)
     else:
-        ax.set_zticks([z_min+0.5*i for i in range(int((z_max-z_min)/0.5)+1)])
+        ax.set_zticks([z_min + 0.5 * i for i in 
+                       range(int((z_max - z_min) / 0.5) + 1)])
 
 
 def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
@@ -647,7 +648,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     default_opts = {'figsize': None, 'cmap': 'jet', 'cmap_min': 0.,
                     'cmap_max': 1., 'zticks': None, 'bars_spacing': 0.1,
                     'bars_alpha': 1., 'bars_lw': 0.5, 'bars_edgecolor': 'k',
-                    'shade': False, 'azim': 65, 'elev': 30,
+                    'shade': False, 'azim': -35, 'elev': 35,
                     'proj_type': 'ortho', 'stick': False,
                     'cbar_pad': 0.04, 'cbarmax_to_zmax': False}
 
@@ -696,7 +697,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         ax = _axes3D(fig,
                      azim=default_opts['azim'] % 360,
                      elev=default_opts['elev'] % 360)
-    ax.set_proj_type(default_opts['proj_type'])
+        ax.set_proj_type(default_opts['proj_type'])
 
     ax.bar3d(xpos, ypos, zpos, dx, dy, dz, color=colors,
              edgecolors=default_opts['bars_edgecolor'],

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -416,16 +416,16 @@ def sphereplot(theta, phi, values, fig=None, ax=None, save=False):
 
 
 def _limit_finder(z):
-    """Finds nearest proper 0.5 value
-    This funtion is used when limits is not passed to matrix_histogtam
+    """finds nearest proper 0.5 value
+    funtion used when limits is not passed to matrix_histogtam
     If z > 0 it returns the higher half value
     If z < 0 it returns the lower half value
     examples:
-        if z=+0.1  returns 0.5
-        if z=-0.1 returns -0.5
-        if z=-2.4 returns -2.5
-        if z=+3.8  returns 4.0
-        if z=-5.0 returns -5.0
+        if z = +0.1 returns +0.5
+        if z = -0.1 returns -0.5
+        if z = -2.4 returns -2.5
+        if z = +3.8 returns +4.0
+        if z = -5.0 returns -5.0
 
     Parameters
     ----------
@@ -445,7 +445,7 @@ def _limit_finder(z):
 
 def _remove_margins(axis):
     """
-    Removes margins about z=0 and improves the style
+    removes margins about z = 0 and improves the style
     by monkey patching
     """
     def _get_coord_info_new(renderer):
@@ -461,7 +461,7 @@ def _remove_margins(axis):
 
 def _truncate_colormap(cmap, minval=0.0, maxval=1.0, n=100):
     """
-    Truncates portion of a colormap and returns the new one
+    truncates portion of a colormap and returns the new one
     """
     if isinstance(cmap, str):
         cmap = plt.get_cmap(cmap)
@@ -473,7 +473,7 @@ def _truncate_colormap(cmap, minval=0.0, maxval=1.0, n=100):
 
 
 def _stick_to_planes(stick, azim, ax, M, spacing):
-    """Adjusts xlim and ylim in way that bars will
+    """adjusts xlim and ylim in way that bars will
     Stick to xz and yz planes
     """
     if stick is True:
@@ -483,12 +483,12 @@ def _stick_to_planes(stick, azim, ax, M, spacing):
             ax.set_xlim(1 - .5,)
         elif 90 < azim <= 180:
             ax.set_ylim(1 - .5,)
-            ax.set_xlim(0, M.shape[0]+(.5 - spacing))
+            ax.set_xlim(0, M.shape[0] + (.5 - spacing))
         elif 180 < azim <= 270:
-            ax.set_ylim(0, M.shape[1]+(.5 - spacing))
-            ax.set_xlim(0, M.shape[0]+(.5 - spacing))
+            ax.set_ylim(0, M.shape[1] + (.5 - spacing))
+            ax.set_xlim(0, M.shape[0] + (.5 - spacing))
         elif 270 < azim < 360:
-            ax.set_ylim(0, M.shape[1]+(.5 - spacing))
+            ax.set_ylim(0, M.shape[1] + (.5 - spacing))
             ax.set_xlim(1 - .5,)
 
 
@@ -496,7 +496,7 @@ def _update_yaxis(spacing, M, ax, ylabels):
     """
     updates the y-axis
     """
-    ytics = [x+(1 - (spacing / 2)) for x in range(M.shape[1])]
+    ytics = [x + (1 - (spacing / 2)) for x in range(M.shape[1])]
     ax.axes.w_yaxis.set_major_locator(plt.FixedLocator(ytics))
     if ylabels:
         nylabels = len(ylabels)
@@ -507,14 +507,14 @@ def _update_yaxis(spacing, M, ax, ylabels):
         ax.set_yticklabels([str(y + 1) for y in range(M.shape[1])])
         ax.set_yticklabels([str(i) for i in range(M.shape[1])])
     ax.tick_params(axis='y', labelsize=14)
-    ax.set_yticks([y+(1 - (spacing / 2)) for y in range(M.shape[1])])
+    ax.set_yticks([y + (1 - (spacing / 2)) for y in range(M.shape[1])])
 
 
 def _update_xaxis(spacing, M, ax, xlabels):
     """
     updates the x-axis
     """
-    xtics = [x+(1 - (spacing / 2)) for x in range(M.shape[1])]
+    xtics = [x + (1 - (spacing / 2)) for x in range(M.shape[1])]
     ax.axes.w_xaxis.set_major_locator(plt.FixedLocator(xtics))
     if xlabels:
         nxlabels = len(xlabels)
@@ -525,7 +525,7 @@ def _update_xaxis(spacing, M, ax, xlabels):
         ax.set_xticklabels([str(x + 1) for x in range(M.shape[0])])
         ax.set_xticklabels([str(i) for i in range(M.shape[0])])
     ax.tick_params(axis='x', labelsize=14)
-    ax.set_xticks([x+(1 - (spacing / 2)) for x in range(M.shape[0])])
+    ax.set_xticks([x + (1 - (spacing / 2)) for x in range(M.shape[0])])
 
 
 def _update_zaxis(ax, z_min, z_max, zticks):
@@ -606,20 +606,20 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
             color of bars' edges, examples: 'k', (0.1, 0.2, 0.5), '#0f0f0f80'
 
         'shade' : bool (default: True)
-            when True, this shades the dark sides of the bars (relative
-            to the plot's source of light).
+            when True, this shades dark sides of the bars (relative
+            to plot's source of light).
 
         'azim' : float
-            Azimuthal viewing angle.
+            azimuthal viewing angle.
 
         'elev' : float
-            Elevation viewing angle.
+            elevation viewing angle.
 
-        'proj_type' : string (default: 'ortho')
+        'proj_type' : string (default: 'ortho' if ax is not passed)
             type of projection ('ortho' or 'persp')
 
         'stick' : bool (default: False)
-            changes xlim and ylim in a way that bars next to the
+            changes xlim and ylim in a way that bars next to
             xz and yz planes will stick to those planes
             works if ax is not passed to the function
 
@@ -648,7 +648,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
 
     # default options
     default_opts = {'figsize': None, 'cmap': 'jet', 'cmap_min': 0.,
-                    'cmap_max': 1., 'zticks': None, 'bars_spacing': 0.1,
+                    'cmap_max': 1., 'zticks': None, 'bars_spacing': 0.2,
                     'bars_alpha': 1., 'bars_lw': 0.5, 'bars_edgecolor': 'k',
                     'shade': False, 'azim': -35, 'elev': 35,
                     'proj_type': 'ortho', 'stick': False,
@@ -673,7 +673,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     xpos = xpos.T.flatten() + 0.5
     ypos = ypos.T.flatten() + 0.5
     zpos = np.zeros(n)
-    dx = dy = (1-default_opts['bars_spacing']) * np.ones(n)
+    dx = dy = (1 - default_opts['bars_spacing']) * np.ones(n)
     dz = np.real(M.flatten())
 
     if isinstance(limits, list) and len(limits) == 2:

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -67,7 +67,6 @@ try:
     import matplotlib as mpl
     from matplotlib import cm
     from mpl_toolkits.mplot3d import Axes3D
-    from mpl_toolkits.mplot3d.axis3d import Axis
 
     # Define a custom _axes3D function based on the matplotlib version.
     # The auto_add_to_figure keyword is new for matplotlib>=3.4.
@@ -577,30 +576,34 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         show colorbar
 
     options : dict
-        dictionary containing extra options
-        all keys are of type `str` and values have different types
-        key:value  pairs should be as follows:
+        A dictionary containing extra options for the plot.
+        The names (keys) and values of the options are 
+        described below:
 
         'zticks' : list of numbers
-            list of z-axis ticks location
+            A list of z-axis tick locations.
 
         'cmap' : string (default: 'jet')
-            colormap name
+            The name of the color map to use.
 
         'cmap_min' : float (default: 0.0)
-            colormap truncation minimum, a value in range 0-1
+            The lower bound to truncate the color map at.
+            A value in range 0 - 1. The default, 0, leaves the lower
+            bound of the map unchanged.
 
         'cmap_max' : float (default: 1.0)
-            colormap truncation maximum, a value in range 0-1
+            The upper bound to truncate the color map at.
+            A value in range 0 - 1. The default, 1, leaves the upper
+            bound of the map unchanged.
 
         'bars_spacing' : float (default: 0.1)
-            spacing between bars
+            spacing between bars.
 
         'bars_alpha' : float (default: 1.)
-            transparency of bars, should be in range 0-1
+            transparency of bars, should be in range 0 - 1
 
         'bars_lw' : float (default: 0.5)
-            linewidth of bars' edges
+            linewidth of bars' edges.
 
         'bars_edgecolor' : color (default: 'k')
             color of bars' edges, examples: 'k', (0.1, 0.2, 0.5), '#0f0f0f80'
@@ -616,22 +619,24 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
             elevation viewing angle.
 
         'proj_type' : string (default: 'ortho' if ax is not passed)
-            type of projection ('ortho' or 'persp')
+            The type of projection ('ortho' or 'persp')
 
         'stick' : bool (default: False)
-            changes xlim and ylim in a way that bars next to
-            xz and yz planes will stick to those planes
-            works if ax is not passed to the function
+            Changes xlim and ylim in such a way that bars next to
+            XZ and YZ planes will stick to those planes.
+            This option has no effect if ``ax`` is passed as a parameter.
 
         'cbar_pad' : float (default: 0.04)
-            fraction of original axes between colorbar and new image axes
-            (padding between 3D figure and colorbar).
+            The fraction of the original axes between the colorbar
+            and the new image axes.
+            (i.e. the padding between the 3D figure and the colorbar).
 
         'cbarmax_to_zmax' : bool (default: False)
-            set color of maximum z-value to maximum color of colorbar
+            Whether to set the color of maximum z-value to the maximum color
+            in the colorbar (True) or not (False).
 
         'figsize' : tuple of two numbers
-            size of the figure
+            The size of the figure.
 
     Returns :
     -------

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -414,34 +414,6 @@ def sphereplot(theta, phi, values, fig=None, ax=None, save=False):
     return fig, ax
 
 
-def _limit_finder(z):
-    """finds nearest proper 0.5 value
-    funtion used when limits is not passed to matrix_histogtam
-    If z > 0 it returns the higher half value
-    If z < 0 it returns the lower half value
-    examples:
-        if z = +0.1 returns +0.5
-        if z = -0.1 returns -0.5
-        if z = -2.4 returns -2.5
-        if z = +3.8 returns +4.0
-        if z = -5.0 returns -5.0
-
-    Parameters
-    ----------
-    z : float or int
-
-    Returns
-    -------
-    limit : float
-        nearest proper 0.5 value.
-    """
-    if z > 0:
-        limit = np.ceil(z * 2) / 2
-    else:
-        limit = np.floor(z * 2) / 2
-    return limit
-
-
 def _remove_margins(axis):
     """
     removes margins about z = 0 and improves the style
@@ -542,9 +514,6 @@ def _update_zaxis(ax, z_min, z_max, zticks):
 
     if zticks:
         ax.set_zticks(zticks)
-    else:
-        ax.set_zticks([z_min + 0.5 * i for i in
-                       range(int((z_max - z_min) / 0.5) + 1)])
 
 
 def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
@@ -632,9 +601,9 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
             and the new image axes.
             (i.e. the padding between the 3D figure and the colorbar).
 
-        'cbarmax_to_zmax' : bool (default: False)
-            Whether to set the color of maximum z-value to the maximum color
-            in the colorbar (True) or not (False).
+        'cbar_to_z' : bool (default: False)
+            Whether to set the color of maximum and minimum z-values to the
+            maximum and minimum colors in the colorbar (True) or not (False).
 
         'figsize' : tuple of two numbers
             The size of the figure.
@@ -658,7 +627,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
                     'bars_alpha': 1., 'bars_lw': 0.5, 'bars_edgecolor': 'k',
                     'shade': False, 'azim': -35, 'elev': 35,
                     'proj_type': 'ortho', 'stick': False,
-                    'cbar_pad': 0.04, 'cbarmax_to_zmax': False}
+                    'cbar_pad': 0.04, 'cbar_to_z': False}
 
     # update default_opts from input options
     if options:
@@ -686,11 +655,13 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         z_min = limits[0]
         z_max = limits[1]
     else:
-        limits = [_limit_finder(min(dz)), _limit_finder(max(dz))]
-        z_min = limits[0]
-        z_max = limits[1]
+        z_min = min(dz)
+        z_max = max(dz)
+        if z_min == z_max:
+            z_min -= 0.1
+            z_max += 0.1
 
-    if default_opts['cbarmax_to_zmax']:
+    if default_opts['cbar_to_z']:
         norm = mpl.colors.Normalize(min(dz), max(dz))
     else:
         norm = mpl.colors.Normalize(z_min, z_max)

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -544,7 +544,7 @@ def _update_zaxis(ax, z_min, z_max, zticks):
     if zticks:
         ax.set_zticks(zticks)
     else:
-        ax.set_zticks([z_min + 0.5 * i for i in 
+        ax.set_zticks([z_min + 0.5 * i for i in
                        range(int((z_max - z_min) / 0.5) + 1)])
 
 
@@ -619,7 +619,9 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
             type of projection ('ortho' or 'persp')
 
         'stick' : bool (default: False)
-            works for Azimuthal viewing angles
+            changes xlim and ylim in a way that bars next to the
+            xz and yz planes will stick to those planes
+            works if ax is not passed to the function
 
         'cbar_pad' : float (default: 0.04)
             fraction of original axes between colorbar and new image axes

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -657,12 +657,11 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     if options:
         # check if keys in options dict are valid
         if set(options) - set(default_opts):
-            raise ValueError("invalid key(s) found in options: "\
+            raise ValueError("invalid key(s) found in options: "+
                              f"{', '.join(set(options) - set(default_opts))}")
         else:
             # updating default options
             default_opts.update(options)
-
 
     if isinstance(M, Qobj):
         # extract matrix data from Qobj
@@ -724,7 +723,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
 
     # stick to xz and yz plane
     _stick_to_planes(default_opts['stick'],
-                     default_opts['azim'],ax, M,
+                     default_opts['azim'], ax, M,
                      default_opts['bars_spacing'])
 
     # color axis

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -606,17 +606,17 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
             linewidth of bars' edges.
 
         'bars_edgecolor' : color (default: 'k')
-            color of bars' edges, examples: 'k', (0.1, 0.2, 0.5), '#0f0f0f80'
+            The colors of the bars' edges. For example: 'k', (0.1, 0.2, 0.5) or '#0f0f0f80'.
 
         'shade' : bool (default: True)
-            when True, this shades dark sides of the bars (relative
-            to plot's source of light).
+            Whether to shade the dark sides of the bars (True) or not (False). The shading is relative
+            to plot's source of light.
 
         'azim' : float
-            azimuthal viewing angle.
+            The azimuthal viewing angle.
 
         'elev' : float
-            elevation viewing angle.
+            The elevation viewing angle.
 
         'proj_type' : string (default: 'ortho' if ax is not passed)
             The type of projection ('ortho' or 'persp')

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -655,7 +655,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     if options:
         # check if keys in options dict are valid
         if set(options) - set(default_opts):
-            raise ValueError("invalid key(s) found in options: " + \
+            raise ValueError("invalid key(s) found in options: "
                              f"{', '.join(set(options) - set(default_opts))}")
         else:
             # updating default options

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -606,11 +606,12 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
             linewidth of bars' edges.
 
         'bars_edgecolor' : color (default: 'k')
-            The colors of the bars' edges. For example: 'k', (0.1, 0.2, 0.5) or '#0f0f0f80'.
+            The colors of the bars' edges.
+            Examples: 'k', (0.1, 0.2, 0.5) or '#0f0f0f80'.
 
         'shade' : bool (default: True)
-            Whether to shade the dark sides of the bars (True) or not (False). The shading is relative
-            to plot's source of light.
+            Whether to shade the dark sides of the bars (True) or not (False).
+            The shading is relative to plot's source of light.
 
         'azim' : float
             The azimuthal viewing angle.

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -623,7 +623,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
                     'cbar_pad': 0.04, 'cbar_to_z': False}
 
     # update default_opts from input options
-    if options:
+    if isinstance(options, dict):
         # check if keys in options dict are valid
         if set(options) - set(default_opts):
             raise ValueError("invalid key(s) found in options: "
@@ -631,6 +631,8 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         else:
             # updating default options
             default_opts.update(options)
+    else:
+        raise ValueError("options must be a dictionary")
 
     if isinstance(M, Qobj):
         # extract matrix data from Qobj
@@ -661,7 +663,6 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     cmap = _truncate_colormap(default_opts['cmap'],
                               default_opts['cmap_min'],
                               default_opts['cmap_max'])
-    # Spectral
     colors = cmap(norm(dz))
 
     if ax is None:

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -415,11 +415,12 @@ def sphereplot(theta, phi, values, fig=None, ax=None, save=False):
     return fig, ax
 
 
-def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None, title=None, limits=None,
-                     fig=None, ax=None, figsize=None,
-                     colorbar=True, cmap='jet', cmap_min=0., cmap_max=1., 
-                     bars_spacing=0.1, bars_alpha=1., bars_lw=0.5, bars_edgecolor='k', shade=False,
-                     azim=65, elev=30, proj_type='ortho', stick=False, cbar_pad=0.04):
+def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None,
+                     title=None, limits=None, fig=None, ax=None, figsize=None,
+                     colorbar=True, cmap='jet', cmap_min=0., cmap_max=1.,
+                     bars_spacing=0.1, bars_alpha=1., bars_lw=0.5,
+                     bars_edgecolor='k', shade=False, azim=65, elev=30,
+                     proj_type='ortho', stick=False, cbar_pad=0.04):
     """
     Draw a histogram for the matrix M, with the given x and y labels and title.
 
@@ -447,25 +448,25 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None, title=None, lim
         The axes context in which the plot will be drawn.
 
     cmap : string (default: 'jet')
-        colormap name 
-    
+        colormap name
+
     cmap_min : float (default: 0.0)
         colormap truncation minimum, a value in range 0-1
 
     cmap_max : float (default: 1.0)
         colormap truncation maximum, a value in range 0-1
-    
+
     bars_spacing : float (default: 0.1)
         spacing between bars
-    
+
     bars_alpha : float (default: 1.)
         transparency of bars, should be in range 0-1
 
     bars_lw : float (default: 0.5)
         linewidth of bars' edges
-        
+
     bars_edgecolor : color (default: 'k')
-        color of bars' edges, examples: 'k', '1', (0.1, 0.2, 0.5), '#0f0f0f80',...
+        color of bars' edges, examples: 'k', (0.1, 0.2, 0.5), '#0f0f0f80'
     
     shade : bool (default: True)
         when True, this shades the dark sides of the bars (relative
@@ -473,23 +474,24 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None, title=None, lim
 
     azim : float
         Azimuthal viewing angle.
-    
+
     elev : float
         Elevation viewing angle.
-    
+
     proj_type : string (default: 'ortho')
         type of projection ('ortho' or 'persp')
-    
+
     stick : bool (default: False)
-        works for Azimuthal viewing angles between -360 and +360 
-    
+        works for Azimuthal viewing angles between -360 and +360
+
     cbar_pad : float (default: 0.04)
-        fraction of original axes between colorbar and new image axes (padding between 3D figure and colorbar).
+        fraction of original axes between colorbar and new image axes
+        (padding between 3D figure and colorbar).
 
     figsize : tuple of two numbers
         size of the figure
 
-    Returns : 
+    Returns :
     -------
     fig, ax : tuple
         A tuple of the matplotlib figure and axes instances used to produce
@@ -504,39 +506,40 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None, title=None, lim
 
     # limit finder function
     def lim_finder(z):
-        if z>0:
-            if int(z+0.5)<z<int(z)+0.5 or z%1==0.5:
-                return int(z)+0.5
+        if z > 0:
+            if int(z+0.5) < z < int(z)+0.5 or z % 1 == 0.5:
+                limit = int(z)+0.5
             else:
-                return int(z+0.5)
-        elif z<0:
-            if int(z-0.5)>z>int(z)-0.5 or z%1==0.5:
-                return int(z)-0.5 
+                limit = int(z+0.5)
+        elif z < 0:
+            if int(z-0.5) > z > int(z)-0.5 or z % 1 == 0.5:
+                limit = int(z)-0.5
             else:
-                return int(z-0.5)
+                limit = int(z-0.5)
         else:
-            return 0
+            limit = 0
+        return limit
 
     # colormap truncation function
     def truncate_colormap(cmap, minval=0.0, maxval=1.0, n=100):
         if isinstance(cmap, str):
             cmap = plt.get_cmap(cmap)
         new_cmap = mpl.colors.LinearSegmentedColormap.from_list(
-            'trunc({n},{a:.2f},{b:.2f})'.format(n=cmap.name, a=minval, b=maxval),
-                                                cmap(np.linspace(minval, maxval, n)))
+            'trunc({n},{a:.2f},{b:.2f})'.format(
+                n=cmap.name, a=minval, b=maxval),
+            cmap(np.linspace(minval, maxval, n)))
         return new_cmap
 
     # patch
     if not hasattr(Axis, "_get_coord_info_old"):
         def _get_coord_info_new(self, renderer):
-            mins, maxs, centers, deltas, tc, highs = self._get_coord_info_old(renderer)
-            mins += deltas / 4
-            maxs -= deltas / 4
+            mins, maxs, centers, deltas, tc, highs = \
+                self._get_coord_info_old(renderer)
+            mins += deltas/4
+            maxs -= deltas/4
             return mins, maxs, centers, deltas, tc, highs
-        Axis._get_coord_info_old = Axis._get_coord_info  
+        Axis._get_coord_info_old = Axis._get_coord_info
         Axis._get_coord_info = _get_coord_info_new
-
-
 
     if isinstance(M, Qobj):
         # extract matrix data from Qobj
@@ -554,7 +557,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None, title=None, lim
         z_min = limits[0]
         z_max = limits[1]
     else:
-        limits = [lim_finder(min(dz)),lim_finder(max(dz))]
+        limits = [lim_finder(min(dz)), lim_finder(max(dz))]
         z_min = limits[0]
         z_max = limits[1]
 
@@ -570,7 +573,9 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None, title=None, lim
         ax = _axes3D(fig, azim=azim, elev=elev)
     ax.set_proj_type(proj_type)
 
-    ax.bar3d(xpos, ypos, zpos, dx, dy, dz, color=colors, edgecolors=bars_edgecolor, linewidths=bars_lw, alpha=bars_alpha, shade=shade)
+    ax.bar3d(xpos, ypos, zpos, dx, dy, dz, color=colors,
+             edgecolors=bars_edgecolor, linewidths=bars_lw,
+             alpha=bars_alpha, shade=shade)
     # remove vertical lines on xz and yz plane
     ax.yaxis._axinfo["grid"]['linewidth'] = 0
     ax.xaxis._axinfo["grid"]['linewidth'] = 0
@@ -606,17 +611,15 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None, title=None, lim
     ax.set_yticks([y+(1-(bars_spacing/2)) for y in range(M.shape[1])])
     ax.set_yticklabels([str(i) for i in range(M.shape[1])])
 
-
     # z axis
     ax.axes.w_zaxis.set_major_locator(plt.IndexLocator(1, 0.5))
     # ax.set_zlim3d([min(z_min, 0), z_max])
-    if z_min>0 and z_max>0:
+    if z_min > 0 and z_max > 0:
         ax.set_zlim3d([0, z_max])
-    elif z_min<0 and z_max<0:
+    elif z_min < 0 and z_max < 0:
         ax.set_zlim3d([0, z_min])
     else:
         ax.set_zlim3d([z_min, z_max])
-    
 
     if zticks:
         ax.set_zticks(zticks)
@@ -624,18 +627,18 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None, title=None, lim
         ax.set_zticks([z_min+0.5*i for i in range(int((z_max-z_min)/0.5)+1)])
 
     # stick to xz and yz plane
-    if stick== True:
-        if 0<azim<=90 or -360<=azim<-270 or azim==0:
+    if stick is True:
+        if 0 < azim <= 90 or -360 <= azim <- 270 or azim == 0:
             ax.set_ylim(1-0.55,)
             ax.set_xlim(1-0.55,)
-        elif 90<azim<=180 or -270<=azim<-180:
+        elif 90 < azim <= 180 or -270 <= azim <- 180:
             ax.set_ylim(1-0.55,)
-            ax.set_xlim(0,M.shape[0]+(.5-bars_spacing))     
-        elif 180<azim<=270 or -180<=azim<-90:
-            ax.set_ylim(0,M.shape[1]+(.5-bars_spacing))
-            ax.set_xlim(0,M.shape[0]+(.5-bars_spacing))
-        elif 270<azim<=360 or -90<=azim<0:
-            ax.set_ylim(0,M.shape[1]+(.5-bars_spacing))
+            ax.set_xlim(0, M.shape[0]+(.5-bars_spacing))
+        elif 180 < azim <= 270 or -180 <= azim <- 90:
+            ax.set_ylim(0, M.shape[1]+(.5-bars_spacing))
+            ax.set_xlim(0, M.shape[0]+(.5-bars_spacing))
+        elif 270 < azim <= 360 or -90 <= azim < 0:
+            ax.set_ylim(0, M.shape[1]+(.5-bars_spacing))
             ax.set_xlim(1-0.55,)
 
     # color axis

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -496,6 +496,36 @@ def _stick_to_planes(stick, azim, ax, M, bars_spacing):
             ax.set_xlim(1-0.55,)
 
 
+def _update_yaxis(bars_spacing, M, ax, ylabels):
+    ytics = [x+(1-(bars_spacing/2)) for x in range(M.shape[1])]
+    ax.axes.w_yaxis.set_major_locator(plt.FixedLocator(ytics))
+    if ylabels:
+        nylabels = len(ylabels)
+        if nylabels != len(ytics):
+            raise ValueError(f"got {nylabels} ylabels but needed {len(ytics)}")
+        ax.set_yticklabels(ylabels)
+    else:
+        ax.set_yticklabels([str(y+1) for y in range(M.shape[1])])
+    ax.tick_params(axis='y', labelsize=14)
+    ax.set_yticks([y+(1-(bars_spacing/2)) for y in range(M.shape[1])])
+    ax.set_yticklabels([str(i) for i in range(M.shape[1])])
+
+def _update_xaxis(bars_spacing, M, ax, xlabels):
+    xtics = [x+(1-(bars_spacing/2)) for x in range(M.shape[1])]
+    ax.axes.w_xaxis.set_major_locator(plt.FixedLocator(xtics))
+    if xlabels:
+        nxlabels = len(xlabels)
+        if nxlabels != len(xtics):
+            raise ValueError(f"got {nxlabels} xlabels but needed {len(xtics)}")
+        ax.set_xticklabels(xlabels)
+    else:
+        ax.set_xticklabels([str(x+1) for x in range(M.shape[0])])
+
+    ax.tick_params(axis='x', labelsize=14)
+    ax.set_xticks([x+(1-(bars_spacing/2)) for x in range(M.shape[0])])
+    ax.set_xticklabels([str(i) for i in range(M.shape[0])])
+
+
 def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
                      colorbar=True, fig=None, ax=None, options=None):
     """
@@ -613,6 +643,23 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         # updating default options
         default_opts.update(options)
 
+    figsize = default_opts['figsize']
+    cmap = default_opts['cmap']
+    cmap_min = default_opts['cmap_min']
+    cmap_max = default_opts['cmap_max']
+    zticks = default_opts['zticks']
+    bars_spacing = default_opts['bars_spacing']
+    bars_alpha = default_opts['bars_alpha']
+    bars_lw = default_opts['bars_lw']
+    bars_edgecolor = default_opts['bars_edgecolor']
+    shade = default_opts['shade']
+    azim = default_opts['azim']
+    elev = default_opts['elev']
+    proj_type = default_opts['proj_type']
+    stick = default_opts['stick']
+    cbar_pad = default_opts['cbar_pad']
+    cbarmax_to_zmax = default_opts['cbarmax_to_zmax']
+
     if isinstance(M, Qobj):
         # extract matrix data from Qobj
         M = M.full()
@@ -622,7 +669,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     xpos = xpos.T.flatten() + 0.5
     ypos = ypos.T.flatten() + 0.5
     zpos = np.zeros(n)
-    dx = dy = (1-default_opts['bars_spacing']) * np.ones(n)
+    dx = dy = (1-bars_spacing) * np.ones(n)
     dz = np.real(M.flatten())
 
     if isinstance(limits, list) and len(limits) == 2:
@@ -633,31 +680,25 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         z_min = limits[0]
         z_max = limits[1]
 
-    if default_opts['cbarmax_to_zmax']:
+    if cbarmax_to_zmax:
         norm = mpl.colors.Normalize(min(dz), max(dz))
     else:
         norm = mpl.colors.Normalize(z_min, z_max)
-    cmap = _truncate_colormap(default_opts['cmap'],
-                              default_opts['cmap_min'],
-                              default_opts['cmap_max'])
+    cmap = _truncate_colormap(cmap, cmap_min, cmap_max)
     # Spectral
     colors = cmap(norm(dz))
 
     if ax is None:
-        if default_opts['figsize']:
-            fig = plt.figure(figsize=default_opts['figsize'])
+        if figsize:
+            fig = plt.figure(figsize=figsize)
         else:
             fig = plt.figure()
-        ax = _axes3D(fig,
-                     azim=default_opts['azim'],
-                     elev=default_opts['elev'])
-    ax.set_proj_type(default_opts['proj_type'])
+        ax = _axes3D(fig, azim=azim, elev=elev)
+    ax.set_proj_type(proj_type)
 
     ax.bar3d(xpos, ypos, zpos, dx, dy, dz, color=colors,
-             edgecolors=default_opts['bars_edgecolor'],
-             linewidths=default_opts['bars_lw'],
-             alpha=default_opts['bars_alpha'],
-             shade=default_opts['shade'])
+             edgecolors=bars_edgecolor, linewidths=bars_lw,
+             alpha=bars_alpha, shade=shade)
     # remove vertical lines on xz and yz plane
     ax.yaxis._axinfo["grid"]['linewidth'] = 0
     ax.xaxis._axinfo["grid"]['linewidth'] = 0
@@ -666,37 +707,14 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         ax.set_title(title)
 
     # x axis
-    xtics = [x+(1-(default_opts['bars_spacing']/2)) for x in range(M.shape[1])]
-    ax.axes.w_xaxis.set_major_locator(plt.FixedLocator(xtics))
-    if xlabels:
-        nxlabels = len(xlabels)
-        if nxlabels != len(xtics):
-            raise ValueError(f"got {nxlabels} xlabels but needed {len(xtics)}")
-        ax.set_xticklabels(xlabels)
-    else:
-        ax.set_xticklabels([str(x+1) for x in range(M.shape[0])])
-
-    ax.tick_params(axis='x', labelsize=14)
-    ax.set_xticks([x+(1-(default_opts['bars_spacing']/2)) for x in range(M.shape[0])])
-    ax.set_xticklabels([str(i) for i in range(M.shape[0])])
+    _update_xaxis(bars_spacing, M, ax, xlabels)
 
     # y axis
-    ytics = [x+(1-(default_opts['bars_spacing']/2)) for x in range(M.shape[1])]
-    ax.axes.w_yaxis.set_major_locator(plt.FixedLocator(ytics))
-    if ylabels:
-        nylabels = len(ylabels)
-        if nylabels != len(ytics):
-            raise ValueError(f"got {nylabels} ylabels but needed {len(ytics)}")
-        ax.set_yticklabels(ylabels)
-    else:
-        ax.set_yticklabels([str(y+1) for y in range(M.shape[1])])
-    ax.tick_params(axis='y', labelsize=14)
-    ax.set_yticks([y+(1-(default_opts['bars_spacing']/2)) for y in range(M.shape[1])])
-    ax.set_yticklabels([str(i) for i in range(M.shape[1])])
+    _update_yaxis(bars_spacing, M, ax, ylabels)
 
     # z axis
     ax.axes.w_zaxis.set_major_locator(plt.IndexLocator(1, 0.5))
-
+    # ax.set_zlim3d([min(z_min, 0), z_max])
     if z_min > 0 and z_max > 0:
         ax.set_zlim3d([0, z_max])
     elif z_min < 0 and z_max < 0:
@@ -704,19 +722,17 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     else:
         ax.set_zlim3d([z_min, z_max])
 
-    if default_opts['zticks']:
-        ax.set_zticks(default_opts['zticks'])
+    if zticks:
+        ax.set_zticks(zticks)
     else:
         ax.set_zticks([z_min+0.5*i for i in range(int((z_max-z_min)/0.5)+1)])
 
     # stick to xz and yz plane
-    _stick_to_planes(default_opts['stick'], default_opts['azim'],
-                     ax, M, default_opts['bars_spacing'])
+    _stick_to_planes(stick, azim, ax, M, bars_spacing)
 
     # color axis
     if colorbar:
-        cax, kw = mpl.colorbar.make_axes(ax, shrink=.75,
-                                         pad=default_opts['cbar_pad'])
+        cax, kw = mpl.colorbar.make_axes(ax, shrink=.75, pad=cbar_pad)
         mpl.colorbar.ColorbarBase(cax, cmap=cmap, norm=norm)
 
     return fig, ax

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -510,6 +510,7 @@ def _update_yaxis(bars_spacing, M, ax, ylabels):
     ax.set_yticks([y+(1-(bars_spacing/2)) for y in range(M.shape[1])])
     ax.set_yticklabels([str(i) for i in range(M.shape[1])])
 
+
 def _update_xaxis(bars_spacing, M, ax, xlabels):
     xtics = [x+(1-(bars_spacing/2)) for x in range(M.shape[1])]
     ax.axes.w_xaxis.set_major_locator(plt.FixedLocator(xtics))
@@ -520,10 +521,25 @@ def _update_xaxis(bars_spacing, M, ax, xlabels):
         ax.set_xticklabels(xlabels)
     else:
         ax.set_xticklabels([str(x+1) for x in range(M.shape[0])])
-
     ax.tick_params(axis='x', labelsize=14)
     ax.set_xticks([x+(1-(bars_spacing/2)) for x in range(M.shape[0])])
     ax.set_xticklabels([str(i) for i in range(M.shape[0])])
+
+
+def _update_zaxis(ax, z_min, z_max, zticks):
+    ax.axes.w_zaxis.set_major_locator(plt.IndexLocator(1, 0.5))
+    # ax.set_zlim3d([min(z_min, 0), z_max])
+    if z_min > 0 and z_max > 0:
+        ax.set_zlim3d([0, z_max])
+    elif z_min < 0 and z_max < 0:
+        ax.set_zlim3d([0, z_min])
+    else:
+        ax.set_zlim3d([z_min, z_max])
+
+    if zticks:
+        ax.set_zticks(zticks)
+    else:
+        ax.set_zticks([z_min+0.5*i for i in range(int((z_max-z_min)/0.5)+1)])
 
 
 def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
@@ -713,19 +729,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     _update_yaxis(bars_spacing, M, ax, ylabels)
 
     # z axis
-    ax.axes.w_zaxis.set_major_locator(plt.IndexLocator(1, 0.5))
-    # ax.set_zlim3d([min(z_min, 0), z_max])
-    if z_min > 0 and z_max > 0:
-        ax.set_zlim3d([0, z_max])
-    elif z_min < 0 and z_max < 0:
-        ax.set_zlim3d([0, z_min])
-    else:
-        ax.set_zlim3d([z_min, z_max])
-
-    if zticks:
-        ax.set_zticks(zticks)
-    else:
-        ax.set_zticks([z_min+0.5*i for i in range(int((z_max-z_min)/0.5)+1)])
+    _update_zaxis(ax, z_min, z_max, zticks)
 
     # stick to xz and yz plane
     _stick_to_planes(stick, azim, ax, M, bars_spacing)

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -416,7 +416,7 @@ def sphereplot(theta, phi, values, fig=None, ax=None, save=False):
 
 
 def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
-                      colorbar=True, fig=None, ax=None, options=None):
+                     colorbar=True, fig=None, ax=None, options=None):
     """
     Draw a histogram for the matrix M, with the given x and y labels and title.
 

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -549,11 +549,12 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         Axis._get_coord_info = _get_coord_info_new
 
     # default options
-    default_opts = {'figsize':None, 'cmap':'jet', 'cmap_min':0., 'cmap_max':1.,
-            'zticks':None, 'bars_spacing':0.1, 'bars_alpha':1., 'bars_lw':0.5,
-            'bars_edgecolor':'k', 'shade':False, 'azim':65, 'elev':30,
-            'proj_type':'ortho', 'stick':False,
-            'cbar_pad':0.04, 'cbarmax_to_zmax':False}
+    default_opts = {'figsize': None, 'cmap': 'jet', 'cmap_min': 0.,
+                    'cmap_max': 1., 'zticks': None, 'bars_spacing': 0.1,
+                    'bars_alpha': 1., 'bars_lw': 0.5, 'bars_edgecolor': 'k',
+                    'shade': False, 'azim': 65, 'elev': 30,
+                    'proj_type': 'ortho', 'stick': False,
+                    'cbar_pad': 0.04, 'cbarmax_to_zmax': False}
 
     if options:
         # check if keys in option dict are valid

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -415,12 +415,8 @@ def sphereplot(theta, phi, values, fig=None, ax=None, save=False):
     return fig, ax
 
 
-def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None,
-                     title=None, limits=None, fig=None, ax=None, figsize=None,
-                     colorbar=True, cmap='jet', cmap_min=0., cmap_max=1.,
-                     bars_spacing=0.1, bars_alpha=1., bars_lw=0.5,
-                     bars_edgecolor='k', shade=False, azim=65, elev=30,
-                     proj_type='ortho', stick=False, cbar_pad=0.04):
+def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
+                      colorbar=True, fig=None, ax=None, options=None):
     """
     Draw a histogram for the matrix M, with the given x and y labels and title.
 
@@ -434,9 +430,6 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None,
 
     ylabels : list of strings
         list of y labels
-    
-    zticks : list of numbers
-        list of z-axis ticks location
 
     title : string
         title of the plot (optional)
@@ -447,49 +440,63 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None,
     ax : a matplotlib axes instance
         The axes context in which the plot will be drawn.
 
-    cmap : string (default: 'jet')
-        colormap name
+    colorbar : bool (default: True)
+        show colorbar
 
-    cmap_min : float (default: 0.0)
-        colormap truncation minimum, a value in range 0-1
+    options : dict
+        dictionary containing extra options
+        all keys are of type `str` and values have different types
+        key:value  pairs should be as follows:
 
-    cmap_max : float (default: 1.0)
-        colormap truncation maximum, a value in range 0-1
+        'zticks' : list of numbers
+            list of z-axis ticks location
 
-    bars_spacing : float (default: 0.1)
-        spacing between bars
+        'cmap' : string (default: 'jet')
+            colormap name
 
-    bars_alpha : float (default: 1.)
-        transparency of bars, should be in range 0-1
+        'cmap_min' : float (default: 0.0)
+            colormap truncation minimum, a value in range 0-1
 
-    bars_lw : float (default: 0.5)
-        linewidth of bars' edges
+        'cmap_max' : float (default: 1.0)
+            colormap truncation maximum, a value in range 0-1
 
-    bars_edgecolor : color (default: 'k')
-        color of bars' edges, examples: 'k', (0.1, 0.2, 0.5), '#0f0f0f80'
-    
-    shade : bool (default: True)
-        when True, this shades the dark sides of the bars (relative
-        to the plot's source of light).
+        'bars_spacing' : float (default: 0.1)
+            spacing between bars
 
-    azim : float
-        Azimuthal viewing angle.
+        'bars_alpha' : float (default: 1.)
+            transparency of bars, should be in range 0-1
 
-    elev : float
-        Elevation viewing angle.
+        'bars_lw' : float (default: 0.5)
+            linewidth of bars' edges
 
-    proj_type : string (default: 'ortho')
-        type of projection ('ortho' or 'persp')
+        'bars_edgecolor' : color (default: 'k')
+            color of bars' edges, examples: 'k', (0.1, 0.2, 0.5), '#0f0f0f80'
 
-    stick : bool (default: False)
-        works for Azimuthal viewing angles between -360 and +360
+        'shade' : bool (default: True)
+            when True, this shades the dark sides of the bars (relative
+            to the plot's source of light).
 
-    cbar_pad : float (default: 0.04)
-        fraction of original axes between colorbar and new image axes
-        (padding between 3D figure and colorbar).
+        'azim' : float
+            Azimuthal viewing angle.
 
-    figsize : tuple of two numbers
-        size of the figure
+        'elev' : float
+            Elevation viewing angle.
+
+        'proj_type' : string (default: 'ortho')
+            type of projection ('ortho' or 'persp')
+
+        'stick' : bool (default: False)
+            works for Azimuthal viewing angles between -360 and +360
+
+        'cbar_pad' : float (default: 0.04)
+            fraction of original axes between colorbar and new image axes
+            (padding between 3D figure and colorbar).
+
+        'cbarmax_to_zmax' : bool (default: False)
+            set color of maximum z-value to maximum color of colorbar
+
+        'figsize' : tuple of two numbers
+            size of the figure
 
     Returns :
     -------
@@ -541,6 +548,39 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None,
         Axis._get_coord_info_old = Axis._get_coord_info
         Axis._get_coord_info = _get_coord_info_new
 
+    # default options
+    default_opts = {'figsize':None, 'cmap':'jet', 'cmap_min':0., 'cmap_max':1.,
+            'zticks':None, 'bars_spacing':0.1, 'bars_alpha':1., 'bars_lw':0.5,
+            'bars_edgecolor':'k', 'shade':False, 'azim':65, 'elev':30,
+            'proj_type':'ortho', 'stick':False,
+            'cbar_pad':0.04, 'cbarmax_to_zmax':False}
+
+    if options:
+        # check if keys in option dict are valid
+        for key in options:
+            if key not in default_opts:
+                raise ValueError(f"{key} is not a valid option")
+
+        # updating default options
+        default_opts.update(options)
+
+    figsize = default_opts['figsize']
+    cmap = default_opts['cmap']
+    cmap_min = default_opts['cmap_min']
+    cmap_max = default_opts['cmap_max']
+    zticks = default_opts['zticks']
+    bars_spacing = default_opts['bars_spacing']
+    bars_alpha = default_opts['bars_alpha']
+    bars_lw = default_opts['bars_lw']
+    bars_edgecolor = default_opts['bars_edgecolor']
+    shade = default_opts['shade']
+    azim = default_opts['azim']
+    elev = default_opts['elev']
+    proj_type = default_opts['proj_type']
+    stick = default_opts['stick']
+    cbar_pad = default_opts['cbar_pad']
+    cbarmax_to_zmax = default_opts['cbarmax_to_zmax']
+
     if isinstance(M, Qobj):
         # extract matrix data from Qobj
         M = M.full()
@@ -561,8 +601,12 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None,
         z_min = limits[0]
         z_max = limits[1]
 
-    norm = mpl.colors.Normalize(z_min, z_max)
-    cmap = truncate_colormap(cmap, cmap_min, cmap_max)  # Spectral
+    if cbarmax_to_zmax:
+        norm = mpl.colors.Normalize(min(dz), max(dz))
+    else:
+        norm = mpl.colors.Normalize(z_min, z_max)
+    cmap = truncate_colormap(cmap, cmap_min, cmap_max)
+    # Spectral
     colors = cmap(norm(dz))
 
     if ax is None:
@@ -628,13 +672,13 @@ def matrix_histogram(M, xlabels=None, ylabels=None, zticks=None,
 
     # stick to xz and yz plane
     if stick is True:
-        if 0 < azim <= 90 or -360 <= azim <- 270 or azim == 0:
+        if 0 < azim <= 90 or -360 <= azim < -270 or azim == 0:
             ax.set_ylim(1-0.55,)
             ax.set_xlim(1-0.55,)
-        elif 90 < azim <= 180 or -270 <= azim <- 180:
+        elif 90 < azim <= 180 or -270 <= azim < -180:
             ax.set_ylim(1-0.55,)
             ax.set_xlim(0, M.shape[0]+(.5-bars_spacing))
-        elif 180 < azim <= 270 or -180 <= azim <- 90:
+        elif 180 < azim <= 270 or -180 <= azim < -90:
             ax.set_ylim(0, M.shape[1]+(.5-bars_spacing))
             ax.set_xlim(0, M.shape[0]+(.5-bars_spacing))
         elif 270 < azim <= 360 or -90 <= azim < 0:

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -496,7 +496,6 @@ def _stick_to_planes(stick, azim, ax, M, bars_spacing):
             ax.set_xlim(1-0.55,)
 
 
-
 def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
                      colorbar=True, fig=None, ax=None, options=None):
     """
@@ -614,23 +613,6 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         # updating default options
         default_opts.update(options)
 
-    figsize = default_opts['figsize']
-    cmap = default_opts['cmap']
-    cmap_min = default_opts['cmap_min']
-    cmap_max = default_opts['cmap_max']
-    zticks = default_opts['zticks']
-    bars_spacing = default_opts['bars_spacing']
-    bars_alpha = default_opts['bars_alpha']
-    bars_lw = default_opts['bars_lw']
-    bars_edgecolor = default_opts['bars_edgecolor']
-    shade = default_opts['shade']
-    azim = default_opts['azim']
-    elev = default_opts['elev']
-    proj_type = default_opts['proj_type']
-    stick = default_opts['stick']
-    cbar_pad = default_opts['cbar_pad']
-    cbarmax_to_zmax = default_opts['cbarmax_to_zmax']
-
     if isinstance(M, Qobj):
         # extract matrix data from Qobj
         M = M.full()
@@ -640,7 +622,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     xpos = xpos.T.flatten() + 0.5
     ypos = ypos.T.flatten() + 0.5
     zpos = np.zeros(n)
-    dx = dy = (1-bars_spacing) * np.ones(n)
+    dx = dy = (1-default_opts['bars_spacing']) * np.ones(n)
     dz = np.real(M.flatten())
 
     if isinstance(limits, list) and len(limits) == 2:
@@ -651,25 +633,31 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         z_min = limits[0]
         z_max = limits[1]
 
-    if cbarmax_to_zmax:
+    if default_opts['cbarmax_to_zmax']:
         norm = mpl.colors.Normalize(min(dz), max(dz))
     else:
         norm = mpl.colors.Normalize(z_min, z_max)
-    cmap = _truncate_colormap(cmap, cmap_min, cmap_max)
+    cmap = _truncate_colormap(default_opts['cmap'],
+                              default_opts['cmap_min'],
+                              default_opts['cmap_max'])
     # Spectral
     colors = cmap(norm(dz))
 
     if ax is None:
-        if figsize:
-            fig = plt.figure(figsize=figsize)
+        if default_opts['figsize']:
+            fig = plt.figure(figsize=default_opts['figsize'])
         else:
             fig = plt.figure()
-        ax = _axes3D(fig, azim=azim, elev=elev)
-    ax.set_proj_type(proj_type)
+        ax = _axes3D(fig,
+                     azim=default_opts['azim'],
+                     elev=default_opts['elev'])
+    ax.set_proj_type(default_opts['proj_type'])
 
     ax.bar3d(xpos, ypos, zpos, dx, dy, dz, color=colors,
-             edgecolors=bars_edgecolor, linewidths=bars_lw,
-             alpha=bars_alpha, shade=shade)
+             edgecolors=default_opts['bars_edgecolor'],
+             linewidths=default_opts['bars_lw'],
+             alpha=default_opts['bars_alpha'],
+             shade=default_opts['shade'])
     # remove vertical lines on xz and yz plane
     ax.yaxis._axinfo["grid"]['linewidth'] = 0
     ax.xaxis._axinfo["grid"]['linewidth'] = 0
@@ -678,7 +666,7 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         ax.set_title(title)
 
     # x axis
-    xtics = [x+(1-(bars_spacing/2)) for x in range(M.shape[1])]
+    xtics = [x+(1-(default_opts['bars_spacing']/2)) for x in range(M.shape[1])]
     ax.axes.w_xaxis.set_major_locator(plt.FixedLocator(xtics))
     if xlabels:
         nxlabels = len(xlabels)
@@ -689,11 +677,11 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
         ax.set_xticklabels([str(x+1) for x in range(M.shape[0])])
 
     ax.tick_params(axis='x', labelsize=14)
-    ax.set_xticks([x+(1-(bars_spacing/2)) for x in range(M.shape[0])])
+    ax.set_xticks([x+(1-(default_opts['bars_spacing']/2)) for x in range(M.shape[0])])
     ax.set_xticklabels([str(i) for i in range(M.shape[0])])
 
     # y axis
-    ytics = [x+(1-(bars_spacing/2)) for x in range(M.shape[1])]
+    ytics = [x+(1-(default_opts['bars_spacing']/2)) for x in range(M.shape[1])]
     ax.axes.w_yaxis.set_major_locator(plt.FixedLocator(ytics))
     if ylabels:
         nylabels = len(ylabels)
@@ -703,12 +691,12 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     else:
         ax.set_yticklabels([str(y+1) for y in range(M.shape[1])])
     ax.tick_params(axis='y', labelsize=14)
-    ax.set_yticks([y+(1-(bars_spacing/2)) for y in range(M.shape[1])])
+    ax.set_yticks([y+(1-(default_opts['bars_spacing']/2)) for y in range(M.shape[1])])
     ax.set_yticklabels([str(i) for i in range(M.shape[1])])
 
     # z axis
     ax.axes.w_zaxis.set_major_locator(plt.IndexLocator(1, 0.5))
-    # ax.set_zlim3d([min(z_min, 0), z_max])
+
     if z_min > 0 and z_max > 0:
         ax.set_zlim3d([0, z_max])
     elif z_min < 0 and z_max < 0:
@@ -716,17 +704,19 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
     else:
         ax.set_zlim3d([z_min, z_max])
 
-    if zticks:
-        ax.set_zticks(zticks)
+    if default_opts['zticks']:
+        ax.set_zticks(default_opts['zticks'])
     else:
         ax.set_zticks([z_min+0.5*i for i in range(int((z_max-z_min)/0.5)+1)])
 
     # stick to xz and yz plane
-    _stick_to_planes(stick, azim, ax, M, bars_spacing)
+    _stick_to_planes(default_opts['stick'], default_opts['azim'],
+                     ax, M, default_opts['bars_spacing'])
 
     # color axis
     if colorbar:
-        cax, kw = mpl.colorbar.make_axes(ax, shrink=.75, pad=cbar_pad)
+        cax, kw = mpl.colorbar.make_axes(ax, shrink=.75,
+                                         pad=default_opts['cbar_pad'])
         mpl.colorbar.ColorbarBase(cax, cmap=cmap, norm=norm)
 
     return fig, ax


### PR DESCRIPTION
**Description**
`matrix_histogram` is much more eye-catching and has more options for syling:
1- zticks: ticks for z-axis
2- cmap: used colormap
3- cmap_min and cmap_max: truncating a portion of a colormap is now possible
4- bars_spacing: spacing between bars can be changed
5- bars_alpha: alpha channel of bars can be changed
6- bars_lw: bars' linewidth can be changed
7- bars_edgecolor: bars' color can be changed
8- shade: it's possible to turn on and off the shading
9- azimuthal and elevation angles can be changed
10- stick: bars can stick to xz and yz planes (z values can be read more easily)
11- cbar_pad: padding between the figure and the colorbar can be changed
12- proj_type: projection type can be changed to either 'perspective' or 'orthogonal'
13- xticks and yticks are now perfectly aligned to bars' center

**Changelog**

Improve the default colors and styling of matrix_histogram and provide additional styling options.