### PR TITLE
Faster Husimi Q with saved state

### DIFF
--- a/doc/apidoc/classes.rst
+++ b/doc/apidoc/classes.rst
@@ -37,6 +37,13 @@ Bloch sphere
     :members:
 
 
+Distributions
+-------------
+
+.. autoclass:: qutip.QFunc
+    :members:
+
+
 Cubic Spline
 ---------------
 

--- a/doc/guide/guide-visualization.rst
+++ b/doc/guide/guide-visualization.rst
@@ -234,33 +234,35 @@ distribution for harmonic modes. It is defined as
 
 where :math:`\left|\alpha\right>` is a coherent state and
 :math:`\alpha = x + iy`. In QuTiP, the Husimi Q function can be computed given
-a state ket or density matrix using the function :func:`qutip.wigner.qfunc`, as
+a state ket or density matrix using the function :func:`.qfunc`, as
 demonstrated below.
 
 .. plot::
     :context: close-figs
 
     Q_coherent = qfunc(rho_coherent, xvec, xvec)
-
     Q_thermal = qfunc(rho_thermal, xvec, xvec)
-
     Q_fock = qfunc(rho_fock, xvec, xvec)
-
     fig, axes = plt.subplots(1, 3, figsize=(12,3))
-
     cont0 = axes[0].contourf(xvec, xvec, Q_coherent, 100)
-
     lbl0 = axes[0].set_title("Coherent state")
-
     cont1 = axes[1].contourf(xvec, xvec, Q_thermal, 100)
-
     lbl1 = axes[1].set_title("Thermal state")
-
     cont0 = axes[2].contourf(xvec, xvec, Q_fock, 100)
-
     lbl2 = axes[2].set_title("Fock state")
-
     plt.show()
+
+If you need to calculate the Q function for many states with the same
+phase-space coordinates, it is more efficient to use the :obj:`.QFunc` class.
+This stores various intermediary results to achieve an order-of-magnitude
+improvement compared to calling :obj:`.qfunc` in a loop.
+
+.. code-block:: python
+
+   xs = np.linspace(-1, 1, 101)
+   qfunc_calculator = qutip.QFunc(xs, xs)
+   q_state1 = qfunc_calculator(qutip.rand_dm(5))
+   q_state2 = qfunc_calculator(qutip.rand_ket(100))
 
 
 .. _visual-oper:

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -4,66 +4,230 @@ from scipy.special import laguerre
 from numpy.random import rand
 from numpy.testing import assert_, run_module_suite, assert_equal
 
+import qutip
 from qutip.states import coherent, fock, ket, bell_state
-from qutip.wigner import (
-    qfunc, qfunc_precompute, wigner, wigner_transform, _parity,
-)
+from qutip.wigner import wigner, wigner_transform, _parity
 from qutip.random_objects import rand_dm, rand_ket
 
 
-def test_qfunc_ket():
-    "Husimi Q: Compare with/without precomputation for rand. ket"
-    N = 20
-    xvec = np.linspace(-10, 10, 128)
-    for _ in range(3):
-        rho = rand_ket(N)
+class TestHusimiQ:
+    @pytest.mark.parametrize('xs', ["", 1, None], ids=['str', 'int', 'none'])
+    def test_failure_if_non_arraylike_coordinates(self, xs):
+        state = qutip.rand_ket(4)
+        valid = np.linspace(-1, 1, 5)
+        with pytest.raises(TypeError) as e:
+            qutip.qfunc(state, xs, valid)
+        assert "must be array-like" in e.value.args[0]
+        with pytest.raises(TypeError) as e:
+            qutip.qfunc(state, valid, xs)
+        assert "must be array-like" in e.value.args[0]
+        with pytest.raises(TypeError) as e:
+            qutip.QFunc(xs, valid)
+        assert "must be array-like" in e.value.args[0]
+        with pytest.raises(TypeError) as e:
+            qutip.QFunc(valid, xs)
+        assert "must be array-like" in e.value.args[0]
 
-        precomp = qfunc_precompute(xvec, xvec, N)
+    @pytest.mark.parametrize('ndim', [2, 3])
+    def test_failure_if_coordinates_not_1d(self, ndim):
+        state = qutip.rand_ket(4)
+        valid = np.linspace(-1, 1, 5)
+        bad = valid.reshape((-1,) + (1,)*(ndim - 1))
+        with pytest.raises(ValueError) as e:
+            qutip.qfunc(state, bad, valid)
+        assert "must be 1D" in e.value.args[0]
+        with pytest.raises(ValueError) as e:
+            qutip.qfunc(state, valid, bad)
+        assert "must be 1D" in e.value.args[0]
+        with pytest.raises(ValueError) as e:
+            qutip.QFunc(bad, valid)
+        assert "must be 1D" in e.value.args[0]
+        with pytest.raises(ValueError) as e:
+            qutip.QFunc(valid, bad)
+        assert "must be 1D" in e.value.args[0]
 
-        q_default = qfunc(rho, xvec, xvec, precompute=None)
-        q_false = qfunc(rho, xvec, xvec, precompute=False)
-        q_true = qfunc(rho, xvec, xvec, precompute=True)
-        q_precomp = qfunc(rho, xvec, xvec, precompute=precomp)
-        # Default: do not precompute
-        assert_equal(q_false, q_default)
-        # Compare precomputing before/during the call
-        assert_equal(q_true, q_precomp)
-        assert_equal(np.sum(np.abs(q_true - q_false)) < 1e-7, True)
+    @pytest.mark.parametrize('dm', [True, False], ids=['dm', 'ket'])
+    def test_failure_if_tensor_hilbert_space(self, dm):
+        if dm:
+            state = qutip.rand_dm(4, dims=[[2, 2], [2, 2]])
+        else:
+            state = qutip.rand_ket(4, dims=[[2, 2], [1, 1]])
+        xs = np.linspace(-1, 1, 5)
+        with pytest.raises(ValueError) as e:
+            qutip.qfunc(state, xs, xs)
+        assert "must not have tensor structure" in e.value.args[0]
+        with pytest.raises(ValueError) as e:
+            qutip.QFunc(xs, xs)(state)
+        assert "must not have tensor structure" in e.value.args[0]
 
