### PR TITLE
Fixed __rmul__ to be consistent with __mul__ behaviour.

### DIFF
--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -499,7 +499,6 @@ class Qobj:
 
         return other.__matmul__(self)
 
-
     @_tidyup
     def __matmul__(self, other):
         if not isinstance(other, Qobj):

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -487,11 +487,18 @@ class Qobj:
                     copy=False)
 
     def __rmul__(self, other):
-        # Shouldn't be here unless `other.__mul__` has already been tried, so
-        # we _shouldn't_ check that `other` is `Qobj`.
-        if not isinstance(other, numbers.Number):
+        if isinstance(other, numbers.Number):
+            return self.__mul__(complex(other))
+
+        # Try creating a Qobj with other. If not possible (TypeError) we raise
+        # NotImplemented so that other can try to handle __mul__.
+        try:
+            other = Qobj(other)
+        except TypeError:
             return NotImplemented
-        return self.__mul__(complex(other))
+
+        return other.__matmul__(self)
+
 
     @_tidyup
     def __matmul__(self, other):

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -292,6 +292,43 @@ def test_QobjMultiplication():
 
     assert q3 == q4
 
+def test_QobjNumpyMultiplication():
+    """qutip.Qobj multiplication times another object(ndarray). We test both
+    left multiplication and right multiplication."""
+    data1 = np.array([[1, 2], [3, 4]])
+    data2 = np.array([[5, 6], [7, 8]])
+
+    result1 = np.dot(data1, data2)
+    result1 = qutip.Qobj(result1)
+
+    result2 = np.dot(data2, data1)
+    result2 = qutip.Qobj(result2)
+
+    q1 = qutip.Qobj(data1)
+    expect1 = q1 * data2
+    expect2 = data2 * q1
+
+    assert result1 == expect1
+    assert result2 == expect2
+
+def test_QobjMulNotImplmented():
+    """We test that if Qobj does not know how to handle an object it defaults to
+    the objects it raises NotImplmented, which in turn should raise TypeError as
+    DummyClass does not have __mul__ or __rmul__."""
+    class DummyClass():
+        pass
+
+    dummy_object = DummyClass()
+    qobj = qutip.Qobj(1)
+
+    with pytest.raises(TypeError):
+        dummy_object * qobj
+
+    with pytest.raises(TypeError):
+        qobj * dummy_object
+
+
+
 
 def test_QobjDivision():
     "qutip.Qobj division"

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -292,6 +292,7 @@ def test_QobjMultiplication():
 
     assert q3 == q4
 
+
 def test_QobjNumpyMultiplication():
     """qutip.Qobj multiplication times another object(ndarray). We test both
     left multiplication and right multiplication."""
@@ -311,10 +312,11 @@ def test_QobjNumpyMultiplication():
     assert result1 == expect1
     assert result2 == expect2
 
+
 def test_QobjMulNotImplmented():
-    """We test that if Qobj does not know how to handle an object it defaults to
-    the objects it raises NotImplmented, which in turn should raise TypeError as
-    DummyClass does not have __mul__ or __rmul__."""
+    """We test that if Qobj does not know how to handle an object it defaults
+    to the objects it raises NotImplmented, which in turn should raise
+    TypeError as DummyClass does not have __mul__ or __rmul__."""
     class DummyClass():
         pass
 
@@ -326,8 +328,6 @@ def test_QobjMulNotImplmented():
 
     with pytest.raises(TypeError):
         qobj * dummy_object
-
-
 
 
 def test_QobjDivision():


### PR DESCRIPTION
**Description**
Before this fix the following two situations were incosinsten:
```python
matrix = np.random.random((2, 2))
qobj = qutip.Qobj(array)

qobj * matrix # This would perform a matrix multiplication as `__mul__` tries to convert matrix into `Qobj`.
matrix * qobj # This would raise an error as `__rmul__` assumed that matrix was a `Qobj`.
```

I assumed that `qobj * matrix` behaviour is the correct one as it is explicitly programmed to work like that. With this fix `matrix * qobj` will first try to convert matrix to `Qobj` and perform a matmul between matrix and `Qobj`.

**Related issues or PRs**
Issue #1607  is related to this although this PR does not close that issue.

**Changelog**
__rmul__ now accepts as `other` an array_like that is understood by `Qobj`.
