### PR TITLE
Allow f(t, **args) as coefficient function alternative (alternative approach)

### DIFF
--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -53,7 +53,7 @@ def coefficient(base, *, tlist=None, args={}, args_ctypes={},
       ``args``
 
     By default the signature style is controlled by the
-    :obj:`qutip.core.settings.function_coefficient_style` setting, but it
+    ``qutip.settings.core["function_coefficient_style"]`` setting, but it
     may be overriden here by specifying either ``function_style="pythonc"``
     or ``function_style="dict"``.
 

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -41,15 +41,36 @@ class StringParsingWarning(Warning):
 def coefficient(base, *, tlist=None, args={}, args_ctypes={},
                 _stepInterpolation=False, compile_opt=None,
                 function_style=None):
-    """Coefficient for Qutip time dependent systems.
+    """Coefficient for time dependent systems.
+
     The coefficients are either a function, a string or a numpy array.
 
-    For function format, the function signature must be f(t, args).
-    *Examples*
-        def f1_t(t, args):
-            return np.exp(-1j * t * args["w1"])
+    For function based coefficients, the function signature must be either:
 
-        coeff = coefficient(f1_t, args={"w1":1.})
+    * ``f(t, ...)`` where the other arguments are supplied as ordinary
+      "pythonic" arguments (e.g. ``f(t, w, a=5))
+    * ``f(t, args)`` where the arguments are supplied in a "dict" named
+      ``args``
+
+    By default the signature style is controlled by the
+    :obj:`qutip.core.settings.function_coefficient_style` setting, but it
+    may be overriden here by specifying either ``function_style="pythonc"``
+    or ``function_style="dict"``.
+
+    *Examples*
+        # pythonic style function signature
+
+        def f1_t(t, w):
+            return np.exp(-1j * t * w)
+
+        coeff1 = coefficient(f1_t, args={"w": 1.})
+
+        # dict style function signature
+
+        def f2_t(t, args):
+            return np.exp(-1j * t * args["w"])
+
+        coeff2 = coefficient(f2_t, args={"w": 1.})
 
     For string based coeffients, the string must be a compilable python code
     resulting in a complex. The following symbols are defined:
@@ -61,6 +82,7 @@ def coefficient(base, *, tlist=None, args={}, args_ctypes={},
         scipy.special as spe (python interface)
         and cython_special (cython interface)
         [https://docs.scipy.org/doc/scipy/reference/special.cython_special.html].
+
     *Examples*
         coeff = coefficient('exp(-1j*w1*t)', args={"w1":1.})
     'args' is needed for string coefficient at compilation.
@@ -76,6 +98,7 @@ def coefficient(base, *, tlist=None, args={}, args_ctypes={},
     at time t.
     If the coefficients are to be treated as step function, use the arguments:
     _stepInterpolation=True
+
     *Examples*
         tlist = np.logspace(-5,0,100)
         H = QobjEvo(np.exp(-1j*tlist), tlist=tlist)

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -7,6 +7,7 @@ import dis
 import hashlib
 import glob
 import importlib
+import inspect
 import shutil
 import numbers
 from contextlib import contextmanager
@@ -103,7 +104,7 @@ def coefficient(base, *, tlist=None, args={}, args_ctypes={},
         return coeff_from_str(base, args, args_ctypes, compile_opt)
 
     elif callable(base):
-        op = FunctionCoefficient(base, args.copy())
+        op = FunctionCoefficient.by_inspection(base, args.copy())
         if not isinstance(op(0), numbers.Number):
             raise TypeError("The coefficient function must return a number")
         return op

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -54,7 +54,7 @@ def coefficient(base, *, tlist=None, args={}, args_ctypes={},
 
     By default the signature style is controlled by the
     ``qutip.settings.core["function_coefficient_style"]`` setting, but it
-    may be overriden here by specifying either ``function_style="pythonc"``
+    may be overriden here by specifying either ``function_style="pythonic"``
     or ``function_style="dict"``.
 
     *Examples*

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -39,7 +39,8 @@ class StringParsingWarning(Warning):
 
 
 def coefficient(base, *, tlist=None, args={}, args_ctypes={},
-                _stepInterpolation=False, compile_opt=None):
+                _stepInterpolation=False, compile_opt=None,
+                function_style=None):
     """Coefficient for Qutip time dependent systems.
     The coefficients are either a function, a string or a numpy array.
 
@@ -104,7 +105,7 @@ def coefficient(base, *, tlist=None, args={}, args_ctypes={},
         return coeff_from_str(base, args, args_ctypes, compile_opt)
 
     elif callable(base):
-        op = FunctionCoefficient.by_inspection(base, args.copy())
+        op = FunctionCoefficient(base, args.copy(), style=function_style)
         if not isinstance(op(0), numbers.Number):
             raise TypeError("The coefficient function must return a number")
         return op

--- a/qutip/core/cy/_element.pxd
+++ b/qutip/core/cy/_element.pxd
@@ -25,6 +25,8 @@ cdef class _FuncElement(_BaseElement):
     cdef object _func
     cdef dict _args
     cdef tuple _previous
+    cdef bint _f_is_t_args
+    cdef object _f_arg_names
 
 
 cdef class _MapElement(_BaseElement):

--- a/qutip/core/cy/_element.pxd
+++ b/qutip/core/cy/_element.pxd
@@ -25,8 +25,8 @@ cdef class _FuncElement(_BaseElement):
     cdef object _func
     cdef dict _args
     cdef tuple _previous
-    cdef object _f_pythonic
-    cdef object _f_parameters
+    cdef bint _f_pythonic
+    cdef set _f_parameters
 
 
 cdef class _MapElement(_BaseElement):

--- a/qutip/core/cy/_element.pxd
+++ b/qutip/core/cy/_element.pxd
@@ -25,8 +25,8 @@ cdef class _FuncElement(_BaseElement):
     cdef object _func
     cdef dict _args
     cdef tuple _previous
-    cdef bint _f_is_t_args
-    cdef object _f_arg_names
+    cdef bint _f_is_pythonic
+    cdef object _f_parameters
 
 
 cdef class _MapElement(_BaseElement):

--- a/qutip/core/cy/_element.pxd
+++ b/qutip/core/cy/_element.pxd
@@ -25,7 +25,7 @@ cdef class _FuncElement(_BaseElement):
     cdef object _func
     cdef dict _args
     cdef tuple _previous
-    cdef bint _f_is_pythonic
+    cdef object _f_pythonic
     cdef object _f_parameters
 
 

--- a/qutip/core/cy/_element.pyx
+++ b/qutip/core/cy/_element.pyx
@@ -406,8 +406,12 @@ cdef class _FuncElement(_BaseElement):
 
     _UNSET = object()
 
-    def __init__(self, func, args, style=None, bint _f_pythonic=_UNSET, _f_parameters=_UNSET):
+    def __init__(self, func, args, style=None, _f_pythonic=_UNSET, _f_parameters=_UNSET):
         if _f_pythonic is self._UNSET or _f_parameters is self._UNSET:
+            if not (_f_pythonic is self._UNSET and _f_parameters is self._UNSET):
+                raise TypeError(
+                    "_f_pythonic and _f_parameters should always be given together."
+                )
             _f_pythonic, _f_parameters = coefficient_function_parameters(
                 func, style=style)
         if _f_parameters is not None:

--- a/qutip/core/cy/_element.pyx
+++ b/qutip/core/cy/_element.pyx
@@ -396,7 +396,7 @@ cdef class _FuncElement(_BaseElement):
 
     style : {None, "pythonic", "dict", "auto"}
         The style of the signature used. If style is ``None``,
-        the value of :obj:`qutip.core.settings.function_coefficient_style`
+        the value of ``qutip.settings.core["function_coefficient_style"]``
         is used. Otherwise the supplied value overrides the global setting.
 
     The parameters ``_f_pythonic`` and ``_f_parameters`` override function

--- a/qutip/core/cy/_element.pyx
+++ b/qutip/core/cy/_element.pyx
@@ -414,10 +414,8 @@ cdef class _FuncElement(_BaseElement):
                 )
             _f_pythonic, _f_parameters = coefficient_function_parameters(
                 func, style=style)
-        if _f_parameters is not None:
-            args = {k: args[k] for k in _f_parameters & args.keys()}
-        else:
-            args = args.copy()
+            if _f_parameters is not None:
+                args = {k: args[k] for k in _f_parameters & args.keys()}
         self._func = func
         self._args = args
         self._f_pythonic = _f_pythonic

--- a/qutip/core/cy/_element.pyx
+++ b/qutip/core/cy/_element.pyx
@@ -416,6 +416,8 @@ cdef class _FuncElement(_BaseElement):
                 func, style=style)
             if _f_parameters is not None:
                 args = {k: args[k] for k in _f_parameters & args.keys()}
+            else:
+                args = args.copy()
         self._func = func
         self._args = args
         self._f_pythonic = _f_pythonic

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -21,11 +21,12 @@ cdef extern from "<complex>" namespace "std" nogil:
 def coefficient_function_parameters(func, style=None):
     """
     Return the function style (either "pythonic" or not) and a list of
-    additional parameters accepted. Used by :obj:`FunctionCoefficient`
-    and :obj:`_FuncElement` to determine the call signature of the
-    supplied function based on the
-    :obj:`qutip.core.settings.function_coefficient_signature` setting and
-    the supplied function signature.
+    additional parameters accepted.
+
+    Used by :obj:`FunctionCoefficient` and :obj:`_FuncElement` to determine the
+    call signature of the supplied function based on the given style (or
+    ``qutip.settings.core["function_coefficient_style"]`` if no style is given)
+    and the signature of the given function.
 
     Parameters
     ----------
@@ -37,7 +38,7 @@ def coefficient_function_parameters(func, style=None):
 
     style : {None, "pythonic", "dict", "auto"}
         The style of the signature used. If style is ``None``,
-        the value of :obj:`qutip.core.settings.function_coefficient_style`
+        the value of ``qutip.settings.core["function_coefficient_style"]``
         is used. Otherwise the supplied value overrides the global setting.
 
     Returns
@@ -176,7 +177,7 @@ cdef class FunctionCoefficient(Coefficient):
 
     style : {None, "pythonic", "dict", "auto"}
         The style of function signature used. If style is ``None``,
-        the value of :obj:`qutip.core.settings.function_coefficient_style`
+        the value of ``qutip.settings.core["function_coefficient_style"]``
         is used. Otherwise the supplied value overrides the global setting.
 
     The parameters ``_f_pythonic`` and ``_f_parameters`` override function

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -185,13 +185,17 @@ cdef class FunctionCoefficient(Coefficient):
     the public interface.
     """
     cdef object func
-    cdef object _f_pythonic
-    cdef object _f_parameters
+    cdef bint _f_pythonic
+    cdef set _f_parameters
 
     _UNSET = object()
 
     def __init__(self, func, dict args, style=None, _f_pythonic=_UNSET, _f_parameters=_UNSET):
         if _f_pythonic is self._UNSET or _f_parameters is self._UNSET:
+            if not (_f_pythonic is self._UNSET and _f_parameters is self._UNSET):
+                raise TypeError(
+                    "_f_pythonic and _f_parameters should always be given together."
+                )
             _f_pythonic, _f_parameters = coefficient_function_parameters(
                 func, style=style)
         if _f_parameters is not None:

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -29,26 +29,26 @@ def coefficient_function_parameters(func, style=None):
 
     Parameters
     ----------
-    func: function
+    func : function
         The :obj:`FunctionCoefficient` to inspect. The first argument
         of the function is assumed to be ``t`` (the time at which to
         evaluate the coefficient). The remaining arguments depend on
         the signature style (see below).
 
-    style: {None, "pythonic", "dict", "auto"}
+    style : {None, "pythonic", "dict", "auto"}
         The style of the signature used. If style is ``None``,
         the value of :obj:`qutip.core.settings.function_coefficient_signature`
         is used. Otherwise the supplied value overrides the global setting.
 
-    Return
-    ------
+    Returns
+    -------
     (f_is_pythonic, f_parameters)
 
-    f_is_pythonic: bool
+    f_is_pythonic : bool
         True if the function should be called as ``f(t, **kw)`` and False
         if the function should be called as ``f(t, kw_dict)``.
 
-    f_parameters: set or None
+    f_parameters : set or None
         The set of parameters (other than ``t``) of the function or
         ``None`` if the function accepts arbitrary parameters.
     """
@@ -174,13 +174,13 @@ cdef class FunctionCoefficient(Coefficient):
     args : dict
         Values of the arguments to pass to ``func``.
 
-    f_is_t_args : bint
+    f_is_pythonic : bint
         Set to true if ``func`` should be called in the old QuTiP 4 style
         as ``func(t, args)`` where ``args`` is a dictionary that contains
         all the arguments. Otherwise set to false and ``func`` will be
         called as ``f(t, **args)``.
 
-    f_arg_names : set or None
+    f_parameters : set or None
         The set of argument names ``func`` accepts or ``None`` is ``func``
         accepts all possible arguments (e.g. via a ``**kw`` argument).
     """

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -200,6 +200,8 @@ cdef class FunctionCoefficient(Coefficient):
                 func, style=style)
             if _f_parameters is not None:
                 args = {k: args[k] for k in _f_parameters & args.keys()}
+            else:
+                args = args.copy()
         self.func = func
         self.args = args
         self._f_pythonic = _f_pythonic

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -198,8 +198,8 @@ cdef class FunctionCoefficient(Coefficient):
                 )
             _f_pythonic, _f_parameters = coefficient_function_parameters(
                 func, style=style)
-        if _f_parameters is not None:
-            args = {k: args[k] for k in _f_parameters & args.keys()}
+            if _f_parameters is not None:
+                args = {k: args[k] for k in _f_parameters & args.keys()}
         self.func = func
         self.args = args
         self._f_pythonic = _f_pythonic

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -243,14 +243,14 @@ cdef class QobjEvo:
             )
             qobj = op[0]
         elif callable(op):
-            qobj = op(0, args)
+            out = _FuncElement.by_inspection(op, args)
+            qobj = out.qobj(0)
             if not isinstance(qobj, Qobj):
                 raise TypeError(
                     "Function based time-dependent elements must have the"
                     " signature f(t: double, args: dict) -> Qobj, but"
                     " {!r} returned: {!r}".format(op, qobj)
                 )
-            out = _FuncElement(op, args)
         else:
             raise TypeError(
                 "QobjEvo terms should be Qobjs, a list of [Qobj, coefficient],"

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -92,6 +92,12 @@ cdef class QobjEvo:
 
         See :meth:`compress`.
 
+    function_style : {None, "pythonic", "dict", "auto"}
+        The style of function signature used by callables in ``Q_object``.
+        If style is ``None``, the value of
+        :obj:`qutip.core.settings.function_coefficient_style`
+        is used. Otherwise the supplied value overrides the global setting.
+
     Attributes
     ----------
     dims : list
@@ -186,7 +192,8 @@ cdef class QobjEvo:
     ```
     """
     def __init__(QobjEvo self, Q_object, args=None, tlist=None,
-                 step_interpolation=False, copy=True, compress=True):
+                 step_interpolation=False, copy=True, compress=True,
+                 function_style=None):
         if isinstance(Q_object, QobjEvo):
             self.dims = Q_object.dims.copy()
             self.shape = Q_object.shape
@@ -220,17 +227,25 @@ cdef class QobjEvo:
         if isinstance(Q_object, list):
             for op in Q_object:
                 self.elements.append(
-                    self._read_element(op, copy, tlist, args, step_interpolation)
+                    self._read_element(
+                        op, copy=copy, tlist=tlist, args=args,
+                        use_step_func=step_interpolation,
+                        function_style=function_style
+                    )
                 )
         else:
             self.elements.append(
-              self._read_element(Q_object, copy, tlist, args, step_interpolation)
+                self._read_element(
+                    Q_object, copy=copy, tlist=tlist, args=args,
+                    use_step_func=step_interpolation,
+                    function_style=function_style
+                )
             )
 
         if compress:
             self.compress()
 
-    def _read_element(self, op, copy, tlist, args, use_step_func):
+    def _read_element(self, op, copy, tlist, args, use_step_func, function_style):
         """ Read a Q_object item and return an element for that item. """
         if isinstance(op, Qobj):
             out = _ConstantElement(op.copy() if copy else op)
@@ -243,7 +258,7 @@ cdef class QobjEvo:
             )
             qobj = op[0]
         elif callable(op):
-            out = _FuncElement.by_inspection(op, args)
+            out = _FuncElement(op, args, style=function_style)
             qobj = out.qobj(0)
             if not isinstance(qobj, Qobj):
                 raise TypeError(

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -95,7 +95,7 @@ cdef class QobjEvo:
     function_style : {None, "pythonic", "dict", "auto"}
         The style of function signature used by callables in ``Q_object``.
         If style is ``None``, the value of
-        :obj:`qutip.core.settings.function_coefficient_style`
+        ``qutip.settings.core["function_coefficient_style"]``
         is used. Otherwise the supplied value overrides the global setting.
 
     Attributes

--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -29,6 +29,22 @@ class CoreOptions:
         The absolute tolerance used in automatic tidyup (see the ``auto_tidyup``
         parameter above) and the default value of ``atol`` used in
         :method:`Qobj.tidyup`.
+
+    function_coefficient_signature : str {"auto"}
+        The signature expected by function coefficients. The options are:
+
+        - "pythonic": the signature should be ``f(t, ...)`` where ``t``
+          is the time and the ``...`` are the remaining arguments passed
+          directly into the function. E.g. ``f(t, w, b=5)``.
+
+        - "dict": the signature shoule be ``f(t, args)`` where ``t`` is
+          the time and ``args`` is a dict containing the remaining arguments.
+          E.g. ``f(t, {"w": w, "b": 5})``.
+
+        - "auto": select automatically between the two options above based
+          on signature of the supplied function. If the function signature
+          is exactly ``f(t, args)`` then ``dict`` is used. Otherwise
+          ``pythonic`` is used.
     """
     options = {
         # use auto tidyup
@@ -42,5 +58,7 @@ class CoreOptions:
         # general relative tolerance
         "rtol": 1e-12,
         # use auto tidyup absolute tolerance
-        "auto_tidyup_atol": 1e-14
+        "auto_tidyup_atol": 1e-14,
+        # signature style expected by function coefficients
+        "function_coefficient_signature": "auto",
     }

--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -30,7 +30,7 @@ class CoreOptions:
         parameter above) and the default value of ``atol`` used in
         :method:`Qobj.tidyup`.
 
-    function_coefficient_signature : str {"auto"}
+    function_coefficient_style : str {"auto"}
         The signature expected by function coefficients. The options are:
 
         - "pythonic": the signature should be ``f(t, ...)`` where ``t``
@@ -42,7 +42,7 @@ class CoreOptions:
           E.g. ``f(t, {"w": w, "b": 5})``.
 
         - "auto": select automatically between the two options above based
-          on signature of the supplied function. If the function signature
+          on the signature of the supplied function. If the function signature
           is exactly ``f(t, args)`` then ``dict`` is used. Otherwise
           ``pythonic`` is used.
     """
@@ -60,5 +60,5 @@ class CoreOptions:
         # use auto tidyup absolute tolerance
         "auto_tidyup_atol": 1e-14,
         # signature style expected by function coefficients
-        "function_coefficient_signature": "auto",
+        "function_coefficient_style": "auto",
     }

--- a/qutip/tests/solve/test_correlation.py
+++ b/qutip/tests/solve/test_correlation.py
@@ -239,8 +239,8 @@ def _step(t):
 def test_hamiltonian_order_unimportant():
     # Testing for regression on issue 1048.
     sp = qutip.sigmap()
-    H = [[qutip.sigmax(), lambda t, _: _step(t-2)],
-         [qutip.qeye(2), lambda t, _: _step(-(t-2))]]
+    H = [[qutip.sigmax(), lambda t: _step(t-2)],
+         [qutip.qeye(2), lambda t: _step(-(t-2))]]
     start = qutip.basis(2, 0)
     times = np.linspace(0, 5, 6)
     forwards = qutip.correlation_2op_2t(H, start, times, times, [sp],

--- a/qutip/tests/solve/test_mesolve.py
+++ b/qutip/tests/solve/test_mesolve.py
@@ -396,7 +396,7 @@ class TestMESolveTDDecay:
         H = num(N)
         psi0 = basis(N, 9)
         tlist = np.linspace(0, 10, 100)
-        c_ops = [[[a, partial(lambda t, args, k:
+        c_ops = [[[a, partial(lambda t, k:
                               np.sqrt(k * np.exp(-t)), k=kappa)]]
                  for kappa in [0.05, 0.1, 0.2]]
 
@@ -577,7 +577,7 @@ class TestMESolveSuperInit:
         rho0vec = operator_to_vector(psi0*psi0.dag())
         E0 = sprepost(qeye(N), qeye(N))
         tlist = np.linspace(0, 10, 100)
-        c_ops = [[[a, partial(lambda t, args, k:
+        c_ops = [[[a, partial(lambda t, k:
                               np.sqrt(k * np.exp(-t)), k=kappa)]]
                  for kappa in [0.05, 0.1, 0.2]]
 


### PR DESCRIPTION
**Description**
Allow function-based Coefficients and QobjEvo elements to support functions with more natural argument signatures like `f(t, w)` or `f(t, **kw)` in addition to the old `f(t, args)` signature. The old style signature is used if the arguments to the function are exactly `(t, args)`. Otherwise the new calling convention is used.

This PR also limits the arguments stored to those accepted by the function, potentially reducing some extra copies of functions when `.replace_arguments()` is called.

**Related issues or PRs**
This is an alternative implementation of #1609. This implementation retains single FunctionCoefficient and _FuncElement classes and simplifies the logic for deciding whether the old or new-style calling convention is used.

**Changelog**
Allow function-based Coefficients and QobjEvo elements to support functions with more natural argument signatures like `f(t, w)` or `f(t, **kw)` in addition to the old `f(t, args)`.