+    def test_QFunc_raises_if_insufficient_memory(self):
+        xs = np.linspace(-1, 1, 11)
+        state = qutip.rand_ket(4)
+        qfunc = qutip.QFunc(xs, xs, memory=0)
+        with pytest.raises(MemoryError) as e:
+            qfunc(state)
+        assert e.value.args[0].startswith("Refusing to precompute")
 
-def test_qfunc_dm():
-    "Husimi Q: Compare with/without precomputation for rand. dm"
-    N = 20
-    xvec = np.linspace(-10, 10, 128)
-    for _ in range(3):
-        rho = rand_dm(N)
+    def test_qfunc_warns_if_insufficient_memory(self):
+        xs = np.linspace(-1, 1, 11)
+        state = qutip.rand_dm(4)
+        with pytest.warns(UserWarning) as e:
+            qutip.qfunc(state, xs, xs, precompute_memory=0)
+        assert (
+            e[0].message.args[0]
+            .startswith("Falling back to iterative algorithm")
+        )
 
-        precomp = qfunc_precompute(xvec, xvec, N)
+    @pytest.mark.parametrize('obj', [
+        pytest.param(np.eye(2, dtype=np.complex128), id='ndarray'),
+        pytest.param([[1, 0], [0, 1]], id='list'),
+        pytest.param(1, id='int'),
+    ])
+    def test_failure_if_not_a_Qobj(self, obj):
+        xs = np.linspace(-1, 1, 11)
+        with pytest.raises(TypeError) as e:
+            qutip.qfunc(obj, xs, xs)
+        assert e.value.args[0].startswith("state must be Qobj")
+        qfunc = qutip.QFunc(xs, xs)
+        with pytest.raises(TypeError) as e:
+            qfunc(obj)
+        assert e.value.args[0].startswith("state must be Qobj")
 
-        q_default = qfunc(rho, xvec, xvec, precompute=None)
-        q_false = qfunc(rho, xvec, xvec, precompute=False)
-        q_true = qfunc(rho, xvec, xvec, precompute=True)
-        q_precomp = qfunc(rho, xvec, xvec, precompute=precomp)
+    # Use indirection so that the tests can still be collected if there's a bug
+    # in the generating QuTiP functions.
+    @pytest.mark.parametrize('state', [
+        pytest.param(lambda: qutip.rand_super(2), id='super'),
+        pytest.param(lambda: qutip.rand_ket(2).dag(), id='bra'),
+        pytest.param(lambda: 1j*qutip.rand_dm(2), id='non-dm operator'),
+        pytest.param(lambda: qutip.Qobj([[1, 0], [0, 0]], dims=[[2], [2, 1]]),
+                     id='nonsquare dm'),
+        pytest.param(lambda: qutip.operator_to_vector(qutip.qeye(2)),
+                     id='operator-ket'),
+        pytest.param(lambda: qutip.operator_to_vector(qutip.qeye(2)).dag(),
+                     id='operator-bra'),
+    ])
+    def test_failure_if_not_a_state(self, state):
+        xs = np.linspace(-1, 1, 11)
+        state = state()
+        with pytest.raises(ValueError) as e:
+            qutip.qfunc(state, xs, xs)
+        assert (
+            e.value.args[0].startswith("state must be a ket or density matrix")
+        )
+        qfunc = qutip.QFunc(xs, xs)
+        with pytest.raises(ValueError) as e:
+            qfunc(state)
+        assert (
+            e.value.args[0].startswith("state must be a ket or density matrix")
+        )
 
-        # Default: do not precompute
-        assert_equal(q_false, q_default)
-        # Compare precomputing before/during the call
-        assert_equal(q_true, q_precomp)
-        assert_equal(np.sum(np.abs(q_true - q_false)) < 1e-7, True)
+    @pytest.mark.parametrize('g', [
+        pytest.param(np.sqrt(2), id='natural units'),
+        pytest.param(1, id='arb units'),
+    ])
+    @pytest.mark.parametrize('n_ys', [5, 101])
+    @pytest.mark.parametrize('n_xs', [5, 101])
+    @pytest.mark.parametrize('dm', [True, False], ids=['dm', 'ket'])
+    @pytest.mark.parametrize('size', [5, 32])
+    def test_function_and_class_are_equivalent(self, size, dm, n_xs, n_ys, g):
+        xs = np.linspace(-1, 1, n_xs)
+        ys = np.linspace(0, 2, n_ys)
+        state = qutip.rand_dm(size) if dm else qutip.rand_ket(size)
+        function = qutip.qfunc(state, xs, ys, g)
+        class_ = qutip.QFunc(xs, ys, g)(state)
+        np.testing.assert_allclose(function, class_)
 
+    @pytest.mark.parametrize('g', [
+        pytest.param(np.sqrt(2), id='natural units'),
+        pytest.param(1, id='arb units'),
+    ])
+    @pytest.mark.parametrize('n_ys', [5, 101])
+    @pytest.mark.parametrize('n_xs', [5, 101])
+    @pytest.mark.parametrize('size', [5, 32])
+    def test_iterate_and_precompute_are_equivalent(self, size, n_xs, n_ys, g):
+        xs = np.linspace(-1, 1, n_xs)
+        ys = np.linspace(0, 2, n_ys)
+        state = qutip.rand_dm(size)
+        iterate = qutip.qfunc(state, xs, ys, g, precompute_memory=None)
+        precompute = qutip.qfunc(state, xs, ys, g, precompute_memory=np.inf)
+        np.testing.assert_allclose(iterate, precompute)
 
