### PR TITLE
Improve coverage of states and operators tests

### DIFF
--- a/qutip/states.py
+++ b/qutip/states.py
@@ -238,7 +238,7 @@ def coherent(N, alpha, offset=0, method='operator'):
         return Qobj(sqrtn)
 
     else:
-        raise TypeError(
+        raise ValueError(
             "The method option can only take values 'operator' or 'analytic'")
 
 
@@ -445,8 +445,8 @@ shape = [5, 5], type = oper, isHerm = True
             rm = sp.spdiags((1.0 + n) ** (-1.0) * (n / (1.0 + n)) ** (i),
                             0, N, N, format='csr')
         else:
-            raise ValueError(
-                "'method' keyword argument must be 'operator' or 'analytic'")
+            raise ValueError("The method option can only take "
+                             "values 'operator' or 'analytic'")
     return Qobj(rm)
 
 

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -291,17 +291,8 @@ shape = [3, 3], type = oper, isHerm = True
     but would in that case give more accurate coefficients.
 
     """
-    if method == "operator":
-        psi = coherent(N, alpha, offset=offset)
-        return psi * psi.dag()
-
-    elif method == "analytic":
-        psi = coherent(N, alpha, offset=offset, method='analytic')
-        return psi * psi.dag()
-
-    else:
-        raise TypeError(
-            "The method option can only take values 'operator' or 'analytic'")
+    psi = coherent(N, alpha, offset=offset, method=method)
+    return psi * psi.dag()
 
 
 def fock_dm(dimensions, n=None, offset=None):
@@ -1221,7 +1212,7 @@ def triplet_states():
     .. math::
 
         \lvert T_1\rangle = \lvert11\rangle
-        \lvert T_2\rangle = \frac1{\sqrt2}(\lvert01\rangle - \lvert10\rangle)
+        \lvert T_2\rangle = \frac1{\sqrt2}(\lvert01\rangle + \lvert10\rangle)
         \lvert T_3\rangle = \lvert00\rangle
 
     Returns

--- a/qutip/tests/test_enr_state_operator.py
+++ b/qutip/tests/test_enr_state_operator.py
@@ -112,6 +112,12 @@ def test_fock_state(dimensions, n_excitations):
             assert abs(n.matrix_element(state.dag(), state)) - x < 1e-10
 
 
+def test_fock_state_error():
+    with pytest.raises(ValueError) as e:
+        state = qutip.enr_fock([2, 2, 2], 1, [1, 1, 1])
+    assert str(e.value).startswith("The state tuple ")
+
+
 def _reference_dm(dimensions, n_excitations, nbars):
     """
     Get the reference density matrix using `Qobj.eliminate_states` explicitly,
@@ -136,7 +142,7 @@ def test_thermal_dm(dimensions, n_excitations, nbar_type):
         nbars = 0.1 * n_excitations / len(dimensions)
     else:
         nbars = np.random.rand(len(dimensions))
-        nbars = (0.1 * n_excitations) / np.sum(nbars)
+        nbars *= (0.1 * n_excitations) / np.sum(nbars)
     test_dm = qutip.enr_thermal_dm(dimensions, n_excitations, nbars)
     expect_dm = _reference_dm(dimensions, n_excitations, nbars)
     np.testing.assert_allclose(test_dm.full(), expect_dm.full(), atol=1e-12)

--- a/qutip/tests/test_operators.py
+++ b/qutip/tests/test_operators.py
@@ -33,17 +33,15 @@
 
 import numbers
 import numpy as np
-from numpy.testing import assert_equal, run_module_suite
 import pytest
-
 import qutip
-from qutip import (jmat, basis, destroy, create, displace, qzero, qeye,
-                    num, squeeze, charge, tunneling)
+
+
+N = 5
 
 
 def test_jmat_12():
-    "Spin 1/2 operators"
-    spinhalf = jmat(1 / 2.)
+    spinhalf = qutip.jmat(1 / 2.)
 
     paulix = np.array([[0.0 + 0.j, 0.5 + 0.j], [0.5 + 0.j, 0.0 + 0.j]])
     pauliy = np.array([[0. + 0.j, 0. - 0.5j], [0. + 0.5j, 0. + 0.j]])
@@ -51,16 +49,27 @@ def test_jmat_12():
     sigmap = np.array([[0. + 0.j, 1. + 0.j], [0. + 0.j, 0. + 0.j]])
     sigmam = np.array([[0. + 0.j, 0. + 0.j], [1. + 0.j, 0. + 0.j]])
 
-    assert_equal(np.allclose(spinhalf[0].full(), paulix), True)
-    assert_equal(np.allclose(spinhalf[1].full(), pauliy), True)
-    assert_equal(np.allclose(spinhalf[2].full(), pauliz), True)
-    assert_equal(np.allclose(jmat(1 / 2., '+').full(), sigmap), True)
-    assert_equal(np.allclose(jmat(1 / 2., '-').full(), sigmam), True)
+    np.testing.assert_allclose(spinhalf[0].full(), paulix)
+    np.testing.assert_allclose(spinhalf[1].full(), pauliy)
+    np.testing.assert_allclose(spinhalf[2].full(), pauliz)
+    np.testing.assert_allclose(qutip.jmat(1 / 2., '+').full(), sigmap)
+    np.testing.assert_allclose(qutip.jmat(1 / 2., '-').full(), sigmam)
+
+    np.testing.assert_allclose(qutip.spin_Jx(1 / 2.).full(), paulix)
+    np.testing.assert_allclose(qutip.spin_Jy(1 / 2.).full(), pauliy)
+    np.testing.assert_allclose(qutip.spin_Jz(1 / 2.).full(), pauliz)
+    np.testing.assert_allclose(qutip.spin_Jp(1 / 2.).full(), sigmap)
+    np.testing.assert_allclose(qutip.spin_Jm(1 / 2.).full(), sigmam)
+
+    np.testing.assert_allclose(qutip.sigmax().full(), paulix * 2)
+    np.testing.assert_allclose(qutip.sigmay().full(), pauliy * 2)
+    np.testing.assert_allclose(qutip.sigmaz().full(), pauliz * 2)
+    np.testing.assert_allclose(qutip.sigmap().full(), sigmap)
+    np.testing.assert_allclose(qutip.sigmam().full(), sigmam)
 
 
 def test_jmat_32():
-    "Spin 3/2 operators"
-    spin32 = jmat(3 / 2.)
+    spin32 = qutip.jmat(3 / 2.)
 
     paulix32 = np.array(
         [[0.0000000 + 0.j, 0.8660254 + 0.j, 0.0000000 + 0.j, 0.0000000 + 0.j],
@@ -79,61 +88,49 @@ def test_jmat_32():
                          [0.0 + 0.j, 0.0 + 0.j, -0.5 + 0.j, 0.0 + 0.j],
                          [0.0 + 0.j, 0.0 + 0.j, 0.0 + 0.j, -1.5 + 0.j]])
 
-    assert_equal(np.allclose(spin32[0].full(), paulix32), True)
-    assert_equal(np.allclose(spin32[1].full(), pauliy32), True)
-    assert_equal(np.allclose(spin32[2].full(), pauliz32), True)
+    np.testing.assert_allclose(spin32[0].full(), paulix32)
+    np.testing.assert_allclose(spin32[1].full(), pauliy32)
+    np.testing.assert_allclose(spin32[2].full(), pauliz32)
 
 
-def test_jmat_42():
-    "Spin 2 operators"
-    spin42 = jmat(4 / 2., '+')
-    assert_equal(spin42.dims == [[5], [5]], True)
+@pytest.mark.parametrize(['spin', 'N'], [
+    pytest.param(3/2., 4, id="1.5"),
+    pytest.param(5/2., 6, id="2.5"),
+    pytest.param(3.0, 7, id="3.0"),
+])
+def test_jmat_dims(spin, N):
+    spin_mat = qutip.jmat(spin, '+')
+    assert spin_mat.dims == [[N], [N]]
+    assert spin_mat.shape == (N, N)
 
 
-def test_jmat_52():
-    "Spin 5/2 operators"
-    spin52 = jmat(5 / 2., '+')
-    assert_equal(spin52.shape == (6, 6), True)
+@pytest.mark.parametrize(['oper_func', 'diag', 'offset', 'args'], [
+    pytest.param(qutip.destroy, np.arange(1, N)**0.5, 1, (), id="destroy"),
+    pytest.param(qutip.destroy, np.arange(6, N+5)**0.5, 1, (5,),
+                 id="destroy_offset"),
+    pytest.param(qutip.create, np.arange(1, N)**0.5, -1, (), id="create"),
+    pytest.param(qutip.create, np.arange(6, N+5)**0.5, -1, (5,),
+                 id="create_offset"),
+    pytest.param(qutip.num, np.arange(N), 0, (), id="num"),
+    pytest.param(qutip.num, np.arange(5, N+5), 0, (5,), id="num_offset"),
+    pytest.param(qutip.charge, np.arange(-N, N+1), 0, (), id="charge"),
+    pytest.param(qutip.charge, np.arange(2, N+1)/3, 0, (2, 1/3),
+                 id="charge_args"),
+])
+def test_diagonal_oper(oper_func, diag, offset, args):
+    oper = oper_func(N, *args)
+    assert oper == qutip.Qobj(np.diag(diag, offset))
 
 
-def test_destroy():
-    "Destruction operator"
-    b4 = basis(5, 4)
-    d5 = destroy(5)
-    test1 = d5 * b4
-    assert_equal(np.allclose(test1.full(), 2.0 * basis(5, 3).full()), True)
-    d3 = destroy(3)
-    matrix3 = np.array(
-        [[0.00000000 + 0.j, 1.00000000 + 0.j, 0.00000000 + 0.j],
-         [0.00000000 + 0.j, 0.00000000 + 0.j, 1.41421356 + 0.j],
-         [0.00000000 + 0.j, 0.00000000 + 0.j, 0.00000000 + 0.j]])
-
-    assert_equal(np.allclose(matrix3, d3.full()), True)
-
-
-def test_create():
-    "Creation operator"
-    b3 = basis(5, 3)
-    c5 = create(5)
-    test1 = c5 * b3
-    assert_equal(np.allclose(test1.full(), 2.0 * basis(5, 4).full()), True)
-    c3 = create(3)
-    matrix3 = np.array(
-        [[0.00000000 + 0.j, 0.00000000 + 0.j, 0.00000000 + 0.j],
-         [1.00000000 + 0.j, 0.00000000 + 0.j, 0.00000000 + 0.j],
-         [0.00000000 + 0.j, 1.41421356 + 0.j, 0.00000000 + 0.j]])
-
-    assert_equal(np.allclose(matrix3, c3.full()), True)
-
-
-@pytest.mark.parametrize("to_test, expected", [
-        (qutip.qzero, lambda x: np.zeros((x, x), dtype=complex)),
-        (qutip.qeye, lambda x: np.eye(x, dtype=complex)),
-    ])
-@pytest.mark.parametrize("dimension", [1, 5, 100])
-def test_simple_operator_creation(to_test, expected, dimension):
-    qobj = to_test(dimension)
-    assert np.allclose(qobj.full(), expected(dimension))
+@pytest.mark.parametrize(['function', 'message'], [
+    (qutip.qeye, "All dimensions must be integers >= 0"),
+    (qutip.destroy, "Hilbert space dimension must be integer value"),
+    (qutip.create, "Hilbert space dimension must be integer value"),
+], ids=["qeye", "destroy", "create"])
+def test_diagonal_raise(function, message):
+    with pytest.raises(ValueError) as e:
+        function(2.5)
+    assert str(e.value) == message
 
 
 @pytest.mark.parametrize("to_test", [qutip.qzero, qutip.qeye, qutip.identity])
@@ -160,18 +157,20 @@ def test_super_operator_creation(to_test):
     assert implicit == explicit
 
 
-def test_num():
-    "Number operator"
-    n5 = num(5)
-    assert_equal(
-        np.allclose(n5.full(),
-                    np.diag([0 + 0j, 1 + 0j, 2 + 0j, 3 + 0j, 4 + 0j])),
-        True)
+@pytest.mark.parametrize(["to_test", "factor", "phase"], [
+    (qutip.position, 1, 1),
+    (qutip.momentum, 1j, -1),
+])
+def test_bidiagonal(to_test, factor, phase):
+    N = 5
+    operator = to_test(N)
+    expected = (np.diag((np.arange(1, N) / 2)**0.5, k=-1) +
+                np.diag((np.arange(1, N) / 2)**0.5, k=1) * phase) * factor
+    np.testing.assert_allclose(operator.full(), expected)
 
 
 def test_squeeze():
-    "Squeezing operator"
-    sq = squeeze(4, 0.1 + 0.1j)
+    sq = qutip.squeeze(4, 0.1 + 0.1j)
     sqmatrix = np.array([[0.99500417 + 0.j, 0.00000000 + 0.j,
                           0.07059289 - 0.07059289j, 0.00000000 + 0.j],
                          [0.00000000 + 0.j, 0.98503746 + 0.j,
@@ -180,13 +179,18 @@ def test_squeeze():
                           0.99500417 + 0.j, 0.00000000 + 0.j],
                          [0.00000000 + 0.j, -0.12186303 - 0.12186303j,
                           0.00000000 + 0.j, 0.98503746 + 0.j]])
+    np.testing.assert_allclose(sq.full(), sqmatrix, atol=1e-8)
 
-    assert_equal(np.allclose(sq.full(), sqmatrix), True)
+
+def test_squeezing():
+    squeeze = qutip.squeeze(4, 0.1 + 0.1j)
+    a = qutip.destroy(4)
+    squeezing = qutip.squeezing(a, a, 0.1 + 0.1j)
+    assert squeeze == squeezing
 
 
 def test_displace():
-    "Displacement operator"
-    dp = displace(4, 0.25)
+    dp = qutip.displace(4, 0.25)
     dpmatrix = np.array(
         [[0.96923323 + 0.j, -0.24230859 + 0.j, 0.04282883 + 0.j, -
           0.00626025 + 0.j],
@@ -196,30 +200,23 @@ def test_displace():
           0.j, -0.41083747 + 0.j],
          [0.00626025 + 0.j, 0.07418172 + 0.j, 0.41083747 + 0.j,
           0.90866411 + 0.j]])
