### PR TITLE
Fix dimensions in calls to mesolve when calculating propagators for superoperators or with collapse operators present.

### DIFF
--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -236,8 +236,12 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
             for n in range(N * N):
                 progress_bar.update(n)
                 col_idx, row_idx = np.unravel_index(n, (N, N))
-                rho0 = Qobj(sp.csr_matrix(([1], ([row_idx], [col_idx])),
-                                          shape=(N, N), dtype=complex))
+                rho0 = Qobj(
+                    sp.csr_matrix(
+                        ([1], ([row_idx], [col_idx])),
+                        shape=(N, N), dtype=complex),
+                    dims=H0.dims,
+                )
                 output = mesolve(H, rho0, tlist, c_op_list, [], args, options,
                                  _safe_mode=False)
                 for k, t in enumerate(tlist):

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -211,7 +211,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
         else:
             rho0 = qeye(H0.dims[0])
             output = mesolve(H, rho0, tlist, None, [], args, options,
-                             _safe_mode=True)
+                             _safe_mode=False)
             return output.states[-1] if len(tlist) == 2 else output.states
 
     else:

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -208,10 +208,9 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                 for k, t in enumerate(tlist):
                     u[:, n, k] = mat2vec(output[n].states[k].full()).T
         else:
-            rho0 = qeye(N, N)
-            rho0.dims = [[sqrt_N, sqrt_N], [sqrt_N, sqrt_N]]
-            output = mesolve(H, psi0, tlist, [], args, options,
-                             _safe_mode=False)
+            rho0 = qeye(H0.dims[0])
+            output = mesolve(H, rho0, tlist, None, [], args, options,
+                             _safe_mode=True)
             return output.states[-1] if len(tlist) == 2 else output.states
 
     else:

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -48,7 +48,7 @@ from qutip.sparse import sp_reshape
 from qutip.cy.sparse_utils import unit_row_norm
 from qutip.mesolve import mesolve
 from qutip.sesolve import sesolve
-from qutip.states import basis
+from qutip.states import basis, projection
 from qutip.solver import Options, _solver_safety_check, config
 from qutip.parallel import parallel_map, _default_kwargs
 from qutip.ui.progressbar import BaseProgressBar, TextProgressBar
@@ -238,12 +238,8 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
             for n in range(N * N):
                 progress_bar.update(n)
                 col_idx, row_idx = np.unravel_index(n, (N, N))
-                rho0 = Qobj(
-                    sp.csr_matrix(
-                        ([1], ([row_idx], [col_idx])),
-                        shape=(N, N), dtype=complex),
-                    dims=H0.dims,
-                )
+                rho0 = projection(N, row_idx, col_idx)
+                rho0.dims = H0.dims
                 output = mesolve(
                     H, rho0, tlist, c_ops=c_op_list, args=args,
                     options=options, _safe_mode=False)
@@ -311,8 +307,8 @@ def _parallel_sesolve(n, N, H, tlist, args, options):
 
 def _parallel_mesolve(n, N, H, tlist, c_op_list, args, options, dims=None):
     col_idx, row_idx = np.unravel_index(n, (N, N))
-    rho0 = Qobj(sp.csr_matrix(([1], ([row_idx], [col_idx])),
-                              shape=(N, N), dtype=complex), dims=dims)
+    rho0 = projection(N, row_idx, col_idx)
+    rho0.dims = dims
     output = mesolve(
         H, rho0, tlist, c_ops=c_op_list, args=args, options=options,
         _safe_mode=False)

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -210,8 +210,9 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                     u[:, n, k] = mat2vec(output[n].states[k].full()).T
         else:
             rho0 = qeye(H0.dims[0])
-            output = mesolve(H, rho0, tlist, None, [], args, options,
-                             _safe_mode=False)
+            output = mesolve(
+                H, rho0, tlist, args=args, options=options,
+                _safe_mode=False)
             return output.states[-1] if len(tlist) == 2 else output.states
 
     else:
@@ -243,8 +244,9 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
                         shape=(N, N), dtype=complex),
                     dims=H0.dims,
                 )