-def test_qfunc_exceptions():
-    "Husimi Q: Test Memory Safeguard"
-    xvec = np.linspace(-10, 10, 256)
+    @pytest.mark.parametrize('initial_size', [5, 8])
+    @pytest.mark.parametrize('dm', [True, False], ids=['dm', 'ket'])
+    def test_same_class_can_take_many_sizes(self, dm, initial_size):
+        xs = np.linspace(-1, 1, 11)
+        ys = np.linspace(0, 2, 11)
+        shape = np.meshgrid(xs, ys)[0].shape
+        sizes = initial_size + np.array([0, 1, -1, 4])
+        qfunc = qutip.QFunc(xs, ys)
+        for size in sizes:
+            state = qutip.rand_dm(size) if dm else qutip.rand_ket(size)
+            out = qfunc(state)
+            assert isinstance(out, np.ndarray)
+            assert out.shape == shape
 
-    # Test only the MemoryError, testing the fallback is too slow
-    try:
-        qfunc_precompute(xvec, xvec, 257, max_memory=256)
-    except MemoryError:
-        pass
-    else:
-        raise Exception
-    qfunc_precompute(xvec, xvec, 256, max_memory=256)
+    @pytest.mark.parametrize('dm_first', [True, False])
+    def test_same_class_can_mix_ket_and_dm(self, dm_first):
+        dms = [True, False, True, False]
+        if not dm_first:
+            dms = dms[::-1]
+        xs = np.linspace(-1, 1, 11)
+        ys = np.linspace(0, 2, 11)
+        shape = np.meshgrid(xs, ys)[0].shape
+        qfunc = qutip.QFunc(xs, ys)
+        for dm in dms:
+            state = qutip.rand_dm(4) if dm else qutip.rand_ket(4)
+            out = qfunc(state)
+            assert isinstance(out, np.ndarray)
+            assert out.shape == shape
+
+    @pytest.mark.parametrize('n_ys', [5, 101])
+    @pytest.mark.parametrize('n_xs', [5, 101])
+    @pytest.mark.parametrize('mix', [0.1, 0.5])
+    def test_qfunc_is_linear(self, n_xs, n_ys, mix):
+        xs = np.linspace(-1, 1, n_xs)
+        ys = np.linspace(-1, 1, n_ys)
+        qfunc = qutip.QFunc(xs, ys)
+        left, right = qutip.rand_dm(5), qutip.rand_dm(5)
+        qleft, qright = qfunc(left), qfunc(right)
+        qboth = qfunc(mix*left + (1-mix)*right)
+        np.testing.assert_allclose(mix*qleft + (1-mix)*qright, qboth)
+
+    @pytest.mark.parametrize('n_ys', [5, 101])
+    @pytest.mark.parametrize('n_xs', [5, 101])
+    @pytest.mark.parametrize('size', [5, 32])
+    def test_ket_and_dm_give_same_result(self, n_xs, n_ys, size):
+        xs = np.linspace(-1, 1, n_xs)
+        ys = np.linspace(-1, 1, n_ys)
+        state = qutip.rand_ket(size)
+        qfunc = qutip.QFunc(xs, ys)
+        np.testing.assert_allclose(qfunc(state), qfunc(state.proj()))
+
+    @pytest.mark.parametrize('g', [
+        pytest.param(np.sqrt(2), id='natural units'),
+        pytest.param(1, id='arb units'),
+    ])
+    @pytest.mark.parametrize('ys', [
+        pytest.param(np.linspace(-1, 1, 5), id='(-1,1,5)'),
+        pytest.param(np.linspace(0, 2, 3), id='(0,2,3)'),
+    ])
+    @pytest.mark.parametrize('xs', [
+        pytest.param(np.linspace(-1, 1, 5), id='(-1,1,5)'),
+        pytest.param(np.linspace(0, 2, 3), id='(0,2,3)'),
+    ])
+    @pytest.mark.parametrize('size', [3, 5])
+    def test_against_naive_implementation(self, xs, ys, g, size):
+        state = qutip.rand_dm(size)
+        state_np = state.full()
+        x, y = np.meshgrid(xs, ys)
+        alphas = 0.5*g * (x + 1j*y)
+        naive = np.empty(alphas.shape, dtype=np.float64)
+        for i, alpha in enumerate(alphas.flat):
+            coh = qutip.coherent(size, alpha, method='analytic').full()
+            naive.flat[i] = (coh.conj().T @ state_np @ coh).real
+        naive *= (0.5*g)**2 / np.pi
+        np.testing.assert_allclose(naive, qutip.qfunc(state, xs, ys, g))
+        np.testing.assert_allclose(naive, qutip.QFunc(xs, ys, g)(state))
 
 
 def test_wigner_bell1_su2parity():

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -5,8 +5,65 @@ from numpy.random import rand
 from numpy.testing import assert_, run_module_suite, assert_equal
 
 from qutip.states import coherent, fock, ket, bell_state
-from qutip.wigner import wigner, wigner_transform, _parity
+from qutip.wigner import (
+    qfunc, qfunc_precompute, wigner, wigner_transform, _parity,
+)
 from qutip.random_objects import rand_dm, rand_ket
