### PR TITLE
Merge pull request #1588 from hodgestar/feature/fix-propagator-dimensions

### DIFF
--- a/qutip/tests/solve/test_propagator.py
+++ b/qutip/tests/solve/test_propagator.py
@@ -129,3 +129,50 @@ def testPropHDims():
     H = tensor([qeye(2), qeye(2)])
     U = propagator(H, 1, unitary_mode='single')
     assert U.dims == H.dims
+
+
+def testPropHSuperWithoutCops():
+    "Propagator: super operator without collapse operators"
+    H = tensor(sigmaz(), qeye(2))
+    H = liouvillian(H)
+    tlist = np.linspace(0, 10, 11)
+    Fs = propagator(H, tlist)
+    rho0 = qeye([[2, 2], [2, 2]])
+    expected_Fs = mesolve(H, rho0, tlist).states
+    assert Fs == expected_Fs
+
+
+def testPropHSuperWithoutCopsParallel():
+    "Propagator: super operator without collapse operators using parallel"
+    H = tensor(sigmaz(), qeye(2))
+    H = liouvillian(H)
+    tlist = np.linspace(0, 10, 11)
+    Fs = propagator(H, tlist, parallel=True)
+    rho0 = qeye([[2, 2], [2, 2]])
+    expected_Fs = mesolve(H, rho0, tlist).states
+    for k, _ in enumerate(tlist):
+        assert (Fs[k] - expected_Fs[k]).norm() < 1e-3
+
+
+def testPropHWithCops():
+    "Propagator: with collapse operators"
+    H = tensor(sigmaz(), qeye(2))
+    c_ops = [np.sqrt(1) * tensor(sigmam(), qeye(2))]
+    tlist = np.linspace(0, 10, 11)
+    Fs = propagator(H, tlist, c_op_list=c_ops)
+    rho0 = ket2dm(tensor(basis(2, 0), basis(2, 0))).unit()
+    rho_fs = [vector_to_operator(F * operator_to_vector(rho0)) for F in Fs]
+    expected_rho_fs = mesolve(H, rho0, tlist, c_ops=c_ops).states
+    assert rho_fs == expected_rho_fs
+
+
+def testPropHWithCopsParallel():
+    "Propagator: with collapse operators in parallel"
+    H = tensor(sigmaz(), qeye(2))
+    c_ops = [np.sqrt(1) * tensor(sigmam(), qeye(2))]
+    tlist = np.linspace(0, 10, 11)
+    Fs = propagator(H, tlist, c_op_list=c_ops, parallel=True)
+    rho0 = ket2dm(tensor(basis(2, 0), basis(2, 0))).unit()
+    rho_fs = [vector_to_operator(F * operator_to_vector(rho0)) for F in Fs]
+    expected_rho_fs = mesolve(H, rho0, tlist, c_ops=c_ops).states
+    assert rho_fs == expected_rho_fs


### PR DESCRIPTION
This merges #1588 from master into dev.major.

- Fixed support for calculating the ``propagator`` of a density matrix with collapse operators. QuTiP 4.6.2 introduced extra sanity checks on the dimensions of inputs to mesolve (#1459), but the propagator function's calls to ``mesolve`` violated these checks by supplying initial states with the dimensions incorrectly set. ``propagator`` now calls ``mesolve`` with the correct dimensions set on the initial state. Fixes #1585.

- Fixed support for calculating the ``propagator`` for a superoperator without collapse operators. This functionality was not tested by the test suite and appears to have broken sometime during 2019. Tests have now been added and the code breakages fixed.