-                output = mesolve(H, rho0, tlist, c_op_list, [], args, options,
-                                 _safe_mode=False)
+                output = mesolve(
+                    H, rho0, tlist, c_ops=c_op_list, args=args,
+                    options=options, _safe_mode=False)
                 for k, t in enumerate(tlist):
                     u[:, n, k] = mat2vec(output.states[k].full()).T
             progress_bar.finished()

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -311,6 +311,7 @@ def _parallel_mesolve(n, N, H, tlist, c_op_list, args, options, dims=None):
     col_idx, row_idx = np.unravel_index(n, (N, N))
     rho0 = Qobj(sp.csr_matrix(([1], ([row_idx], [col_idx])),
                               shape=(N, N), dtype=complex), dims=dims)
-    output = mesolve(H, rho0, tlist, c_op_list, [], args, options,
-                     _safe_mode=False)
+    output = mesolve(
+        H, rho0, tlist, c_ops=c_op_list, args=args, options=options,
+        _safe_mode=False)
     return output

--- a/qutip/tests/test_propagator.py
+++ b/qutip/tests/test_propagator.py
@@ -132,12 +132,12 @@ def testPropHWithCOps():
     "Propagator: with collapse operators"
     H = tensor(sigmaz(), qeye(2))
     c_ops = [np.sqrt(1) * tensor(sigmam(), qeye(2))]
-    tlist = np.linspace(0, 10, 201)
+    tlist = np.linspace(0, 10, 11)
+    Fs = propagator(H, tlist, c_op_list=c_ops)
     rho0 = ket2dm(tensor(basis(2, 0), basis(2, 0))).unit()
-    F = propagator(H, tlist, c_op_list=c_ops)[-1]
-    rho_f = vector_to_operator(F * operator_to_vector(rho0))
-    expected_rho_f = mesolve(H, rho0, tlist, c_ops=c_ops).states[-1]
-    assert rho_f == expected_rho_f
+    rho_fs = [vector_to_operator(F * operator_to_vector(rho0)) for F in Fs]
+    expected_rho_fs = mesolve(H, rho0, tlist, c_ops=c_ops).states
+    assert rho_fs == expected_rho_fs
 
 
 if __name__ == "__main__":

--- a/qutip/tests/test_propagator.py
+++ b/qutip/tests/test_propagator.py
@@ -139,7 +139,7 @@ def testPropHSuperWithoutCops():
     assert Fs == expected_Fs
 
 
-def testPropHWithCOps():
+def testPropHWithCops():
     "Propagator: with collapse operators"
     H = tensor(sigmaz(), qeye(2))
     c_ops = [np.sqrt(1) * tensor(sigmam(), qeye(2))]

--- a/qutip/tests/test_propagator.py
+++ b/qutip/tests/test_propagator.py
@@ -131,7 +131,7 @@ def testPropHDims():
 def testPropHSuperWithoutCops():
     "Propagator: super operator without collapse operators"
     H = tensor(sigmaz(), qeye(2))
-    H = to_super(H)
+    H = liouvillian(H)
     tlist = np.linspace(0, 10, 11)
     Fs = propagator(H, tlist)
     rho0 = qeye([[2, 2], [2, 2]])

--- a/qutip/tests/test_propagator.py
+++ b/qutip/tests/test_propagator.py
@@ -128,6 +128,17 @@ def testPropHDims():
     assert_equal(U.dims,H.dims)
 
 
+def testPropHSuperWithoutCops():
+    "Propagator: super operator without collapse operators"
+    H = tensor(sigmaz(), qeye(2))
+    H = to_super(H)
+    tlist = np.linspace(0, 10, 11)
+    Fs = propagator(H, tlist)
+    rho0 = qeye([[2, 2], [2, 2]])
+    expected_Fs = mesolve(H, rho0, tlist).states
+    assert Fs == expected_Fs
+
+
 def testPropHWithCOps():
     "Propagator: with collapse operators"
     H = tensor(sigmaz(), qeye(2))

--- a/qutip/tests/test_propagator.py
+++ b/qutip/tests/test_propagator.py
@@ -139,12 +139,36 @@ def testPropHSuperWithoutCops():
     assert Fs == expected_Fs
 
 
