### PR TITLE
Added expect tests for data layer.

### DIFF
--- a/qutip/core/data/expect.pyx
+++ b/qutip/core/data/expect.pyx
@@ -21,19 +21,27 @@ __all__ = [
 ]
 
 cdef void _check_shape_ket(Data op, Data state) nogil except *:
-    if op.shape[1] != state.shape[0] or state.shape[1] != 1:
+    if (op.shape[1] != state.shape[0]  # Matrix multiplication
+        or state.shape[1] != 1  # State is ket
+        or op.shape[0] != op.shape[1]  # op must be square matrix
+       ):
         raise ValueError("incorrect input shapes "
                          + str(op.shape) + " and " + str(state.shape))
 
 cdef void _check_shape_dm(Data op, Data state) nogil except *:
-    if op.shape[0] != state.shape[1] or op.shape[1] != state.shape[0]:
+    if (op.shape[0] != op.shape[1]  # Matrix multiplication
+        or state.shape[0] != state.shape[1]  # State is square 
+        or op.shape[1] != state.shape[0]  # Op is square
+       ):
         raise ValueError("incorrect input shapes "
                          + str(op.shape) + " and " + str(state.shape))
 
 cdef void _check_shape_super(Data op, Data state) nogil except *:
     if state.shape[1] != 1:
         raise ValueError("expected a column-stacked matrix")
-    if op.shape[1] != state.shape[0]:
+    if ( op.shape[1] != state.shape[0]  # Matrix multiplication
+       or op.shape[0] != op.shape[1]  # Square matrix
+       ):
         raise ValueError("incompatible shapes " + str(op.shape) + ", " + str(state.shape))
 
 

--- a/qutip/core/data/expect.pyx
+++ b/qutip/core/data/expect.pyx
@@ -29,9 +29,9 @@ cdef void _check_shape_ket(Data op, Data state) nogil except *:
                          + str(op.shape) + " and " + str(state.shape))
 
 cdef void _check_shape_dm(Data op, Data state) nogil except *:
-    if (op.shape[0] != op.shape[1]  # Matrix multiplication
+    if (op.shape[1] != state.shape[0]  # Matrix multiplication
         or state.shape[0] != state.shape[1]  # State is square 
-        or op.shape[1] != state.shape[0]  # Op is square
+        or op.shape[0] != op.shape[1]  # Op is square
        ):
         raise ValueError("incorrect input shapes "
                          + str(op.shape) + " and " + str(state.shape))
@@ -39,8 +39,8 @@ cdef void _check_shape_dm(Data op, Data state) nogil except *:
 cdef void _check_shape_super(Data op, Data state) nogil except *:
     if state.shape[1] != 1:
         raise ValueError("expected a column-stacked matrix")
-    if ( op.shape[1] != state.shape[0]  # Matrix multiplication
-       or op.shape[0] != op.shape[1]  # Square matrix
+    if (op.shape[1] != state.shape[0]  # Matrix multiplication
+        or op.shape[0] != op.shape[1]  # Square matrix
        ):
         raise ValueError("incompatible shapes " + str(op.shape) + ", " + str(state.shape))
 

--- a/qutip/core/data/expect.pyx
+++ b/qutip/core/data/expect.pyx
@@ -21,27 +21,30 @@ __all__ = [
 ]
 
 cdef void _check_shape_ket(Data op, Data state) nogil except *:
-    if (op.shape[1] != state.shape[0]  # Matrix multiplication
+    if (
+        op.shape[1] != state.shape[0]  # Matrix multiplication
         or state.shape[1] != 1  # State is ket
         or op.shape[0] != op.shape[1]  # op must be square matrix
-       ):
+    ):
         raise ValueError("incorrect input shapes "
                          + str(op.shape) + " and " + str(state.shape))
 
 cdef void _check_shape_dm(Data op, Data state) nogil except *:
-    if (op.shape[1] != state.shape[0]  # Matrix multiplication
+    if (
+        op.shape[1] != state.shape[0]  # Matrix multiplication
         or state.shape[0] != state.shape[1]  # State is square 
         or op.shape[0] != op.shape[1]  # Op is square
-       ):
+    ):
         raise ValueError("incorrect input shapes "
                          + str(op.shape) + " and " + str(state.shape))
 
 cdef void _check_shape_super(Data op, Data state) nogil except *:
     if state.shape[1] != 1:
         raise ValueError("expected a column-stacked matrix")
-    if (op.shape[1] != state.shape[0]  # Matrix multiplication
+    if (
+        op.shape[1] != state.shape[0]  # Matrix multiplication
         or op.shape[0] != op.shape[1]  # Square matrix
-       ):
+    ):
         raise ValueError("incompatible shapes " + str(op.shape) + ", " + str(state.shape))
 
 

--- a/qutip/tests/core/data/test_expect.py
+++ b/qutip/tests/core/data/test_expect.py
@@ -29,7 +29,7 @@ class TestExpect(BinaryOpMixin):
         (_op, _ket),
         (_op, _dm),
     ]
-    bad_shapes = list(product([_not_op], [_ket, _dm]))  # Bad op
+    bad_shapes = list(product(_not_op, [_ket, _dm]))  # Bad op
     bad_shapes += [
         (_op, _nonsquare),
         (_op, _bra),

--- a/qutip/tests/core/data/test_expect.py
+++ b/qutip/tests/core/data/test_expect.py
@@ -1,0 +1,67 @@
+"""This file provides tests for expect specialisation. For tests at Qobj level
+see `qutip/tests/core/test_expect.py`"""
+
+from .test_mathematics import BinaryOpMixin
+import pytest
+import numpy as np
+from qutip import data
+from qutip.core.data import CSR, Dense
+from itertools import product
+
+
+class TestExpect(BinaryOpMixin):
+    def op_numpy(self, op, state):
+        is_ket = state.shape[1] == 1
+        if is_ket:
+            return np.conj(state.T)@op@state
+        else:
+            return np.trace(op@state)
+
+    _dim = 100
+    _ket = pytest.param((_dim, 1), id="ket")
+    _dm = pytest.param((_dim, _dim), id="dm")
+    _op = pytest.param((_dim, _dim), id="op")
+    _bra = pytest.param((1, _dim), id="bra")
+    _nonsquare = pytest.param((2, _dim), id="nonsquare")
+    _not_op = [_bra, _ket, _nonsquare]
+
+    shapes = [
+        (_op, _ket),
+        (_op, _dm),
+    ]
+    bad_shapes = list(product([_not_op], [_ket, _dm]))  # Bad op
+    bad_shapes += [
+        (_op, _nonsquare),
+        (_op, _bra),
+    ]  # Bad ket/dm
+
+    specialisations = [
+        pytest.param(data.expect_csr, CSR, CSR, complex),
+        pytest.param(data.expect_dense, Dense, Dense, complex),
+        pytest.param(data.expect_csr_dense, CSR, Dense, complex),
+    ]
+
+
+class TestExpectSuper(BinaryOpMixin):
+    def op_numpy(self, op, state):
+        n = np.sqrt(state.shape[0]).astype(int)
+        out_shape = (n, n)
+        return np.trace(np.reshape(op@state, newshape=out_shape))
+
+    _dim = 100
+    _super_ket = pytest.param((_dim, 1), id="super_ket")
+    _super_op = pytest.param((_dim, _dim), id="super_op")
+    _bra = pytest.param((1, _dim), id="row_stacked")
+    _nonsquare = pytest.param((2, _dim), id="nonsquare")
+    _not_super_ket = [_super_op, _bra, _nonsquare]
+    _not_super_op = [_super_ket, _bra, _nonsquare]
+
+    shapes = [(_super_op, _super_ket), ]
+    bad_shapes = list(product(_not_super_op, [_super_ket]))  # Bad super op
+    bad_shapes += list(product([_super_op], _not_super_ket))  # Bad super ket
+
+    specialisations = [
+        pytest.param(data.expect_super_dense, Dense, Dense, complex),
+        pytest.param(data.expect_super_csr, CSR, CSR, complex),
+        pytest.param(data.expect_super_csr_dense, CSR, Dense, complex),
+    ]


### PR DESCRIPTION
**Description**
Added tests for expect specialisations. The tests follow the structure in `test_mathematics` which helps developing new data 

**Notes**
I changed the logic in `expect.pyx` to also raise `ValuError` when op is not a square matrix. `expect_csr` was crashing with a segment fault when passing a nonsquare matrix as `op`.  I am not sure why this error was not being caught by the tests for `qutip.expect`. I guess this function does some check to the Qobj given as argument.