+
+
+def test_qfunc_ket():
+    "Husimi Q: Compare with/without precomputation for rand. ket"
+    N = 20
+    xvec = np.linspace(-10, 10, 128)
+    for _ in range(3):
+        rho = rand_ket(N)
+
+        precomp = qfunc_precompute(xvec, xvec, N)
+
+        q_default = qfunc(rho, xvec, xvec, precompute=None)
+        q_false = qfunc(rho, xvec, xvec, precompute=False)
+        q_true = qfunc(rho, xvec, xvec, precompute=True)
+        q_precomp = qfunc(rho, xvec, xvec, precompute=precomp)
+        # Default: do not precompute
+        assert_equal(q_false, q_default)
+        # Compare precomputing before/during the call
+        assert_equal(q_true, q_precomp)
+        assert_equal(np.sum(np.abs(q_true - q_false)) < 1e-7, True)
+
+
+def test_qfunc_dm():
+    "Husimi Q: Compare with/without precomputation for rand. dm"
+    N = 20
+    xvec = np.linspace(-10, 10, 128)
+    for _ in range(3):
+        rho = rand_dm(N)
+
+        precomp = qfunc_precompute(xvec, xvec, N)
+
+        q_default = qfunc(rho, xvec, xvec, precompute=None)
+        q_false = qfunc(rho, xvec, xvec, precompute=False)
+        q_true = qfunc(rho, xvec, xvec, precompute=True)
+        q_precomp = qfunc(rho, xvec, xvec, precompute=precomp)
+
+        # Default: do not precompute
+        assert_equal(q_false, q_default)
+        # Compare precomputing before/during the call
+        assert_equal(q_true, q_precomp)
+        assert_equal(np.sum(np.abs(q_true - q_false)) < 1e-7, True)
+
+
+def test_qfunc_exceptions():
+    "Husimi Q: Test Memory Safeguard"
+    xvec = np.linspace(-10, 10, 256)
+
+    # Test only the MemoryError, testing the fallback is too slow
+    try:
+        qfunc_precompute(xvec, xvec, 257, max_memory=256)
+    except MemoryError:
+        pass
+    else:
+        raise Exception
+    qfunc_precompute(xvec, xvec, 256, max_memory=256)
 
 
 def test_wigner_bell1_su2parity():

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -1,5 +1,7 @@
-__all__ = ['wigner', 'qfunc', 'QFunc', 'spin_q_function',
-           'spin_wigner', 'wigner_transform']
+__all__ = [
+    'wigner', 'qfunc', 'QFunc', 'spin_q_function', 'spin_wigner',
+    'wigner_transform',
+]
 
 import numpy as np
 import warnings
@@ -492,7 +494,7 @@ def _wig_laguerre_val(L, x, c):
     where
 
     .. math:
-    LL_n^L = (-1)^n \sqrt(L!n!/(L+n)!) LaguerreL[n,L,x]
+        LL_n^L = (-1)^n \sqrt(L!n!/(L+n)!) LaguerreL[n,L,x]
 
     The evaluation uses Clenshaw recursion.
     """
@@ -541,32 +543,67 @@ def _qfunc_check_state(state: Qobj):
     return state
 
 
-def _qfunc_check_coordinates(xs, ys):
-    if np.isscalar(xs) or xs is None:
-        raise TypeError("xs must be array-like, but is " + repr(xs))
-    if np.isscalar(ys) or ys is None:
-        raise TypeError("ys must be array-like, but is " + repr(ys))
-    xs = np.asarray(xs, dtype=np.float64)
-    ys = np.asarray(ys, dtype=np.float64)
-    if xs.ndim != 1 or ys.ndim != 1:
+def _qfunc_check_coordinates(xvec, yvec):
+    if np.isscalar(xvec) or xvec is None:
+        raise TypeError("xvec must be array-like, but is " + repr(xvec))
+    if np.isscalar(yvec) or yvec is None:
+        raise TypeError("yvec must be array-like, but is " + repr(yvec))
+    xvec = np.asarray(xvec, dtype=np.float64)
+    yvec = np.asarray(yvec, dtype=np.float64)
+    if xvec.ndim != 1 or yvec.ndim != 1:
         raise ValueError(
-            f"xs and ys must be 1D, but have shapes {xs.shape} and {ys.shape}."
+            f"xvec and yvec must be 1D, but have shapes {xvec.shape} and {yvec.shape}."
         )
-    return xs, ys
+    return xvec, yvec
 
 
-class _qfunc_alpha_matrix:
+class _QFuncCoherentGrid:
     """
-    Internal class used to centrally manage the creation of tensors related to
-    coherent states used in the calculation of the Husimi-Q function.
+    Internal function to compute coherent state operators corresponding to a
+    grid of complex values in phase space.  For efficiency reasons, this class
+    produces the adjoint of the coherent states, to save allocations when
+    calculating inner products later.
+
+    Examples
+    --------
+    Initialise the grid calculator.
+
+    >>> xvec = yvec = np.linspace(-1, 1, 21)
+    >>> g = np.sqrt(0.5)
+    >>> max_ns = 10
+    >>> grid = _QFuncCoherentGrid(xvec, yvec, g)
+
+    The naive construction of the grid is
+
+    >>> xs, ys = np.meshgrid(xvec, yvec)
+    >>> all_alphas = 0.5 * g * (xs + 1j*ys)
+    >>> naive = np.array([
+    ...     [
+    ...         qutip.coherent(max_ns, alpha, method='analytic')
+    ...             .dag().full().ravel()
+    ...         for alpha in x_alphas
+    ...     ]
+    ...     for y_alphas in all_alphas
+    ... ])
+
+    The naive approach is typically several of orders of magnitude slower than
+    this class, which uses much simpler vectorised operations.  The outputs are
+    within close tolerance, however:
+
+    >>> np.allclose(naive, grid(max_ns))
+    True
+    >>> np.allclose(naive[:, :, 4:7], grid(4, 7))
+    True
     """
-    def __init__(self, xs, ys, g: float):
-        self.xs, self.ys = _qfunc_check_coordinates(xs, ys)
-        x, y = np.meshgrid(0.5*g*self.xs, 0.5*g*self.ys)
-        self.conj = np.empty(x.shape, dtype=np.complex128)
-        self.conj.real = x
-        self.conj.imag = -y
-        self.prefactor = np.exp(-0.5 * (x*x + y*y)).astype(np.complex128)
+    def __init__(self, xvec, yvec, g: float):
+        self.xvec, self.yvec = _qfunc_check_coordinates(xvec, yvec)
+        x, y = np.meshgrid(0.5 * g * self.xvec, 0.5 * g * self.yvec)
+        self.grid = np.empty(x.shape, dtype=np.complex128)
+        self.grid.real = x
+        # We produce the adjoint of the coherent states to save an operation
+        # later when computing dot products, hence the negative imaginary part.
+        self.grid.imag = -y
+        self.prefactor = np.exp(-0.5 * (x * x + y * y)).astype(np.complex128)
 
     def _start(self, first: int):
         """