-
-    assert_equal(np.allclose(dp.full(), dpmatrix), True)
-
-
-def test_charge():
-    "Charge operator"
-    N = 5
-    M = - np.random.randint(N)
-    ch = charge(N,M)
-    ch_matrix = np.diag(np.arange(M,N+1))
-    assert_equal(np.allclose(ch.full(), ch_matrix), True)
+    np.testing.assert_allclose(dp.full(), dpmatrix, atol=1e-8)
 
 
-def test_tunneling():
-    "Tunneling operator"
-    N = 5
-    tn = tunneling(2*N+1)
-    tn_matrix = np.diag(np.ones(2*N),k=-1) + np.diag(np.ones(2*N),k=1)
-    assert_equal(np.allclose(tn.full(), tn_matrix), True) 
-    
-    tn = tunneling(2*N+1,2)
-    tn_matrix = np.diag(np.ones(2*N-1),k=-2) + np.diag(np.ones(2*N-1),k=2)
-    assert_equal(np.allclose(tn.full(), tn_matrix), True)
+@pytest.mark.parametrize("shift", [1, 2])
+def test_tunneling(shift):
+    N = 10
+    tn = qutip.tunneling(N, shift)
+    tn_matrix = np.diag(np.ones(N - shift), k=shift)
+    tn_matrix += tn_matrix.T
+    np.testing.assert_allclose(tn.full(), tn_matrix)
 
 
-if __name__ == "__main__":
-    run_module_suite()
+def test_commutator():
+    A = qutip.qeye(N)
+    B = qutip.destroy(N)
+    assert qutip.commutator(A, B) == qutip.qzero(N)
+
+    sx = qutip.sigmax()
+    sy = qutip.sigmay()
+    assert qutip.commutator(sx, sy) / 2 == (qutip.sigmaz() * 1j)

