### PR TITLE
faster state_number_enumerate

### DIFF
--- a/qutip/states.py
+++ b/qutip/states.py
@@ -757,7 +757,7 @@ def bra(seq, dim=2):
 #
 # quantum state number helper functions
 #
-def state_number_enumerate(dims, excitations=None, state=None, idx=0):
+def state_number_enumerate(dims, excitations=None, state=None, idx=0, nexc=0):
     """
     An iterator that enumerate all the state number arrays (quantum numbers on
     the form [n1, n2, n3, ...]) for a system with dimensions given by dims.
@@ -786,6 +786,9 @@ def state_number_enumerate(dims, excitations=None, state=None, idx=0):
     idx : integer
         Current index in the iteration. Used internally.
 
+    nexc : integer
+        Number of excitations in modes [0..idx-1]. Used internally.
+
     Returns
     -------
     state_number : list
@@ -797,17 +800,23 @@ def state_number_enumerate(dims, excitations=None, state=None, idx=0):
     if state is None:
         state = np.zeros(len(dims), dtype=int)
 
-    if excitations and sum(state[0:idx]) > excitations:
-        pass
-    elif idx == len(dims):
+    if idx == len(dims):
         if excitations is None:
             yield np.array(state)
         else:
             yield tuple(state)
     else:
-        for n in range(dims[idx]):
+        if excitations is None:
+            nlim = dims[idx]
+        else:
+            # modes [0..idx-1] have nexc excitations,
+            # so mode idx can have at most excitations-nexc excitations
+            nlim = min(dims[idx], 1 + excitations - nexc)
+
+        for n in range(nlim):
             state[idx] = n
-            for s in state_number_enumerate(dims, excitations, state, idx + 1):
+            for s in state_number_enumerate(dims, excitations,
+                                            state, idx + 1, nexc + n):
                 yield s
 
 


### PR DESCRIPTION
**Description**
When the number of excitations in `state_number_enumerate` is limited, instead of iterating over all states and discarding the ones with too many excitations, directly choose the limits to only iterate over allowed states. As a small additional optimization, do not redo the same sum every time, but keep track of the sum within the algorithm. For the tests I've made, this is a factor of ~4-10 faster than the current version. Together with #1593, this reduces the runtime of `enr_destroy` (which uses `state_number_enumerate`) from almost 4s to 15 ms for the case I just treated, and another much bigger case takes 2.5 s now, while it hadn't finished after more than an hour with the previous version.

Note that since the two PRs (this one and #1593) are somewhat related, it might make sense to combine them into a single one. I'd be happy to do that.

**Changelog**
Made state_number_enumerate somewhat faster.