+def testPropHSuperWithoutCopsParallel():
+    "Propagator: super operator without collapse operators using parallel"
+    H = tensor(sigmaz(), qeye(2))
+    H = liouvillian(H)
+    tlist = np.linspace(0, 10, 11)
+    Fs = propagator(H, tlist, parallel=True)
+    rho0 = qeye([[2, 2], [2, 2]])
+    expected_Fs = mesolve(H, rho0, tlist).states
+    for k, _ in enumerate(tlist):
+        assert (Fs[k] - expected_Fs[k]).norm() < 1e-3
+
+
 def testPropHWithCops():
     "Propagator: with collapse operators"
     H = tensor(sigmaz(), qeye(2))
     c_ops = [np.sqrt(1) * tensor(sigmam(), qeye(2))]
     tlist = np.linspace(0, 10, 11)
     Fs = propagator(H, tlist, c_op_list=c_ops)
+    rho0 = ket2dm(tensor(basis(2, 0), basis(2, 0))).unit()
+    rho_fs = [vector_to_operator(F * operator_to_vector(rho0)) for F in Fs]
+    expected_rho_fs = mesolve(H, rho0, tlist, c_ops=c_ops).states
+    assert rho_fs == expected_rho_fs
+
+
+def testPropHWithCopsParallel():
+    "Propagator: with collapse operators in parallel"
+    H = tensor(sigmaz(), qeye(2))
+    c_ops = [np.sqrt(1) * tensor(sigmam(), qeye(2))]
+    tlist = np.linspace(0, 10, 11)
+    Fs = propagator(H, tlist, c_op_list=c_ops, parallel=True)
     rho0 = ket2dm(tensor(basis(2, 0), basis(2, 0))).unit()
     rho_fs = [vector_to_operator(F * operator_to_vector(rho0)) for F in Fs]
     expected_rho_fs = mesolve(H, rho0, tlist, c_ops=c_ops).states

--- a/qutip/tests/test_propagator.py
+++ b/qutip/tests/test_propagator.py
@@ -127,5 +127,18 @@ def testPropHDims():
     U = propagator(H,1, unitary_mode='single')
     assert_equal(U.dims,H.dims)
 
+
+def testPropHWithCOps():
+    "Propagator: with collapse operators"
+    H = tensor(sigmaz(), qeye(2))
+    c_ops = [np.sqrt(1) * tensor(sigmam(), qeye(2))]
+    tlist = np.linspace(0, 10, 201)
+    rho0 = ket2dm(tensor(basis(2, 0), basis(2, 0))).unit()
+    F = propagator(H, tlist, c_op_list=c_ops)[-1]
+    rho_f = vector_to_operator(F * operator_to_vector(rho0))
+    expected_rho_f = mesolve(H, rho0, tlist, c_ops=c_ops).states[-1]
+    assert rho_f == expected_rho_f
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
**Description**
A lot of the code in `propagators.py` is quite old and manipulates `Qobj` shapes directly and unnecessarily converts backwards and forward between numpy arrays and `Qobj`s. This PR attempts to address two important bugs in dimension checking -- the one reported in #1585 (when calculating propagators for collapse operators) and another I found while reading the nearby code. A more thorough rework of the code should probably happen on `dev.major` for QuTiP version 5.

The `propagator` method could do with more input sanity checking for QuTiP version 5, e.g.
* rename `c_op_list` to `c_ops` for consistency with the solver
* complain if `c_ops` are supplied along with a superoperator (?)
* perhaps remove the `single` or `batch` unitary_mode option, or at least complain if the parameters supplied don't make sense.

**Related issues or PRs**
* #1585

**Changelog**
- Fixed support for calculating the ``propagator`` of a density matrix with collapse operators. QuTiP 4.6.2 introduced extra sanity checks on the dimensions of inputs to mesolve (#1459), but the propagator function's calls to ``mesolve`` violated these checks by supplying initial states with the dimensions incorrectly set. ``propagator`` now calls ``mesolve`` with the correct dimensions set on the initial state. Fixes #1585.
- Fixed support for calculating the ``propagator`` for a superoperator without collapse operators. This functionality was not tested by the test suite and appears to have broken sometime during 2019. Tests have now been added and the code breakages fixed. 