--- a/qutip/tests/test_states.py
+++ b/qutip/tests/test_states.py
@@ -152,7 +152,7 @@ def test_CoherentState():
     c3 = qutip.coherent(N, alpha, offset=0, method="analytic")
     np.testing.assert_allclose(c1.full()[3:], c2.full(), atol=1e-7)
     np.testing.assert_allclose(c1.full(), c3.full(), atol=1e-7)
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(ValueError) as e:
         qutip.coherent(N, alpha, method="other")
     assert str(e.value) == ("The method option can only take "
                             "values 'operator' or 'analytic'")
@@ -168,10 +168,10 @@ def test_thermal():
     np.testing.assert_allclose(thermal_operator.full(),
                                thermal_analytic.full(), atol=2e-5)
 
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(ValueError) as e:
         qutip.thermal_dm(N, beta, method="other")
-    assert str(e.value) == ("'method' keyword argument must be "
-                            "'operator' or 'analytic'")
+    assert str(e.value) == ("The method option can only take "
+                            "values 'operator' or 'analytic'")
 
 
 @pytest.mark.parametrize('func', [

--- a/qutip/tests/test_states.py
+++ b/qutip/tests/test_states.py
@@ -38,10 +38,6 @@ from functools import partial
 from itertools import combinations
 
 
-_2PI = 2 * np.pi
-N = 5
-
-
 @pytest.mark.parametrize("size, n", [(2, 0), (2, 1), (100, 99)])
 def test_basis_simple(size, n):
     qobj = qutip.basis(size, n)
@@ -50,12 +46,37 @@ def test_basis_simple(size, n):
     assert np.array_equal(qobj.full(), numpy)
 
 
-@pytest.mark.parametrize("to_test", [qutip.basis, qutip.fock, qutip.fock_dm])
+@pytest.mark.parametrize("to_test", [
+    qutip.basis, qutip.fock, qutip.fock_dm, qutip.state_number_qobj
+])
 @pytest.mark.parametrize("size, n", [([2, 2], [0, 1]), ([2, 3, 4], [1, 2, 0])])
 def test_implicit_tensor_basis_like(to_test, size, n):
     implicit = to_test(size, n)
-    explicit = qutip.tensor(*[to_test(ss, nn) for ss, nn in zip(size, n)])
+    explicit = qutip.tensor(*[to_test([ss], [nn]) for ss, nn in zip(size, n)])
     assert implicit == explicit
+
+
+@pytest.mark.parametrize("size, n, offset, msg", [
+    ([2, 2], [0, 1, 1], [0, 0], "All list inputs must be the same length."),
+    ([2, 2], [0, 1], 0, "All list inputs must be the same length."),
+    (-1, 0, 0, "All dimensions must be >= 0."),
+    (1.5, 0, 0, "All dimensions must be >= 0."),
+    (5, 5, 0, "All basis indices must be `offset <= n < dimension+offset`."),
+    (5, 0, 2, "All basis indices must be `offset <= n < dimension+offset`."),
+], ids=["n too long", "offset too long", "neg dims",
+        "fraction dims", "n too large", "n too small"]
+)
+def test_basis_error(size, n, offset, msg):
+    with pytest.raises(ValueError) as e:
+        qutip.basis(size, n, offset)
+    assert str(e.value) == msg
+
+
+def test_basis_error_type():
+    with pytest.raises(TypeError) as e:
+        qutip.basis(5, 3.5)
+    assert str(e.value) == ("Dimensions must be an integer "
+                            "or list of integers.")
 
 
 @pytest.mark.parametrize("size, n, m", [
@@ -73,24 +94,25 @@ def test_implicit_tensor_projection(size, n, m):
     pytest.param(qutip.basis, qutip.num, (10, 3), (10,), 3,
                  id="basis"),
     pytest.param(qutip.basis, qutip.num, (10, 3, 1), (10, 1), 3,
-                 id="basis_offset"),
+                 id="basis,offset"),
     pytest.param(qutip.fock, qutip.num, (10, 3), (10,), 3,
                  id="fock"),
     pytest.param(qutip.fock_dm, qutip.num, (10, 3), (10,), 3,
                  id="fock_dm"),
     pytest.param(qutip.fock_dm, qutip.num, (10, 3, 1), (10, 1), 3,
-                 id="fock_dm_offset"),
+                 id="fock_dm,offset"),
     pytest.param(qutip.coherent, qutip.destroy, (20, 0.75), (20,), 0.75,
                  id="coherent"),
     pytest.param(qutip.coherent, qutip.destroy, (50, 4.25, 1), (50, 1), 4.25,
-                 id="coherent_offset"),
+                 id="coherent,offset"),
     pytest.param(qutip.coherent_dm, qutip.destroy, (25, 1.25), (25,), 1.25,
                  id="coherent_dm"),
-    pytest.param(qutip.phase_basis, qutip.phase, (10, 3), (10,), 3 * _2PI / 10,
+    pytest.param(qutip.phase_basis, qutip.phase,
+                 (10, 3), (10,), 3 * 2 * np.pi / 10,
                  id="phase_basis"),
     pytest.param(qutip.phase_basis, qutip.phase,
-                 (10, 3, 1), (10, 1), 3 * _2PI / 10 + 1,
-                 id="phase_basis_phi0"),
+                 (10, 3, 1), (10, 1), 3 * 2 * np.pi / 10 + 1,
+                 id="phase_basis,phi0"),
     pytest.param(qutip.spin_state, qutip.spin_Jz, (3, 2), (3,), 2,
                  id="spin_state"),
     pytest.param(qutip.zero_ket, qutip.qeye, (10,), (10,), 0,
@@ -119,7 +141,7 @@ def test_dm(dm):
     N = 5
     rho = dm(N)
     # make sure rho has trace close to 1.0
-    assert abs(rho.tr() - 1.0) < 1e-12
+    assert rho.tr() == pytest.approx(1.0)
 
 
 def test_CoherentState():
@@ -127,20 +149,71 @@ def test_CoherentState():
     alpha = 0.5
     c1 = qutip.coherent(N, alpha)  # displacement method
     c2 = qutip.coherent(7, alpha, offset=3)  # analytic method
-    assert abs(qutip.expect(qutip.destroy(N), c1) - alpha) < 1e-10
-    assert (qutip.Qobj(c1[3:]) - c2).norm() < 1e-7
+    c3 = qutip.coherent(N, alpha, offset=0, method="analytic")
+    np.testing.assert_allclose(c1.full()[3:], c2.full(), atol=1e-7)
+    np.testing.assert_allclose(c1.full(), c3.full(), atol=1e-7)
+    with pytest.raises(TypeError) as e:
+        qutip.coherent(N, alpha, method="other")
+    assert str(e.value) == ("The method option can only take "
+                            "values 'operator' or 'analytic'")
+
+
+def test_thermal():
+    N = 10
+    beta = 0.5
+    assert qutip.thermal_dm(N, 0) == qutip.fock_dm(N, 0)
+
+    thermal_operator = qutip.thermal_dm(N, beta)
+    thermal_analytic = qutip.thermal_dm(N, beta, method="analytic")
+    np.testing.assert_allclose(thermal_operator.full(),
+                               thermal_analytic.full(), atol=2e-5)
+
+    with pytest.raises(TypeError) as e:
+        qutip.thermal_dm(N, beta, method="other")
+    assert str(e.value) == ("'method' keyword argument must be "
+                            "'operator' or 'analytic'")
+
+
+@pytest.mark.parametrize('func', [
+    qutip.spin_state, partial(qutip.spin_coherent, phi=0.5)
+])
+def test_spin_output(func):
+    assert qutip.isket(func(1.0, 0, type='ket'))
+    assert qutip.isbra(func(1.0, 0, type='bra'))
+    assert qutip.isoper(func(1.0, 0, type='dm'))
+
+    with pytest.raises(ValueError) as e:
+        func(1.0, 0, type='something')
+    assert str(e.value) == "invalid value keyword argument 'type'"
+
+
+@pytest.mark.parametrize('N', [2.5, -1])
+def test_maximally_mixed_dm_error(N):
+    with pytest.raises(ValueError) as e:
+        qutip.maximally_mixed_dm(N)
+    assert str(e.value) == "N must be integer N > 0"
 
 
 def test_TripletStateNorm():
     for triplet in qutip.triplet_states():
-        assert abs(triplet.norm() - 1.) < 1e-12
+        assert triplet.norm() == pytest.approx(1.)
+    for t1, t2 in combinations(qutip.triplet_states(), 2):
+        assert t1.overlap(t2) == pytest.approx(0.)
 
 
 def test_ket2dm():
     N = 5
-    state = qutip.coherent(N, 2)
-    oper = qutip.ket2dm(state)
-    assert np.abs(qutip.expect(oper, state) - 1) < 1e-12
+    ket = qutip.coherent(N, 2)
+    bra = ket.dag()
+    oper = qutip.ket2dm(ket)
+    oper_from_bra = qutip.ket2dm(bra)
+    assert qutip.expect(oper, ket) == pytest.approx(1.)
+    assert qutip.isoper(oper)
+    assert oper == ket * bra
+    assert oper == oper_from_bra
+    with pytest.raises(TypeError) as e:
+        qutip.ket2dm(oper)
+    assert str(e.value) == "Input is not a ket or bra vector."
 
 
 @pytest.mark.parametrize('state', [[0, 1], [0, 0], [0, 1, 0, 1]])
@@ -148,6 +221,13 @@ def test_qstate(state):
     from_basis = qutip.basis([2] * len(state), state)
     from_qstate = qutip.qstate("".join({0: "d", 1: "u"}[i] for i in state))
     assert from_basis == from_qstate
+
+
+def test_qstate_error():
+    with pytest.raises(TypeError) as e:
+        qutip.qstate("eeggg")
+    assert str(e.value) == ('String input to QSTATE must consist ' +
+                            'of "u" and "d" elements only')
 
 
 @pytest.mark.parametrize('state', ["11000", "eeggg", "dduuu", "VVHHH"])
@@ -170,7 +250,7 @@ def test_w_states():
 
 
 def test_ghz_states():
-    state = (qutip.qstate("uuu") + qutip.qstate("ddd")) * 0.5**0.5
+    state = (qutip.qstate("uuu") + qutip.qstate("ddd")).unit()
     assert state == qutip.ghz_state(3)
 
 

--- a/qutip/tests/test_states.py
+++ b/qutip/tests/test_states.py
@@ -33,10 +33,13 @@
 
 import pytest
 import numpy as np
-from numpy.testing import assert_, run_module_suite
 import qutip
-from qutip import (expect, destroy, coherent, coherent_dm, thermal_dm,
-                   fock_dm, triplet_states)
+from functools import partial
+from itertools import combinations
+
+
+_2PI = 2 * np.pi
+N = 5
 
 
 @pytest.mark.parametrize("size, n", [(2, 0), (2, 1), (100, 99)])
@@ -66,63 +69,124 @@ def test_implicit_tensor_projection(size, n, m):
     assert implicit == explicit
 
 
-class TestStates:
-    """
-    A test class for the QuTiP functions for generating quantum states
-    """
-
-    def testCoherentState(self):
-        """
-        states: coherent state
-        """
-        N = 10
-        alpha = 0.5
-        c1 = coherent(N, alpha) # displacement method
-        c2 = coherent(7, alpha, offset=3) # analytic method
-        assert_(abs(expect(destroy(N), c1) - alpha) < 1e-10)
-        assert_((c1[3:]-c2).norm() < 1e-7)
-
-
-    def testCoherentDensityMatrix(self):
-        """
-        states: coherent density matrix
-        """
-        N = 10
-
-        rho = coherent_dm(N, 1)
-
-        # make sure rho has trace close to 1.0
-        assert_(abs(rho.tr() - 1.0) < 1e-12)
-
-    def testThermalDensityMatrix(self):
-        """
-        states: thermal density matrix
-        """
-        N = 40
-
-        rho = thermal_dm(N, 1)
-
-        # make sure rho has trace close to 1.0
-        assert_(abs(rho.tr() - 1.0) < 1e-12)
-
-    def testFockDensityMatrix(self):
-        """
-        states: Fock density matrix
-        """
-        N = 10
-        for i in range(N):
-            rho = fock_dm(N, i)
-            # make sure rho has trace close to 1.0
-            assert_(abs(rho.tr() - 1.0) < 1e-12)
-            assert_(rho.data[i, i] == 1.0)
-
-    def testTripletStateNorm(self):
-        """
-        Test the states returned by function triplet_states are normalized.
-        """
-        for triplet in triplet_states():
-            assert_(abs(triplet.norm() - 1.) < 1e-12)
+@pytest.mark.parametrize("base, operator, args, opargs, eigenval", [
+    pytest.param(qutip.basis, qutip.num, (10, 3), (10,), 3,
+                 id="basis"),
+    pytest.param(qutip.basis, qutip.num, (10, 3, 1), (10, 1), 3,
+                 id="basis_offset"),
+    pytest.param(qutip.fock, qutip.num, (10, 3), (10,), 3,
+                 id="fock"),
+    pytest.param(qutip.fock_dm, qutip.num, (10, 3), (10,), 3,
+                 id="fock_dm"),
+    pytest.param(qutip.fock_dm, qutip.num, (10, 3, 1), (10, 1), 3,
+                 id="fock_dm_offset"),
+    pytest.param(qutip.coherent, qutip.destroy, (20, 0.75), (20,), 0.75,
+                 id="coherent"),
+    pytest.param(qutip.coherent, qutip.destroy, (50, 4.25, 1), (50, 1), 4.25,
+                 id="coherent_offset"),
+    pytest.param(qutip.coherent_dm, qutip.destroy, (25, 1.25), (25,), 1.25,
+                 id="coherent_dm"),
+    pytest.param(qutip.phase_basis, qutip.phase, (10, 3), (10,), 3 * _2PI / 10,
+                 id="phase_basis"),
+    pytest.param(qutip.phase_basis, qutip.phase,
+                 (10, 3, 1), (10, 1), 3 * _2PI / 10 + 1,
+                 id="phase_basis_phi0"),
+    pytest.param(qutip.spin_state, qutip.spin_Jz, (3, 2), (3,), 2,
+                 id="spin_state"),
+    pytest.param(qutip.zero_ket, qutip.qeye, (10,), (10,), 0,
+                 id="zero_ket"),
+])
+def test_diverse_basis(base, operator, args, opargs, eigenval):
+    # For state which are supposed to eigenvector of an operator
+    # Verify that correspondance
+    state = base(*args)
+    oper = operator(*opargs)
+    assert qutip.expect(oper, state) == pytest.approx(eigenval)
 
 
-if __name__ == "__main__":
-    run_module_suite()
+@pytest.mark.parametrize('dm', [
+    partial(qutip.thermal_dm, n=1.),
+    qutip.maximally_mixed_dm,
+    partial(qutip.coherent_dm, alpha=0.5),
+    partial(qutip.fock_dm, n=1),
+    partial(qutip.spin_state, m=2, type='dm'),
+    partial(qutip.spin_coherent, theta=1, phi=2, type='dm'),
+], ids=[
+    'thermal_dm', 'maximally_mixed_dm', 'coherent_dm',
+    'fock_dm', 'spin_state', 'spin_coherent'
+])
+def test_dm(dm):
+    N = 5
+    rho = dm(N)
+    # make sure rho has trace close to 1.0
+    assert abs(rho.tr() - 1.0) < 1e-12
+
+
+def test_CoherentState():
+    N = 10
+    alpha = 0.5
+    c1 = qutip.coherent(N, alpha)  # displacement method
+    c2 = qutip.coherent(7, alpha, offset=3)  # analytic method
+    assert abs(qutip.expect(qutip.destroy(N), c1) - alpha) < 1e-10
+    assert (qutip.Qobj(c1[3:]) - c2).norm() < 1e-7
+
+
+def test_TripletStateNorm():
+    for triplet in qutip.triplet_states():
+        assert abs(triplet.norm() - 1.) < 1e-12
+
+
+def test_ket2dm():
+    N = 5
+    state = qutip.coherent(N, 2)
+    oper = qutip.ket2dm(state)
+    assert np.abs(qutip.expect(oper, state) - 1) < 1e-12
+
+
+@pytest.mark.parametrize('state', [[0, 1], [0, 0], [0, 1, 0, 1]])
+def test_qstate(state):
+    from_basis = qutip.basis([2] * len(state), state)
+    from_qstate = qutip.qstate("".join({0: "d", 1: "u"}[i] for i in state))
+    assert from_basis == from_qstate
+
+
+@pytest.mark.parametrize('state', ["11000", "eeggg", "dduuu", "VVHHH"])
+def test_bra_ket(state):
+    from_basis = qutip.basis([2, 2, 2, 2, 2], [1, 1, 0, 0, 0])
+    from_ket = qutip.ket(state)
+    from_bra = qutip.bra(state).dag()
+    assert from_basis == from_ket
+    assert from_basis == from_bra
+
+
+def test_w_states():
+    state = (
+        qutip.qstate("uddd") +
+        qutip.qstate("dudd") +
+        qutip.qstate("ddud") +
+        qutip.qstate("dddu")
+    ) / 2
+    assert state == qutip.w_state(4)
+
+
+def test_ghz_states():
+    state = (qutip.qstate("uuu") + qutip.qstate("ddd")) * 0.5**0.5
+    assert state == qutip.ghz_state(3)
+
+
+def test_bell_state():
+    states = [
+        qutip.bell_state('00'),
+        qutip.bell_state('01'),
+        qutip.bell_state('10'),
+        qutip.bell_state('11')
+    ]
+    exited = qutip.basis([2, 2], [1, 1])
+    for state, overlap in zip(states, [0.5**0.5, -0.5**0.5, 0, 0]):
+        assert state.norm() == pytest.approx(1.0)
+        assert state.overlap(exited) == pytest.approx(overlap)
+
+    for state1, state2 in combinations(states, 2):
+        assert state1.overlap(state2) == pytest.approx(0.0)
+
+    assert qutip.singlet_state() == qutip.bell_state('11')


### PR DESCRIPTION
Add tests for previously untested function in states and operators and parametrize some of the existing tests.
Should improve the coverall by about 100 lines.

**Changelog**
Improve test coverage of states and operators functions.