### PR TITLE
Tidy up pep8 and minor logic bugs

### DIFF
--- a/qutip/control/pulsegen.py
+++ b/qutip/control/pulsegen.py
@@ -59,29 +59,29 @@ def create_pulse_gen(pulse_type='RND', dyn=None, pulse_params=None):
     The pulse generators each produce a different type of pulse,
     see the gen_pulse function description for details.
     These are the random pulse options:
-        
+
         RND - Independent random value in each timeslot
         RNDFOURIER - Fourier series with random coefficients
         RNDWAVES - Summation of random waves
         RNDWALK1 - Random change in amplitude each timeslot
         RNDWALK2 - Random change in amp gradient each timeslot
-    
+
     These are the other non-periodic options:
-        
+
         LIN - Linear, i.e. contant gradient over the time
         ZERO - special case of the LIN pulse, where the gradient is 0
-    
+
     These are the periodic options
-        
+
         SINE - Sine wave
         SQUARE - Square wave
         SAW - Saw tooth wave
         TRIANGLE - Triangular wave
-    
+
     If a Dynamics object is passed in then this is used in instantiate
     the PulseGen, meaning that some timeslot and amplitude properties
     are copied over.
-    
+
     """
 
     if pulse_type == 'RND':
@@ -106,11 +106,11 @@ def create_pulse_gen(pulse_type='RND', dyn=None, pulse_params=None):
         return PulseGenSaw(dyn, params=pulse_params)
     elif pulse_type == 'TRIANGLE':
         return PulseGenTriangle(dyn, params=pulse_params)
-    elif pulse_type == 'GAUSSIAN':  
+    elif pulse_type == 'GAUSSIAN':
         return PulseGenGaussian(dyn, params=pulse_params)
     elif pulse_type == 'CRAB_FOURIER':
         return PulseGenCrabFourier(dyn, params=pulse_params)
-    elif pulse_type == 'GAUSSIAN_EDGE':  
+    elif pulse_type == 'GAUSSIAN_EDGE':
         return PulseGenGaussianEdge(dyn, params=pulse_params)
     else:
         raise ValueError("No option for pulse_type '{}'".format(pulse_type))
@@ -212,19 +212,19 @@ class PulseGen(object):
         self.lbound = None
         self.ubound = None
         self.ramping_pulse = None
-        
+
         self.apply_params()
-        
+
     def apply_params(self, params=None):
         """
-        Set object attributes based on the dictionary (if any) passed in the 
+        Set object attributes based on the dictionary (if any) passed in the
         instantiation, or passed as a parameter
         This is called during the instantiation automatically.
         The key value pairs are the attribute name and value
-        """               
+        """
         if not params:
             params = self.params
-        
+
         if isinstance(params, dict):
             self.params = params
             for key in params:
@@ -232,8 +232,8 @@ class PulseGen(object):
 
     @property
     def log_level(self):
-        return logger.level        
-        
+        return logger.level
+
     @log_level.setter
     def log_level(self, lvl):
         """
@@ -241,7 +241,7 @@ class PulseGen(object):
         that is call logger.setLevel(lvl)
         """
         logger.setLevel(lvl)
-        
+
     def gen_pulse(self):
         """
         returns the pulse as an array of vales for each timeslot
@@ -259,12 +259,12 @@ class PulseGen(object):
         if self.tau is None:
             self.tau = np.ones(self.num_tslots, dtype='f') * \
                 self.pulse_time/self.num_tslots
-                
+
         if self._uses_time:
             self.time = np.zeros(self.num_tslots, dtype=float)
             for k in range(self.num_tslots-1):
                 self.time[k+1] = self.time[k] + self.tau[k]
-                
+
         self._pulse_initialised = True
 
         if not self.lbound is None:
@@ -273,7 +273,7 @@ class PulseGen(object):
         if not self.ubound is None:
             if np.isinf(self.ubound):
                 self.ubound = None
-        
+
         if not self.ubound is None and not self.lbound is None:
             if self.ubound < self.lbound:
                 raise ValueError("ubound cannot be less the lbound")
@@ -317,9 +317,9 @@ class PulseGen(object):
             ramping_pulse = self.ramping_pulse
         if ramping_pulse is not None:
             pulse = pulse*ramping_pulse
-            
+
         return pulse
-        
+
 class PulseGenZero(PulseGen):
     """
     Generates a flat pulse
@@ -651,7 +651,7 @@ class PulseGenLinear(PulseGen):
 
     def init_pulse(self, gradient=None, start_val=None, end_val=None):
         """
-        Calculate the gradient if pulse is defined by start and 
+        Calculate the gradient if pulse is defined by start and
         end point values
         """
         PulseGen.init_pulse(self)
@@ -874,7 +874,7 @@ class PulseGenTriangle(PulseGenPeriodic):
             t = t + self.tau[k]
 
         return self._apply_bounds_and_offset(pulse)
-        
+
 class PulseGenGaussian(PulseGen):
     """
     Generates pulses with a Gaussian profile
@@ -888,7 +888,7 @@ class PulseGenGaussian(PulseGen):
         self.mean = 0.5*self.pulse_time
         self.variance = 0.5*self.pulse_time
         self.apply_params()
-        
+
     def gen_pulse(self, mean=None, variance=None):
         """
         Generate a pulse with Gaussian shape. The peak is centre around the
