### PR TITLE
Set `superrep` for operator-ket and operator-bra.

### DIFF
--- a/qutip/core/cy/cqobjevo.pyx
+++ b/qutip/core/cy/cqobjevo.pyx
@@ -71,6 +71,7 @@ cdef class CQobjEvo:
         self.shape = constant.shape
         self.dims = constant.dims
         self.type = constant.type
+        self.superrep = constant.superrep
         self.issuper = constant.issuper
         self.constant = constant.data
         self.n_ops = 0 if ops is None else len(ops)
@@ -84,6 +85,7 @@ cdef class CQobjEvo:
             if (
                 qobj.shape != self.shape
                 or qobj.type != self.type
+                or qobj.superrep != self.superrep
                 or qobj.dims != self.dims
             ):
                 raise ValueError("not all inputs have the same structure")

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -377,7 +377,7 @@ class Qobj:
                     repr(self._data.shape[0]),
                 ]))
             self.dims = [[[root]]*2]*2
-        if self.type == 'super':
+        if self.type in ['super', 'operator-ket', 'operator-bra']:
             superrep = superrep or 'super'
         self.superrep = superrep
 

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -507,7 +507,7 @@ class Qobj:
                 " and ",
                 repr(other.dims),
             ]))
-        if self.issuper and other.issuper and self.superrep != other.superrep:
+        if self.superrep != other.superrep:
             raise TypeError("".join([
                 "incompatible superoperator representations ",
                 repr(self.superrep),

--- a/qutip/core/superoperator.py
+++ b/qutip/core/superoperator.py
@@ -269,6 +269,7 @@ def operator_to_vector(op):
     return Qobj(stack_columns(op.data),
                 dims=[op.dims, [1]],
                 type='operator-ket',
+                superrep="super",
                 copy=False)
 
 
@@ -280,6 +281,8 @@ def vector_to_operator(op):
     """
     if not op.isoperket:
         raise TypeError("only defined for operator-kets")
+    if op.superrep != "super":
+        raise TypeError("only defined for operator-kets in super format")
     dims = op.dims[0]
     return Qobj(unstack_columns(op.data, (np.prod(dims[0]), np.prod(dims[1]))),
                 dims=dims,

--- a/qutip/core/superoperator.py
+++ b/qutip/core/superoperator.py
@@ -266,6 +266,9 @@ def operator_to_vector(op):
     representation.  Note that QuTiP uses the _column-stacking_ convention,
     which may be different to what you expect.
     """
+    if op.type in ['super', 'operator-ket', 'operator-bra']:
+        raise TypeError("Cannot convert object already "
+                        "in super representation")
     return Qobj(stack_columns(op.data),
                 dims=[op.dims, [1]],
                 type='operator-ket',

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -387,6 +387,17 @@ def test_CheckMulType():
     assert opbra2.dag() == opket2
 
 
+def test_operator_ket_superrep():
+    sop = qutip.to_super(qutip.sigmax())
+    opket1 = qutip.operator_to_vector(qutip.fock_dm(2, 0))
+    opket2 = sop * opket1
+    assert opket1.superrep == opket2.superrep
+
+    opbra1 = qutip.operator_to_vector(qutip.fock_dm(2, 0)).dag()
+    opbra2 = opbra1 * sop
+    assert opbra1.superrep == opbra2.superrep
+
+
 def test_QobjConjugate():
     "qutip.Qobj conjugate"
     data = _random_not_singular(5)

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -100,6 +100,19 @@ def test_QobjType():
     super_qobj = qutip.Qobj(super_data, dims=[[[3]], [[3]]])
     assert super_qobj.type == 'super'
     assert super_qobj.issuper
+    assert super_qobj.superrep == 'super'
+
+    super_data = np.random.random(N)
+    super_qobj = qutip.Qobj(super_data, dims=[[[3], [3]], [[1]]])
+    assert super_qobj.type == 'operator-ket'
+    assert super_qobj.isoperket
+    assert super_qobj.superrep == 'super'
+
+    super_data = np.random.random(N)
+    super_qobj = qutip.Qobj(super_data, dims=[[[1]], [[3], [3]]])
+    assert super_qobj.type == 'operator-bra'
+    assert super_qobj.isoperbra
+    assert super_qobj.superrep == 'super'
 
     operket_qobj = qutip.operator_to_vector(oper_qobj)
     assert operket_qobj.isoperket

--- a/qutip/tests/core/test_superoper.py
+++ b/qutip/tests/core/test_superoper.py
@@ -73,11 +73,18 @@ class TestMatVec:
         rho1 = qutip.rand_dm(N)
         as_vec = qutip.operator_to_vector(rho1)
         assert as_vec.superrep == 'super'
+
         with pytest.raises(TypeError) as err:
             as_vec.superrep = ""
             qutip.vector_to_operator(as_vec)
         assert err.value.args[0] == ("only defined for operator-kets "
                                      "in super format")
+
+        with pytest.raises(TypeError) as err:
+            qutip.operator_to_vector(as_vec)
+        assert err.value.args[0] == ("Cannot convert object already "
+                                     "in super representation")
+
 
     def testOperatorVectorTensor(self):
         """

--- a/qutip/tests/core/test_superoper.py
+++ b/qutip/tests/core/test_superoper.py
@@ -75,8 +75,9 @@ class TestMatVec:
         assert as_vec.superrep == 'super'
 
         with pytest.raises(TypeError) as err:
-            as_vec.superrep = ""
-            qutip.vector_to_operator(as_vec)
+            bad_vec = as_vec.copy()
+            bad_vec.superrep = ""
+            qutip.vector_to_operator(bad_vec)
         assert err.value.args[0] == ("only defined for operator-kets "
                                      "in super format")
 

--- a/qutip/tests/core/test_superoper.py
+++ b/qutip/tests/core/test_superoper.py
@@ -36,6 +36,7 @@ import scipy.linalg
 
 import qutip
 from qutip.core import data as _data
+import pytest
 
 
 def f(t, args):
@@ -66,6 +67,17 @@ class TestMatVec:
         rho1 = qutip.rand_dm(N)
         rho2 = qutip.vector_to_operator(qutip.operator_to_vector(rho1))
         np.testing.assert_allclose(rho1.full(), rho2.full(), 1e-8)
+
+    def testsuperrep(self):
+        N = 3
+        rho1 = qutip.rand_dm(N)
+        as_vec = qutip.operator_to_vector(rho1)
+        assert as_vec.superrep == 'super'
+        with pytest.raises(TypeError) as err:
+            as_vec.superrep = ""
+            qutip.vector_to_operator(as_vec)
+        assert err.value.args[0] == ("only defined for operator-kets "
+                                     "in super format")
 
     def testOperatorVectorTensor(self):
         """


### PR DESCRIPTION
**Description**
Set `operator-ket`'s `superrep` to `'super'`.
`operator-ket` are the states of super operators, ie. `super @ operator-ket` make sense but `oper @ operator-ket` does not. So it is natural that they have an attached `superrep`. This will make `choi_super @ operator-ket` error unless care is taken in making the `superrep` match.

TODO? Have `to_choi`, etc. work for operator-kets?
closes #1586
