### PR TITLE
Expm and  project tests.

### DIFF
--- a/qutip/core/data/project.pyx
+++ b/qutip/core/data/project.pyx
@@ -87,7 +87,7 @@ cpdef CSR project_csr(CSR state):
         out = csr.empty(state.shape[1], state.shape[1], nnz_in*nnz_in)
         _project_bra_csr(state, out)
         return out
-    raise TypeError("state must be a ket or a bra.")
+    raise ValueError("state must be a ket or a bra.")
 
 cpdef Dense project_dense(Dense state):
     """
@@ -105,7 +105,7 @@ cpdef Dense project_dense(Dense state):
         size = state.shape[1]
         fortran = False
     else:
-        raise TypeError("state must be a ket or a bra.")
+        raise ValueError("state must be a ket or a bra.")
     out = dense.zeros(size, size, fortran)
     for i in range(size):
         for j in range(size):

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -385,10 +385,10 @@ class _GenericOpMixin:
 class UnaryOpMixin(_GenericOpMixin):
     """
     Mix-in for unary mathematical operations on Data instances (e.g. unary
-    negation).  Only generates the test `mathematically_correct`, since there
-    can't be a shape mismatch when there's only one argument.
+    negation).
     """
     shapes = [(x,) for x in shapes_unary()]
+    bad_shapes = []
 
     def test_mathematically_correct(self, op, data_m, out_type):
         matrix = data_m()
@@ -409,8 +409,9 @@ class UnaryOpMixin(_GenericOpMixin):
 
     def test_incorrect_shape_raises(self, op, data_m):
         """
-        Test that the operation produces a suitable error if the shape is not a
-        square matrix.
+        Test that the operation produces a suitable error if the shapes of the
+        given operand is not compatible with the operation. Useful for
+        operations that require square matrices (trace, pow, ...).
         """
         with pytest.raises(ValueError):
             op(data_m())

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -93,7 +93,7 @@ def shapes_binary_bad_matmul(dim=100):
     ]
 
 
-def shapes_square(dim=10):
+def shapes_square(dim=100):
     """Allowed shapes for operations that require square matrices. Examples of
     these operations are trace, pow, expm and the trace norm."""
     return [

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -781,7 +781,7 @@ class TestPow(UnaryOpMixin):
         pytest.param(data.pow_csr, CSR, CSR),
     ]
 
-    @pytest.mark.parametrize("n", [0, 1, 10], ids=["n_1", "n_10"])
+    @pytest.mark.parametrize("n", [0, 1, 10], ids=["n_0", "n_1", "n_10"])
     def test_mathematically_correct(self, op, data_m, out_type, n):
         matrix = data_m()
         expected = self.op_numpy(matrix.to_array(), n)

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -409,7 +409,7 @@ class UnaryOpMixin(_GenericOpMixin):
 
     def test_incorrect_shape_raises(self, op, data_m):
         """
-        Test that the operation produces a suitable error if the shapes of the
+        Test that the operation produces a suitable error if the shape of the
         given operand is not compatible with the operation. Useful for
         operations that require square matrices (trace, pow, ...).
         """


### PR DESCRIPTION
**Description**
This adds a few more tests to the specialisations. I also found a Bug in expm and changed `TypeError` to `ValueError`.

- Expm: 
  - Added tests for its specialisations.
  - There was a _bug_ in expm where if the matrix was csr and diagonal, zero values where not being exponentiated as they did not appear in scipy's data attribute. This case is now handled properly with the same scaling in resources (O(N) where N is the non-cero diagonal elements in the matrix).
  - Incorrect shape now raises ValueError.
 
- UnaryOpMixin: 
  - It did not check for bad shapes. It now does have a function that checks for them (this avoids code duplication in `trace`, `expm` and some others). 
  - As a result of this change a hidden bug emerged: even though `TestProject` had a non-empty `bad_shapes` attribute, it was not doing anything as `UnaryOpMixin` did not generate tests for bad shapes. It now does.

- Project:
  -  Changed `TypeError` to `ValueError`.
  - Removed redundant `TestProject`

- Pow:
  - Added the case where `n=0` as it is a special case.


**Changelog**
`project` specialisations now return `ValueError` when matrix has not valid shapes.
Removed redundant `TestProject`.
Added special test case for Pow (n=0).
`UnaryOpMixin` now has test_incorrect_shapes (by default it does not have any bad shapes)
Added tests for `expm` specialisations.
Fixed bug where diagonal `CSR` matrix was not exponentiating zero values in the diagonal.
`expm` specialisations now raises `ValueError` when matrix is not square.


_Edit: Added "Removed redundant `TestProject`"_
_Edit2: Added changelog_