### PR TITLE
faster algorithm for enr_destroy

### DIFF
--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -892,12 +892,13 @@ def enr_destroy(dims, excitations):
              for _ in range(len(dims))]
 
     for n1, state1 in idx2state.items():
-        for n2, state2 in idx2state.items():
-            for idx, a in enumerate(a_ops):
-                s1 = [s for idx2, s in enumerate(state1) if idx != idx2]
-                s2 = [s for idx2, s in enumerate(state2) if idx != idx2]
-                if (state1[idx] == state2[idx] - 1) and (s1 == s2):
-                    a_ops[idx][n1, n2] = np.sqrt(state2[idx])
+        for idx, s in enumerate(state1):
+            # if s > 0, the annihilation operator of mode idx has a non-zero
+            # entry with one less excitation in mode idx in the final state
+            if s > 0:
+                state2 = state1[:idx] + (s-1,) + state1[idx+1:]
+                n2 = state2idx[state2]
+                a_ops[idx][n2, n1] = np.sqrt(s)
 
     return [Qobj(a, dims=[dims, dims]) for a in a_ops]
 


### PR DESCRIPTION
**Description**
The algorithm used in `enr_destroy` was extremely inefficient, with a triple loop. This PR replaces it with a much simpler algorithm with only a single loop. For `dims = [3,8,2,4,6,1,3]` and `Nexc = 6`, on my computer `enr_destroy(dims,Nexc)` took almost 4 s, with the new algorithm it takes 20 ms. I've checked that the output is identical.

**Changelog**
Made enr_destroy significantly faster.