### PR TITLE
Expect return real value only when possible.

### DIFF
--- a/qutip/core/expect.py
+++ b/qutip/core/expect.py
@@ -33,6 +33,8 @@
 
 __all__ = ['expect', 'variance']
 
+import numbers
+
 import numpy as np
 
 from .qobj import Qobj
@@ -77,6 +79,7 @@ def expect(oper, state):
             return np.array([_single_qobj_expect(op, state) for op in oper],
                             dtype=dtype)
         return [expect(op, state) for op in oper]
+
     elif isinstance(state, (list, np.ndarray)):
         dtype = np.complex128
         if oper.isherm and all(op.isherm or op.isket for op in state):
@@ -99,7 +102,12 @@ def _single_qobj_expect(oper, state):
         )
         raise ValueError(msg)
     out = _data.expect(oper.data, state.data)
-    return out.real if oper.isherm and (state.isket or state.isherm) else out
+
+    # This ensures that expect can return something that is not a number.
+    try:
+        return out.real if oper.isherm and (state.isket or state.isherm) else out
+    except AttributeError:
+        return out
 
 
 def variance(oper, state):

--- a/qutip/core/expect.py
+++ b/qutip/core/expect.py
@@ -33,8 +33,6 @@
 
 __all__ = ['expect', 'variance']
 
-import numbers
-
 import numpy as np
 
 from .qobj import Qobj


### PR DESCRIPTION
**Description**
Changes expect to cast to real only when attribute real exist. This was a problem for qutip-tensorflow as it returned a `tf.Tensor` that does not have the real attribute. 

I did not add any test yet. I thought of adding a test that creates a dummy_specialisation that always returns a dummy class. However, this is was quite involved test. I can include it although I wondered if it was the correct approach to test the code.

Also, note that I am not using an `isinstance(out, number.Number)` deliberately. There are examples of class that do implement the `real` and `imag` attribute, such us numpy arrays. Furthermore, I opened an [issue](https://github.com/tensorflow/tensorflow/issues/51463) in TensorFlow to see if they would like to support the `real` and `imag` attributes. 

**Changelog**
`expect` can now return arbitrary python objects.
