### PR TITLE
Pow tests for data layer.

### DIFF
--- a/qutip/core/data/pow.pyx
+++ b/qutip/core/data/pow.pyx
@@ -16,7 +16,7 @@ __all__ = [
 @cython.cdivision(True)
 cpdef CSR pow_csr(CSR matrix, unsigned long long n):
     if matrix.shape[0] != matrix.shape[1]:
-        raise TypeError("matrix power only works with square matrices")
+        raise ValueError("matrix power only works with square matrices")
     if n == 0:
         return csr.identity(matrix.shape[0])
     if n == 1:

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -93,13 +93,17 @@ def shapes_binary_bad_matmul(dim=100):
 
 
 def shapes_square(dim=100):
+    """Allowed shapes for operations that require square matrices. Examples of
+    these operations are trace, pow, expm and the trace norm."""
     return [
         (pytest.param((1, 1), id="1"),),
         (pytest.param((dim, dim), id=str(dim)),),
     ]
 
 
-def shapes_bad_square(dim=100):
+def shapes_not_square(dim=100):
+    """Disallowed shapes for operations that require square matrices. Examples of
+    these operations are trace, pow, expm and the trace norm."""
     return [
         (x,) for x in shapes_unary(dim) if x.values[0][0] != x.values[0][1]
     ]
@@ -766,7 +770,7 @@ class TestTrace(UnaryOpMixin):
         return np.sum(np.diag(matrix))
 
     shapes = shapes_square()
-    bad_shapes = shapes_bad_square()
+    bad_shapes = shapes_not_square()
     specialisations = [
         pytest.param(data.trace_csr, CSR, complex),
         pytest.param(data.trace_dense, Dense, complex),
@@ -787,7 +791,7 @@ class TestPow(UnaryOpMixin):
         return np.linalg.matrix_power(matrix, n)
 
     shapes = shapes_square()
-    bad_shapes = shapes_bad_square()
+    bad_shapes = shapes_not_square()
     specialisations = [
         pytest.param(data.pow_csr, CSR, CSR),
     ]

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -95,13 +95,13 @@ def shapes_binary_bad_matmul(dim=100):
 def shapes_square(dim=100):
     return [
         (pytest.param((1, 1), id="1"),),
-        (pytest.param((dim, dim), id="100"),),
+        (pytest.param((dim, dim), id=str(dim)),),
     ]
 
 
 def shapes_bad_square(dim=100):
     return [
-        (x,) for x in shapes_unary() if x.values[0][0] != x.values[0][1]
+        (x,) for x in shapes_unary(dim) if x.values[0][0] != x.values[0][1]
     ]
 
 # Set up the special cases for each type of matrix that will be tested.  These

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -802,17 +802,9 @@ class TestPow(UnaryOpMixin):
         expected = self.op_numpy(matrix.to_array(), n)
         test = op(matrix, n)
         assert isinstance(test, out_type)
-        if issubclass(out_type, Data):
-            assert test.shape == expected.shape
-            np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol)
-        elif out_type is list:
-            for test_, expected_ in zip(test, expected):
-                assert test_.shape == expected_.shape
-                np.testing.assert_allclose(test_.to_array(),
-                                           expected_, atol=self.tol)
-        else:
-            assert abs(test - expected) < self.tol
+        assert test.shape == expected.shape
+        np.testing.assert_allclose(test.to_array(), expected,
+                                   atol=self.tol)
 
     # Pow actually does have bad shape, so we put that in too.
     def test_incorrect_shape_raises(self, op, data_m):

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -91,11 +91,13 @@ def shapes_binary_bad_matmul(dim=100):
         if x.values[0][1] != y.values[0][0]
     ]
 
+
 def shapes_square(dim=100):
     return [
         (pytest.param((1, 1), id="1"),),
         (pytest.param((dim, dim), id="100"),),
     ]
+
 
 def shapes_bad_square(dim=100):
     return [
@@ -779,6 +781,7 @@ class TestTrace(UnaryOpMixin):
         with pytest.raises(ValueError):
             op(data_m())
 
+
 class TestPow(UnaryOpMixin):
     def op_numpy(self, matrix, n):
         return np.linalg.matrix_power(matrix, n)
@@ -789,7 +792,7 @@ class TestPow(UnaryOpMixin):
         pytest.param(data.pow_csr, CSR, CSR),
     ]
 
-    @pytest.mark.parametrize("n",[1,10], ids=["n_1", "n_10"])
+    @pytest.mark.parametrize("n", [1, 10], ids=["n_1", "n_10"])
     def test_mathematically_correct(self, op, data_m, out_type, n):
         matrix = data_m()
         expected = self.op_numpy(matrix.to_array(), n)
@@ -815,6 +818,7 @@ class TestPow(UnaryOpMixin):
         """
         with pytest.raises(ValueError):
             op(data_m(), 10)
+
 
 class TestTranspose(UnaryOpMixin):
     def op_numpy(self, matrix):


### PR DESCRIPTION
**Description**
Added tests for pow specialisation. I also changed the raised error to `ValueError` to be consistent with the rest of the specialisations (and in particular with trace that also raises `ValueError` if input matrix is not square). 

The tests do not contemplate the cases where:
- n is not an integer (float): Float is cast to integer so: `pow_csr(matrix, 0.1) == pow_csr(matrix, 0)`. We may want to raise `TypeError` instead.
- n is not positive: `OverflowError` is raised instead of `TypeError`. This is due to how Cython works but we may want to raise TypeError for consistency with the rest of the code.

For instance, raising `TypeError` in these cases is what NumPy does. What should we do?

**Related issues or PRs**
None

**Changelog**
Give a short description of the PR in a few words. This will be shown in the QuTiP change log after the PR gets merged.
For example: 
Tests for pow specisalisation.
Pow now raises ValueError instead of TypeError if matrix is not square.
