### PR TITLE
Fixed bug where copy argument was not being passed to create dispatcher.

### DIFF
--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -353,7 +353,7 @@ class Qobj:
             else:
                 self._data = _data.identity(size, scale=complex(arg))
         else:
-            self._data = _data.create(arg)
+            self._data = _data.create(arg, copy=copy)
             self.dims = dims or [[self._data.shape[0]], [self._data.shape[1]]]
 
     def __init__(self, arg=None, dims=None, type=None,

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -76,7 +76,7 @@ def test_QobjData():
     assert isinstance(q2.data, qutip.core.data.Data)
 
 
-@pytest.mark.parametrize("data",
+@pytest.mark.parametrize("original_data",
                          [
                             qutip.data.Dense(_random_not_singular(2)),
                             qutip.data.csr.identity(2),
@@ -87,28 +87,30 @@ def test_QobjData():
                              "Dense",
                              "CSR",
                              "Qobj",
-                             "Numpy",
+                             "ndarray",
                          ])
 @pytest.mark.parametrize("copy", [True, False],
                          ids=["copy=True", "copy=False"])
-def test_QobjCopyArgument(data, copy):
+def test_QobjCopyArgument(original_data, copy):
     """Tests that Qobj copy argument works properly when instantiating Qobj."""
-    qobj_data = qutip.Qobj(data, copy=copy).data
+    qobj_data = qutip.Qobj(original_data, copy=copy).data
 
-    if isinstance(data, qutip.Qobj):
-        data = data.data  # Qobj copies the data of another Qobj
+    if isinstance(original_data, qutip.Qobj):
+        # Qobj copies the data of another Qobj, so we take `data` if
+        # original_data was a Qobj
+        original_data = original_data.data
 
-    if isinstance(data, np.ndarray):
+    if isinstance(original_data, np.ndarray):
         # For numpy object we compare with data's data. This should be dense so
         # we get its data as ndarray.
         qobj_data = qobj_data.as_ndarray()
 
         # We look at the memory and see if it is shared or not to asses wether 
         # copy argument worked or not.
-        assert np.shares_memory(qobj_data, data) != copy
+        assert np.shares_memory(qobj_data, original_data) != copy
 
     else:
-        assert (data is qobj_data) != copy
+        assert (original_data is qobj_data) != copy
 
 
 def test_QobjType():

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -1060,4 +1060,3 @@ def test_contract(expanded, contracted, inplace):
     assert out.dims == contracted
     assert out.shape == qobj.shape
     assert np.all(out.full() == qobj.full())
-

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -89,7 +89,8 @@ def test_QobjData():
                              "Qobj",
                              "Numpy",
                          ])
-@pytest.mark.parametrize("copy", [True, False])
+@pytest.mark.parametrize("copy", [True, False],
+                         ids=["copy=True", "copy=False"])
 def test_QobjCopyArgument(data, copy):
     """Tests that Qobj copy argument works properly when instantiating Qobj."""
     qobj_data = qutip.Qobj(data, copy=copy).data
@@ -97,15 +98,17 @@ def test_QobjCopyArgument(data, copy):
     if isinstance(data, qutip.Qobj):
         data = data.data  # Qobj copies the data of another Qobj
 
-    # For numpy object we compare with data's data. This should be dense so we
-    # get its data as ndarray.
     if isinstance(data, np.ndarray):
+        # For numpy object we compare with data's data. This should be dense so
+        # we get its data as ndarray.
         qobj_data = qobj_data.as_ndarray()
 
-    if copy:
-        assert data is not qobj_data
+        # We look at the memory and see if it is shared or not to asses wether 
+        # copy argument worked or not.
+        assert np.shares_memory(qobj_data, data) != copy
+
     else:
-        assert data is qobj_data
+        assert (data is qobj_data) != copy
 
 
 def test_QobjType():

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -75,6 +75,7 @@ def test_QobjData():
     q2 = qutip.Qobj(data2)
     assert isinstance(q2.data, qutip.core.data.Data)
 
+
 @pytest.mark.parametrize("data",
                          [
                             qutip.data.Dense(_random_not_singular(2)),
@@ -98,6 +99,7 @@ def test_QobjCopyArgument(data, copy):
         assert data is not q.data
     else:
         assert data is q.data
+
 
 def test_QobjType():
     "qutip.Qobj type"

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -75,6 +75,29 @@ def test_QobjData():
     q2 = qutip.Qobj(data2)
     assert isinstance(q2.data, qutip.core.data.Data)
 
+@pytest.mark.parametrize("data",
+                         [
+                            qutip.data.Dense(_random_not_singular(2)),
+                            qutip.data.csr.identity(2),
+                            qutip.Qobj(_random_not_singular(2)),
+                         ],
+                         ids=[
+                             "Dense",
+                             "CSR",
+                             "Qobj",
+                         ])
+@pytest.mark.parametrize("copy", [True, False])
+def test_QobjCopyArgument(data, copy):
+    """Tests that Qobj copy argument works properly when instantiating Qobj."""
+    q = qutip.Qobj(data, copy=copy)
+
+    if isinstance(data, qutip.Qobj):
+        data = data.data  # Qobj copies the data of another Qobj
+
+    if copy:
+        assert data is not q.data
+    else:
+        assert data is q.data
 
 def test_QobjType():
     "qutip.Qobj type"
@@ -1023,3 +1046,4 @@ def test_contract(expanded, contracted, inplace):
     assert out.dims == contracted
     assert out.shape == qobj.shape
     assert np.all(out.full() == qobj.full())
+

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -81,24 +81,31 @@ def test_QobjData():
                             qutip.data.Dense(_random_not_singular(2)),
                             qutip.data.csr.identity(2),
                             qutip.Qobj(_random_not_singular(2)),
+                            _random_not_singular(2),
                          ],
                          ids=[
                              "Dense",
                              "CSR",
                              "Qobj",
+                             "Numpy",
                          ])
 @pytest.mark.parametrize("copy", [True, False])
 def test_QobjCopyArgument(data, copy):
     """Tests that Qobj copy argument works properly when instantiating Qobj."""
-    q = qutip.Qobj(data, copy=copy)
+    qobj_data = qutip.Qobj(data, copy=copy).data
 
     if isinstance(data, qutip.Qobj):
         data = data.data  # Qobj copies the data of another Qobj
 
+    # For numpy object we compare with data's data. This should be dense so we
+    # get its data as ndarray.
+    if isinstance(data, np.ndarray):
+        qobj_data = qobj_data.as_ndarray()
+
     if copy:
-        assert data is not q.data
+        assert data is not qobj_data
     else:
-        assert data is q.data
+        assert data is qobj_data
 
 
 def test_QobjType():


### PR DESCRIPTION
**Description**
Qobj's copy argument was not being passed to create dispatcher. This resulted in a copy of `data` regardless of the `copy` argument when `data` was not an instance of `data.Data` or `Qobj`.

Example (I am using here qutip-tensorflow as I do not know how this translates into numpys ndarray, see comment below):
```python
tfconstant = tf.constant(np.random.random((2,2))) # random tensor
qobj = qutip.Qobj(tfconstant, copy=False) 
print(qobj.data._tf is not tfconstant) # True but should be False
```

**Changelog**
Copy argument is now handled correctly.