### PR TITLE
Allow f(t, **args) as coefficient function alternative

### DIFF
--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -24,6 +24,7 @@ from .data import Data
 from .interpolate import Cubic_Spline
 from .cy.coefficient import (InterpolateCoefficient, InterCoefficient,
                              StepCoefficient, FunctionCoefficient,
+                             KwFunctionCoefficient,
                              ConjCoefficient, NormCoefficient,
                              ShiftCoefficient, StrFunctionCoefficient,
                              Coefficient)
@@ -103,7 +104,13 @@ def coefficient(base, *, tlist=None, args={}, args_ctypes={},
         return coeff_from_str(base, args, args_ctypes, compile_opt)
 
     elif callable(base):
-        op = FunctionCoefficient(base, args.copy())
+        try:
+            # Try f(t, **kwargs)
+            base(0, **args, _checkkwargs=True)
+            op = KwFunctionCoefficient(base, args.copy())
+        except TypeError:
+            # Fallback on f(t, args)
+            op = FunctionCoefficient(base, args.copy())
         if not isinstance(op(0), numbers.Number):
             raise TypeError("The coefficient function must return a number")
         return op

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -30,7 +30,7 @@ cdef class Coefficient:
     def replace_arguments(self, _args=None, **kwargs):
         """
         Replace the arguments (``args``) of a coefficient.
-        
+
         Returns a new :obj:`Coefficient` if the coefficient has arguments, or the original coefficient if it does not.
         Arguments to replace may be supplied either in a dictionary as the first position argument, or passed as
         keywords, or as a combination of the two. Arguments not replaced retain their previous values.
@@ -131,12 +131,12 @@ cdef class FunctionCoefficient(Coefficient):
 
     cpdef Coefficient copy(self):
         """Return a copy of the :obj:`Coefficient`."""
-        return FunctionCoefficient(self.func, self.args.copy())
+        return self.__class__(self.func, self.args.copy())
 
     def replace_arguments(self, _args=None, **kwargs):
         """
         Replace the arguments (``args``) of a coefficient.
-        
+
         Returns a new :obj:`Coefficient` if the coefficient has arguments, or the original coefficient if it does not.
         Arguments to replace may be supplied either in a dictionary as the first position argument, or passed as
         keywords, or as a combination of the two. Arguments not replaced retain their previous values.
@@ -152,8 +152,26 @@ cdef class FunctionCoefficient(Coefficient):
         if _args:
             kwargs.update(_args)
         if kwargs:
-            return FunctionCoefficient(self.func, {**self.args, **kwargs})
+            return self.__class__(self.func, {**self.args, **kwargs})
         return self
+
+
+@cython.auto_pickle(True)
+cdef class KwFunctionCoefficient(FunctionCoefficient):
+    """
+    :obj:`Coefficient` wrapping a Python function.
+    Use keywords argument.
+
+    Parameters
+    ----------
+    func : callable(t : float, **args) -> complex
+        Function computing the coefficient value.
+
+    args : dict
+        Values of the arguments to pass to `func`.
+    """
+    cdef complex _call(self, double t) except *:
+        return self.func(t, **self.args)
 
 
 def proj(x):
@@ -250,7 +268,7 @@ def coeff(t, args):
     def replace_arguments(self, _args=None, **kwargs):
         """
         Replace the arguments (``args``) of a coefficient.
-        
+
         Returns a new :obj:`Coefficient` if the coefficient has arguments, or the original coefficient if it does not.
         Arguments to replace may be supplied either in a dictionary as the first position argument, or passed as
         keywords, or as a combination of the two. Arguments not replaced retain their previous values.
@@ -383,7 +401,7 @@ cdef Coefficient add_inter(InterCoefficient left, InterCoefficient right):
 cdef class StepCoefficient(Coefficient):
     """
     A step function :obj:`Coefficient` whose values are specified in a numpy array.
-    
+
     At each point in time, the value of the coefficient is the most recent previous value given in the numpy array.
 
     Parameters
@@ -439,9 +457,9 @@ cdef class StepCoefficient(Coefficient):
 cdef class SumCoefficient(Coefficient):
     """
     A :obj:`Coefficient` built from the sum of two other coefficients.
-    
+
     A :obj:`SumCoefficient` is returned as the result of the addition of two coefficients, e.g. ::
-    
+
         coefficient("t * t") + coefficient("t")  # SumCoefficient
     """
     cdef Coefficient first
@@ -465,7 +483,7 @@ cdef class SumCoefficient(Coefficient):
     def replace_arguments(self, _args=None, **kwargs):
         """
         Replace the arguments (``args``) of a coefficient.
-        
+
         Returns a new :obj:`Coefficient` if the coefficient has arguments, or the original coefficient if it does not.
         Arguments to replace may be supplied either in a dictionary as the first position argument, or passed as
         keywords, or as a combination of the two. Arguments not replaced retain their previous values.
@@ -488,9 +506,9 @@ cdef class SumCoefficient(Coefficient):
 cdef class MulCoefficient(Coefficient):
     """
     A :obj:`Coefficient` built from the product of two other coefficients.
-    
+
     A :obj:`MulCoefficient` is returned as the result of the multiplication of two coefficients, e.g. ::
-    
+
         coefficient("w * t", args={'w': 1}) * coefficient("t")  # MulCoefficient
     """
     cdef Coefficient first
@@ -510,7 +528,7 @@ cdef class MulCoefficient(Coefficient):
     def replace_arguments(self, _args=None, **kwargs):
         """
         Replace the arguments (``args``) of a coefficient.
-        
+
         Returns a new :obj:`Coefficient` if the coefficient has arguments, or the original coefficient if it does not.
         Arguments to replace may be supplied either in a dictionary as the first position argument, or passed as
         keywords, or as a combination of the two. Arguments not replaced retain their previous values.
@@ -551,7 +569,7 @@ cdef class ConjCoefficient(Coefficient):
     def replace_arguments(self, _args=None, **kwargs):
         """
         Replace the arguments (``args``) of a coefficient.
-        
+
         Returns a new :obj:`Coefficient` if the coefficient has arguments, or the original coefficient if it does not.
         Arguments to replace may be supplied either in a dictionary as the first position argument, or passed as
         keywords, or as a combination of the two. Arguments not replaced retain their previous values.
@@ -573,7 +591,7 @@ cdef class ConjCoefficient(Coefficient):
 cdef class NormCoefficient(Coefficient):
     """
     The L2 :func:`norm` of a :obj:`Coefficient`. A shortcut for ``conj(coeff) * coeff``.
-    
+
     :obj:`NormCoefficient` is returned by ``qutip.coefficent.norm(Coefficient)``.
     """
     cdef Coefficient base
@@ -584,7 +602,7 @@ cdef class NormCoefficient(Coefficient):
     def replace_arguments(self, _args=None, **kwargs):
         """
         Replace the arguments (``args``) of a coefficient.
-        
+
         Returns a new :obj:`Coefficient` if the coefficient has arguments, or the original coefficient if it does not.
         Arguments to replace may be supplied either in a dictionary as the first position argument, or passed as
         keywords, or as a combination of the two. Arguments not replaced retain their previous values.
@@ -613,9 +631,9 @@ cdef class NormCoefficient(Coefficient):
 cdef class ShiftCoefficient(Coefficient):
     """
     Introduce a time shift into the :obj:`Coefficient`.
-    
+
     Used internally within qutip when calculating correlations.
-    
+
     :obj:ShiftCoefficient is returned by ``qutip.coefficent.shift(Coefficient)``.
     """
     cdef Coefficient base
@@ -628,7 +646,7 @@ cdef class ShiftCoefficient(Coefficient):
     def replace_arguments(self, _args=None, **kwargs):
         """
         Replace the arguments (``args``) of a coefficient.
-        
+
         Returns a new :obj:`Coefficient` if the coefficient has arguments, or the original coefficient if it does not.
         Arguments to replace may be supplied either in a dictionary as the first position argument, or passed as
         keywords, or as a combination of the two. Arguments not replaced retain their previous values.

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -53,6 +53,14 @@ def g(t, args):
     return np.cos(args["w"] * t * np.pi)
 
 
+def f_kw(t, w, **args):
+    return np.exp(w * t * np.pi)
+
+
+def g_kw(t, w, **args):
+    return np.cos(w * t * np.pi)
+
+
 def h(t, args):
     return args["a"] + args["b"] + t
 
@@ -82,11 +90,15 @@ def coeff_generator(style, func):
     """Make a Coefficient"""
     if func == "f":
         base = f
+        base_kw = f_kw
     else:
         base = g
+        base_kw = g_kw
 
     if style == "func":
         return coefficient(base, args=args)
+    if style == "func_kw":
+        return coefficient(base_kw, args=args)
     if style == "array":
         return coefficient(base(tlist, args), tlist=tlist)
     if style == "arraylog":
@@ -108,6 +120,8 @@ def coeff_generator(style, func):
 @pytest.mark.parametrize(['base', 'kwargs', 'tol'], [
     pytest.param(f, {'args': args},
                  1e-10, id="func"),
+    pytest.param(f_kw, {'args': args},
+                 1e-10, id="func_kw"),
     pytest.param(f_asarray, {'tlist': tlist},
                  1e-6,  id="array"),
     pytest.param(f_asarray, {'tlist': tlist, '_stepInterpolation': True},
@@ -132,6 +146,8 @@ def test_CoeffCreationCall(base, kwargs, tol):
 @pytest.mark.parametrize(['base', 'kwargs', 'tol'], [
     pytest.param(f, {'args': args},
                  1e-10, id="func"),
+    pytest.param(f_kw, {'args': args},
+                 1e-10, id="func_kw"),
     pytest.param("exp(w * t * pi)", {'args': args},
                  1e-10, id="string")
 ])
@@ -162,6 +178,7 @@ def test_CoeffCallArguments(base, tol):
 
 @pytest.mark.parametrize(['style'], [
     pytest.param("func", id="func"),
+    pytest.param("func_kw", id="func_kw"),
     pytest.param("array", id="array"),
     pytest.param("arraylog", id="logarray"),
     pytest.param("spline", id="Cubic_Spline"),
@@ -180,6 +197,7 @@ def test_CoeffUnitaryTransform(style, transform, expected):
 
 @pytest.mark.parametrize(['style'], [
     pytest.param("func", id="func"),
+    pytest.param("func_kw", id="func_kw"),
     pytest.param("array", id="array"),
     pytest.param("arraylog", id="logarray"),
     pytest.param("spline", id="Cubic_Spline"),
@@ -196,6 +214,7 @@ def test_CoeffShift(style):
 
 @pytest.mark.parametrize(['style_left'], [
     pytest.param("func", id="func"),
+    pytest.param("func_kw", id="func_kw"),
     pytest.param("array", id="array"),
     pytest.param("arraylog", id="logarray"),
     pytest.param("spline", id="Cubic_Spline"),
@@ -205,6 +224,7 @@ def test_CoeffShift(style):
 ])
 @pytest.mark.parametrize(['style_right'], [
     pytest.param("func", id="func"),
+    pytest.param("func_kw", id="func_kw"),
     pytest.param("array", id="array"),
     pytest.param("arraylog", id="logarray"),
     pytest.param("spline", id="Cubic_Spline"),
@@ -319,6 +339,7 @@ def _shift(coeff):
 
 @pytest.mark.parametrize(['style'], [
     pytest.param("func", id="func"),
+    pytest.param("func_kw", id="func_kw"),
     pytest.param("array", id="array"),
     pytest.param("arraylog", id="logarray"),
     pytest.param("spline", id="Cubic_Spline"),
@@ -343,6 +364,7 @@ def test_Coeffpickle(style, transform):
 
 @pytest.mark.parametrize(['style'], [
     pytest.param("func", id="func"),
+    pytest.param("func_kw", id="func_kw"),
     pytest.param("array", id="array"),
     pytest.param("arraylog", id="logarray"),
     pytest.param("spline", id="Cubic_Spline"),


### PR DESCRIPTION
**Description**
With Coefficient, supporting func(t, **kwargs) in parallel to f(t, args) for function coefficient is mostly free. 
This signature is more 'pythonic' and would probably by appreciated if available. 
With this new scheme, `t` is positional and the `**kwargs` is needed even if unused.
For backward compatibility, we should not remove the old format.

Example:
```
def f(t, args):
    return t*args['w']

def g(t, w, **kwargs):
    return t*w

qevo_old = QobjEvo([qeye(3), f], args={'w':1})

qevo_new = QobjEvo([qeye(3), g], args={'w':1})

for t in any_ts:
    qevo_old(t) == qevo_new(t)
```

**Changelog**
For time-depedent function, f(t, **args) is available with 
