### PR TITLE
Fix bugs in spin_q_function and spin_wigner, add test cases

### DIFF
--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -606,7 +606,7 @@ def test_wigner_clenshaw_sp_iter_dm():
     pytest.param(False, id="mixed")
 ])
 def test_spin_q_function(spin, pure):
-    d = int(2 * spin + 1)
+    d = int(2*spin + 1)
     rho = rand_dm(d, pure=pure)
 
     # Points at which to evaluate the spin Q function
@@ -653,7 +653,7 @@ def test_spin_q_function_normalized(spin, pure):
     pytest.param(False, id="mixed")
 ])
 def test_spin_wigner_normalized_and_real(spin, pure):
-    d = int(2 * spin + 1)
+    d = int(2*spin + 1)
     rho = rand_dm(d, pure=pure)
 
     # Points at which to evaluate the spin Wigner function

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -616,7 +616,7 @@ def test_spin_q_function(spin, pure):
 
     for k, (phi_prime, theta_prime) in enumerate(itertools.product(phi, theta)):
         state = qutip.spin_coherent(spin, theta_prime, phi_prime)
-        direct_Q = (2 * spin + 1) / (4 * np.pi) * (state.dag() * rho * state).norm()
+        direct_Q = (state.dag() * rho * state).norm()
         assert_almost_equal(Q.flat[k], direct_Q, decimal=9)
 
 @pytest.mark.parametrize(['spin'], [
@@ -638,7 +638,7 @@ def test_spin_q_function_normalized(spin, pure):
     phi = np.linspace(-np.pi, np.pi, 1024, endpoint=True)
     Q, THETA, _ = qutip.spin_q_function(rho, theta, phi)
 
-    norm = np.trapz(np.trapz(Q * np.sin(THETA), theta), phi)
+    norm = d / (4 * np.pi) * np.trapz(np.trapz(Q * np.sin(THETA), theta), phi)
     assert_almost_equal(norm, 1, decimal=5)
 
 
@@ -652,7 +652,7 @@ def test_spin_q_function_normalized(spin, pure):
     pytest.param(True, id="pure"),
     pytest.param(False, id="mixed")
 ])
-def test_spin_wigner_normalized_and_real(spin, pure):
+def test_spin_wigner_normalized(spin, pure):
     d = int(2*spin + 1)
     rho = rand_dm(d, pure=pure)
 
@@ -661,9 +661,7 @@ def test_spin_wigner_normalized_and_real(spin, pure):
     phi = np.linspace(-np.pi, np.pi, 512, endpoint=True)
     W, THETA, PHI = qutip.spin_wigner(rho, theta, phi)
 
