### PR TITLE
Tests for norm

### DIFF
--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -46,6 +46,10 @@ cpdef double one_csr(CSR matrix) except -1:
 cpdef double trace_csr(CSR matrix, sparse=False, tol=0, maxiter=None) except -1:
     # We use the general eigenvalue solver which involves a Python call, so
     # there's no point attempting to release the GIL.
+
+    if matrix.shape[0] != matrix.shape[1]:
+        raise ValueError(f"matrix shape {matrix.shape} is not square.")
+
     cdef CSR op = matmul_csr(matrix, adjoint_csr(matrix))
     cdef size_t i
     cdef double [::1] eigs

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -1,0 +1,70 @@
+from . import test_mathematics as testing
+import numpy as np
+import scipy as sc
+import pytest
+from qutip import data
+from qutip.core.data import CSR, Dense
+import numbers
+
+class TestOneNorm(testing.UnaryOpMixin):
+    def op_numpy(self, matrix):
+        return sc.linalg.norm(matrix, 1)
+
+    specialisations = [
+        pytest.param(data.norm.one_csr, CSR, numbers.Number),
+        pytest.param(data.norm.one_dense, Dense, numbers.Number),
+    ]
+
+
+class TestFrobeniusNorm(testing.UnaryOpMixin):
+    def op_numpy(self, matrix):
+        return sc.linalg.norm(matrix, 'fro')
+
+    specialisations = [
+        pytest.param(data.norm.frobenius_csr, CSR, numbers.Number),
+        pytest.param(data.norm.frobenius_dense, Dense, numbers.Number),
+    ]
+
+
+class TestMaxNorm(testing.UnaryOpMixin):
+    def op_numpy(self, matrix):
+        # There is no scipy-equvalent as sc.linalg.norm(matrix, np.inf)
+        # works differently for matrices.
+        return np.max(np.abs(matrix))
+
+    specialisations = [
+        pytest.param(data.norm.max_csr, CSR, numbers.Number),
+        pytest.param(data.norm.max_dense, Dense, numbers.Number),
+    ]
+
+
+class TestL2Norm(testing.UnaryOpMixin):
+    def op_numpy(self, matrix):
+        return sc.linalg.norm(matrix, 'fro')
+
+    # These shapes correspond to kets or bras
+    shapes = [
+        (x,) for x in testing.shapes_unary() if (x.values[0][0] == 1
+                                         or x.values[0][1] == 1)
+    ]
+    # These shapes are everything except for kets and bras
+    bad_shapes = [
+        (x,) for x in testing.shapes_unary() if not (x.values[0][0] == 1
+                                             or x.values[0][1] == 1)
+    ]
+    specialisations = [
+        pytest.param(data.norm.l2_csr, CSR, numbers.Number),
+        pytest.param(data.norm.l2_dense, Dense, numbers.Number),
+    ]
+
+
+class TestTraceNorm(testing.UnaryOpMixin):
+    def op_numpy(self, matrix):
+        matrix = matrix@np.conj(matrix.T)
+        return np.trace(sc.linalg.sqrtm(matrix))
+
+    shapes = testing.shapes_square()
+    bad_shapes = testing.shapes_not_square()
+    specialisations = [
+        pytest.param(data.norm.trace_csr, CSR, numbers.Number),
+    ]


### PR DESCRIPTION
**Changelog**
Added tests for Norm.
`norm.trace` raises `ValueError` instead of `TypeError` when the input is not a square matrix.