@@ -575,16 +612,18 @@ class _qfunc_alpha_matrix:
         """
         if first == 0:
             return self.prefactor.copy()
-        out = np.power(self.conj, first)
+        out = np.power(self.grid, first)
         out *= self.prefactor
         return out
 
     def __call__(self, first: int, last: int = None):
         """
-        Get a 3D array of the coherent-state matrices for all the Fock states
-        in the range ``first`` to ``last`` (if ``last`` is not given, then from
-        ``0`` to ``first``), not including the last element (like ``range``).
-        The last axis of the array is the Fock-state axis.
+        Get a 3D array of shape ``(yvec.size, xvec.size, last - first)`` of the
+        coherent-state vectors for all the Fock states in the range ``first``
+        to ``last``, excluding the end point.  The first two axes are the y-
+        and x-coordinates of phase space (i.e. Cartesian indexing, like
+        ``numpy.meshgrid``), and the last runs over the selected range of
+        Fock-space dimensions.
         """
         ns = np.arange(first, last).reshape(1, 1, -1)
         # Technically we could avoid hitting the limits of floating-point
@@ -593,12 +632,10 @@ class _qfunc_alpha_matrix:
         # floating-point operations overall, and needs special care around the
         # point alpha = 0 to avoid nan appearing, due to how Python handles
         # mixed-width arithmetic operations.
-        out = np.empty(
-            self.conj.shape + (ns.size,), dtype=np.complex128,
-        )
+        out = np.empty(self.grid.shape + (ns.size,), dtype=np.complex128)
         out[:, :, 0] = self._start(ns.flat[0])
         for i in range(ns.size - 1):
-            out[:, :, i+1] = out[:, :, i] * self.conj
+            out[:, :, i+1] = out[:, :, i] * self.grid
         out /= np.sqrt(scipy.special.factorial(ns))
         return out
 
@@ -606,14 +643,15 @@ class _qfunc_alpha_matrix:
 class QFunc:
     r"""
     Class-based method of calculating the Husimi-Q function of many different
-    quantum states at fixed points ``xs + i*ys``.  This class has slightly
-    higher first-usage costs than :obj:`.qfunc`, but subsequent operations will
-    be several times faster, and it can require quite a lot of memory.  Call
-    the created object as a function to retrieve the Husimi-Q function.
+    quantum states at fixed phase-space points ``0.5*g* (xvec + i*yvec)``.
+    This class has slightly higher first-usage costs than :obj:`.qfunc`, but
+    subsequent operations will be several times faster. However, it can require
+    quite a lot of memory. Call the created object as a function to retrieve
+    the Husimi-Q function.
 
     Parameters
     ----------
-    xs, ys : array_like
+    xvec, yvec : array_like
         x- and y-coordinates at which to calculate the Husimi-Q function.
 
     g : float, default sqrt(2)
@@ -634,9 +672,9 @@ class QFunc:
     Initialise the class for a square set of coordinates, with some states we
     want to investigate.
 
-    >>> xs = np.linspace(-2, 2, 101)
+    >>> xvec = np.linspace(-2, 2, 101)
     >>> states = [qutip.rand_dm(10) for _ in [None]*10]
-    >>> qfunc = qutip.QFunc(xs, xs)
+    >>> qfunc = qutip.QFunc(xvec, xvec)
 
     Now we can calculate the Husimi-Q function over each of the states more
     efficiently with:
@@ -649,11 +687,14 @@ class QFunc:
         a single function version, which will involve computing several
         quantities multiple times in order to use less memory.
     """
-    def __init__(self, xs, ys, g: float = np.sqrt(2), memory: float = 1024):
+
+    def __init__(
+        self, xvec, yvec, g: float = np.sqrt(2), memory: float = 1024
+    ):
         self._g = g
-        self._alpha_matrix = _qfunc_alpha_matrix(xs, ys, g)
+        self._coherent_grid = _QFuncCoherentGrid(xvec, yvec, g)
         # 16 bytes per complex, 1024**2 bytes per MB.
-        self._size_mb = self._alpha_matrix.conj.size * 16 / (1024**2)
+        self._size_mb = self._coherent_grid.grid.size * 16 / (1024 ** 2)
         self._memory_mb = memory
         self._max_size = int(self._memory_mb // self._size_mb)
         self._current_size = 0
@@ -674,12 +715,11 @@ class QFunc:
                 f" but only {self._memory_mb} MB is allowed."
             )
         if self._cache is None:
-            self._cache = self._alpha_matrix(self._current_size, size)
+            self._cache = self._coherent_grid(self._current_size, size)
         else:
-            self._cache = np.dstack([
-                self._cache,
-                self._alpha_matrix(self._current_size, size)
-            ])
+            self._cache = np.dstack(
+                [self._cache, self._coherent_grid(self._current_size, size)]
+            )
         self._current_size = size
         return self._cache
 
@@ -688,7 +728,7 @@ class QFunc:
         Get the Q function (without the :math:`\pi` scaling factor) of a single
         state vector.
         """