-    assert_allclose(W.imag, 0, atol=1e-9)
-
-    norm = np.trapz(np.trapz(W * np.sin(THETA), theta), phi)
+    norm = np.trapz(np.trapz(W * np.sin(THETA) * np.sqrt(d / (4*np.pi)), theta), phi)
     assert_almost_equal(norm, 1, decimal=4)
 
 @pytest.mark.parametrize(['spin'], [
@@ -690,7 +688,7 @@ def test_spin_wigner_overlap(spin, pure, n=10):
         state_overlap = (test_state*rho).tr().real
 
         W_state, _, _ = qutip.spin_wigner(test_state, theta, phi)
-        W_overlap = (4 * np.pi / (2 * spin + 1)) * np.trapz(
+        W_overlap = np.trapz(
             np.trapz(W_state * W * np.sin(THETA), theta), phi).real
         assert_almost_equal(W_overlap, state_overlap, decimal=4)
 

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -616,7 +616,7 @@ def test_spin_q_function(spin, pure):
 
     for k, (p, t) in enumerate(itertools.product(phi_prime, theta_prime)):
         state = qutip.spin_coherent(spin, t, p)
-        direct_Q = (state.dag() * rho * state).norm() * (2 * j + 1) / (4 * pi)
+        direct_Q = (state.dag() * rho * state).norm() * (2 * spin + 1) / (4 * np.pi)
         assert_almost_equal(Q.flat[k], direct_Q, decimal=9)
 
 @pytest.mark.parametrize(["spin"], [

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -606,7 +606,7 @@ def test_wigner_clenshaw_sp_iter_dm():
     pytest.param(False, id="mixed")
 ])
 def test_spin_q_function(spin, pure):
-    d = int(2*spin + 1)
+    d = int(2 * spin + 1)
     rho = rand_dm(d, pure=pure)
 
     # Points at which to evaluate the spin Q function
@@ -616,7 +616,7 @@ def test_spin_q_function(spin, pure):
 
     for k, (p, t) in enumerate(itertools.product(phi_prime, theta_prime)):
         state = qutip.spin_coherent(spin, t, p)
-        direct_Q = (state.dag() * rho * state).norm() * (2 * j + 1) / (4*pi)
+        direct_Q = (state.dag() * rho * state).norm() * (2 * j + 1) / (4 * pi)
         assert_almost_equal(Q.flat[k], direct_Q, decimal=9)
 
 @pytest.mark.parametrize(["spin"], [
@@ -630,7 +630,7 @@ def test_spin_q_function(spin, pure):
     pytest.param(False, id="mixed")
 ])
 def test_spin_wigner_normalized_and_real(spin, pure):
-    d = int(2*spin + 1)
+    d = int(2 * spin + 1)
     rho = rand_dm(d, pure=pure)
 
     # Points at which to evaluate the spin Wigner function
@@ -642,7 +642,7 @@ def test_spin_wigner_normalized_and_real(spin, pure):
                     err_msg=f"Wigner function is non-real with maximum "
                             f"imaginary value {np.max(W.imag)}")
 
-    norm = np.trapz(np.trapz(W*np.sin(THETA), theta_prime), phi_prime)
+    norm = np.trapz(np.trapz(W * np.sin(THETA), theta_prime), phi_prime)
     assert_almost_equal(norm.real, 1, decimal=3,
                         err_msg=f"Wigner function is not normalized.")
 

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -611,8 +611,8 @@ def test_spin_q_function(spin, pure):
 
     # Points at which to evaluate the spin Q function
     theta_prime = np.linspace(0, np.pi, 32, endpoint=True)
-        phi_prime = np.linspace(-np.pi, np.pi, 64, endpoint=True)
-        Q, _, _ = qutip.spin_q_function(rho, theta_prime, phi_prime)
+    phi_prime = np.linspace(-np.pi, np.pi, 64, endpoint=True)
+    Q, _, _ = qutip.spin_q_function(rho, theta_prime, phi_prime)
 
     for k, (p, t) in enumerate(itertools.product(phi_prime, theta_prime)):
         state = qutip.spin_coherent(spin, t, p)

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -610,8 +610,8 @@ def test_spin_q_function(spin, pure):
     rho = rand_dm(d, pure=pure)
 
     # Points at which to evaluate the spin Q function
-    theta = np.linspace(0, np.pi, 32, endpoint=True)
-    phi = np.linspace(-np.pi, np.pi, 64, endpoint=True)
+    theta = np.linspace(0, np.pi, 16, endpoint=True)
+    phi = np.linspace(-np.pi, np.pi, 32, endpoint=True)
     Q, _, _ = qutip.spin_q_function(rho, theta, phi)
 
     for k, (phi_prime, theta_prime) in enumerate(itertools.product(phi, theta)):
@@ -634,19 +634,19 @@ def test_spin_q_function_normalized(spin, pure):
     rho = rand_dm(d, pure=pure)
 
     # Points at which to evaluate the spin Q function
-    theta = np.linspace(0, np.pi, 512, endpoint=True)
-    phi = np.linspace(-np.pi, np.pi, 1024, endpoint=True)
+    theta = np.linspace(0, np.pi, 128, endpoint=True)
+    phi = np.linspace(-np.pi, np.pi, 256, endpoint=True)
     Q, THETA, _ = qutip.spin_q_function(rho, theta, phi)
 
     norm = d / (4 * np.pi) * np.trapz(np.trapz(Q * np.sin(THETA), theta), phi)
-    assert_almost_equal(norm, 1, decimal=5)
+    assert_almost_equal(norm, 1, decimal=4)
 
 
 @pytest.mark.parametrize(["spin"], [
     pytest.param(1/2, id="spin-one-half"),
-    pytest.param(3, id="spin-three"),
-    pytest.param(13/2, id="spin-thirteen-half"),
-    pytest.param(7, id="spin-seven")
+    pytest.param(1, id="spin-one"),
+    pytest.param(3/2, id="spin-three-half"),
+    pytest.param(2, id="spin-two")
 ])
 @pytest.mark.parametrize("pure", [
     pytest.param(True, id="pure"),
@@ -665,16 +665,16 @@ def test_spin_wigner_normalized(spin, pure):
     assert_almost_equal(norm, 1, decimal=4)
 
 @pytest.mark.parametrize(['spin'], [
-    pytest.param(1/2, id="spin-one-half"),
-    pytest.param(3, id="spin-three"),
-    pytest.param(13/2, id="spin-thirteen-half"),
-    pytest.param(7, id="spin-seven")
+    pytest.param(1 / 2, id="spin-one-half"),
+    pytest.param(1, id="spin-one"),
+    pytest.param(3 / 2, id="spin-three-half"),
+    pytest.param(2, id="spin-two")
 ])
 @pytest.mark.parametrize("pure", [
     pytest.param(True, id="pure"),
     pytest.param(False, id="mixed")
 ])
-def test_spin_wigner_overlap(spin, pure, n=10):
+def test_spin_wigner_overlap(spin, pure, n=5):
     d = int(2*spin + 1)
     rho = rand_dm(d, pure=pure)
 

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -4,7 +4,7 @@ import itertools
 from scipy.special import laguerre
 from numpy.random import rand
 from numpy.testing import assert_, run_module_suite, assert_equal, \
-    assert_almost_equal
+    assert_almost_equal, assert_allclose
 
 import qutip
 from qutip.states import coherent, fock, ket, bell_state
@@ -614,11 +614,11 @@ def test_spin_q_function(spin, pure):
         phi_prime = np.linspace(-np.pi, np.pi, 64, endpoint=True)
         Q, _, _ = qutip.spin_q_function(rho, theta_prime, phi_prime)
 
-        Q = Q.transpose()
-        for k, (t, p) in enumerate(itertools.product(theta_prime, phi_prime)):
-            state = qutip.spin_coherent(spin, t, p)
-            direct_Q = (state.dag() * rho * state).norm() / np.pi
-            assert_almost_equal(direct_Q, Q.flat[k], decimal=9)
+    for k, (p, t) in enumerate(itertools.product(phi_prime, theta_prime)):
+        state = qutip.spin_coherent(spin, t, p)
+        direct_Q = (state.dag() * rho * state).norm() * (2 * j + 1) / (4*pi)
+        assert_almost_equal(Q.flat[k], direct_Q, decimal=9)
+
 @pytest.mark.parametrize(["spin"], [
     pytest.param(1/2, id="spin-one-half"),
     pytest.param(3, id="spin-three"),

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -595,14 +595,22 @@ def test_wigner_clenshaw_sp_iter_dm():
         Wdiff = abs(W - Wclen)
         assert_equal(np.sum(abs(Wdiff)) < 1e-7, True)
 
-@pytest.mark.slow
-def test_spin_q_function():
-    for spin in [1/2, 3, 11/2, 21]:
-        d = int(2*spin + 1)
-        rho = rand_dm(d)
+@pytest.mark.parametrize(['spin'], [
+    pytest.param(1/2, id="spin-one-half"),
+    pytest.param(3, id="spin-three"),
+    pytest.param(13/2, id="spin-thirteen-half"),
+    pytest.param(7, id="spin-seven")
+])
+@pytest.mark.parametrize("pure", [
+    pytest.param(True, id="pure"),
+    pytest.param(False, id="mixed")
+])
+def test_spin_q_function(spin, pure):
+    d = int(2*spin + 1)
+    rho = rand_dm(d, pure=pure)
 
-        # Points at which to evaluate the spin Q function
-        theta_prime = np.linspace(0, np.pi, 32, endpoint=True)
+    # Points at which to evaluate the spin Q function
+    theta_prime = np.linspace(0, np.pi, 32, endpoint=True)
         phi_prime = np.linspace(-np.pi, np.pi, 64, endpoint=True)
         Q, _, _ = qutip.spin_q_function(rho, theta_prime, phi_prime)
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -939,7 +939,7 @@ def _rho_kq(rho, j, k, q):
                     (-1) ** (2 * j - k - m1 - m2)
                     * np.sqrt((2 * k + 1) / (2 * j + 1))
                     * qutip.clebsch(j, k, j, -m1, q, -m2)
-                    * rho.data[j - m1, j - m2]
+                    * rho.data[int(j - m1), int(j - m2)]
             )
     return v
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -890,15 +890,16 @@ def spin_q_function(rho, theta, phi):
     Q = np.zeros_like(THETA, dtype=complex)
 
     for m1 in arange(-j, j + 1):
-        Q += binom(2 * j, j + m1) * cos(THETA / 2) ** (2 * (j + m1)) * sin(THETA / 2) ** \
-             (2 * (j - m1)) * rho.data[int(j - m1), int(j - m1)]
+        Q += binom(2 * j, j + m1) * cos(THETA / 2) ** (2 * (j + m1)) * \
+             sin(THETA / 2) ** (2 * (j - m1)) * \
+             rho.data[int(j - m1), int(j - m1)]
 
         for m2 in arange(m1 + 1, j + 1):
             Q += (sqrt(binom(2 * j, j + m1)) * sqrt(binom(2 * j, j + m2)) *
-                  cos(THETA / 2) ** (2 * j + m1 + m2) * sin(THETA / 2) **
-                  (2 * j - m1 - m2)) * \
-                 (exp(1j * (m1 - m2) * PHI) * rho.data[int(j - m1), int(j - m2)] +
-                  exp(1j * (m2 - m1) * PHI) * rho.data[int(j - m2), int(j - m1)])
+                  cos(THETA / 2) ** (2 * j + m1 + m2) *
+                  sin(THETA / 2) ** (2 * j - m1 - m2)) * \
+             (exp(1j * (m1 - m2) * PHI) * rho.data[int(j - m1), int(j - m2)] +
+              exp(1j * (m2 - m1) * PHI) * rho.data[int(j - m2), int(j - m1)])
 
     return Q.real / pi, THETA, PHI
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -901,7 +901,8 @@ def spin_q_function(rho, theta, phi):
              (exp(1j * (m1 - m2) * PHI) * rho.data[int(j - m1), int(j - m2)] +
               exp(1j * (m2 - m1) * PHI) * rho.data[int(j - m2), int(j - m1)])
 
-    return Q.real / pi, THETA, PHI
+    return Q.real * (2 * j + 1) / (4*pi), THETA, PHI
+
 
 def _rho_kq(rho, j, k, q):
     """

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -856,21 +856,17 @@ def qfunc(
 # PSEUDO DISTRIBUTION FUNCTIONS FOR SPINS
 #
 def spin_q_function(rho, theta, phi):
-    """Husimi Q-function for spins.
-
-    The Husimi Q function for spins is defined as:
-        Q(theta, phi) = <s,theta,phi| rho |s,theta,phi>/pi
-    where |s,theta,phi> is the spin coherent state for a spin with length s
-    and pointing along (theta,phi). The Q function can be calculated using
-    the elements of rho using the definition of spin coherent states (e.g.
-    Loh and Kim 2015 doi: 10.1119/1.4898595)
+    r"""The Husimi Q function for spins is defined as
+    ``Q(theta, phi) = SCS.dag()* rho * SCS*(2*j+1)/(4*pi)`` for the spin
+    coherent state ``SCS = spin_coherent(j, theta, phi)``.
+    The implementation here is more efficient (see references).
 
     Parameters
     ----------
     state : qobj
         A state vector or density matrix for a spin-j quantum system.
     theta : array_like
-        Polar angle at which to calculate the Husimi-Q function.
+        Polar (colatitude) angle at which to calculate the Husimi-Q function.
     phi : array_like
         Azimuthal angle at which to calculate the Husimi-Q function.
 
@@ -879,6 +875,11 @@ def spin_q_function(rho, theta, phi):
     Q, THETA, PHI : 2d-array
         Values representing the spin Husimi Q function at the values specified
         by THETA and PHI.
+
+    References
+    ----------
+    [1] Lee Loh, Y., & Kim, M. (2015). American J. of Phys., 83(1), 30–35.
+    https://doi.org/10.1119/1.4898595
 
     """
 
@@ -945,15 +946,14 @@ def _rho_kq(rho, j, k, q):
 
 
 def spin_wigner(rho, theta, phi):
-    """Wigner function for a spin-j system on the 2-sphere of radius j
-       (for j = 1/2 this is the Bloch sphere).
+    r"""Wigner function for a spin-j system.
 
     Parameters
     ----------
     state : qobj
         A state vector or density matrix for a spin-j quantum system.
     theta : array_like
-        Polar angle at which to calculate the W function.
+        Polar (colatitude) angle at which to calculate the W function.
     phi : array_like
         Azimuthal angle at which to calculate the W function.
 
@@ -964,13 +964,16 @@ def spin_wigner(rho, theta, phi):
         by THETA and PHI.
 
     References
-    -----
+    ----------
     [1] Agarwal, G. S. (1981). Phys. Rev. A, 24(6), 2889–2896.
     https://doi.org/10.1103/PhysRevA.24.2889
+
     [2] Dowling, J. P., Agarwal, G. S., & Schleich, W. P. (1994).
     Phys. Rev. A, 49(5), 4101–4109. https://doi.org/10.1103/PhysRevA.49.4101
+
     [3] Conversion between Wigner 3-j symbol and Clebsch-Gordan coefficients
     taken from Wikipedia (https://en.wikipedia.org/wiki/3-j_symbol)
+
     """
 
     if rho.type == 'bra':

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -904,13 +904,35 @@ def spin_q_function(rho, theta, phi):
     return Q.real / pi, THETA, PHI
 
 def _rho_kq(rho, j, k, q):
+    """
+    This calculates the trace of the multipole operator T_kq and the density
+    matrix rho for use in the spin Wigner quasiprobability distribution.
+
+    Parameters
+    ----------
+    rho : qobj
+        A density matrix for a spin-j quantum system.
+    j : float
+        The spin length of the system.
+    k : int
+        Spherical harmonic degree
+    q : int
+        Spherical harmonic order
+
+    Returns
+    -------
+    v : float
+        Overlap of state with multipole operator T_kq
+    """
+
     v = 0j
     for m1 in arange(-j, j+1):
         for m2 in arange(-j, j+1):
             v += (
-                (-1)**(j - m1 - q)
-                * qutip.clebsch(j, j, k, m1, -m2, q)
-                * rho.data[m1 + j, m2 + j]
+                (-1)**(2*j - k - m1 - m2)
+                * np.sqrt((2*k+1)/(2*j+1))
+                * qutip.clebsch(j, k, j, -m1, q, -m2)
+                * rho.data[j - m1, j - m2]
             )
     return v
 
@@ -934,10 +956,13 @@ def spin_wigner(rho, theta, phi):
         Values representing the spin Wigner function at the values specified
         by THETA and PHI.
 
-    Notes
+    References
     -----
-    Experimental.
-
+    [1] Agarwal, G. S. (1981). Phys. Rev. A, 24(6), 2889–2896. https://doi.org/10.1103/PhysRevA.24.2889
+    [2] Dowling, J. P., Agarwal, G. S., & Schleich, W. P. (1994).
+    Phys. Rev. A, 49(5), 4101–4109. https://doi.org/10.1103/PhysRevA.49.4101
+    [3] Conversion between Wigner 3-j symbol and Clebsch-Gordan coefficients
+    taken from Wikipedia (https://en.wikipedia.org/wiki/3-j_symbol)
     """
 
     if rho.type == 'bra':
@@ -958,4 +983,4 @@ def spin_wigner(rho, theta, phi):
             # sph_harm takes azimuthal angle then polar angle as arguments
             W += _rho_kq(rho, j, k, q) * sph_harm(q, k, PHI, THETA)
 
-    return W, THETA, PHI
+    return W*np.sqrt((2*j + 1)/(4*pi)), THETA, PHI

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -850,10 +850,16 @@ def qfunc(
 # PSEUDO DISTRIBUTION FUNCTIONS FOR SPINS
 #
 def spin_q_function(rho, theta, phi):
-    r"""The Husimi Q function for spins is defined as
-    ``Q(theta, phi) = SCS.dag()* rho * SCS*(2*j+1)/(4*pi)`` for the spin
-    coherent state ``SCS = spin_coherent(j, theta, phi)``.
-    The implementation here is more efficient (see references).
+    r"""The Husimi Q function for spins is defined as ``Q(theta, phi) =
+    SCS.dag() * rho * SCS`` for the spin coherent state ``SCS = spin_coherent(
+    j, theta, phi)`` where j is the spin length.
+    The implementation here is more efficient as it doesn't
+    generate all of the SCS at theta and phi (see references).
+
+    The spin Q function is normal when integrated over the surface of the sphere
+
+    .. math:: \frac{4 \pi}{2j + 1}\int_\phi \int_\theta
+              Q(\theta, \phi) \sin(\theta) d\theta d\phi = 1
 
     Parameters
     ----------
@@ -902,7 +908,7 @@ def spin_q_function(rho, theta, phi):
              (exp(1j * (m1 - m2) * PHI) * rho.data[int(j - m1), int(j - m2)] +
               exp(1j * (m2 - m1) * PHI) * rho.data[int(j - m2), int(j - m1)])
 
-    return Q.real * (2 * j + 1) / (4*pi), THETA, PHI
+    return Q.real, THETA, PHI
 
 
 def _rho_kq(rho, j, k, q):
@@ -941,6 +947,12 @@ def _rho_kq(rho, j, k, q):
 
 def spin_wigner(rho, theta, phi):
     r"""Wigner function for a spin-j system.
+
+    The spin W function is normal when integrated over the surface of the sphere
+
+    .. math:: \sqrt{\frac{4 \pi}{2j + 1}}\int_\phi \int_\theta
+              W(\theta,\phi) \sin(\theta) d\theta d\phi = 1
+
 
     Parameters
     ----------
@@ -988,4 +1000,4 @@ def spin_wigner(rho, theta, phi):
             # sph_harm takes azimuthal angle then polar angle as arguments
             W += _rho_kq(rho, j, k, q) * sph_harm(q, k, PHI, THETA)
 
-    return W*np.sqrt((2*j + 1)/(4*pi)), THETA, PHI
+    return W.real, THETA, PHI

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -884,15 +884,15 @@ def spin_q_function(rho, theta, phi):
 
     for m1 in arange(-j, j+1):
 
-        Q += binom(2*j, j+m1) * cos(THETA/2) ** (2*(j-m1)) * sin(THETA/2) ** (2*(j+m1)) * \
+        Q += binom(2*j, j+m1) * cos(THETA/2) ** (2*(j+m1)) * sin(THETA/2) ** (2*(j-m1)) * \
              rho.data[int(j-m1), int(j-m1)]
 
         for m2 in arange(m1+1, j+1):
 
             Q += (sqrt(binom(2*j, j+m1)) * sqrt(binom(2*j, j+m2)) *
-                  cos(THETA/2) ** (2*j-m1-m2) * sin(THETA/2) ** (2*j+m1+m2)) * \
-                  (exp(1j * (m2-m1) * PHI) * rho.data[int(j-m1), int(j-m2)] +
-                   exp(1j * (m1-m2) * PHI) * rho.data[int(j-m2), int(j-m1)])
+                  cos(THETA/2) ** (2*j+m1+m2) * sin(THETA/2) ** (2*j-m1-m2)) * \
+                (exp(1j * (m1 - m2) * PHI) * rho.data[int(j - m1), int(j - m2)] +
+                 exp(1j * (m2 - m1) * PHI) * rho.data[int(j - m2), int(j - m1)])
 
     return Q.real/pi, THETA, PHI
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -72,7 +72,7 @@ def wigner_transform(psi, j, fullparity, steps, slicearray):
     else:
         rho = psi
 
-    sun = 2  # The order of the SU group
+    sun = 2   # The order of the SU group
 
     # calculate total number of particles in quantum state:
     N = np.int32(np.log(np.shape(rho)[0]) / np.log(2 * j + 1))
@@ -88,7 +88,7 @@ def wigner_transform(psi, j, fullparity, steps, slicearray):
 
     wigner = np.zeros((steps, steps))
     if fullparity:
-        pari = _parity(sun ** N, j)
+        pari = _parity(sun**N, j)
     else:
         pari = _parity(sun, j)
     for t in range(steps):
@@ -131,7 +131,7 @@ def _kernelsu2(theta, phi, N, j, parity, fullparity):
     for i in range(0, N):
         U = np.kron(U, _rotation_matrix(theta[i], phi[i], j))
     if not fullparity:
-        op_parity = parity  # The parity for a one particle system
+        op_parity = parity   # The parity for a one particle system
         for i in range(1, N):
             parity = np.kron(parity, op_parity)
     matrix = U @ parity @ U.conj().T
@@ -184,17 +184,16 @@ def wigner(psi, xvec, yvec, method='clenshaw', g=sqrt(2),
         value `hbar=1`.
 
     method : string {'clenshaw', 'iterative', 'laguerre', 'fft'}
-        Select method 'clenshaw' 'iterative', 'laguerre', or 'fft',
-        where 'clenshaw' and 'iterative' use an iterative method to evaluate
-        the Wigner functions for density matrices :math:`|m><n|`,
-        while 'laguerre' uses the Laguerre polynomials in scipy for the same
-        task. The 'fft' method evaluates the Fourier transform of the density
-        matrix. The 'iterative' method is default, and in general
-        recommended, but the 'laguerre' method is more efficient for very
-        sparse density matrices (e.g., superpositions of Fock states in a
-        large Hilbert space). The 'clenshaw' method is the preferred method
-        for dealing with density matrices that have a large number of
-        excitations (>~50). 'clenshaw' is a fast and numerically stable method.
+        Select method 'clenshaw' 'iterative', 'laguerre', or 'fft', where 'clenshaw'
+        and 'iterative' use an iterative method to evaluate the Wigner functions for density
+        matrices :math:`|m><n|`, while 'laguerre' uses the Laguerre polynomials
+        in scipy for the same task. The 'fft' method evaluates the Fourier
+        transform of the density matrix. The 'iterative' method is default, and
+        in general recommended, but the 'laguerre' method is more efficient for
+        very sparse density matrices (e.g., superpositions of Fock states in a
+        large Hilbert space). The 'clenshaw' method is the preferred method for
+        dealing with density matrices that have a large number of excitations
+        (>~50). 'clenshaw' is a fast and numerically stable method.
 
     sparse : bool {False, True}
         Tells the default solver whether or not to keep the input density
@@ -408,19 +407,18 @@ def _wigner_fft(psi, xvec):
     Evaluates the Fourier transformation of a given state vector.
     Returns the corresponding density matrix and range
     """
-    n = 2 * len(psi.T)
+    n = 2*len(psi.T)
     r1 = np.concatenate((np.array([[0]]),
-                         np.fliplr(psi.conj()),
-                         np.zeros((1, n // 2 - 1))), axis=1)
+                        np.fliplr(psi.conj()),
+                        np.zeros((1, n//2 - 1))), axis=1)
     r2 = np.concatenate((np.array([[0]]), psi,
-                         np.zeros((1, n // 2 - 1))), axis=1)
-    w = la.toeplitz(np.zeros((n // 2, 1)), r1) * \
-        np.flipud(la.toeplitz(np.zeros((n // 2, 1)), r2))
-    w = np.concatenate((w[:, n // 2:n], w[:, 0:n // 2]), axis=1)
+                        np.zeros((1, n//2 - 1))), axis=1)
+    w = la.toeplitz(np.zeros((n//2, 1)), r1) * \
+        np.flipud(la.toeplitz(np.zeros((n//2, 1)), r2))
+    w = np.concatenate((w[:, n//2:n], w[:, 0:n//2]), axis=1)
     w = ft.fft(w)
-    w = np.real(
-        np.concatenate((w[:, 3 * n // 4:n + 1], w[:, 0:n // 4]), axis=1))
-    p = np.arange(-n / 4, n / 4) * np.pi / (n * (xvec[1] - xvec[0]))
+    w = np.real(np.concatenate((w[:, 3*n//4:n+1], w[:, 0:n//4]), axis=1))
+    p = np.arange(-n/4, n/4)*np.pi / (n*(xvec[1] - xvec[0]))
     w = w / (p[1] - p[0]) / n
     return w, p
 
@@ -440,7 +438,7 @@ def _osc_eigen(N, pnts):
         A[1, :] = np.sqrt(2) * pnts * A[0, :]
         for k in range(2, N):
             A[k, :] = np.sqrt(2.0 / k) * pnts * A[k - 1, :] - \
-                      np.sqrt((k - 1.0) / k) * A[k - 2, :]
+                np.sqrt((k - 1.0) / k) * A[k - 2, :]
         return A
 
 
@@ -456,34 +454,33 @@ def _wigner_clenshaw(rho, xvec, yvec, g=sqrt(2), sparse=False):
     """
 
     M = np.prod(rho.shape[0])
-    X, Y = np.meshgrid(xvec, yvec)
-    # A = 0.5 * g * (X + 1.0j * Y)
-    A2 = g * (X + 1.0j * Y)  # this is A2 = 2*A
+    X,Y = np.meshgrid(xvec, yvec)
+    #A = 0.5 * g * (X + 1.0j * Y)
+    A2 = g * (X + 1.0j * Y) #this is A2 = 2*A
 
     B = np.abs(A2)
     B *= B
-    w0 = (2 * rho.data[0, -1]) * np.ones_like(A2)
-    L = M - 1
-    # calculation of \sum_{L} c_L (2x)^L / \sqrt(L!)
-    # using Horner's method
+    w0 = (2*rho.data[0,-1])*np.ones_like(A2)
+    L = M-1
+    #calculation of \sum_{L} c_L (2x)^L / \sqrt(L!)
+    #using Horner's method
     if not sparse:
-        rho = rho.full() * (2 * np.ones((M, M)) - np.diag(np.ones(M)))
+        rho = rho.full() * (2*np.ones((M,M)) - np.diag(np.ones(M)))
         while L > 0:
             L -= 1
-            # here c_L = _wig_laguerre_val(L, B, np.diag(rho, L))
-            w0 = _wig_laguerre_val(L, B, np.diag(rho, L)) + w0 * A2 * (
-                        L + 1) ** -0.5
+            #here c_L = _wig_laguerre_val(L, B, np.diag(rho, L))
+            w0 = _wig_laguerre_val(L, B, np.diag(rho, L)) + w0 * A2 * (L+1)**-0.5
     else:
         while L > 0:
             L -= 1
-            diag = _csr_get_diag(rho.data.data, rho.data.indices,
-                                 rho.data.indptr, L)
+            diag = _csr_get_diag(rho.data.data,rho.data.indices,
+                                rho.data.indptr,L)
             if L != 0:
                 diag *= 2
-            # here c_L = _wig_laguerre_val(L, B, np.diag(rho, L))
-            w0 = _wig_laguerre_val(L, B, diag) + w0 * A2 * (L + 1) ** -0.5
+            #here c_L = _wig_laguerre_val(L, B, np.diag(rho, L))
+            w0 = _wig_laguerre_val(L, B, diag) + w0 * A2 * (L+1)**-0.5
 
-    return w0.real * np.exp(-B * 0.5) * (g * g * 0.5 / pi)
+    return w0.real * np.exp(-B*0.5) * (g*g*0.5 / pi)
 
 
 def _wig_laguerre_val(L, x, c):
@@ -514,11 +511,10 @@ def _wig_laguerre_val(L, x, c):
         y1 = c[-1]
         for i in range(3, len(c) + 1):
             k -= 1
-            y0, y1 = c[-i] - y1 * (float((k - 1) * (L + k - 1)) / (
-                        (L + k) * k)) ** 0.5, y0 - y1 * (
-                                 (L + 2 * k - 1) - x) * ((L + k) * k) ** -0.5
+            y0,    y1 = c[-i] - y1 * (float((k - 1)*(L + k - 1))/((L+k)*k))**0.5, \
+            y0 - y1 * ((L + 2*k -1) - x) * ((L+k)*k)**-0.5
 
-    return y0 - y1 * ((L + 1) - x) * (L + 1) ** -0.5
+    return y0 - y1 * ((L + 1) - x) * (L + 1)**-0.5
 
 
 # -----------------------------------------------------------------------------
@@ -530,10 +526,10 @@ def _qfunc_check_state(state: Qobj):
     # This is only approximate, but it's enough for our purposes; doing more
     # than this would take computational effort we don't _need_ to do.
     isdm = (
-            state.isoper
-            and state.dims[0] == state.dims[1]
-            and state.isherm
-            and abs(state.tr() - 1) < qutip.settings.atol
+        state.isoper
+        and state.dims[0] == state.dims[1]
+        and state.isherm
+        and abs(state.tr() - 1) < qutip.settings.atol
     )
     if not (state.isket or isdm):
         raise ValueError(
@@ -556,8 +552,7 @@ def _qfunc_check_coordinates(xvec, yvec):
     yvec = np.asarray(yvec, dtype=np.float64)
     if xvec.ndim != 1 or yvec.ndim != 1:
         raise ValueError(
-            f"xvec and yvec must be 1D, but have shapes {xvec.shape} and "
-            f"{yvec.shape}."
+            f"xvec and yvec must be 1D, but have shapes {xvec.shape} and {yvec.shape}."
         )
     return xvec, yvec
 
@@ -600,7 +595,6 @@ class _QFuncCoherentGrid:
     >>> np.allclose(naive[:, :, 4:7], grid(4, 7))
     True
     """
-
     def __init__(self, xvec, yvec, g: float):
         self.xvec, self.yvec = _qfunc_check_coordinates(xvec, yvec)
         x, y = np.meshgrid(0.5 * g * self.xvec, 0.5 * g * self.yvec)
@@ -641,7 +635,7 @@ class _QFuncCoherentGrid:
         out = np.empty(self.grid.shape + (ns.size,), dtype=np.complex128)
         out[:, :, 0] = self._start(ns.flat[0])
         for i in range(ns.size - 1):
-            out[:, :, i + 1] = out[:, :, i] * self.grid
+            out[:, :, i+1] = out[:, :, i] * self.grid
         out /= np.sqrt(scipy.special.factorial(ns))
         return out
 
@@ -695,7 +689,7 @@ class QFunc:
     """
 
     def __init__(
-            self, xvec, yvec, g: float = np.sqrt(2), memory: float = 1024
+        self, xvec, yvec, g: float = np.sqrt(2), memory: float = 1024
     ):
         self._g = g
         self._coherent_grid = _QFuncCoherentGrid(xvec, yvec, g)
@@ -758,7 +752,7 @@ class QFunc:
 
 
 def _qfunc_iterative_single(
-        vector: np.ndarray, alpha_grid: _QFuncCoherentGrid, g: float,
+    vector: np.ndarray, alpha_grid: _QFuncCoherentGrid, g: float,
 ):
     r"""
     Get the Q function (without the :math:`\pi` scaling factor) of a single
@@ -767,19 +761,19 @@ def _qfunc_iterative_single(
     """
     ns = np.arange(vector.shape[0])
     out = np.polyval(
-        (0.5 * g * vector / np.sqrt(scipy.special.factorial(ns)))[::-1],
+        (0.5*g * vector / np.sqrt(scipy.special.factorial(ns)))[::-1],
         alpha_grid.grid,
     )
     out *= alpha_grid.prefactor
-    return np.abs(out) ** 2
+    return np.abs(out)**2
 
 
 def qfunc(
-        state: Qobj,
-        xvec,
-        yvec,
-        g: float = sqrt(2),
-        precompute_memory: float = 1024,
+    state: Qobj,
+    xvec,
+    yvec,
+    g: float = sqrt(2),
+    precompute_memory: float = 1024,
 ):
     r"""
     Husimi-Q function of a given state vector or density matrix at phase-space
@@ -824,8 +818,8 @@ def qfunc(
     xvec, yvec = _qfunc_check_coordinates(xvec, yvec)
     required_memory = state.shape[0] * xvec.size * yvec.size * 16 / (1024 ** 2)
     enough_memory = (
-            precompute_memory is not None
-            and precompute_memory > required_memory
+        precompute_memory is not None
+        and precompute_memory > required_memory
     )
     if state.isoper and enough_memory:
         return QFunc(xvec, yvec, g)(state)
@@ -908,7 +902,7 @@ def spin_q_function(rho, theta, phi):
              (exp(1j * (m1 - m2) * PHI) * rho.data[int(j - m1), int(j - m2)] +
               exp(1j * (m2 - m1) * PHI) * rho.data[int(j - m2), int(j - m1)])
 
-    return Q.real * (2 * j + 1) / (4 * pi), THETA, PHI
+    return Q.real * (2 * j + 1) / (4*pi), THETA, PHI
 
 
 def _rho_kq(rho, j, k, q):
@@ -934,8 +928,8 @@ def _rho_kq(rho, j, k, q):
     """
 
     v = 0j
-    for m1 in arange(-j, j + 1):
-        for m2 in arange(-j, j + 1):
+    for m1 in arange(-j, j+1):
+        for m2 in arange(-j, j+1):
             v += (
                     (-1) ** (2 * j - k - m1 - m2)
                     * np.sqrt((2 * k + 1) / (2 * j + 1))
@@ -989,9 +983,9 @@ def spin_wigner(rho, theta, phi):
 
     W = np.zeros_like(THETA, dtype=complex)
 
-    for k in range(int(2 * j) + 1):
-        for q in arange(-k, k + 1):
+    for k in range(int(2 * j)+1):
+        for q in arange(-k, k+1):
             # sph_harm takes azimuthal angle then polar angle as arguments
             W += _rho_kq(rho, j, k, q) * sph_harm(q, k, PHI, THETA)
 
-    return W * np.sqrt((2 * j + 1) / (4 * pi)), THETA, PHI
+    return W*np.sqrt((2*j + 1)/(4*pi)), THETA, PHI

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -72,7 +72,7 @@ def wigner_transform(psi, j, fullparity, steps, slicearray):
     else:
         rho = psi
 
-    sun = 2   # The order of the SU group
+    sun = 2  # The order of the SU group
 
     # calculate total number of particles in quantum state:
     N = np.int32(np.log(np.shape(rho)[0]) / np.log(2 * j + 1))
@@ -88,7 +88,7 @@ def wigner_transform(psi, j, fullparity, steps, slicearray):
 
     wigner = np.zeros((steps, steps))
     if fullparity:
-        pari = _parity(sun**N, j)
+        pari = _parity(sun ** N, j)
     else:
         pari = _parity(sun, j)
     for t in range(steps):
@@ -131,7 +131,7 @@ def _kernelsu2(theta, phi, N, j, parity, fullparity):
     for i in range(0, N):
         U = np.kron(U, _rotation_matrix(theta[i], phi[i], j))
     if not fullparity:
-        op_parity = parity   # The parity for a one particle system
+        op_parity = parity  # The parity for a one particle system
         for i in range(1, N):
             parity = np.kron(parity, op_parity)
     matrix = U @ parity @ U.conj().T
@@ -184,16 +184,17 @@ def wigner(psi, xvec, yvec, method='clenshaw', g=sqrt(2),
         value `hbar=1`.
 
     method : string {'clenshaw', 'iterative', 'laguerre', 'fft'}
-        Select method 'clenshaw' 'iterative', 'laguerre', or 'fft', where 'clenshaw'
-        and 'iterative' use an iterative method to evaluate the Wigner functions for density
-        matrices :math:`|m><n|`, while 'laguerre' uses the Laguerre polynomials
-        in scipy for the same task. The 'fft' method evaluates the Fourier
-        transform of the density matrix. The 'iterative' method is default, and
-        in general recommended, but the 'laguerre' method is more efficient for
-        very sparse density matrices (e.g., superpositions of Fock states in a
-        large Hilbert space). The 'clenshaw' method is the preferred method for
-        dealing with density matrices that have a large number of excitations
-        (>~50). 'clenshaw' is a fast and numerically stable method.
+        Select method 'clenshaw' 'iterative', 'laguerre', or 'fft',
+        where 'clenshaw' and 'iterative' use an iterative method to evaluate
+        the Wigner functions for density matrices :math:`|m><n|`,
+        while 'laguerre' uses the Laguerre polynomials in scipy for the same
+        task. The 'fft' method evaluates the Fourier transform of the density
+        matrix. The 'iterative' method is default, and in general
+        recommended, but the 'laguerre' method is more efficient for very
+        sparse density matrices (e.g., superpositions of Fock states in a
+        large Hilbert space). The 'clenshaw' method is the preferred method
+        for dealing with density matrices that have a large number of
+        excitations (>~50). 'clenshaw' is a fast and numerically stable method.
 
     sparse : bool {False, True}
         Tells the default solver whether or not to keep the input density
@@ -407,18 +408,19 @@ def _wigner_fft(psi, xvec):
     Evaluates the Fourier transformation of a given state vector.
     Returns the corresponding density matrix and range
     """
-    n = 2*len(psi.T)
+    n = 2 * len(psi.T)
     r1 = np.concatenate((np.array([[0]]),
-                        np.fliplr(psi.conj()),
-                        np.zeros((1, n//2 - 1))), axis=1)
+                         np.fliplr(psi.conj()),
+                         np.zeros((1, n // 2 - 1))), axis=1)
     r2 = np.concatenate((np.array([[0]]), psi,
-                        np.zeros((1, n//2 - 1))), axis=1)
-    w = la.toeplitz(np.zeros((n//2, 1)), r1) * \
-        np.flipud(la.toeplitz(np.zeros((n//2, 1)), r2))
-    w = np.concatenate((w[:, n//2:n], w[:, 0:n//2]), axis=1)
+                         np.zeros((1, n // 2 - 1))), axis=1)
+    w = la.toeplitz(np.zeros((n // 2, 1)), r1) * \
+        np.flipud(la.toeplitz(np.zeros((n // 2, 1)), r2))
+    w = np.concatenate((w[:, n // 2:n], w[:, 0:n // 2]), axis=1)
     w = ft.fft(w)
-    w = np.real(np.concatenate((w[:, 3*n//4:n+1], w[:, 0:n//4]), axis=1))
-    p = np.arange(-n/4, n/4)*np.pi / (n*(xvec[1] - xvec[0]))
+    w = np.real(
+        np.concatenate((w[:, 3 * n // 4:n + 1], w[:, 0:n // 4]), axis=1))
+    p = np.arange(-n / 4, n / 4) * np.pi / (n * (xvec[1] - xvec[0]))
     w = w / (p[1] - p[0]) / n
     return w, p
 
@@ -438,7 +440,7 @@ def _osc_eigen(N, pnts):
         A[1, :] = np.sqrt(2) * pnts * A[0, :]
         for k in range(2, N):
             A[k, :] = np.sqrt(2.0 / k) * pnts * A[k - 1, :] - \
-                np.sqrt((k - 1.0) / k) * A[k - 2, :]
+                      np.sqrt((k - 1.0) / k) * A[k - 2, :]
         return A
 
 
@@ -454,33 +456,34 @@ def _wigner_clenshaw(rho, xvec, yvec, g=sqrt(2), sparse=False):
     """
 
     M = np.prod(rho.shape[0])
-    X,Y = np.meshgrid(xvec, yvec)
-    #A = 0.5 * g * (X + 1.0j * Y)
-    A2 = g * (X + 1.0j * Y) #this is A2 = 2*A
+    X, Y = np.meshgrid(xvec, yvec)
+    # A = 0.5 * g * (X + 1.0j * Y)
+    A2 = g * (X + 1.0j * Y)  # this is A2 = 2*A
 
     B = np.abs(A2)
     B *= B
-    w0 = (2*rho.data[0,-1])*np.ones_like(A2)
-    L = M-1
-    #calculation of \sum_{L} c_L (2x)^L / \sqrt(L!)
-    #using Horner's method
+    w0 = (2 * rho.data[0, -1]) * np.ones_like(A2)
+    L = M - 1
+    # calculation of \sum_{L} c_L (2x)^L / \sqrt(L!)
+    # using Horner's method
     if not sparse:
-        rho = rho.full() * (2*np.ones((M,M)) - np.diag(np.ones(M)))
+        rho = rho.full() * (2 * np.ones((M, M)) - np.diag(np.ones(M)))
         while L > 0:
             L -= 1
-            #here c_L = _wig_laguerre_val(L, B, np.diag(rho, L))
-            w0 = _wig_laguerre_val(L, B, np.diag(rho, L)) + w0 * A2 * (L+1)**-0.5
+            # here c_L = _wig_laguerre_val(L, B, np.diag(rho, L))
+            w0 = _wig_laguerre_val(L, B, np.diag(rho, L)) + w0 * A2 * (
+                        L + 1) ** -0.5
     else:
         while L > 0:
             L -= 1
-            diag = _csr_get_diag(rho.data.data,rho.data.indices,
-                                rho.data.indptr,L)
+            diag = _csr_get_diag(rho.data.data, rho.data.indices,
+                                 rho.data.indptr, L)
             if L != 0:
                 diag *= 2
-            #here c_L = _wig_laguerre_val(L, B, np.diag(rho, L))
-            w0 = _wig_laguerre_val(L, B, diag) + w0 * A2 * (L+1)**-0.5
+            # here c_L = _wig_laguerre_val(L, B, np.diag(rho, L))
+            w0 = _wig_laguerre_val(L, B, diag) + w0 * A2 * (L + 1) ** -0.5
 
-    return w0.real * np.exp(-B*0.5) * (g*g*0.5 / pi)
+    return w0.real * np.exp(-B * 0.5) * (g * g * 0.5 / pi)
 
 
 def _wig_laguerre_val(L, x, c):
@@ -511,10 +514,11 @@ def _wig_laguerre_val(L, x, c):
         y1 = c[-1]
         for i in range(3, len(c) + 1):
             k -= 1
-            y0,    y1 = c[-i] - y1 * (float((k - 1)*(L + k - 1))/((L+k)*k))**0.5, \
-            y0 - y1 * ((L + 2*k -1) - x) * ((L+k)*k)**-0.5
+            y0, y1 = c[-i] - y1 * (
+                        float((k - 1) * (L + k - 1)) / ((L + k) * k)) ** 0.5, \
+                     y0 - y1 * ((L + 2 * k - 1) - x) * ((L + k) * k) ** -0.5
 
-    return y0 - y1 * ((L + 1) - x) * (L + 1)**-0.5
+    return y0 - y1 * ((L + 1) - x) * (L + 1) ** -0.5
 
 
 # -----------------------------------------------------------------------------
@@ -526,10 +530,10 @@ def _qfunc_check_state(state: Qobj):
     # This is only approximate, but it's enough for our purposes; doing more
     # than this would take computational effort we don't _need_ to do.
     isdm = (
-        state.isoper
-        and state.dims[0] == state.dims[1]
-        and state.isherm
-        and abs(state.tr() - 1) < qutip.settings.atol
+            state.isoper
+            and state.dims[0] == state.dims[1]
+            and state.isherm
+            and abs(state.tr() - 1) < qutip.settings.atol
     )
     if not (state.isket or isdm):
         raise ValueError(
@@ -552,7 +556,8 @@ def _qfunc_check_coordinates(xvec, yvec):
     yvec = np.asarray(yvec, dtype=np.float64)
     if xvec.ndim != 1 or yvec.ndim != 1:
         raise ValueError(
-            f"xvec and yvec must be 1D, but have shapes {xvec.shape} and {yvec.shape}."
+            f"xvec and yvec must be 1D, but have shapes {xvec.shape} and "
+            f"{yvec.shape}."
         )
     return xvec, yvec
 
@@ -595,6 +600,7 @@ class _QFuncCoherentGrid:
     >>> np.allclose(naive[:, :, 4:7], grid(4, 7))
     True
     """
+
     def __init__(self, xvec, yvec, g: float):
         self.xvec, self.yvec = _qfunc_check_coordinates(xvec, yvec)
         x, y = np.meshgrid(0.5 * g * self.xvec, 0.5 * g * self.yvec)
@@ -635,7 +641,7 @@ class _QFuncCoherentGrid:
         out = np.empty(self.grid.shape + (ns.size,), dtype=np.complex128)
         out[:, :, 0] = self._start(ns.flat[0])
         for i in range(ns.size - 1):
-            out[:, :, i+1] = out[:, :, i] * self.grid
+            out[:, :, i + 1] = out[:, :, i] * self.grid
         out /= np.sqrt(scipy.special.factorial(ns))
         return out
 
@@ -689,7 +695,7 @@ class QFunc:
     """
 
     def __init__(
-        self, xvec, yvec, g: float = np.sqrt(2), memory: float = 1024
+            self, xvec, yvec, g: float = np.sqrt(2), memory: float = 1024
     ):
         self._g = g
         self._coherent_grid = _QFuncCoherentGrid(xvec, yvec, g)
@@ -752,7 +758,7 @@ class QFunc:
 
 
 def _qfunc_iterative_single(
-    vector: np.ndarray, alpha_grid: _QFuncCoherentGrid, g: float,
+        vector: np.ndarray, alpha_grid: _QFuncCoherentGrid, g: float,
 ):
     r"""
     Get the Q function (without the :math:`\pi` scaling factor) of a single
@@ -761,19 +767,19 @@ def _qfunc_iterative_single(
     """
     ns = np.arange(vector.shape[0])
     out = np.polyval(
-        (0.5*g * vector / np.sqrt(scipy.special.factorial(ns)))[::-1],
+        (0.5 * g * vector / np.sqrt(scipy.special.factorial(ns)))[::-1],
         alpha_grid.grid,
     )
     out *= alpha_grid.prefactor
-    return np.abs(out)**2
+    return np.abs(out) ** 2
 
 
 def qfunc(
-    state: Qobj,
-    xvec,
-    yvec,
-    g: float = sqrt(2),
-    precompute_memory: float = 1024,
+        state: Qobj,
+        xvec,
+        yvec,
+        g: float = sqrt(2),
+        precompute_memory: float = 1024,
 ):
     r"""
     Husimi-Q function of a given state vector or density matrix at phase-space
@@ -818,8 +824,8 @@ def qfunc(
     xvec, yvec = _qfunc_check_coordinates(xvec, yvec)
     required_memory = state.shape[0] * xvec.size * yvec.size * 16 / (1024 ** 2)
     enough_memory = (
-        precompute_memory is not None
-        and precompute_memory > required_memory
+            precompute_memory is not None
+            and precompute_memory > required_memory
     )
     if state.isoper and enough_memory:
         return QFunc(xvec, yvec, g)(state)
@@ -901,7 +907,7 @@ def spin_q_function(rho, theta, phi):
              (exp(1j * (m1 - m2) * PHI) * rho.data[int(j - m1), int(j - m2)] +
               exp(1j * (m2 - m1) * PHI) * rho.data[int(j - m2), int(j - m1)])
 
-    return Q.real * (2 * j + 1) / (4*pi), THETA, PHI
+    return Q.real * (2 * j + 1) / (4 * pi), THETA, PHI
 
 
 def _rho_kq(rho, j, k, q):
@@ -927,13 +933,13 @@ def _rho_kq(rho, j, k, q):
     """
 
     v = 0j
-    for m1 in arange(-j, j+1):
-        for m2 in arange(-j, j+1):
+    for m1 in arange(-j, j + 1):
+        for m2 in arange(-j, j + 1):
             v += (
-                (-1)**(2*j - k - m1 - m2)
-                * np.sqrt((2*k+1)/(2*j+1))
-                * qutip.clebsch(j, k, j, -m1, q, -m2)
-                * rho.data[j - m1, j - m2]
+                    (-1) ** (2 * j - k - m1 - m2)
+                    * np.sqrt((2 * k + 1) / (2 * j + 1))
+                    * qutip.clebsch(j, k, j, -m1, q, -m2)
+                    * rho.data[j - m1, j - m2]
             )
     return v
 
@@ -959,7 +965,8 @@ def spin_wigner(rho, theta, phi):
 
     References
     -----
-    [1] Agarwal, G. S. (1981). Phys. Rev. A, 24(6), 2889–2896. https://doi.org/10.1103/PhysRevA.24.2889
+    [1] Agarwal, G. S. (1981). Phys. Rev. A, 24(6), 2889–2896.
+    https://doi.org/10.1103/PhysRevA.24.2889
     [2] Dowling, J. P., Agarwal, G. S., & Schleich, W. P. (1994).
     Phys. Rev. A, 49(5), 4101–4109. https://doi.org/10.1103/PhysRevA.49.4101
     [3] Conversion between Wigner 3-j symbol and Clebsch-Gordan coefficients
@@ -979,9 +986,9 @@ def spin_wigner(rho, theta, phi):
 
     W = np.zeros_like(THETA, dtype=complex)
 
-    for k in range(int(2 * j)+1):
-        for q in arange(-k, k+1):
+    for k in range(int(2 * j) + 1):
+        for q in arange(-k, k + 1):
             # sph_harm takes azimuthal angle then polar angle as arguments
             W += _rho_kq(rho, j, k, q) * sph_harm(q, k, PHI, THETA)
 
-    return W*np.sqrt((2*j + 1)/(4*pi)), THETA, PHI
+    return W * np.sqrt((2 * j + 1) / (4 * pi)), THETA, PHI

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -856,7 +856,8 @@ def spin_q_function(rho, theta, phi):
     The implementation here is more efficient as it doesn't
     generate all of the SCS at theta and phi (see references).
 
-    The spin Q function is normal when integrated over the surface of the sphere
+    The spin Q function is normal when integrated over the surface of the
+    sphere
 
     .. math:: \frac{4 \pi}{2j + 1}\int_\phi \int_\theta
               Q(\theta, \phi) \sin(\theta) d\theta d\phi = 1
@@ -948,7 +949,8 @@ def _rho_kq(rho, j, k, q):
 def spin_wigner(rho, theta, phi):
     r"""Wigner function for a spin-j system.
 
-    The spin W function is normal when integrated over the surface of the sphere
+    The spin W function is normal when integrated over the surface of the
+    sphere
 
     .. math:: \sqrt{\frac{4 \pi}{2j + 1}}\int_\phi \int_\theta
               W(\theta,\phi) \sin(\theta) d\theta d\phi = 1

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -852,6 +852,12 @@ def qfunc(
 def spin_q_function(rho, theta, phi):
     """Husimi Q-function for spins.
 
+    The Husimi Q function for spins is defined as:
+        Q(theta, phi) = <s,theta,phi| rho |s,theta,phi>/pi
+    where |s,theta,phi> is the spin coherent state for a spin with length s and pointing
+    along (theta,phi). The Q function can be calculated using the elements of rho using
+    the definition of spin coherent states (e.g. Loh and Kim 2015 doi: 10.1119/1.4898595)
+
     Parameters
     ----------
     state : qobj
@@ -882,19 +888,19 @@ def spin_q_function(rho, theta, phi):
 
     Q = np.zeros_like(THETA, dtype=complex)
 
-    for m1 in arange(-j, j+1):
+    for m1 in arange(-j, j + 1):
+        Q += binom(2 * j, j + m1) * cos(THETA / 2) ** (2 * (j + m1)) * sin(THETA / 2) ** (
+                    2 * (j - m1)) * \
+             rho.data[int(j - m1), int(j - m1)]
 
-        Q += binom(2*j, j+m1) * cos(THETA/2) ** (2*(j+m1)) * sin(THETA/2) ** (2*(j-m1)) * \
-             rho.data[int(j-m1), int(j-m1)]
+        for m2 in arange(m1 + 1, j + 1):
+            Q += (sqrt(binom(2 * j, j + m1)) * sqrt(binom(2 * j, j + m2)) *
+                  cos(THETA / 2) ** (2 * j + m1 + m2) * sin(THETA / 2) ** (
+                              2 * j - m1 - m2)) * \
+                 (exp(1j * (m1 - m2) * PHI) * rho.data[int(j - m1), int(j - m2)] +
+                  exp(1j * (m2 - m1) * PHI) * rho.data[int(j - m2), int(j - m1)])
 
-        for m2 in arange(m1+1, j+1):
-
-            Q += (sqrt(binom(2*j, j+m1)) * sqrt(binom(2*j, j+m2)) *
-                  cos(THETA/2) ** (2*j+m1+m2) * sin(THETA/2) ** (2*j-m1-m2)) * \
-                (exp(1j * (m1 - m2) * PHI) * rho.data[int(j - m1), int(j - m2)] +
-                 exp(1j * (m2 - m1) * PHI) * rho.data[int(j - m2), int(j - m1)])
-
-    return Q.real/pi, THETA, PHI
+    return Q.real / pi, THETA, PHI
 
 def _rho_kq(rho, j, k, q):
     v = 0j

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -514,9 +514,9 @@ def _wig_laguerre_val(L, x, c):
         y1 = c[-1]
         for i in range(3, len(c) + 1):
             k -= 1
-            y0, y1 = c[-i] - y1 * (
-                        float((k - 1) * (L + k - 1)) / ((L + k) * k)) ** 0.5, \
-                     y0 - y1 * ((L + 2 * k - 1) - x) * ((L + k) * k) ** -0.5
+            y0, y1 = c[-i] - y1 * (float((k - 1) * (L + k - 1)) / (
+                        (L + k) * k)) ** 0.5, y0 - y1 * (
+                                 (L + 2 * k - 1) - x) * ((L + k) * k) ** -0.5
 
     return y0 - y1 * ((L + 1) - x) * (L + 1) ** -0.5
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -854,9 +854,10 @@ def spin_q_function(rho, theta, phi):
 
     The Husimi Q function for spins is defined as:
         Q(theta, phi) = <s,theta,phi| rho |s,theta,phi>/pi
-    where |s,theta,phi> is the spin coherent state for a spin with length s and pointing
-    along (theta,phi). The Q function can be calculated using the elements of rho using
-    the definition of spin coherent states (e.g. Loh and Kim 2015 doi: 10.1119/1.4898595)
+    where |s,theta,phi> is the spin coherent state for a spin with length s
+    and pointing along (theta,phi). The Q function can be calculated using
+    the elements of rho using the definition of spin coherent states (e.g.
+    Loh and Kim 2015 doi: 10.1119/1.4898595)
 
     Parameters
     ----------
@@ -889,14 +890,13 @@ def spin_q_function(rho, theta, phi):
     Q = np.zeros_like(THETA, dtype=complex)
 
     for m1 in arange(-j, j + 1):
-        Q += binom(2 * j, j + m1) * cos(THETA / 2) ** (2 * (j + m1)) * sin(THETA / 2) ** (
-                    2 * (j - m1)) * \
-             rho.data[int(j - m1), int(j - m1)]
+        Q += binom(2 * j, j + m1) * cos(THETA / 2) ** (2 * (j + m1)) * sin(THETA / 2) ** \
+             (2 * (j - m1)) * rho.data[int(j - m1), int(j - m1)]
 
         for m2 in arange(m1 + 1, j + 1):
             Q += (sqrt(binom(2 * j, j + m1)) * sqrt(binom(2 * j, j + m2)) *
-                  cos(THETA / 2) ** (2 * j + m1 + m2) * sin(THETA / 2) ** (
-                              2 * j - m1 - m2)) * \
+                  cos(THETA / 2) ** (2 * j + m1 + m2) * sin(THETA / 2) **
+                  (2 * j - m1 - m2)) * \
                  (exp(1j * (m1 - m2) * PHI) * rho.data[int(j - m1), int(j - m2)] +
                   exp(1j * (m2 - m1) * PHI) * rho.data[int(j - m2), int(j - m1)])
 


### PR DESCRIPTION
**Description**

- Fixed some errors in the transcription of the husimi Q and Wigner W functions for spins into code.
- Ensure Q and W functions are normalized over (theta, phi).
- Add tests for correctness and normalization of spin Q function.
- Add tests for normalization and real-ness of spin W function. Correctness is established by comparing the overlap of two states and the overlap of their Wigner functions.
- Spin Q function tests take ~11s to complete, spin Wigner tests take ~10s to complete on my laptop.

**To do**
- [x] Decide if the `spin_wigner` function should return only real values be default (as is currently done for the `spin_q_function`).
- [x] Find a simple test for correctness of the spin W function.
- [x] Decide whether to integrate the W function normalization in `_rho_kq` rather than at the top level. We divide all terms by `(2*j + 1)` only to end up multiplying it back out at the end which is a waste of time (`_rho_kq` is called `d**2` times, `d=2*j+1`) . The benefit of leaving it as-is is that it reads like most definitions in literature.
- [x] Update docstring for spin Q function.
- [x] Decide if normalization factor for Wigner and spin Q function should be included (Davis et al. suggest the normalization factor is only introduced during integration: Eq 14 https://arxiv.org/abs/2008.10167)

**Related issues or PRs**
This issue was raised in another PR #1195 which didn't resolve this issue as intended. The original issue this fixes was #1128.

**Changelog**
Fixed error for calculation of Husimi `spin_q_function` and `spin_wigner`.
Added tests to `tests/test_wigner.py` for these functions.