### PR TITLE
Convert README CI badge to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ QuTiP: Quantum Toolbox in Python
 [P. D. Nation](https://github.com/nonhermitian),
 and [J. R. Johansson](https://github.com/jrjohansson)
 
-[![Build Status](https://img.shields.io/travis/qutip/qutip?logo=Travis)](https://travis-ci.org/qutip/qutip)
+[![Build Status](https://github.com/qutip/qutip/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/qutip/qutip/actions/workflows/tests.yml)
 [![Coverage Status](https://img.shields.io/coveralls/qutip/qutip.svg?logo=Coveralls)](https://coveralls.io/r/qutip/qutip)
 [![Maintainability](https://api.codeclimate.com/v1/badges/df502674f1dfa1f1b67a/maintainability)](https://codeclimate.com/github/qutip/qutip/maintainability)
 [![license](https://img.shields.io/badge/license-New%20BSD-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)  


### PR DESCRIPTION
We don't use Travis CI any more.

**Changelog**: change README badge to point to GitHub Actions, not Travis