-        return np.abs(np.dot(alphas, (self._g*0.5)*vector))**2
+        return np.abs(np.dot(alphas, (self._g * 0.5) * vector)) ** 2
 
     def __call__(self, state: Qobj):
         """
@@ -712,9 +752,7 @@ class QFunc:
 
 
 def _qfunc_iterative_single(
-        vector: np.ndarray,
-        alpha: _qfunc_alpha_matrix,
-        g: float,
+    vector: np.ndarray, alpha_grid: _QFuncCoherentGrid, g: float,
 ):
     r"""
     Get the Q function (without the :math:`\pi` scaling factor) of a single
@@ -724,22 +762,22 @@ def _qfunc_iterative_single(
     ns = np.arange(vector.shape[0])
     out = np.polyval(
         (0.5*g * vector / np.sqrt(scipy.special.factorial(ns)))[::-1],
-        alpha.conj,
+        alpha_grid.grid,
     )
-    out *= alpha.prefactor
+    out *= alpha_grid.prefactor
     return np.abs(out)**2
 
 
 def qfunc(
-        state: Qobj,
-        xvec,
-        yvec,
-        g: float = sqrt(2),
-        precompute_memory: float = 1024,
+    state: Qobj,
+    xvec,
+    yvec,
+    g: float = sqrt(2),
+    precompute_memory: float = 1024,
 ):
     r"""
-    Husimi-Q function of a given state vector or density matrix at points
-    ``xvec + i*yvec``.
+    Husimi-Q function of a given state vector or density matrix at phase-space
+    points ``0.5 * g * (xvec + i*yvec)``.
 
     Parameters
     ----------
@@ -777,14 +815,14 @@ def qfunc(
         Husimi-Q function for several states over the same coordinates.
     """
     state = _qfunc_check_state(state)
-    xs, ys = _qfunc_check_coordinates(xvec, yvec)
-    required_memory = state.shape[0] * xs.size * ys.size * 16 / (1024**2)
+    xvec, yvec = _qfunc_check_coordinates(xvec, yvec)
+    required_memory = state.shape[0] * xvec.size * yvec.size * 16 / (1024 ** 2)
     enough_memory = (
         precompute_memory is not None
         and precompute_memory > required_memory
     )
     if state.isoper and enough_memory:
-        return QFunc(xs, ys, g)(state)
+        return QFunc(xvec, yvec, g)(state)
     if precompute_memory is not None and state.isoper:
         warnings.warn(
             "Falling back to iterative algorithm due to lack of memory."
@@ -792,18 +830,18 @@ def qfunc(
             f" {precompute_memory:.2f} MB.  Increase `precompute_memory` to"
             " raise limit, or set to `None` to suppress warning."
         )
-    alpha = _qfunc_alpha_matrix(xs, ys, g)
+    alpha_grid = _QFuncCoherentGrid(xvec, yvec, g)
     if state.isket:
-        out = _qfunc_iterative_single(state.full().ravel(), alpha, g)
+        out = _qfunc_iterative_single(state.full().ravel(), alpha_grid, g)
         out /= np.pi
         return out
     # We don't use Qobj.eigenstates() to avoid building many unnecessary CSR
     # versions of dense matrices.
     values, vectors = eigh(state.full())
     vectors = vectors.T
-    out = values[0] * _qfunc_iterative_single(vectors[0], alpha, g)
+    out = values[0] * _qfunc_iterative_single(vectors[0], alpha_grid, g)
     for value, vector in zip(values[1:], vectors[1:]):
-        out += value * _qfunc_iterative_single(vector, alpha, g)
+        out += value * _qfunc_iterative_single(vector, alpha_grid, g)
     out /= np.pi
     return out
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -2,6 +2,7 @@ __all__ = ['wigner', 'qfunc', 'spin_q_function',
            'spin_wigner', 'wigner_transform']
 
 import numpy as np
+import warnings
 from numpy import (
     zeros, array, arange, exp, real, conj, pi, copy, sqrt, meshgrid, size,
     conjugate, cos, sin, polyval, fliplr,
@@ -454,7 +455,6 @@ def _wigner_clenshaw(rho, xvec, yvec, g=sqrt(2), sparse=False):
     :math:`W = e^(-0.5*x^2)/pi * \sum_{L} c_L (2x)^L / \sqrt(L!)` where
     :math:`c_L = \sum_n \rho_{n,L+n} LL_n^L` where
     :math:`LL_n^L = (-1)^n \sqrt(L!n!/(L+n)!) LaguerreL[n,L,x]`
-
     """
 
     M = np.prod(rho.shape[0])
@@ -491,10 +491,16 @@ def _wig_laguerre_val(L, x, c):
     r"""
     this is evaluation of polynomial series inspired by hermval from numpy.
     Returns polynomial series
-    \sum_n b_n LL_n^L,
+
+    .. math:
+        \sum_n b_n LL_n^L,
+
     where
+
+    .. math:
     LL_n^L = (-1)^n \sqrt(L!n!/(L+n)!) LaguerreL[n,L,x]
-    The evaluation uses Clenshaw recursion
+
+    The evaluation uses Clenshaw recursion.
     """
 
     if len(c) == 1:
@@ -515,11 +521,10 @@ def _wig_laguerre_val(L, x, c):
     return y0 - y1 * ((L + 1) - x) * (L + 1)**-0.5
 
 
-
 # -----------------------------------------------------------------------------
 # Q FUNCTION
 #
-def qfunc(state, xvec, yvec, g=sqrt(2)):
+def qfunc(state, xvec, yvec, g=sqrt(2), precompute=None):
     """Q-function of a given state vector or density matrix
     at points `xvec + i * yvec`.
 
@@ -541,6 +546,18 @@ def qfunc(state, xvec, yvec, g=sqrt(2)):
         value `hbar=1`.
 
 
+    precompute : None (default), bool or array
+        Use precomputation to speed up the Husimi Q func.
+
+        None (default): True for density matrices, False for bras/kets
+        True / False: Always/Never use precomputation
+        array: The result of the precomputation can be given explicitly.
+               Useful if qfunc is called many times with the same
+               xvec, yvec and dimensions. The precomputed array is returned by
+               qfunc_precompute(xvec, yvec, n, g),
+               where xvec, yvec and g need to be the same as for qfunc,
+               and n is the dim of the chosen system.
+
     Returns
     --------
     Q : array
@@ -556,8 +573,25 @@ def qfunc(state, xvec, yvec, g=sqrt(2)):
 
     qmat = zeros(size(amat))
 
+    if precompute is None:
+        # Decide whether precomputation should be used, if not already set
+        precompute = isoper(state)
+
+    memory = len(xvec) * len(yvec) * state.shape[0] * 16 / 1024**2
+    if (precompute is True) and (memory > 1024):
+        # If too much memory would be used, do not precompute
+        warnings.warn(
+            f"Precomputation uses {memory} MB memory, with a max of "
+            "1024 MB. Falling back to iterative Husimi function"
+        )
+        precompute = False
+
+    if precompute is True:
+        # If precomputation should be used but result not given, do it now
+        precompute = qfunc_precompute(xvec, yvec, state.shape[0], g)
+
     if isket(state):
-        qmat = _qfunc_pure(state, amat)
+        qmat = _qfunc_pure(state, amat, precompute)
     elif isoper(state):
         d, v = la.eig(state.full())
         # d[i]   = eigenvalue i
@@ -565,7 +599,7 @@ def qfunc(state, xvec, yvec, g=sqrt(2)):
 
         qmat = zeros(np.shape(amat))
         for k in arange(0, len(d)):
-            qmat1 = _qfunc_pure(v[:, k], amat)
+            qmat1 = _qfunc_pure(v[:, k], amat, precompute)
             qmat += real(d[k] * qmat1)
 
     qmat = 0.25 * qmat * g ** 2
@@ -578,9 +612,14 @@ def qfunc(state, xvec, yvec, g=sqrt(2)):
 # |psi>   = the state in fock basis
 # |alpha> = the coherent state with amplitude alpha
 #
-def _qfunc_pure(psi, alpha_mat):
+def _qfunc_pure(psi, alpha_mat, precompute=False):
     """
     Calculate the Q-function for a pure state.
+
+    If provided, precompute needs to be computed with
+    qfunc_amat(xvec, yvec, n, g), where xvec, yvec and g
+    need to be the same as for qfunc, and n = np.prod(state.shape) is the dim
+    of a pure state in the chosen system. This gives 3-10x speedup per call
     """
     n = np.prod(psi.shape)
     if isinstance(psi, Qobj):
@@ -588,10 +627,71 @@ def _qfunc_pure(psi, alpha_mat):
     else:
         psi = psi.T
 
-    qmat = abs(polyval(fliplr([psi / sqrt(factorial(arange(n)))])[0],
-                       conjugate(alpha_mat))) ** 2
+    if isinstance(precompute, np.ndarray):
+        qmat = np.dot(precompute, psi)
+    else:
+        qmat = polyval(fliplr([psi / sqrt(factorial(arange(n)))])[0],
+                       conjugate(alpha_mat))
 
-    return real(qmat) * exp(-abs(alpha_mat) ** 2) / pi
+    # faster than np.abs()**2 if len(xvec) >~ 10
+    qmat = qmat.real**2 + qmat.imag**2
+    if not isinstance(precompute, np.ndarray):
+        qmat *= exp(-abs(alpha_mat) ** 2)
+    return qmat / pi
+
+
+def qfunc_precompute(xvec, yvec, n, g=sqrt(2), max_memory=1024):
+    """Helper matrix for fast Q-function at points `xvec + i * yvec`.
+
+    Explanation: A lot of the cost of the Husimi Q function does not depend on
+    the state. If it is called many times (e.g. for a density matrix or when
+    doing multiple states), this can be used for a speedup. This function
+    precomputes everything that does not depend on the state and stores it as
+    a 3d array. The Q function itself is then a dot product between the last
+    axis of the precomputed array and a pure state.
+
+    Warning: The returned array has size
+             len(xvec) * len(yvec) * n * 16 Byte, can be large
+
+    Parameters
+    ----------
+    xvec : array_like
+        x-coordinates at which to calculate the Wigner function.
+
+    yvec : array_like
+        y-coordinates at which to calculate the Wigner function.
+
+    n : int
+        Dimension of the pure states of which the Q func will be evaluated
+
+    g : float
+        Scaling factor for `a = 0.5 * g * (x + iy)`, default `g = sqrt(2)`.
+
+    max_memory : float
+        Maximal memory size in MB, default 1GB.
+
+    Returns
+    --------
+    precomputed : array
+        Precomputed array that contains everything in _qfunc_pure that is not
+        dependent on the state.
+
+    """
+    memory = len(xvec) * len(yvec) * n * 16 / 1024**2
+    if memory > max_memory:
+        raise MemoryError(
+            f"Precomputation uses {memory} MB memory, with a max of "
+            f"{max_memory} MB.Turn precomputation off with precompute=False "
+            "or use a larger max."
+        )
+    X, Y = meshgrid(xvec, yvec)
+    amat = 0.5 * g * (X - Y * 1j)
+
+    powers = np.arange(n)
+    precomputed = np.power(np.expand_dims(amat, axis=-1), powers)
+    precomputed /= sqrt(factorial(arange(n)))
+    precomputed *= np.expand_dims(exp(-abs(amat) ** 2 / 2), axis=-1)
+    return precomputed
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This is a tidied up and completed version of #934.  The first commit is credited to the original author (although I fixed up some little concerns in the PR and rebased it), because it's logically built off that PR, although in the end it's a complete reimplementation.

This is a complete rewrite of the Husimi Q calculations, to make a more formal split between the iterative (low-memory) and precomputed (faster) algorithms, giving full access to both of them.  It's a bit easier to use from a user's perspective, and it's faster than #934 as well.

The concept of the precomputed matrix is encapsulated into a class with a cached tensor, so that the same precomputed system can be used for many states of different sizes, and autoexpands (up to the memory limit) to accommodate larger states.  This is called `QFunc` as opposed to the standard function interface `qfunc`.

It also adds rather more error checking on its inputs, and adds a complete testing suite for the new implementation.

Closes #934

## Examples

Let's say we have some states, and the phase-space coordinates we want to calculate the Husimi Q function at.
```python
>>> import qutip
>>> states = [qutip.rand_dm(32, density=0.2) for _ in [None]*100]
>>> xs = np.linspace(-2, 2, 401)
```

Now the normal way of calculating the Q distribution for a single state is
```python
>>> qutip.qfunc(states[0], xs, xs)
array( ... )
```

This already has some speed advantages over the pre-PR version of `qfunc`, because it caches a lot of its intermediary results, to avoid recomputing them.  This results in calculating more matrix-vector products than before, but far fewr FLOPS overall.  By default, `qfunc` issues a warning if it exceeds a certain amount of memory, and falls back to the low-memory version.  You can control this limit with the `precompute_memory` option:
```python
>>> qutip.qfunc(states[0], xs, xs, precompute_memory=0)
qutip/qutip/wigner.py:822: UserWarning: Falling back to iterative algorithm due to lack of memory.
Needed 78.52 MB, but only allowed to use 0.00 MB.  Increase `precompute_memory` to raise limit, or
set to `None` to suppress warning.
array( ... )
```
To suppress the warning, and always use the iterative approach, you can set `precompute_memory=None`.

Now, even if you're using the `precompute_memory` option, `qfunc` still can't remember its state between calls.  This means it's inefficient.  Instead, we can use the `QFunc` class, which adds an extra step (set-up and call as opposed to just call), but it encapsulates the state.
```python
>>> qfunc_calculator = qutip.QFunc(xs, xs)
>>> husimiqs = [qfunc_calculator(state) for state in states]
```
This is much much faster.  The class version `QFunc` also takes a memory option, but since this is designed to be the precompute version, it errors out if the amount of memory needed is too great, rather than trying to fall back.  This gives users a way to put a limit on the amount of memory used:
```python
>>> qfunc_calculator_low_memory = qutip.QFunc(xs, xs, memory=0)
>>> qfunc_calculator_low_memory(states[0])
MemoryError: Refusing to precompute up to 32 basis states.  This would require 78.52 MB, but only 0 MB is allowed.
```

## Timings

These benchmarks were taken on a Macbook Pro 2.9GHz i5 (2015) with 8GB of RAM.  The different tests had different numbers of phase-space coordinates (the first number in the first column) in each dimension, and the number after 'ket' or 'dm' is the Hilbert space dimension.  The columns are:

- `original`: The state of the code before this and the previous commit
- `prev def`: Direct calls of `qutip.qfunc` with the given state and phase-space coordinates, but everything else at the default for #934
- `prev pre`: Calls of `qutip.qfunc(..., precompute=pre)`, where the calculation of `pre` was done outside the timing.  This times how long it would take to call in a loop many times.
- `cur def`: Direct calls of `qutip.qfunc` with the given state and phase-space coordinates, but everything else at the default for this commit.
- `cur pre`: Calls to a pre-constructed `qutip.QFunc` instance (which was excluded from the timings) for this commit.  This times how long it would take to call in a loop many times.

```text
            │ original  │ prev def  │ prev pre  │  cur def  │  cur pre
────────────┼───────────┼───────────┼───────────┼───────────┼──────────
11,  ket 5  │ 126.07 µs │ 133.02 µs │  89.63 µs │ 108.95 µs │  25.12 µs
11,  ket 32 │ 192.49 µs │ 197.88 µs │  90.91 µs │ 172.13 µs │  29.33 µs
11,  dm 5   │ 481.68 µs │ 440.45 µs │ 316.93 µs │ 304.86 µs │ 161.00 µs
11,  dm 32  │   4.69 ms │   1.87 ms │   1.66 ms │   1.07 ms │ 823.49 µs
            │           │           │           │           │
101, ket 5  │ 570.59 µs │ 566.65 µs │ 501.86 µs │ 463.96 µs │ 329.25 µs
101, ket 32 │   1.61 ms │   1.43 ms │ 751.97 µs │   1.34 ms │ 507.20 µs
101, dm 5   │   2.51 ms │   3.51 ms │   2.20 ms │   2.62 ms │   1.72 ms
101, dm 32  │  42.91 ms │  26.84 ms │  19.73 ms │  23.30 ms │  16.30 ms
            │           │           │           │           │
401, ket 5  │  10.56 ms │  13.50 ms │   7.91 ms │  11.95 ms │   5.28 ms
401, ket 32 │  34.44 ms │  43.73 ms │  10.37 ms │  41.17 ms │   7.70 ms
401, dm 5   │  46.85 ms │  57.51 ms │  33.19 ms │  52.30 ms │  26.71 ms
401, dm 32  │   1.05  s │ 411.32 ms │ 273.93 ms │ 428.32 ms │ 246.59 ms
```

You can see that there are huge benefits to the precomputation, even compared to the previous precomputation implementation.  This makes calling in a loop much much more efficient.


#### Changelog

Large feature, authored by @dweigand (Daniel Weigand) and me (Jake).

Add new Husimi Q algorithms, improving the speed for density matrices, and giving a near order-of-magnitude improvement when calculating the Q function for many different states (using the new `qutip.QFunc` class, instead of the `qutip.qfunc` function).