### PR TITLE
Fix handling of options=None in matrix_histogram.

### DIFF
--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -591,7 +591,9 @@ def matrix_histogram(M, xlabels=None, ylabels=None, title=None, limits=None,
                     'cbar_pad': 0.04, 'cbar_to_z': False}
 
     # update default_opts from input options
-    if isinstance(options, dict):
+    if options is None:
+        pass
+    elif isinstance(options, dict):
         # check if keys in options dict are valid
         if set(options) - set(default_opts):
             raise ValueError("invalid key(s) found in options: "


### PR DESCRIPTION
**Description**
#1573 introduced a bug in matrix_histogram. If no styling options are passed it raises a ValueError. After this change, matrix_histogram uses the default options instead.

**Related issues or PRs**
Fixes a bug introduced in #1573.

**Changelog**
Fixed handling of style options=None (the default) in matrix_histogram.