### PR TITLE
Silenced deprecation warning from pyximport.

### DIFF
--- a/qutip/_pyxbuilder.py
+++ b/qutip/_pyxbuilder.py
@@ -32,9 +32,14 @@
 ###############################################################################
 import sys
 import os
+import warnings
 
 import numpy as np
-import pyximport
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import pyximport
+
 
 old_get_distutils_extension = pyximport.pyximport.get_distutils_extension
 


### PR DESCRIPTION
**Description**
`pyximport` raises a deprecation warning due to importing `imp` instead of `importlib`. I silenced it.  It was causing some problem in qutip-tensorflow testing as all warnings are treated as errors. Let me know if I should have proceeded in a different way. 

**Changelog**
Silenced deprecation warning from `pyximport`.

