### PR TITLE
Clean up pulse optimization sparse solving support.

### DIFF
--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -1555,6 +1555,11 @@ class DynamicsUnitary(Dynamics):
             eig_val, eig_vec = sp_eigs(H.data, H.isherm,
                                        sparse=self.sparse_eigen_decomp)
             eig_vec = eig_vec.T
+            if self.sparse_eigen_decomp:
+                # when sparse=True, sp_eigs returns an ndarray where each
+                # element is a sparse matrix so we convert it into a sparse
+                # matrix we can later pass to Qobj(...)
+                eig_vec = sp.hstack(eig_vec)
 
         elif self.oper_dtype == np.ndarray:
             H = self._dyn_gen[k]

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -1139,7 +1139,8 @@ class Dynamics(object):
             #Target is operator
             targ = la.inv(self.target.full())
             if self.oper_dtype == Qobj:
-                self._onto_evo_target = Qobj(targ)
+                rev_dims = [self.target.dims[1], self.target.dims[0]]
+                self._onto_evo_target = Qobj(targ, dims=rev_dims)
             elif self.oper_dtype == np.ndarray:
                 self._onto_evo_target = targ
             else:

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -724,6 +724,12 @@ class Dynamics(object):
         self._init_phase()
 
         self._set_memory_optimizations()
+        if self.sparse_eigen_decomp and self.sys_shape[0] <= 2:
+            raise ValueError(
+                "Single qubit pulse optimization dynamics cannot use sparse"
+                " eigenvector decomposition because of limitations in"
+                " scipy.linalg.eigsh. Pleae set sparse_eigen_decomp to False"
+                " or increase the size of the system.")
 
         n_ts = self.num_tslots
         n_ctrls = self.num_ctrls

--- a/qutip/control/propcomp.py
+++ b/qutip/control/propcomp.py
@@ -306,16 +306,11 @@ class PropCompAugMat(PropagatorComputer):
             E = dyn._get_phased_ctrl_dyn_gen(k, j).data*dyn.tau[k]
             Z = sp.csr_matrix(dg.data.shape)
             aug = Qobj(sp.vstack([sp.hstack([A, E]), sp.hstack([Z, A])]))
-        elif dyn.oper_dtype == np.ndarray:
+        else:
             A = dg*dyn.tau[k]
             E = dyn._get_phased_ctrl_dyn_gen(k, j)*dyn.tau[k]
             Z = np.zeros(dg.shape)
             aug = np.vstack([np.hstack([A, E]), np.hstack([Z, A])])
-        else:
-            A = dg*dyn.tau[k]
-            E = dyn._get_phased_ctrl_dyn_gen(k, j)*dyn.tau[k]
-            Z = dg*0.0
-            aug = sp.vstack([sp.hstack([A, E]), sp.hstack([Z, A])])
         return aug
 
     def _compute_prop_grad(self, k, j, compute_prop=True):
@@ -388,7 +383,7 @@ class PropCompFrechet(PropagatorComputer):
                 prop_grad_dense = la.expm_frechet(A, E, compute_expm=False)
                 prop_grad = Qobj(prop_grad_dense,
                                             dims=dyn.dyn_dims)
-        elif dyn.oper_dtype == np.ndarray:
+        else:
             A = dyn._get_phased_dyn_gen(k)*dyn.tau[k]
             E = dyn._get_phased_ctrl_dyn_gen(k, j)*dyn.tau[k]
             if compute_prop:
@@ -396,19 +391,6 @@ class PropCompFrechet(PropagatorComputer):
             else:
                 prop_grad = la.expm_frechet(A, E,
                                                     compute_expm=False)
-        else:
-            # Assuming some sparse matrix
-            spcls = dyn._dyn_gen[k].__class__
-            A = (dyn._get_phased_dyn_gen(k)*dyn.tau[k]).toarray()
-            E = (dyn._get_phased_ctrl_dyn_gen(k, j)*dyn.tau[k]).toarray()
-            if compute_prop:
-                prop_dense, prop_grad_dense = la.expm_frechet(A, E)
-                prop = spcls(prop_dense)
-                prop_grad = spcls(prop_grad_dense)
-            else:
-                prop_grad_dense = la.expm_frechet(A, E, compute_expm=False)
-                prop_grad = spcls(prop_grad_dense)
-
         if compute_prop:
             return prop, prop_grad
         else:


### PR DESCRIPTION


Currently qutip.control.optimize_pulse supports four formats for `oper_dtype` (i.e. its internal representation of propagators and intermediate states). The four formats and their statuses before this PR are described below:

- `numpy.ndarray`: Working.
- `Qobj`: Working, except that some dimensions were lost in Qobj construction and using sparse eigenvector decomposition was broken.
- `scipy.sparse.csr_matrix`: Broken. There was an undefined variable referenced in the code to construct the propagators. Many code paths had no explicit support for them and assumed they worked the same as ndarrays in cases where they didn't.
- `anything matrix-like`: Broken for the same reasons as `csr_matrix` above.

This PR removes support for last two oper_dtypes and fixes the `Qobj` one, leaving the situation as follows:

- `numpy.ndarray`: Working.
- `Qobj`: Working.
- `scipy.sparse.csr_matrix`: No longer supported.
- `anything matrix-like`: No longer supported.

Note that `Qobj` uses sparse matrices internally, so CSR matrix support is still available via the `Qobj` oper_dtype.

In QuTiP v5, only `Qobj` support will be retained since `Qobj` will support both sparse and dense representations via the data layer.

**Related issues or PRs**
* Fixes #1617

**Changelog**
Fix qutip.control.optimize_pulse support for sparse eigenvector decomposition with the Qobj oper_dtype (the Qobj oper_dtype is the default for large systems).
Remove qutip.control.optimize_pulse support for scipy.sparse.csr_matrix and generic ndarray-like matrices. Support for these was non-functional.
