### PR TITLE
Changed __mul__ behviour to be more flexible and consistent.

### DIFF
--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -497,7 +497,6 @@ class Qobj:
             isherm = None
             isunitary = None
 
-
         return Qobj(out,
                     dims=self.dims,
                     type=self.type,

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -492,7 +492,7 @@ class Qobj:
         try:
             multiplier = complex(other)
             isherm = (self._isherm and multiplier.imag == 0) or None
-            isunitary = (self._isunitary and abs(multiplier) == 1) or None
+            isunitary = abs(multiplier) == 1 if self._isunitary else None
         except TypeError:
             isherm = None
             isunitary = None

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -185,8 +185,9 @@ class TestQobjHermicity:
 
 
 def assert_unitarity(oper, unitarity):
-    # Check the cached isunitary, if any exists.
+    # Check the cached isunitary.
     assert oper.isunitary == unitarity
+
     # Force a reset of the cached value for isunitary.
     oper._isunitary = None
     # Force a recalculation of isunitary.
@@ -211,6 +212,11 @@ def test_QobjUnitaryOper():
     assert_unitarity(Sx*4, False)
     assert_unitarity(4+Sx, False)
     assert_unitarity(Sx+4, False)
+    # Check that when multipliying scalar numbers with absolute value 1 we
+    # maintain unitarity.
+    assert_unitarity(Sx*np.exp(5j), True)
+    assert_unitarity(Sx*1j, True)
+    assert_unitarity(Sx*1, True)
 
 
 def test_QobjDimsShape():

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -332,7 +332,7 @@ def test_QobjMultiplication():
 # Allowed mul operations (scalar)
 @pytest.mark.parametrize("scalar",
                          [2+2j,  np.array(2+2j), np.array([2+2j])],
-                         ["python_number",
+                         ids=["python_number",
                           "scalar_like_array_shape_0",
                           "scalar_like_array_shape_1"])
 def test_QobjMulValidScalar(scalar):

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -329,42 +329,47 @@ def test_QobjMultiplication():
 
     assert q3 == q4
 
+
 # Allowed mul operations (scalar)
 @pytest.mark.parametrize("scalar",
                          [2+2j,  np.array(2+2j), np.array([2+2j])],
-                         ids=["python_number",
-                          "scalar_like_array_shape_0",
-                          "scalar_like_array_shape_1"])
+                         ids=[
+                             "python_number",
+                             "scalar_like_array_shape_0",
+                             "scalar_like_array_shape_1",
+                         ])
 def test_QobjMulValidScalar(scalar):
     "Tests multiplication of Qobj times scalar."
     data = np.array([[1, 2], [3, 4]])
     q = qutip.Qobj(data)
-    expect = data*(2+2j)
+    expect = data * (2+2j)
 
     # Check __mul__
-    result= q*scalar
-    assert np.all(result.full()==expect)
+    result = q * scalar
+    assert np.all(result.full() == expect)
 
     # Check __rmul__
-    result= scalar*q
-    assert np.all(result.full()==expect)
+    result = scalar * q
+    assert np.all(result.full() == expect)
 
-# Not allowed mul operations.
-class NoComplexClass():
-    """Class without __complex__."""
-    pass
 
-@pytest.mark.parametrize("scalar",
-                         [NoComplexClass(), np.array([2j, 1]),],
-                         ids=["object_without_complex", "not_scalar_like_array"])
-def test_QobjMulNotValidScalar(scalar):
+# We do not allow yet qobj being multiplied by a numpy array that does not
+# represent a scalar. If we include the feature of numpy broadcasting an qobj
+# as scalar, this test should be removed.
+@pytest.mark.parametrize("not_scalar",
+                         [np.array([2j, 1]), np.array([[1, 2], [3, 4]])],
+                         ids=[
+                             "not_scalar_like_vector",
+                             "not_scalar_like_matrix",
+                         ])
+def test_QobjMulNotValidScalar(not_scalar):
     q1 = qutip.Qobj(np.array([[1, 2], [3, 4]]))
 
     with pytest.raises(TypeError):
-        scalar * q1
+        not_scalar * q1
 
     with pytest.raises(TypeError):
-        q1 * scalar
+        q1 * not_scalar
 
 
 def test_QobjDivision():

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -217,6 +217,12 @@ def test_QobjUnitaryOper():
     assert_unitarity(Sx*np.exp(5j), True)
     assert_unitarity(Sx*1j, True)
     assert_unitarity(Sx*1, True)
+    # Chech that if qobj is _not_ unitary, operation by scalar set it to `None`
+    # We do not know if it is unitary until we check the whole matrix again.
+    assert (qutip.sigmam()*4)._isunitary == None  # Non unitary 
+    # This may be removed in the future as if scalar has abs value of 1 and
+    # matrix is not unitary, output wont be unitary.
+    assert (qutip.sigmam()*1)._isunitary == None
 
 
 def test_QobjDimsShape():

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -329,6 +329,43 @@ def test_QobjMultiplication():
 
     assert q3 == q4
 
+# Allowed mul operations (scalar)
+@pytest.mark.parametrize("scalar",
+                         [2+2j,  np.array(2+2j), np.array([2+2j])],
+                         ["python_number",
+                          "scalar_like_array_shape_0",
+                          "scalar_like_array_shape_1"])
+def test_QobjMulValidScalar(scalar):
+    "Tests multiplication of Qobj times scalar."
+    data = np.array([[1, 2], [3, 4]])
+    q = qutip.Qobj(data)
+    expect = data*(2+2j)
+
+    # Check __mul__
+    result= q*scalar
+    assert np.all(result.full()==expect)
+
+    # Check __rmul__
+    result= scalar*q
+    assert np.all(result.full()==expect)
+
+# Not allowed mul operations.
+class NoComplexClass():
+    """Class without __complex__."""
+    pass
+
+@pytest.mark.parametrize("scalar",
+                         [NoComplexClass(), np.array([2j, 1]),],
+                         ids=["object_without_complex", "not_scalar_like_array"])
+def test_QobjMulNotValidScalar(scalar):
+    q1 = qutip.Qobj(np.array([[1, 2], [3, 4]]))
+
+    with pytest.raises(TypeError):
+        scalar * q1
+
+    with pytest.raises(TypeError):
+        q1 * scalar
+
 
 def test_QobjDivision():
     "qutip.Qobj division"


### PR DESCRIPTION
**Description**
I changed __mul__ behaviour following the discussion of issue #1607. However, the implementation details differ slightly from what was discussed there. The current behaviout of `__mul__(self, other)` is:
- If other is a `Qobj`: dispatch to `__matmul__`
- If not try dipatching to mul and return `NotImplemented` if `TypeError` is returned.
- The dispatcher now gets `other` instead of `complex(other)`. This is more flexible and allows specialisations to handle arbitrary scalar like objects (something extremely useful for qutip-tensorflow).
- Infer hermiticity and unitarity when possible trying complex(other)

`__rmul__` now directly dispatches to `__mul__`. Any necessary check (casting to complex included) is done in `__mul__`.

_No_ changes were required to `mul_dense` and `mul_csr` as `add_dense(data, value=np.array(1))` works. It internally tries `complex(np.array(1))` which is guaranteed to work. This is something I was very happy to find as I do not think that specialisations should return `NotImplemented` (although they still can if required).


**Related issues or PRs**
Fixes issue #1611 

**Changelog**

- Qobj `__mul__` now handles consistently right and left multiplications of an arbitrary python object.
-  `__mul__` is now more flexible passing `other` to the dispatcher instead of `complex(other)`.
- `qobj*np.array([1,2])` and `qobj*np.array([1,2])` (or any other numpy array that does not represent an scalar) now raise TypeError. This change is not backwards compatible (!!).

_Edit:  changed changelog and description_