### PR TITLE
improvements in state_number handling

### DIFF
--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -859,7 +859,7 @@ def enr_destroy(dims, excitations):
     a_ops = [sp.lil_matrix((nstates, nstates), dtype=np.complex128)
              for _ in range(len(dims))]
 
-    for n1, state1 in idx2state.items():
+    for n1, state1 in enumerate(idx2state):
         for idx, s in enumerate(state1):
             # if s > 0, the annihilation operator of mode idx has a non-zero
             # entry with one less excitation in mode idx in the final state

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -763,7 +763,7 @@ def state_number_enumerate(dims, excitations=None):
     while True:
         yield state
         idx = len(dims) - 1
-        state = state[:idx] + (state[idx]+1,) + state[idx+1:]
+        state = state[:idx] + (state[idx]+1,)
         nexc += 1
         while nexc > excitations or state[idx] >= dims[idx]:
             # remove all excitations in mode idx, add one in idx-1


### PR DESCRIPTION
**Description**
Speed up and simplify `state_number_enumerate`, `state_number_index`, `state_index_number`, `state_number_qobj`, and `enr_state_dictionaries`. I've changed quite a few functions in states.py, but all the changes are small. It seemed easier to combine this into a single pull request instead of splitting it up into many smaller ones (but this could be done).

The changes in more detail:
 - `state_number_enumerate` and `state_index_number` now always return tuples. Before, `state_number_enumerate` returned arrays for `excitations is None` and tuples otherwise, and `state_index_number` returned a list. For `excitations is None`, I realized that a simple call to `itertools.product` is enough, and is about 20x faster for a (relatively big) test case. It would be trivial to keep returning arrays instead of tuples here as before, but this slows the code down (quite significantly, in fact) and, in any case, returning arrays or tuples depending on whether `excitations` is set seems like an inconsistent interface, so I decided to make it consistent (and faster). I checked that the uses in the code base should not be affected. The algorithm used when the number of excitations is restricted is a slightly more elegant version of the one from my previous pull request (#1594), and is faster by another factor of 5 or more for the "big" test cases I looked at. ~~It is still recursive, but quite fast, and I did not find an elegant non-recursive algorithm.~~ I came up with an even faster non-recursive algorithm after all. It's arguably a bit less elegant, but I think still readable, and another 50% or so faster than the previous one (see the second commit below).
 - `enr_state_dictionaries` now returns a dictionary and a list instead of two dictionaries. Before, `idx2state` was a dictionary with integer keys from 0 to nstates-1, which behaves essentially like a list. However, before Python 3.7, iteration order was not guaranteed to be insertion order (i.e., iterating over the dictionary could give the indices and states in any order, and it seems to me that `enr_thermal_dm`, which did exactly that, was not guaranteed to work).
- `state_number_index` and `state_index_number` now just call `np.ravel_multi_index` and `np.unravel_index`, which are exactly the same operations (mapping between linear and multi-index in a multidimensional array). These are faster and also include error checking. The previous code had no error checks (such as `state` being allowed for the given dims). 

Since the behavior of the code has changed, but the differences should not be noticeable in most cases, I'm not sure if I should do anything else. 

**Related issues or PRs**
This is in some sense a follow-up of #1594. 

**Changelog**
Speed up state_number_enumerate, state_number_index, state_index_number, and add some error checking
Made enr_state_dictionaries return a list for idx2state.