### PR TITLE
Change eigs eigenvector output to Data instead of ndarray

### DIFF
--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -1571,7 +1571,7 @@ class DynamicsUnitary(Dynamics):
             # and eigenvectors as a list of separate 2D kets
             _type = _data.CSR if self.sparse_eigen_decomp else _data.Dense
             eig_val, eig_vec = _data.eigs(_data.to(_type, H.data))
-            eig_vec = np.hstack(eig_vec)
+            eig_vec = eig_vec.to_array()
 
         else:
             H = self._dyn_gen[k]

--- a/qutip/core/data/__init__.py
+++ b/qutip/core/data/__init__.py
@@ -13,6 +13,7 @@ from .expect import *
 from .expm import *
 from .inner import *
 from .kron import *
+from .linalg import *
 from .matmul import *
 from .make import *
 from .mul import *

--- a/qutip/core/data/eigen.py
+++ b/qutip/core/data/eigen.py
@@ -217,6 +217,9 @@ def eigs_csr(data, isherm=None, vecs=True, sort='low', eigvals=0,
     if not isinstance(data, CSR):
         raise TypeError("expected data in CSR format but got "
                         + str(type(data)))
+    if data.shape[0] < 4:
+        # For small matrix, the sparse solver can't compute all eigenvalues.
+        return eigs_dense(data, isherm, vecs, sort, eigvals)
     _eigs_check_shape(data)
     eigvals, num_large, num_small = _eigs_fix_eigvals(data, eigvals, sort)
     isherm = isherm if isherm is not None else _isherm(data)

--- a/qutip/core/data/linalg.py
+++ b/qutip/core/data/linalg.py
@@ -1,0 +1,55 @@
+import scipy.linalg
+import scipy.sparse
+from .dense import Dense
+from .csr import CSR
+
+__all__ = ['inv', 'inv_csr', 'inv_dense']
+
+
+def inv_dense(data):
+    """Compute the inverse of a matrix"""
+    if not isinstance(data, Dense):
+        raise TypeError("expected data in Dense format but got "
+                        + str(type(data)))
+    if data.shape[0] != data.shape[1]:
+        raise ValueError('Cannot compute the matrix inverse'
+                         ' of a nonsquare matrix')
+    return Dense(scipy.linalg.inv(data.as_ndarray()), copy=False)
+
+
+def inv_csr(data):
+    """Compute the inverse of a sparse matrix"""
+    if not isinstance(data, CSR):
+        raise TypeError("expected data in CSR format but got "
+                        + str(type(data)))
+    if data.shape[0] != data.shape[1]:
+        raise ValueError('Cannot compute the matrix inverse '
+                         'of a nonsquare matrix')
+    inv = scipy.sparse.linalg.inv(data.as_scipy().tocsc())
+    # scipy.sparse.linalg.inv can return dense or sparse arrays.
+    return CSR(scipy.sparse.csr_matrix(inv), copy=False)
+
+
+from .dispatch import Dispatcher as _Dispatcher
+
+inv = _Dispatcher(inv_dense, name='inv', inputs=('data',), out=False)
+inv.__doc__ =\
+    """
+    Return matric inverse for a data-layer object.
+
+    Parameters
+    ----------
+    data : Data
+        Input matrix
+
+    Returns
+    -------
+    inverse : Data
+        Inverse of data
+    """
+inv.add_specialisations([
+    (CSR, inv_csr),
+    (Dense, inv_dense),
+], _defer=True)
+
+del _Dispatcher

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -936,7 +936,7 @@ class Qobj:
         """
         if self.dims[0] != self.dims[1]:
             raise TypeError('sqrt only valid on square matrices')
-        if isinstance(self.data, _data.CSR) and sparse and self.shape[0] > 3:
+        if isinstance(self.data, _data.CSR) and sparse:
             evals, evecs = _data.eigs_csr(self.data,
                                           isherm=self._isherm,
                                           tol=tol, maxiter=maxiter)
@@ -1535,7 +1535,7 @@ class Qobj:
         Use sparse only if memory requirements demand it.
 
         """
-        if isinstance(self.data, _data.CSR) and sparse and self.shape[0] > 3:
+        if isinstance(self.data, _data.CSR) and sparse:
             evals, evecs = _data.eigs_csr(self.data,
                                           isherm=self._isherm,
                                           sort=sort, eigvals=eigvals, tol=tol,
@@ -1599,7 +1599,7 @@ class Qobj:
 
         """
         # TODO: consider another way of handling the dispatch here.
-        if isinstance(self.data, _data.CSR) and sparse and self.shape[0] > 3:
+        if isinstance(self.data, _data.CSR) and sparse:
             return _data.eigs_csr(self.data,
                                   vecs=False,
                                   isherm=self._isherm,
@@ -1644,7 +1644,7 @@ class Qobj:
         Use sparse only if memory requirements demand it.
         """
         eigvals = 2 if safe else 1
-        if isinstance(self.data, _data.CSR) and sparse and self.shape[0] > 3:
+        if isinstance(self.data, _data.CSR) and sparse:
             evals, evecs = _data.eigs_csr(self.data,
                                           isherm=self._isherm,
                                           eigvals=eigvals, tol=tol,

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -380,12 +380,13 @@ class UnaryOpMixin(_GenericOpMixin):
         assert isinstance(test, out_type)
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
-            np.testing.assert_allclose(test.to_array(), expected, self.tol)
+            np.testing.assert_allclose(test.to_array(), expected,
+                                       atol=self.tol)
         elif out_type is list:
             for test_, expected_ in zip(test, expected):
                 assert test_.shape == expected_.shape
                 np.testing.assert_allclose(test_.to_array(),
-                                           expected_, self.tol)
+                                           expected_, atol=self.tol)
         else:
             assert abs(test - expected) < self.tol
 
@@ -410,7 +411,8 @@ class UnaryScalarOpMixin(_GenericOpMixin):
         assert isinstance(test, out_type)
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
-            np.testing.assert_allclose(test.to_array(), expected, self.tol)
+            np.testing.assert_allclose(test.to_array(), expected,
+                                       atol=self.tol)
         else:
             assert abs(test - expected) < self.tol
 
@@ -431,7 +433,8 @@ class BinaryOpMixin(_GenericOpMixin):
         assert isinstance(test, out_type)
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
-            np.testing.assert_allclose(test.to_array(), expected, self.tol)
+            np.testing.assert_allclose(test.to_array(), expected,
+                                       atol=self.tol)
         else:
             assert abs(test - expected) < self.tol
 
@@ -464,7 +467,8 @@ class TernaryOpMixin(_GenericOpMixin):
         assert isinstance(test, out_type)
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
-            np.testing.assert_allclose(test.to_array(), expected, self.tol)
+            np.testing.assert_allclose(test.to_array(), expected,
+                                       atol=self.tol)
         else:
             assert abs(test - expected) < self.tol
 
@@ -510,7 +514,8 @@ class TestAdd(BinaryOpMixin):
         assert isinstance(test, out_type)
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
-            np.testing.assert_allclose(test.to_array(), expected, self.tol)
+            np.testing.assert_allclose(test.to_array(), expected,
+                                       atol=self.tol)
         else:
             assert abs(test - expected) < self.tol
 
@@ -598,7 +603,8 @@ class TestInner(BinaryOpMixin):
         assert isinstance(test, out_type)
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
-            np.testing.assert_allclose(test.to_array(), expected, self.tol)
+            np.testing.assert_allclose(test.to_array(), expected,
+                                       atol=self.tol)
         else:
             assert abs(test - expected) < self.tol
 
@@ -664,7 +670,8 @@ class TestInnerOp(TernaryOpMixin):
         assert isinstance(test, out_type)
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
-            np.testing.assert_allclose(test.to_array(), expected, self.tol)
+            np.testing.assert_allclose(test.to_array(), expected,
+                                       atol=self.tol)
         else:
             assert abs(test - expected) < self.tol
 


### PR DESCRIPTION
**Description**
Change `data.eigs` evecs output to a Data object instead of a `ndarray`. This will be useful for `tensorflow` for which `eigh` output is a tensor. `Qobj.eigenstate` have been reworked to use the dispatcher or `eigs_csr`. `eigs_csr` do not have the same signature s `eigs.data`, so it is still called directly.

This had side effect in `Qobj.sqrtm` which was rewritten to work with `Data` instead of `ndarray`.

2 new dispatched functions are added:
`split_columns`: Used in `Qobj.eigenstates`, split each cols into a list of ket shaped Data.
`inv`: matrix inverse.

