### PR TITLE
Remove unnecessary use of scipy.sparse in test_mathematics.

### DIFF
--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -1,6 +1,6 @@
 import itertools
 import numpy as np
-import scipy as sc
+import scipy
 import pytest
 
 from qutip.core import data
@@ -806,7 +806,7 @@ class TestPow(UnaryOpMixin):
 
 class TestExpm(UnaryOpMixin):
     def op_numpy(self, matrix):
-        return sc.linalg.expm(matrix)
+        return scipy.linalg.expm(matrix)
 
     shapes = shapes_square()
     bad_shapes = shapes_not_square()

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -806,7 +806,7 @@ class TestPow(UnaryOpMixin):
 
 class TestExpm(UnaryOpMixin):
     def op_numpy(self, matrix):
-        return sc.sparse.linalg.expm(matrix)
+        return sc.linalg.expm(matrix)
 
     shapes = shapes_square()
     bad_shapes = shapes_not_square()


### PR DESCRIPTION
**Description**

Remove unnecessary use of scipy.sparse in test_mathematics.

**Related issues or PRs**

* Fixes the small issue raised by @jakelishman in https://github.com/qutip/qutip/pull/1630#pullrequestreview-723426389 post merge.

**Changelog**

Remove unnecessary use of scipy.sparse in test_mathematics.