### PR TITLE
Data.__init__ set shape

### DIFF
--- a/qutip/core/data/base.pyx
+++ b/qutip/core/data/base.pyx
@@ -13,18 +13,27 @@ idxint_DTYPE = cnp.NPY_INT32
 # As this is an abstract base class with C entry points, we have to explicitly
 # stub out methods since we can't mark them as abstract.
 cdef class Data:
+    def __init__(self, shape):
+        self.shape = shape
+
     cpdef object to_array(self):
         raise NotImplementedError
+
     cpdef double complex trace(self):
         return NotImplementedError
+
     cpdef Data adjoint(self):
         raise NotImplementedError
+
     cpdef Data conj(self):
         raise NotImplementedError
+
     cpdef Data transpose(self):
         raise NotImplementedError
+
     cpdef Data copy(self):
         raise NotImplementedError
+
 
 class EfficiencyWarning(Warning):
     pass

--- a/qutip/tests/core/data/test_convert.py
+++ b/qutip/tests/core/data/test_convert.py
@@ -4,6 +4,13 @@ from scipy import sparse
 from qutip import data
 
 
+def test_init_empty_data():
+    shape = (3, 3)
+    base_data = data.Data(shape)
+    assert base_data.shape[0] == shape[0]
+    assert base_data.shape[1] == shape[1]
+
+
 @pytest.mark.parametrize(['base', 'dtype'], [
     pytest.param(data.dense.zeros(2, 2), data.Dense, id='data.Dense'),
     pytest.param(data.csr.zeros(2, 2), data.CSR, id='data.CSR'),


### PR DESCRIPTION
Being unable the set the shape is the main constrain in making a new python only data layer.
This allow `Data.__init__` to set it.