### PR TITLE
Fix CodeClimate duplication parser version

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -38,3 +38,9 @@ plugins:
     enabled: true
   pep8:
     enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        python:
+          python_version: 3


### PR DESCRIPTION
The plugin was already enabled by default, so this does not turn it on. However, it also defaults to Python 2, which means it produces a lot of syntax errors, and the run (silently) failed every time.

This may cause our CodeClimate score to drop, not because we actually got worse, but because we suddenly start seeing a load of duplication that was previously hidden.  I'm hoping that getting these parser errors fixed will mean that the "Progress report" tab on CodeClimate will start getting populated.

**Changelog**: (developer changes) fixed Python version for duplication detection in CodeClimate
