### PR TITLE
Norm tests for specialisations.

### DIFF
--- a/qutip/core/data/eigen.py
+++ b/qutip/core/data/eigen.py
@@ -219,7 +219,6 @@ def eigs_csr(data, isherm=None, vecs=True, sort='low', eigvals=0,
                         + str(type(data)))
     if data.shape[0] < 4:
         # For small matrix, the sparse solver can't compute all eigenvalues.
-        # return eigs_dense(from_csr(data), isherm, vecs, sort, eigvals)
         return eigs_dense(from_csr(data), isherm, vecs, sort, eigvals)
     _eigs_check_shape(data)
     eigvals, num_large, num_small = _eigs_fix_eigvals(data, eigvals, sort)

--- a/qutip/core/data/eigen.py
+++ b/qutip/core/data/eigen.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.linalg
 import scipy.sparse as sp
 
-from .dense import Dense
+from .dense import Dense, from_csr
 from .csr import CSR
 from .properties import isherm as _isherm
 from qutip.settings import settings
@@ -219,7 +219,8 @@ def eigs_csr(data, isherm=None, vecs=True, sort='low', eigvals=0,
                         + str(type(data)))
     if data.shape[0] < 4:
         # For small matrix, the sparse solver can't compute all eigenvalues.
-        return eigs_dense(data, isherm, vecs, sort, eigvals)
+        # return eigs_dense(from_csr(data), isherm, vecs, sort, eigvals)
+        return eigs_dense(from_csr(data), isherm, vecs, sort, eigvals)
     _eigs_check_shape(data)
     eigvals, num_large, num_small = _eigs_fix_eigvals(data, eigvals, sort)
     isherm = isherm if isherm is not None else _isherm(data)

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -68,7 +68,7 @@ cpdef double _trace_dense(Dense matrix) except -1:
 cpdef double trace_csr(CSR matrix, sparse=False, tol=0, maxiter=None) except -1:
     # For column and row vectors we simply use the l2 norm as it is equivalent
     # to the trace norm.
-    if matrix.shape[1]==1 or matrix.shape[0]==1:
+    if matrix.shape[0]==1 or matrix.shape[1]==1:
         return l2_csr(matrix)
 
     # For the sparse=False we default to scipy's nuclear norm but for

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -45,9 +45,8 @@ cpdef double one_csr(CSR matrix) except -1:
         mem.PyMem_Free(col)
 
 cpdef double _trace_csr(CSR matrix, tol=0, maxiter=None) except -1:
-    """Compute the trace norm relaying only on sparse operations. This consists
-    on a digitalization of `matrix@matrix.adjoint()` to obtain the result from
-    the diagonals."""
+    """Compute the trace norm using only sparse operations. These consist
+    of determining the eigenvalues of `matrix @ matrix.adjoint()` and summing their square roots."""
 
     cdef CSR op = matmul_csr(matrix, adjoint_csr(matrix))
     cdef size_t i

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -6,7 +6,7 @@ from libc cimport math
 from cpython cimport mem
 
 from scipy.linalg cimport cython_blas as blas
-from scipy.linalg import norm
+import scipy
 
 from qutip.core.data cimport CSR, Dense, csr, dense, Data
 
@@ -65,7 +65,7 @@ cpdef double _trace_csr(CSR matrix, tol=0, maxiter=None) except -1:
 
 cpdef double trace_dense(Dense matrix) except -1:
     """Compute the trace norm relaying scipy for dense operations."""
