### PR TITLE
auto_tidyup options can be set per data type

### DIFF
--- a/qutip/core/data/properties.pyx
+++ b/qutip/core/data/properties.pyx
@@ -51,13 +51,13 @@ cdef bint _isherm_csr_full(CSR matrix, double tol) except 2:
     cdef idxint row, ptr_a, ptr_b, col_a, col_b
     for row in range(matrix.shape[0]):
         ptr_a, ptr_a_end = matrix.row_index[row], matrix.row_index[row + 1]
-        ptr_b, ptr_b_end = transpose.indptr[row], transpose.indptr[row + 1]
+        ptr_b, ptr_b_end = transpose.row_index[row], transpose.row_index[row + 1]
         while ptr_a < ptr_a_end and ptr_b < ptr_b_end:
             # Doing this on every loop actually involves a few more
             # de-references than are strictly necessary, but just
             # simplifies the logic checking for the end of the row.
             col_a = matrix.col_index[ptr_a]
-            col_b = transpose.indices[ptr_b]
+            col_b = transpose.col_index[ptr_b]
             if col_a == col_b:
                 if not _conj_feq(matrix.data[ptr_a], transpose.data[ptr_b], tol):
                     return False

--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -9,8 +9,8 @@ class CoreOptions:
 
     Options
     -------
-    auto_tidyup : bool
-        use auto tidyup
+    auto_tidyup : bool, list
+        Whether to auto tidyup Qobj, or a list of data types to be auto tidyup.
 
     auto_tidyup_dims : boolTrue
         use auto tidyup dims on multiplication
@@ -26,7 +26,7 @@ class CoreOptions:
     """
     options = {
         # use auto tidyup
-        "auto_tidyup": True,
+        "auto_tidyup": ['CSR'],
         # use auto tidyup dims on multiplication
         "auto_tidyup_dims": True,
         # detect hermiticity

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -126,7 +126,15 @@ def _tidyup(method):
     @functools.wraps(method)
     def out(*args, **kwargs):
         out = method(*args, **kwargs)
-        if isinstance(out, Qobj) and settings.core['auto_tidyup']:
+        tidy_type = []
+        if isinstance(settings.core['auto_tidyup'], list):
+            tidy_type = [_data.to.parse(_type)
+                         for _type in settings.core['auto_tidyup']]
+        if (
+            isinstance(out, Qobj) and
+            (settings.core['auto_tidyup'] is True
+            or type(out.data) in tidy_type)
+        ):
             out.tidyup()
         return out
     return out
@@ -1744,6 +1752,7 @@ class Qobj:
     def isherm(self):
         if self._isherm is not None:
             return self._isherm
+        self.tidyup()
         self._isherm = _data.isherm(self._data)
         return self._isherm
 

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1752,7 +1752,6 @@ class Qobj:
     def isherm(self):
         if self._isherm is not None:
             return self._isherm
-        self.tidyup()
         self._isherm = _data.isherm(self._data)
         return self._isherm
 

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -747,6 +747,11 @@ def test_isherm_skew():
     assert_hermicity(qutip.tensor(iH, iH), True)
 
 
+def test_isherm_unbalanced():
+    unbalanced = scipy.sparse.coo_matrix(([1,0,1], ((0,0,1), (0,1,1))))
+    assert qutip.Qobj(unbalanced).isherm == True
+
+
 def test_super_tensor_operket():
     """
     Tensor: Checks that super_tensor respects states.

--- a/qutip/tests/test_gates.py
+++ b/qutip/tests/test_gates.py
@@ -53,7 +53,7 @@ def _remove_global_phase(qobj):
     Return a new Qobj with the gauge fixed for the global phase.  Explicitly,
     we set the first non-zero element to be purely real-positive.
     """
-    flat = qobj.full().flat.copy()
+    flat = qobj.tidyup().full().flat.copy()
     for phase in flat:
         if phase != 0:
             # Fix the gauge for any global phase.

--- a/qutip/tests/test_measurement.py
+++ b/qutip/tests/test_measurement.py
@@ -382,16 +382,16 @@ def test_povm():
     M = [M_1, M_2, M_3]
 
     _, probabilities = measurement_statistics_povm(ket1, M)
-    np.testing.assert_allclose(probabilities, [0, 0.293, 0.707], 0.001)
+    np.testing.assert_allclose(probabilities, [0, 0.293, 0.707], 0.001, 1e-14)
 
     _, probabilities = measurement_statistics_povm(ket2, M)
-    np.testing.assert_allclose(probabilities, [0.293, 0, 0.707], 0.001)
+    np.testing.assert_allclose(probabilities, [0.293, 0, 0.707], 0.001, 1e-14)
 
     _, probabilities = measurement_statistics_povm(dm1, M)
-    np.testing.assert_allclose(probabilities, [0, 0.293, 0.707], 0.001)
+    np.testing.assert_allclose(probabilities, [0, 0.293, 0.707], 0.001, 1e-14)
 
     _, probabilities = measurement_statistics_povm(dm2, M)
-    np.testing.assert_allclose(probabilities, [0.293, 0, 0.707], 0.001)
+    np.testing.assert_allclose(probabilities, [0.293, 0, 0.707], 0.001, 1e-14)
 
 
 @pytest.mark.repeat(10)


### PR DESCRIPTION
**Description**
`Qobj` tidyup after each mathematical operation it the option is set to `True`. This is expected when using sparse matrices, but not as useful for Dense data. This also made it a priority to implement it for new data layer while not doing any of the visible work.

This allows to set `auto_tidyup` setting per data type.

**Changelog**
Allow `auto_tidyup` settings per data type.