@@ -899,7 +899,7 @@ class PulseGenGaussian(PulseGen):
         """
         if not self._pulse_initialised:
             self.init_pulse()
-        
+
         if mean:
             Tm = mean
         else:
@@ -917,9 +917,9 @@ class PulseGenGaussian(PulseGen):
 class PulseGenGaussianEdge(PulseGen):
     """
     Generate pulses with inverted Gaussian ramping in and out
-    It's intended use for a ramping modulation, which is often required in 
+    It's intended use for a ramping modulation, which is often required in
     experimental setups.
-    
+
     Attributes
     ----------
         decay_time : float
@@ -945,7 +945,7 @@ class PulseGenGaussianEdge(PulseGen):
         """
         if not self._pulse_initialised:
             self.init_pulse()
-            
+
         t = self.time
         if decay_time:
             Td = decay_time
@@ -959,7 +959,7 @@ class PulseGenGaussianEdge(PulseGen):
 
 
 ### The following are pulse generators for the CRAB algorithm ###
-# AJGP 2015-05-14: 
+# AJGP 2015-05-14:
 # The intention is to have a more general base class that allows
 # setting of general basis functions
 
@@ -969,19 +969,19 @@ class PulseGenCrab(PulseGen):
     Note these are more involved in the optimisation process as they are
     used to produce piecewise control amplitudes each time new optimisation
     parameters are tried
-    
+
     Attributes
     ----------
     num_coeffs : integer
         Number of coefficients used for each basis function
-        
+
     num_basis_funcs : integer
         Number of basis functions
         In this case set at 2 and should not be changed
-        
+
     coeffs : float array[num_coeffs, num_basis_funcs]
         The basis coefficient values
-        
+
     randomize_coeffs : bool
         If True (default) then the coefficients are set to some random values
         when initialised, otherwise they will all be equal to self.scaling
@@ -991,7 +991,7 @@ class PulseGenCrab(PulseGen):
         self.num_coeffs = num_coeffs
         self.params = params
         self.reset()
-        
+
     def reset(self):
         """
         reset attributes to default values
@@ -1002,7 +1002,7 @@ class PulseGenCrab(PulseGen):
         self._BSC_ALL = 1
         self._BSC_GT_MEAN = 2
         self._BSC_LT_MEAN = 3
-        
+
         self._uses_time = True
         self.time = None
         self.num_basis_funcs = 2
@@ -1014,34 +1014,34 @@ class PulseGenCrab(PulseGen):
         self.guess_pulse = None
         self.guess_pulse_func = None
         self.apply_params()
-        
+
     def init_pulse(self, num_coeffs=None):
         """
         Set the initial freq and coefficient values
         """
         PulseGen.init_pulse(self)
         self.init_coeffs(num_coeffs=num_coeffs)
-        
+
         if self.guess_pulse is not None:
             self.init_guess_pulse()
         self._init_bounds()
-        
+
         if self.log_level <= logging.DEBUG and not self._num_coeffs_estimated:
             logger.debug(
                     "CRAB pulse initialised with {} coefficients per basis "
                     "function, which means a total of {} "
                     "optimisation variables for this pulse".format(
                             self.num_coeffs, self.num_optim_vars))
-        
+
 #    def generate_guess_pulse(self)
 #        if isinstance(self.guess_pulsegen, PulseGen):
 #            self.guess_pulse = self.guess_pulsegen.gen_pulse()
 #        return self.guess_pulse
-        
+
     def init_coeffs(self, num_coeffs=None):
         """
         Generate the initial ceofficent values.
-        
+
         Parameters
         ----------
         num_coeffs : integer
@@ -1051,7 +1051,7 @@ class PulseGenCrab(PulseGen):
         """
         if num_coeffs:
             self.num_coeffs = num_coeffs
-        
+
         self._num_coeffs_estimated = False
         if not self.num_coeffs:
             if isinstance(self.parent, dynamics.Dynamics):
@@ -1061,7 +1061,7 @@ class PulseGenCrab(PulseGen):
             else:
                 self.num_coeffs = self.DEF_NUM_COEFFS
         self.num_optim_vars = self.num_coeffs*self.num_basis_funcs
-        
+
         if self._num_coeffs_estimated:
             if self.log_level <= logging.INFO:
                 logger.info(
@@ -1079,14 +1079,14 @@ class PulseGenCrab(PulseGen):
                         "optimisation. You can set this level explicitly "
                         "to suppress this message.".format(
                             self.num_coeffs, self.NUM_COEFFS_WARN_LVL))
-                            
+
         if self.randomize_coeffs:
             r = np.random.random([self.num_coeffs, self.num_basis_funcs])
             self.coeffs = (2*r - 1.0) * self.scaling
         else:
-            self.coeffs = np.ones([self.num_coeffs, 
+            self.coeffs = np.ones([self.num_coeffs,
                                    self.num_basis_funcs])*self.scaling
-        
+
     def estimate_num_coeffs(self, dim):
         """
         Estimate the number coefficients based on the dimensionality of the
@@ -1098,32 +1098,32 @@ class PulseGenCrab(PulseGen):
         """
         num_coeffs = max(2, dim - 1)
         return num_coeffs
-        
+
     def get_optim_var_vals(self):
         """
         Get the parameter values to be optimised
         Returns
         -------
-        list (or 1d array) of floats 
+        list (or 1d array) of floats
         """
         return self.coeffs.ravel().tolist()
-    
+
     def set_optim_var_vals(self, param_vals):
         """
         Set the values of the any of the pulse generation parameters
         based on new values from the optimisation method
         Typically this will be the basis coefficients
         """
-        # Type and size checking avoided here as this is in the 
+        # Type and size checking avoided here as this is in the
         # main optmisation call sequence
         self.set_coeffs(param_vals)
-        
+
     def set_coeffs(self, param_vals):
         self.coeffs = param_vals.reshape(
                     [self.num_coeffs, self.num_basis_funcs])
-    
+
     def init_guess_pulse(self):
-        
+
         self.guess_pulse_func = None
         if not self.guess_pulse_action:
             logger.WARN("No guess pulse action given, hence ignored.")
@@ -1134,15 +1134,15 @@ class PulseGenCrab(PulseGen):
         else:
             logger.WARN("No option for guess pulse action '{}' "
                         ", hence ignored.".format(self.guess_pulse_action))
-    
+
     def guess_pulse_add(self, pulse):
         pulse = pulse + self.guess_pulse
         return pulse
-        
+
     def guess_pulse_modulate(self, pulse):
         pulse = (1.0 + pulse)*self.guess_pulse
         return pulse
-        
+
     def _init_bounds(self):
         add_guess_pulse_scale = False
         if self.lbound is None and self.ubound is None:
@@ -1176,14 +1176,14 @@ class PulseGenCrab(PulseGen):
             self._bound_mean = 0.5*(self.ubound + self.lbound)
             self._bound_scale = 0.5*(self.ubound - self.lbound)
             self._bound_scale_cond = self._BSC_ALL
-            
+
     def get_guess_pulse_scale(self):
         scale = 0.0
         if self.guess_pulse is not None:
             scale = max(np.amax(self.guess_pulse) - np.amin(self.guess_pulse),
                         np.amax(self.guess_pulse))
         return scale
-        
+
     def _apply_bounds(self, pulse):
         """
         Scaling the amplitudes using the tanh function if there are bounds
@@ -1203,7 +1203,7 @@ class PulseGenCrab(PulseGen):
             return pulse
         else:
             return pulse
-       
+
 
 class PulseGenCrabFourier(PulseGenCrab):
     """
@@ -1230,9 +1230,9 @@ class PulseGenCrabFourier(PulseGenCrab):
         Set the initial freq and coefficient values
         """
         PulseGenCrab.init_pulse(self)
-            
+
         self.init_freqs()
-        
+
     def init_freqs(self):
         """
         Generate the frequencies
@@ -1243,15 +1243,15 @@ class PulseGenCrabFourier(PulseGenCrab):
         ff = 2*np.pi / self.pulse_time
         for i in range(self.num_coeffs):
             self.freqs[i] = ff*(i + 1)
-        
+
         if self.randomize_freqs:
             self.freqs += np.random.random(self.num_coeffs) - 0.5
-        
+
     def gen_pulse(self, coeffs=None):
         """
         Generate a pulse using the Fourier basis with the freqs and
         coeffs attributes.
-        
+
         Parameters
         ----------
         coeffs : float array[num_coeffs, num_basis_funcs]
@@ -1261,10 +1261,10 @@ class PulseGenCrabFourier(PulseGenCrab):
         """
         if coeffs:
             self.coeffs = coeffs
-            
+
         if not self._pulse_initialised:
             self.init_pulse()
-        
+
         pulse = np.zeros(self.num_tslots)
 
         for i in range(self.num_coeffs):
@@ -1273,12 +1273,11 @@ class PulseGenCrabFourier(PulseGenCrab):
 #            basis2comp = self.coeffs[i, 1]*np.cos(phase)
 #            pulse += basis1comp + basis2comp
             pulse += self.coeffs[i, 0]*np.sin(phase) + \
-                        self.coeffs[i, 1]*np.cos(phase) 
+                        self.coeffs[i, 1]*np.cos(phase)
 
         if self.guess_pulse_func:
             pulse = self.guess_pulse_func(pulse)
         if self.ramping_pulse is not None:
             pulse = self._apply_ramping_pulse(pulse)
-            
+
         return self._apply_bounds(pulse)
-    

--- a/qutip/mcsolve.py
+++ b/qutip/mcsolve.py
@@ -62,9 +62,11 @@ if debug:
 # Internal, global variables for storing references to dynamically loaded
 # cython functions
 
+
 # Todo: use real warning
 def warn(text):
     print(text)
+
 
 class qutip_zvode(zvode):
     def step(self, *args):
@@ -74,6 +76,7 @@ class qutip_zvode(zvode):
         r = self.run(*args)
         self.call_args[2] = itask
         return r
+
 
 def mcsolve(H, psi0, tlist, c_ops=[], e_ops=[], ntraj=0,
             args={}, options=None, progress_bar=True,
@@ -196,7 +199,7 @@ def mcsolve(H, psi0, tlist, c_ops=[], e_ops=[], ntraj=0,
 
     try:
         num_traj = int(ntraj)
-    except:
+    except TypeError:
         num_traj = max(ntraj)
 
     # set the physics
@@ -205,7 +208,6 @@ def mcsolve(H, psi0, tlist, c_ops=[], e_ops=[], ntraj=0,
 
     # load monte carlo class
     mc = _MC(options)
-
 
     if isinstance(H, SolverSystem):
         mc.ss = H
@@ -321,7 +323,7 @@ class _MC():
             ss.set_args = _qobjevo_args
             ss.type = "QobjEvo"
 
-        except:
+        except Exception:
             ss.h_func = H
             ss.Hc_td = -0.5 * sum(ss.td_n_ops)
             ss.Hc_td.compile()
@@ -342,7 +344,10 @@ class _MC():
 
         ss = self.ss
         if ss is not None and ss.type == "Diagonal" and not self.e_ops.isfunc:
-            e_op = [Qobj(ss.Ud @ e.full() @ ss.U, dims=e.dims) for e in self.e_ops.e_ops]
+            e_ops = [
+                Qobj(ss.Ud @ e.full() @ ss.U, dims=e.dims)
+                for e in self.e_ops.e_ops
+            ]
             self.e_ops = ExpectOps(e_ops)
 
         if not self.e_ops:
@@ -352,20 +357,20 @@ class _MC():
         try:
             for c_op in self.ss.td_c_ops:
                 c_op.mul_vec(0, self.psi0)
-        except:
-            raise Exception("c_ops are not consistant with psi0")
+        except Exception as e:
+            raise Exception("c_ops are not consistant with psi0") from e
 
         if self.ss.type == "QobjEvo":
             try:
                 self.ss.H_td.mul_vec(0., self.psi0)
-            except:
-                raise Exception("Error calculating H")
+            except Exception as e:
+                raise Exception("Error calculating H") from e
         else:
             try:
-                rhs, ode_args = self.ss.makefunc(ss)
-                rhs(t, self.psi0.full().ravel(), ode_args)
-            except:
-                raise Exception("Error calculating H")
+                rhs, ode_args = self.ss.makefunc(self.ss)
+                rhs(0, self.psi0.full().ravel(), ode_args)
+            except Exception as e:
+                raise Exception("Error calculating H") from e
 
     def run(self, num_traj=0, psi0=None, tlist=None,
             args={}, e_ops=None, options=None,
@@ -430,7 +435,7 @@ class _MC():
 
         # set arguments for input to monte carlo
         map_kwargs_ = {'progress_bar': progress_bar,
-                      'num_cpus': options.num_cpus}
+                       'num_cpus': options.num_cpus}
         map_kwargs_.update(map_kwargs)
         map_kwargs = map_kwargs_
 
@@ -438,9 +443,11 @@ class _MC():
             self.set_e_ops()
 
         if self.ss.type == "Diagonal":
-            results = map_func(self._single_traj_diag, list(range(num_traj)), **map_kwargs)
+            results = map_func(self._single_traj_diag, list(range(num_traj)),
+                               **map_kwargs)
         else:
-            results = map_func(self._single_traj, list(range(num_traj)), **map_kwargs)
+            results = map_func(self._single_traj, list(range(num_traj)),
+                               **map_kwargs)
 
         self.t = self.tlist[-1]
         self.num_traj = num_traj
@@ -475,7 +482,7 @@ class _MC():
         if self._psi_out.shape[1] == 1:
             dm_t = np.zeros((len_, len_), dtype=complex)
             for i in range(self.num_traj):
-                vec = self._psi_out[i,0,:] # .reshape((-1,1))
+                vec = self._psi_out[i, 0]
                 dm_t += np.outer(vec, vec.conj())
             return Qobj(dm_t/self.num_traj, dims=[dims, dims])
         else:
@@ -483,7 +490,7 @@ class _MC():
             for j in range(len(self.tlist)):
                 dm_t = np.zeros((len_, len_), dtype=complex)
                 for i in range(self.num_traj):
-                    vec = self._psi_out[i,j,:] # .reshape((-1,1))
+                    vec = self._psi_out[i, j]
                     dm_t += np.outer(vec, vec.conj())
                 states[j] = Qobj(dm_t/self.num_traj, dims=[dims, dims])
             return states
@@ -494,7 +501,7 @@ class _MC():
         len_ = self._psi_out.shape[2]
         dm_t = np.zeros((len_, len_), dtype=complex)
         for i in range(self.num_traj):
-            vec = self._psi_out[i,-1,:]
+            vec = self._psi_out[i, -1]
             dm_t += np.outer(vec, vec.conj())
         return Qobj(dm_t/self.num_traj, dims=[dims, dims])
 
@@ -503,7 +510,7 @@ class _MC():
         dims = self.psi0.dims[0]
         psis = np.empty((self.num_traj), dtype=object)
         for i in range(self.num_traj):
-            psis[i] = Qobj(dense1D_to_fastcsr_ket(self._psi_out[i,-1,:]),
+            psis[i] = Qobj(dense1D_to_fastcsr_ket(self._psi_out[i, -1]),
                            dims=dims, fast='mc')
         return psis
 
@@ -539,7 +546,7 @@ class _MC():
             dims = self.psi0.dims[0]
             len_ = self.psi0.shape[0]
             return Qobj(np.mean(self._ss_out, axis=0),
-                            [dims, dims], [len_, len_])
+                        dims=[dims, dims], shape=(len_, len_))
         # TO-DO rebuild steady_state from _psi_out if needed
         # elif self._psi_out is not None:
         #     return sum(self.state_average) / self.num_traj
@@ -552,8 +559,8 @@ class _MC():
         psis = np.empty((self.num_traj, len(self.tlist)), dtype=object)
         for i in range(self.num_traj):
             for j in range(len(self.tlist)):
-                psis[i,j] = Qobj(dense1D_to_fastcsr_ket(self._psi_out[i,j,:]),
-                                 dims=dims, fast='mc')
+                psis[i, j] = Qobj(dense1D_to_fastcsr_ket(self._psi_out[i, j]),
+                                  dims=dims, fast='mc')
         return psis
 
     @property
@@ -566,7 +573,7 @@ class _MC():
         for col_ in self._collapse:
             col = list(zip(*col_))
             col = ([] if len(col) == 0 else col[0])
-            out.append( np.array(col) )
+            out.append(np.array(col))
         return out
         return [np.array(list(zip(*col_))[0]) for col_ in self._collapse]
 
@@ -576,7 +583,7 @@ class _MC():
         for col_ in self._collapse:
             col = list(zip(*col_))
             col = ([] if len(col) == 0 else col[1])
-            out.append( np.array(col) )
+            out.append(np.array(col))
         return out
         return [np.array(list(zip(*col_))[1]) for col_ in self._collapse]
 
@@ -710,7 +717,10 @@ class _MC():
         solver_safe["mcsolve"] = ss
 
         if self.e_ops and not self.e_ops.isfunc:
-            e_op = [Qobj(Ud @ e.full() @ U, dims=e.dims) for e in self.e_ops.e_ops]
+            e_ops = [
+                Qobj(Ud @ e.full() @ U, dims=e.dims)
+                for e in self.e_ops.e_ops
+            ]
             self.e_ops = ExpectOps(e_ops)
         self.ss = ss
         self.reset()
@@ -731,8 +741,8 @@ class _MC():
         e_ops.init(tlist)
 
         cymc = CyMcOdeDiag(ss, opt)
-        states_out, ss_out, collapses = cymc.run_ode(self.initial_vector, tlist,
-                                                     e_ops, prng)
+        states_out, ss_out, collapses =\
+            cymc.run_ode(self.initial_vector, tlist, e_ops, prng)
 
         if opt.steady_state_average:
             ss_out = ss.U @ ss_out @ ss.Ud
@@ -740,6 +750,7 @@ class _MC():
         if opt.steady_state_average:
             ss_out /= float(len(tlist))
         return (states_out, ss_out, e_ops, collapses)
+
 
 # -----------------------------------------------------------------------------
 # CODES FOR PYTHON FUNCTION BASED TIME-DEPENDENT RHS
@@ -749,6 +760,7 @@ def _qobjevo_set(ss, psi0=None, args={}, opt=None):
         self.set_args(args)
     rhs = ss.H_td.compiled_qobjevo.mul_vec
     return rhs, ()
+
 
 def _qobjevo_args(ss, args):
     var = _collapse_args(args)
@@ -760,6 +772,7 @@ def _qobjevo_args(ss, args):
     for c in ss.td_n_ops:
         c.solver_set_args(args, psi0, e_ops)
 
+
 def _func_set(HS, psi0=None, args={}, opt=None):
     if args:
         self.set_args(args)
@@ -770,6 +783,7 @@ def _func_set(HS, psi0=None, args={}, opt=None):
     else:
         rhs = _funcrhs_with_state
     return rhs, (ss.h_func, ss.Hc_td, args)
+
 
 def _func_args(ss, args):
     var = _collapse_args(args)
@@ -788,10 +802,12 @@ def _funcrhs(t, psi, h_func, Hc_td, args):
     h_func_term = h_func_data * psi
     return h_func_term + Hc_td.mul_vec(t, psi)
 
+
 def _funcrhs_with_state(t, psi, h_func, Hc_td, args):
     h_func_data = - 1.0j * h_func(t, psi, args).data
     h_func_term = h_func_data * psi
     return h_func_term + Hc_td.mul_vec(t, psi)
+
 
 def _mc_dm_avg(psi_list):
     """
@@ -803,6 +819,7 @@ def _mc_dm_avg(psi_list):
     shape = psi_list[0].shape
     out_data = sum([psi.data for psi in psi_list]) / ln
     return Qobj(out_data, dims=dims, shape=shape, fast='mc-dm')
+
 
 def _collapse_args(args):
     for key in args:

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -45,10 +45,8 @@ __all__ = [
     'rand_dm_hs', 'rand_super_bcsz', 'rand_stochastic', 'rand_super'
 ]
 
-from numpy import arcsin, sqrt, pi
-from scipy.linalg import sqrtm
 import numpy as np
-import numpy.linalg as la
+import scipy.linalg as la
 import scipy.sparse as sp
 from qutip.qobj import Qobj
 from qutip.operators import create, destroy, jmat
@@ -74,24 +72,27 @@ def rand_jacobi_rotation(A, seed=None):
     """
     if seed is not None:
         np.random.seed(seed=seed)
-    if A.shape[0]!=A.shape[1]:
-        raise Exception('Input matrix must be square.')
+    if A.shape[0] != A.shape[1]:
+        raise ValueError('Input matrix must be square.')
     n = A.shape[0]
     angle = 2*np.random.random()*np.pi
     a = 1.0/np.sqrt(2)*np.exp(-1j*angle)
     b = 1.0/np.sqrt(2)*np.exp(1j*angle)
     i = int(np.floor(np.random.random()*n))
     j = i
-    while (i == j):
+    while i == j:
         j = int(np.floor(np.random.random()*n))
-    data = np.hstack((np.array([a,-b,a,b], dtype=complex),
+    data = np.hstack((np.array([a, -b, a, b], dtype=complex),
                       np.ones(n-2, dtype=complex)))
-    diag = np.delete(np.arange(n), [i,j])
-    rows = np.hstack(([i,i,j,j], diag))
-    cols = np.hstack(([i,j,i,j], diag))
-    R = sp.coo_matrix((data,(rows,cols)), shape=[n,n], dtype=complex).tocsr()
+    diag = np.delete(np.arange(n), [i, j])
+    rows = np.hstack(([i, i, j, j], diag))
+    cols = np.hstack(([i, j, i, j], diag))
+    R = sp.coo_matrix(
+        (data, (rows, cols)), shape=(n, n), dtype=complex,
+    ).tocsr()
     A = R*A*R.conj().transpose()
     return A
+
 
 def randnz(shape, norm=1 / np.sqrt(2), seed=None):
     # This function is intended for internal use.
@@ -151,8 +152,8 @@ def rand_herm(N, density=0.75, dims=None, pos_def=False, seed=None):
     """
     if seed is not None:
         np.random.seed(seed=seed)
-    if isinstance(N, (np.ndarray,list)):
-        M = sp.diags(N,0, dtype=complex, format='csr')
+    if isinstance(N, (np.ndarray, list)):
+        M = sp.diags(N, 0, dtype=complex, format='csr')
         N = len(N)
         if dims:
             _check_dims(dims, N, N)
@@ -170,10 +171,7 @@ def rand_herm(N, density=0.75, dims=None, pos_def=False, seed=None):
             M = _rand_herm_dense(N, density, pos_def)
     else:
         raise TypeError('Input N must be an integer or array_like.')
-    if dims:
-        return Qobj(M, dims=dims)
-    else:
-        return Qobj(M)
+    return Qobj(M, dims=dims)
 
 
 def _rand_herm_sparse(N, density, pos_def):
@@ -183,10 +181,10 @@ def _rand_herm_sparse(N, density, pos_def):
     num_elems = int(num_elems)
     data = (2 * np.random.rand(num_elems) - 1) + \
            (2 * np.random.rand(num_elems) - 1) * 1j
-    row_idx, col_idx = zip(*[divmod(index, N) for index
-                             in np.random.choice(N*N,
-                                                 num_elems,
-                                                 replace=False)])
+    row_idx, col_idx = zip(*[
+        divmod(index, N)
+        for index in np.random.choice(N*N, num_elems, replace=False)
+    ])
     M = sp.coo_matrix((data, (row_idx, col_idx)),
                       dtype=complex, shape=(N, N))
     M = 0.5 * (M + M.conj().transpose())
@@ -199,17 +197,17 @@ def _rand_herm_sparse(N, density, pos_def):
 
 
 def _rand_herm_dense(N, density, pos_def):
-    M = (2 * np.random.rand(N, N) - 1) + \
-        (2 * np.random.rand(N, N) - 1) * 1j
+    M = (
+        (2*np.random.rand(N, N) - 1)
+        + 1j*(2*np.random.rand(N, N) - 1)
+    )
     M = 0.5 * (M + M.conj().transpose())
-    target = (1-(density)**0.5)
+    target = 1 - density**0.5
     num_remove = N * (N - 0.666) * target + 0.666 * N * (1 - density)
     num_remove = max([num_remove, 1])
     num_remove = int(num_remove)
-    for row, col in [divmod(index, N)
-                     for index in np.random.choice(N*N,
-                                                   num_remove,
-                                                   replace=False)]:
+    for index in np.random.choice(N*N, num_remove, replace=False):
+        row, col = divmod(index, N)
         M[col, row] = 0
         M[row, col] = 0
     if pos_def:
@@ -243,10 +241,7 @@ def rand_unitary(N, density=0.75, dims=None, seed=None):
         _check_dims(dims, N, N)
     U = (-1.0j * rand_herm(N, density, seed=seed)).expm()
     U.data.sort_indices()
-    if dims:
-        return Qobj(U, dims=dims, shape=[N, N])
-    else:
-        return Qobj(U)
+    return Qobj(U, dims=dims, shape=[N, N])
 
 
 def rand_unitary_haar(N=2, dims=None, seed=None):
@@ -432,7 +427,7 @@ def rand_dm(N, density=0.75, pure=False, dims=None, seed=None):
         if dims:
             _check_dims(dims, N, N)
         if pure:
-            dm_density = sqrt(density)
+            dm_density = np.sqrt(density)
             psi = rand_ket(N, dm_density)
             H = psi * psi.dag()
             H.data.sort_indices()
@@ -451,10 +446,7 @@ def rand_dm(N, density=0.75, pure=False, dims=None, seed=None):
             H.data.sort_indices()
     else:
         raise TypeError('Input N must be an integer or array_like.')
-    if dims:
-        return Qobj(H, dims=dims)
-    else:
-        return Qobj(H)
+    return Qobj(H, dims=dims)
 
 
 def rand_dm_ginibre(N=2, rank=None, dims=None, seed=None):
@@ -563,11 +555,12 @@ def rand_super(N=5, dims=None, seed=None):
         Dimensions of quantum object.  Used for specifying
         tensor structure. Default is dims=[[[N],[N]], [[N],[N]]].
     """
+    from .propagator import propagator
     if dims is not None:
         # TODO: check!
         pass
     else:
-        dims = [[[N],[N]], [[N],[N]]]
+        dims = [[[N], [N]], [[N], [N]]]
     H = rand_herm(N, seed=seed)
     S = propagator(H, np.random.rand(), [
         create(N), destroy(N), jmat(float(N - 1) / 2.0, 'z')
@@ -609,7 +602,7 @@ def rand_super_bcsz(N=2, enforce_tp=True, rank=None, dims=None, seed=None):
         # TODO: check!
         pass
     else:
-        dims = [[[N],[N]], [[N],[N]]]
+        dims = [[[N], [N]], [[N], [N]]]
 
     if rank is None:
         rank = N**2
@@ -639,7 +632,7 @@ def rand_super_bcsz(N=2, enforce_tp=True, rank=None, dims=None, seed=None):
         # matrices directly, as this is important in statistics.
         Z = np.kron(
             np.eye(N),
-            sqrtm(la.inv(Y))
+            la.sqrtm(la.inv(Y))
         )
 
         # Finally, we dot everything together and pack it into a Qobj,
@@ -701,7 +694,7 @@ def rand_stochastic(N, density=0.75, kind='left', dims=None, seed=None):
     col_idx = np.hstack([np.random.permutation(N),
                          np.random.choice(N, num_elems-N)])
     M = sp.coo_matrix((data, (row_idx, col_idx)),
-                      dtype=float, shape=(N,N)).tocsr()
+                      dtype=float, shape=(N, N)).tocsr()
     M = 0.5 * (M + M.conj().transpose())
     num_rows = M.indptr.shape[0]-1
     for row in range(num_rows):
@@ -709,12 +702,9 @@ def rand_stochastic(N, density=0.75, kind='left', dims=None, seed=None):
         row_end = M.indptr[row+1]
         row_sum = np.sum(M.data[row_start:row_end])
         M.data[row_start:row_end] /= row_sum
-    if kind=='left':
+    if kind == 'left':
         M = M.transpose()
-    if dims:
-        return Qobj(M, dims=dims, shape=[N, N])
-    else:
-        return Qobj(M)
+    return Qobj(M, dims=dims, shape=(N, N))
 
 
 def _check_dims(dims, N1, N2):
@@ -727,7 +717,3 @@ def _check_dims(dims, N1, N2):
         raise ValueError("Qobj dimensions must match matrix shape.")
     if len(dims[0]) != len(dims[1]):
         raise TypeError("Qobj dimension components must have same length.")
-
-# TRAILING IMPORTS
-# qutip.propagator depends on rand_dm, so we need to put this import last.
-from qutip.propagator import propagator

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -358,8 +358,6 @@ class StochasticSolverOptions:
                                for op in sc_ops]
             except Exception as e:
                 raise ValueError(msg + str(e)) from e
-            except:
-                raise ValueError(msg)
         else:
             self.sc_ops = sc_ops
 
@@ -372,8 +370,6 @@ class StochasticSolverOptions:
                               for op in c_ops]
             except Exception as e:
                 raise ValueError(msg + str(e)) from e
-            except:
-                raise ValueError(msg)
         else:
             self.c_ops = c_ops
 
@@ -502,16 +498,17 @@ class StochasticSolverOptions:
             if not len(self.sc_ops) == 1 or \
                     not self.sc_ops[0].const or \
                     not self.method == "homodyne":
-                raise ValueError("Taylor2.0 only works with 1 constant " +
-                                "sc_ops and for homodyne method")
+                raise ValueError(
+                    "Taylor2.0 only works with 1 constant sc_ops and for"
+                    " homodyne method"
+                )
         else:
-            raise ValueError((
-                    "The solver should be one of "
-                    "[None, 'euler-maruyama', 'platen', 'pc-euler', "
-                    "'pc-euler-imp', 'milstein', 'milstein-imp', "
-                    "'rouchon', "
-                    "'taylor1.5', 'taylor1.5-imp', 'explicit1.5' "
-                    "'taylor2.0']"))
+            known = [
+                None, 'euler-maruyama', 'platen', 'pc-euler', 'pc-euler-imp',
+                'milstein', 'milstein-imp', 'rouchon', 'taylor1.5',
+                'taylor1.5-imp', 'explicit1.5', 'taylor2.0',
+            ]
+            raise ValueError("The solver should be one of {!r}".format(known))
 
 
 class StochasticSolverOptionsPhoto(StochasticSolverOptions):
@@ -589,8 +586,8 @@ def smesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
         print("stochastic solver with photocurrent method has been moved to "
               "it's own function: photocurrent_mesolve")
         return photocurrent_mesolve(H, rho0, times, c_ops=c_ops, sc_ops=sc_ops,
-                                   e_ops=e_ops, _safe_mode=_safe_mode,
-                                   args=args, **kwargs)
+                                    e_ops=e_ops, _safe_mode=_safe_mode,
+                                    args=args, **kwargs)
     if isket(rho0):
         rho0 = ket2dm(rho0)
 
@@ -716,8 +713,8 @@ def ssesolve(H, psi0, times, sc_ops=[], e_ops=[],
         print("stochastic solver with photocurrent method has been moved to "
               "it's own function: photocurrent_sesolve")
         return photocurrent_sesolve(H, psi0, times, c_ops=c_ops,
-                                   e_ops=e_ops, _safe_mode=_safe_mode,
-                                   args=args, **kwargs)
+                                    e_ops=e_ops, _safe_mode=_safe_mode,
+                                    args=args, **kwargs)
 
     if isinstance(e_ops, dict):
         e_ops_dict = e_ops
@@ -879,7 +876,7 @@ def _positive_map(sso, e_ops_dict):
 
 
 def photocurrent_mesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
-                        _safe_mode=True, args={}, **kwargs):
+                         _safe_mode=True, args={}, **kwargs):
     """
     Solve stochastic master equation using the photocurrent method.
 
@@ -975,7 +972,7 @@ def photocurrent_mesolve(H, rho0, times, c_ops=[], sc_ops=[], e_ops=[],
 
 
 def photocurrent_sesolve(H, psi0, times, sc_ops=[], e_ops=[],
-                        _safe_mode=True, args={}, **kwargs):
+                         _safe_mode=True, args={}, **kwargs):
     """
     Solve stochastic schrodinger equation using the photocurrent method.
 
@@ -1016,7 +1013,7 @@ def photocurrent_sesolve(H, psi0, times, sc_ops=[], e_ops=[],
     """
     if isinstance(e_ops, dict):
         e_ops_dict = e_ops
-        e_ops = [e for e in e_ops.values()]
+        e_ops = list(e_ops.values())
     else:
         e_ops_dict = None
 
@@ -1132,15 +1129,11 @@ def general_stochastic(state0, times, d1, d2, e_ops=[], m_ops=[],
         except Exception as e:
             raise RuntimeError("Safety check: d1(0., state0_vec) failed.:\n" +
                                str(e)) from e
-        except:
-            raise RuntimeError("Safety check: d1(0., state0_vec) failed.")
         try:
             out_d2 = d2(0., sso.rho0)
         except Exception as e:
             raise RuntimeError("Safety check: d2(0., state0_vec) failed:\n" +
                                str(e)) from e
-        except:
-            raise RuntimeError("Safety check: d2(0., state0_vec) failed.")
 
         msg_d1 = ("d1 must return an 1d numpy array with the same number "
                   "of elements as the initial state as a vector.")
@@ -1185,7 +1178,7 @@ def general_stochastic(state0, times, d1, d2, e_ops=[], m_ops=[],
         if sso.dW_factors is None:
             sso.dW_factors = [1.] * len(sso.m_ops)
         elif len(sso.dW_factors) == 1:
-                sso.dW_factors = sso.dW_factors * len(sso.m_ops)
+            sso.dW_factors = sso.dW_factors * len(sso.m_ops)
         elif len(sso.dW_factors) != len(sso.m_ops):
             raise ValueError("The number of dW_factors must fit" +
                              " the number of m_ops.")
@@ -1194,7 +1187,8 @@ def general_stochastic(state0, times, d1, d2, e_ops=[], m_ops=[],
         sso.dW_factors = [1.] * len_d2
     sso.sops = [None] * len_d2
     sso.ce_ops = [QobjEvo(op) for op in sso.e_ops]
-    [op.compile() for op in sso.ce_ops]
+    for op in sso.ce_ops:
+        op.compile()
 
     sso.solver_obj = GenericSSolver
     sso.solver_name = "general_stochastic_solver_" + sso.solver
@@ -1216,7 +1210,9 @@ def _safety_checks(sso):
     l_vec = sso.rho0.shape[0]
     if sso.H.cte.issuper:
         if not sso.me:
-            raise
+            raise ValueError(
+                "Given a Liouvillian for a Schrödinger equation problem."
+            )
         shape_op = sso.H.cte.shape
         if shape_op[0] != l_vec or shape_op[1] != l_vec:
             raise Exception("The size of the hamiltonian does "
@@ -1235,7 +1231,9 @@ def _safety_checks(sso):
     for op in sso.sc_ops:
         if op.cte.issuper:
             if not sso.me:
-                raise
+                raise ValueError(
+                    "Given a Liouvillian for a Schrödinger equation problem."
+                )
             shape_op = op.cte.shape
             if shape_op[0] != l_vec or shape_op[1] != l_vec:
                 raise Exception("The size of the sc_ops does "
@@ -1254,7 +1252,9 @@ def _safety_checks(sso):
     for op in sso.c_ops:
         if op.cte.issuper:
             if not sso.me:
-                raise
+                raise ValueError(
+                    "Given a Liouvillian for a Schrödinger equation problem."
+                )
             shape_op = op.cte.shape
             if shape_op[0] != l_vec or shape_op[1] != l_vec:
                 raise Exception("The size of the c_ops does "
@@ -1369,9 +1369,8 @@ def _sesolve_generic(sso, options, progress_bar):
 def _single_trajectory(i, sso):
     # Only one step?
     ssolver = sso.solver_obj()
-    #ssolver.set_data(sso)
     ssolver.set_solver(sso)
-    result = ssolver.cy_sesolve_single_trajectory(i)#, sso)
+    result = ssolver.cy_sesolve_single_trajectory(i)
     return result
 
 


### PR DESCRIPTION
Some minor pep8 fixes in files I might touch soon with regards to moving to the Numpy 1.17 random-number generation.  There's a bunch of seemingly dead code in `mcsolve` about a "diagonal" system?  Seems to have a few logic bugs in it at the very least, and no way to access it.  I fixed one about `e_ops`, but looking at the log, seems like the whole system might not be needed.

**Changelog**: pep8 changes.