-    return norm(matrix.as_ndarray(), 'nuc')
+    return scipy.linalg.norm(matrix.as_ndarray(), 'nuc')
 
 cpdef double trace_csr(CSR matrix, sparse=False, tol=0, maxiter=None) except -1:
     # For column and row vectors we simply use the l2 norm as it is equivalent

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -209,12 +209,6 @@ one.add_specialisations([
 trace = _Dispatcher(
     _inspect.Signature([
         _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('sparse', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                           default=False),
-        _inspect.Parameter('tol', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                           default=0),
-        _inspect.Parameter('maxiter', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                           default=None),
     ]),
     inputs=('matrix',),
     name='trace',

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -45,7 +45,9 @@ cpdef double one_csr(CSR matrix) except -1:
         mem.PyMem_Free(col)
 
 cpdef double _trace_csr(CSR matrix, tol=0, maxiter=None) except -1:
-    """Compute the trace norm reliying only on sparse operations."""
+    """Compute the trace norm relaying only on sparse operations. This consists
+    on a digitalization of `matrix@matrix.adjoint()` to obtain the result from
+    the diagonals."""
 
     cdef CSR op = matmul_csr(matrix, adjoint_csr(matrix))
     cdef size_t i
@@ -61,8 +63,8 @@ cpdef double _trace_csr(CSR matrix, tol=0, maxiter=None) except -1:
         total += math.sqrt(abs(eigs[i]))
     return total
 
-cpdef double _trace_dense(Dense matrix) except -1:
-    """Compute the trace norm reliying scipy for dense operations."""
+cpdef double trace_dense(Dense matrix) except -1:
+    """Compute the trace norm relaying scipy for dense operations."""
     return norm(matrix.as_ndarray(), 'nuc')
 
 cpdef double trace_csr(CSR matrix, sparse=False, tol=0, maxiter=None) except -1:
@@ -71,12 +73,10 @@ cpdef double trace_csr(CSR matrix, sparse=False, tol=0, maxiter=None) except -1:
     if matrix.shape[0]==1 or matrix.shape[1]==1:
         return l2_csr(matrix)
 
-    # For the sparse=False we default to scipy's nuclear norm but for
-    # sparse=True we compute eigenvalues and get the norm from them.
     if sparse:
         return _trace_csr(matrix, tol=tol, maxiter=maxiter)
     else:
-        return _trace_dense(dense.from_csr(matrix))
+        return trace_dense(dense.from_csr(matrix))
 
 cpdef double max_csr(CSR matrix) nogil:
     cdef size_t ptr
@@ -229,6 +229,7 @@ trace.__doc__ =\
     """
 trace.add_specialisations([
     (CSR, trace_csr),
+    (Dense, trace_dense),
 ], _defer=True)
 
 

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -49,6 +49,11 @@ cpdef double trace_csr(CSR matrix, sparse=False, tol=0, maxiter=None) except -1:
     cdef CSR op = matmul_csr(matrix, adjoint_csr(matrix))
     cdef size_t i
     cdef double [::1] eigs
+
+    # For column and row vectors we simply use the l2 norm.
+    if matrix.shape[1]==1 or matrix.shape[0]==1:
+        return l2_csr(matrix)
+
     if sparse:
         eigs = eigs_csr(op, isherm=True, vecs=False, tol=tol, maxiter=maxiter)
     else:

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -63,6 +63,9 @@ class TestTraceNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
         return scipy.linalg.norm(matrix, 'nuc')
 
+    # CSR[square,sparse] fails if tol is larger.
+    tol = 1e-8
+
     specialisations = [
         pytest.param(data.norm.trace_csr, CSR, numbers.Number),
         pytest.param(data.norm.trace_dense, Dense, numbers.Number),

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -1,6 +1,6 @@
 from . import test_mathematics as testing
 import numpy as np
-import scipy as sc
+from scipy import linalg
 import pytest
 from qutip import data
 from qutip.core.data import CSR, Dense
@@ -9,7 +9,7 @@ import numbers
 
 class TestOneNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        return sc.linalg.norm(matrix, 1)
+        return linalg.norm(matrix, 1)
 
     specialisations = [
         pytest.param(data.norm.one_csr, CSR, numbers.Number),
@@ -19,7 +19,7 @@ class TestOneNorm(testing.UnaryOpMixin):
 
 class TestFrobeniusNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        return sc.linalg.norm(matrix, 'fro')
+        return linalg.norm(matrix, 'fro')
 
     specialisations = [
         pytest.param(data.norm.frobenius_csr, CSR, numbers.Number),
@@ -41,7 +41,7 @@ class TestMaxNorm(testing.UnaryOpMixin):
 
 class TestL2Norm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        return sc.linalg.norm(matrix, 'fro')
+        return linalg.norm(matrix, 'fro')
 
     # These shapes correspond to kets or bras
     shapes = [
@@ -61,7 +61,7 @@ class TestL2Norm(testing.UnaryOpMixin):
 
 class TestTraceNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        return sc.linalg.norm(matrix, 'nuc')
+        return linalg.norm(matrix, 'nuc')
 
     tol = 1e-5
 

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -9,7 +9,7 @@ import numbers
 
 class TestOneNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        return linalg.norm(matrix, 1)
+        return scipy.linalg.norm(matrix, 1)
 
     specialisations = [
         pytest.param(data.norm.one_csr, CSR, numbers.Number),
@@ -19,7 +19,7 @@ class TestOneNorm(testing.UnaryOpMixin):
 
 class TestFrobeniusNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        return linalg.norm(matrix, 'fro')
+        return scipy.linalg.norm(matrix, 'fro')
 
     specialisations = [
         pytest.param(data.norm.frobenius_csr, CSR, numbers.Number),
@@ -41,7 +41,7 @@ class TestMaxNorm(testing.UnaryOpMixin):
 
 class TestL2Norm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        return linalg.norm(matrix, 'fro')
+        return scipy.linalg.norm(matrix, 'fro')
 
     # These shapes correspond to kets or bras
     shapes = [
@@ -61,7 +61,7 @@ class TestL2Norm(testing.UnaryOpMixin):
 
 class TestTraceNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        return linalg.norm(matrix, 'nuc')
+        return scipy.linalg.norm(matrix, 'nuc')
 
     specialisations = [
         pytest.param(data.norm.trace_csr, CSR, numbers.Number),
@@ -72,7 +72,7 @@ class TestTraceNorm(testing.UnaryOpMixin):
 # set to True.
 class TestTraceNormSparseTrue(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        return linalg.norm(matrix, 'nuc')
+        return scipy.linalg.norm(matrix, 'nuc')
 
     specialisations = [
         pytest.param(data.norm.trace_csr, CSR, numbers.Number),

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -67,20 +67,3 @@ class TestTraceNorm(testing.UnaryOpMixin):
         pytest.param(data.norm.trace_csr, CSR, numbers.Number),
         pytest.param(data.norm.trace_dense, Dense, numbers.Number),
     ]
-
-# This test tests the special case where the argument sparse in traces_csr is
-# set to True.
-class TestTraceNormSparseTrue(testing.UnaryOpMixin):
-    def op_numpy(self, matrix):
-        return scipy.linalg.norm(matrix, 'nuc')
-
-    specialisations = [
-        pytest.param(data.norm.trace_csr, CSR, numbers.Number),
-    ]
-
-    def test_mathematically_correct(self, op, data_m, out_type):
-        matrix = data_m()
-        expected = self.op_numpy(matrix.to_array())
-        test = op(matrix, sparse=True)
-        assert isinstance(test, out_type)
-        np.testing.assert_allclose(test, expected, atol=self.tol)

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -65,6 +65,7 @@ class TestTraceNorm(testing.UnaryOpMixin):
 
     specialisations = [
         pytest.param(data.norm.trace_csr, CSR, numbers.Number),
+        pytest.param(data.norm.trace_dense, Dense, numbers.Number),
     ]
 
 # This test tests the special case where the argument sparse in traces_csr is

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -6,6 +6,7 @@ from qutip import data
 from qutip.core.data import CSR, Dense
 import numbers
 
+
 class TestOneNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
         return sc.linalg.norm(matrix, 1)
@@ -45,12 +46,12 @@ class TestL2Norm(testing.UnaryOpMixin):
     # These shapes correspond to kets or bras
     shapes = [
         (x,) for x in testing.shapes_unary() if (x.values[0][0] == 1
-                                         or x.values[0][1] == 1)
+                                                 or x.values[0][1] == 1)
     ]
     # These shapes are everything except for kets and bras
     bad_shapes = [
         (x,) for x in testing.shapes_unary() if not (x.values[0][0] == 1
-                                             or x.values[0][1] == 1)
+                                                     or x.values[0][1] == 1)
     ]
     specialisations = [
         pytest.param(data.norm.l2_csr, CSR, numbers.Number),

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -1,0 +1,72 @@
+from . import test_mathematics as testing
+import numpy as np
+import scipy as sc
+import pytest
+from qutip import data
+from qutip.core.data import CSR, Dense
+import numbers
+
+class TestOneNorm(testing.UnaryOpMixin):
+    def op_numpy(self, matrix):
+        return sc.linalg.norm(matrix, 1)
+
+    specialisations = [
+        pytest.param(data.norm.one_csr, CSR, numbers.Number),
+        pytest.param(data.norm.one_dense, Dense, numbers.Number),
+    ]
+
+
+class TestFrobeniusNorm(testing.UnaryOpMixin):
+    def op_numpy(self, matrix):
+        return sc.linalg.norm(matrix, 'fro')
+
+    specialisations = [
+        pytest.param(data.norm.frobenius_csr, CSR, numbers.Number),
+        pytest.param(data.norm.frobenius_dense, Dense, numbers.Number),
+    ]
+
+
+class TestMaxNorm(testing.UnaryOpMixin):
+    def op_numpy(self, matrix):
+        # There is no scipy-equvalent as sc.linalg.norm(matrix, np.inf)
+        # works differently for matrices.
+        return np.max(np.abs(matrix))
+
+    specialisations = [
+        pytest.param(data.norm.max_csr, CSR, numbers.Number),
+        pytest.param(data.norm.max_dense, Dense, numbers.Number),
+    ]
+
+
+class TestL2Norm(testing.UnaryOpMixin):
+    def op_numpy(self, matrix):
+        return sc.linalg.norm(matrix, 'fro')
+
+    # These shapes correspond to kets or bras
+    shapes = [
+        (x,) for x in testing.shapes_unary() if (x.values[0][0] == 1
+                                         or x.values[0][1] == 1)
+    ]
+    # These shapes are everything except for kets and bras
+    bad_shapes = [
+        (x,) for x in testing.shapes_unary() if not (x.values[0][0] == 1
+                                             or x.values[0][1] == 1)
+    ]
+    specialisations = [
+        pytest.param(data.norm.l2_csr, CSR, numbers.Number),
+        pytest.param(data.norm.l2_dense, Dense, numbers.Number),
+    ]
+
+
+class TestTraceNorm(testing.UnaryOpMixin):
+    def op_numpy(self, matrix):
+        matrix = matrix@np.conj(matrix.T)
+        return np.trace(sc.linalg.sqrtm(matrix))
+
+    # TraceNorm probaly needs lower tol due to how it is being computed with
+    # NumPy
+    tol = 1e-5
+
+    specialisations = [
+        pytest.param(data.norm.trace_csr, CSR, numbers.Number),
+    ]

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -61,11 +61,8 @@ class TestL2Norm(testing.UnaryOpMixin):
 
 class TestTraceNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        matrix = matrix@np.conj(matrix.T)
-        return np.trace(sc.linalg.sqrtm(matrix))
+        return sc.linalg.norm(matrix, 'nuc')
 
-    # TraceNorm probaly needs lower tol due to how it is being computed with
-    # NumPy
     tol = 1e-5
 
     specialisations = [

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -61,10 +61,10 @@ class TestL2Norm(testing.UnaryOpMixin):
 
 class TestTraceNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
-        return scipy.linalg.norm(matrix, 'nuc')
+        return np.linalg.svd(matrix)[1].sum()
 
     # CSR[square,sparse] fails if tol is larger.
-    tol = 1e-8
+    tol = 3.7e-8
 
     specialisations = [
         pytest.param(data.norm.trace_csr, CSR, numbers.Number),

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -1,6 +1,6 @@
 from . import test_mathematics as testing
 import numpy as np
-from scipy import linalg
+import scipy.linalg
 import pytest
 from qutip import data
 from qutip.core.data import CSR, Dense

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -59,11 +59,12 @@ class TestL2Norm(testing.UnaryOpMixin):
     ]
 
 
+# This tests sometimes fails for the case `CSR[square,sparse]->Number`
 class TestTraceNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
         return linalg.norm(matrix, 'nuc')
 
-    tol = 1e-5
+    tol = 1e-7  # With this tol test fails less than 1/5
 
     specialisations = [
         pytest.param(data.norm.trace_csr, CSR, numbers.Number),


### PR DESCRIPTION
**Changelog**
Added specialisations for norm.
`TraceNorm` now uses `scipy.linalg.norm` with `ord='nuc` by default (sparse=False).
Fixed bug for `eigs_sparse` where if the shape was less than 4 it called with wrong arguments to `eigs_dense`.