### PR TITLE
Swappable ODE integrators.

### DIFF
--- a/qutip/core/data/dense.pxd
+++ b/qutip/core/data/dense.pxd
@@ -7,7 +7,7 @@ from .csr cimport CSR
 
 cdef class Dense(base.Data):
     cdef double complex *data
-    cdef bint fortran
+    cdef readonly bint fortran
     cdef object _np
     cdef bint _deallocate
     cdef void _fix_flags(Dense self, object array, bint make_owner=*)

--- a/qutip/core/data/dense.pxd
+++ b/qutip/core/data/dense.pxd
@@ -7,7 +7,7 @@ from .csr cimport CSR
 
 cdef class Dense(base.Data):
     cdef double complex *data
-    cdef readonly bint fortran
+    cdef bint fortran
     cdef object _np
     cdef bint _deallocate
     cdef void _fix_flags(Dense self, object array, bint make_owner=*)

--- a/qutip/solver/__init__.py
+++ b/qutip/solver/__init__.py
@@ -1,2 +1,4 @@
 from .result import *
 from .options import *
+from .integrator import *
+from .ode import *

--- a/qutip/solver/integrator.py
+++ b/qutip/solver/integrator.py
@@ -17,7 +17,7 @@ class IntegratorException(Exception):
 class Integrator:
     """
     A wrapper around ODE solvers.
-    It ensure a common interface for Solver usage.
+    It ensures a common interface for Solver usage.
     It takes and return states as :class:`qutip.core.data.Data`, it may return
     a different data-type than the input type.
 

--- a/qutip/solver/integrator.py
+++ b/qutip/solver/integrator.py
@@ -40,6 +40,7 @@ class Integrator:
         self.system = system
         self._stats = {}
         self.options = options
+        self._is_set = False
         self._prepare()
 
     def _prepare(self):
@@ -124,7 +125,8 @@ class Integrator:
 
     def reset(self):
         """Reset internal state of the ODE solver."""
-        self.set_state(*self.get_state)
+        if self._is_set:
+            self.set_state(*self.get_state())
 
     def update_args(self, args):
         """

--- a/qutip/solver/integrator.py
+++ b/qutip/solver/integrator.py
@@ -33,7 +33,7 @@ class Integrator:
         Options for the solver.
 
     Class Attributes
-    ---------------------
+    ----------------
     supports_blackbox : bool
         If True, then the integrator calls only ``system.matmul``,
         ``system.matmul_data``, ``system.expect``, ``system.expect_data`` and
@@ -47,13 +47,19 @@ class Integrator:
     supports_time_dependent : bool
         If True, then the integrator supports time dependent systems. If False,
         ``supports_blackbox`` should usually be ``False`` too.
+
+    integrator_options : dict
+        A dictionary of options used by the integrator and their default
+        values. Once initiated, ``self.options`` will be a dict with the same
+        keys, not the full options object passed to the solver. Options' keys
+        included here will be supported by the :cls:SolverOdeOptions.
     """
     # Used options in qutip.SolverOdeOptions
     integrator_options = {}
     # Can evolve time dependent system
     support_time_dependant = None
     # Use the QobjEvo's matmul_data method as the driving function
-    use_QobjEvo_matmul = None
+    supports_blackbox = None
     name = ""
 
     def __init__(self, system, options):

--- a/qutip/solver/integrator.py
+++ b/qutip/solver/integrator.py
@@ -73,13 +73,38 @@ class Integrator:
         """
         raise NotImplementedError
 
-    def integrate(self, t, step=False, copy=True):
+    def integrate(self, t, copy=True):
         """
         Evolve to t.
 
-        If `step` advance up to t by one internal solver step.
-        Should be able to retreive the state at any time between the present
-        time and the resulting time with subsequent calls.
+        Before calling `integrate` for the first time, the initial state should
+        be set with `set_state`.
+
+        Parameters
+        ----------
+        t : float
+            Time to integrate to, should be larger than the previous time.
+
+        copy : bool [True]
+            Whether to return a copy of the state or the state itself.
+
+        Return
+        ------
+        (t, state) : (float, qutip.Data)
+            The state of the solver at ``t``.
+        """
+        raise NotImplementedError
+
+    def mcstep(self, t, copy=True):
+        """
+        Evolve toward the time ``t``.
+
+        If ``t`` is larger than the present state's ``t``, advance the internal
+        state toward ``t``. If  ``t`` is smaller than the present ``t``, but
+        larger than the precious one, it does an interpolation step and return
+        the state at that time. When advancing the state, it may return it at a
+        time between present time and the asked ``t`` if more efficent for
+        subsequent interpolation step.
 
         Before calling `integrate` for the first time, the initial step should
         be set with `set_state`.
@@ -91,17 +116,18 @@ class Integrator:
             the last integrate call was use with ``step=True``, the time can be
             between the time at the start of the last call and now.
 
-        step : bool [False]
-            When True, integrate for a one internal step of the ODE solver.
-
         copy : bool [True]
             Whether to return a copy of the state or the state itself.
 
         Return
         ------
         (t, state) : (float, qutip.Data)
-            The state of the solver at ``t``. The returned time ``t`` can differ from
-            the input time only when ``step=True``.
+            The state of the solver at ``t``. The returned time ``t`` can
+            differ from the input time only when ``step=True``.
+
+        .. note:
+            Does not need to be implemented it the Integrator does not support
+            :func:`mcsovle`
         """
         raise NotImplementedError
 

--- a/qutip/solver/integrator.py
+++ b/qutip/solver/integrator.py
@@ -9,13 +9,12 @@ class IntegratorException(Exception):
     """Error from the ODE solver being unable to integrate with the given
     parameters.
 
-    Exemple
+    Example
     -------
     - The solver cannot reach the desired tolerance within the maximum number
     of steps.
     - The step needed to be within desired tolerance is too small.
     """
-    pass
 
 
 class Integrator:
@@ -27,11 +26,25 @@ class Integrator:
 
     Parameters
     ----------
-    sytem: qutip.QobjEvo
+    system: qutip.QobjEvo
         Quantum system in which states evolve.
 
     options: qutip.SolverOdeOptions
         Options for the solver.
+
+    Class Attributes
+    ---------------------
+    supports_blackbox : bool
+          If True, then the integrator calls only ``system.matmul``, ``system.matmul_data``, ``system.expect``, 
+          ``system.expect_data`` and ``isconstant``, ``isoper`` or ``issuper``. This allows the solver using the integrator
+          to modify the system in creative ways. In particular, the solver may modify the system depending on *both*
+          the time ``t`` *and* the current ``state`` the system is being applied to.
+        
+          If the integrator calls any other methods, set to False.
+          
+    supports_time_dependent : bool
+        If True, then the integrator supports time dependent systems. If False, ``supports_blackbox`` should usually be
+        ``False`` too.
     """
     # Used options in qutip.SolverOdeOptions
     used_options = []
@@ -101,7 +114,7 @@ class Integrator:
 
         If ``t`` is larger than the present state's ``t``, advance the internal
         state toward ``t``. If  ``t`` is smaller than the present ``t``, but
-        larger than the precious one, it does an interpolation step and return
+        larger than the previous one, it does an interpolation step and returns
         the state at that time. When advancing the state, it may return it at a
         time between present time and the asked ``t`` if more efficent for
         subsequent interpolation step.
@@ -127,7 +140,7 @@ class Integrator:
 
         .. note:
             Does not need to be implemented it the Integrator does not support
-            :func:`mcsovle`
+            :func:`mcsolve`
         """
         raise NotImplementedError
 

--- a/qutip/solver/integrator.py
+++ b/qutip/solver/integrator.py
@@ -39,6 +39,7 @@ class Integrator:
     support_time_dependant = None
     # Use the QobjEvo's matmul_data method as the driving function
     use_QobjEvo_matmul = None
+    name = ""
 
     def __init__(self, system, options):
         self.system = system
@@ -51,6 +52,7 @@ class Integrator:
     def _prepare(self):
         """
         Initialize the solver
+        It should also set the name of the solver to be displayed in Result.
         """
         raise NotImplementedError
 
@@ -106,6 +108,11 @@ class Integrator:
     def get_state(self, copy=True):
         """
         Obtain the state of the solver as a pair (t, state).
+
+        Parameters
+        ----------
+        copy : bool (True)
+            Whether to return the data stored in the Integrator or a copy.
 
         Return
         ------

--- a/qutip/solver/integrator.py
+++ b/qutip/solver/integrator.py
@@ -1,36 +1,4 @@
-# This file is part of QuTiP: Quantum Toolbox in Python.
-#
-#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
-#    All rights reserved.
-#
-#    Redistribution and use in source and binary forms, with or without
-#    modification, are permitted provided that the following conditions are
-#    met:
-#
-#    1. Redistributions of source code must retain the above copyright notice,
-#       this list of conditions and the following disclaimer.
-#
-#    2. Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#
-#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
-#       of its contributors may be used to endorse or promote products derived
-#       from this software without specific prior written permission.
-#
-#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-###############################################################################
-""" Define `Integrator`: ODE solver wrapper to use in qutip's Solver """
+""" `Integrator`: ODE solver wrapper to use in qutip's Solver """
 
 
 __all__ = ['Integrator', 'IntegratorException', 'add_integrator',

--- a/qutip/solver/integrator.py
+++ b/qutip/solver/integrator.py
@@ -1,0 +1,415 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+""" Define `Integrator`: ODE solver wrapper to use in qutip's Solver """
+
+
+__all__ = ['Integrator', 'integrator_collection', 'IntegratorException']
+
+
+from itertools import product
+from .options import SolverOdeOptions
+from qutip import QobjEvo, qeye, basis
+from functools import partial
+
+
+class IntegratorException(Exception):
+    pass
+
+
+class Integrator:
+    """
+    A wrapper around ODE solvers.
+    It ensure a common interface for Solver usage.
+    It takes and return states as :class:`qutip.core.data.Data`, it may return
+    a different data-type than the input type.
+
+    Parameters
+    ----------
+    sytem: qutip.QobjEvo
+        Quantum system in which states evolve.
+
+    options: qutip.SolverOptions
+        Options for the solver.
+    """
+    used_options = []
+    description = ""
+
+    def __init__(self, system, options):
+        self.system = system
+        self._stats = {}
+        self.options = options
+        self._prepare()
+
+    def _prepare(self):
+        """
+        Initialize the solver
+        """
+        raise NotImplementedError
+
+    def set_state(self, t, state0):
+        """
+        Set the state of the ODE solver.
+
+        Parameters
+        ----------
+        t : float
+            Initial time
+
+        state0 : qutip.Data
+            Initial state.
+        """
+        raise NotImplementedError
+
+    def integrate(self, t, step=False, copy=True):
+        """
+        Evolve to t.
+
+        If `step` advance up to t by one internal solver step.
+        Should be able to retreive the state at any time between the present
+        time and the resulting time with subsequent calls.
+
+        Before calling `integrate` for the first time, the initial step should
+        be set with `set_state`.
+
+        Parameters
+        ----------
+        t : float
+            Time to integrate to, should be larger than the previous time. If
+            the last integrate call was use with ``step=True``, the time can be
+            between the time at the start of the last call and now.
+
+        step : bool [False]
+            When True, integrate for a one internal step of the ODE solver.
+
+        copy : bool [True]
+            Whether to return a copy of the state or the state itself.
+
+        Return
+        ------
+        (t, state) : (float, qutip.Data)
+            The state of the solver at ``t``. The returned this can differ from
+            the input time only when ``step=True``.
+        """
+        raise NotImplementedError
+
+    def get_state(self, copy=True):
+        """
+        Obtain the state of the solver as a pair (t, state).
+
+        Return
+        ------
+        (t, state) : (float, qutip.Data)
+            The state of the solver at ``t``.
+        """
+        raise NotImplementedError
+
+    def run(self, tlist):
+        """
+        Integrate the system yielding the state for each times in tlist.
+
+        Parameters
+        ----------
+        tlist : *list* / *array*
+            List of times to yield the state.
+
+        Yield
+        -----
+        (t, state) : (float, qutip.Data)
+            The state of the solver at each ``t`` of tlist.
+        """
+        for t in tlist[1:]:
+            yield self.integrate(t, False)
+
+    def reset(self):
+        """Reset internal state of the ODE solver."""
+        self.set_state(*self.get_state)
+
+    def update_args(self, args):
+        """
+        Change the argument of the system.
+        Reset the ODE solver to ensure numerical validity.
+
+        Parameters
+        ----------
+        args : dict
+            New arguments
+        """
+        self.system.arguments(args)
+        self.reset()
+
+
+class _IntegratorCollection:
+    """
+    Collection of ODE :obj:`Integrator` available to Qutip's solvers.
+
+    :obj:`Integrator` are composed of 2 parts: `method` and `rhs`:
+    `method` are ODE integration method such as Runge-Kutta or Adams–Moulton.
+    `rhs` are options to control the :obj:`QobjEvo`'s matmul function.
+
+    Parameters
+    ----------
+    known_solvers : list of str
+        list of solver using this ensemble of integrator
+
+    options_class : :func:optionsclass decorated class
+        Option object to add integrator's option to the accepted keys.
+    """
+    def __init__(self, known_solvers, options_class):
+        self.known_solvers = known_solvers
+        self.options_class = options_class
+        # map from method key to integrator
+        self.method2integrator = {}
+        # map from rhs key to rhs function
+        self.rhs2system = {}
+        # methods's keys which support alternative rhs
+        self.base_methods = []
+        # Information about methods
+        self.method_data = {}
+        # Information about rhs
+        self.rhs_data = {}
+
+    def add_method(self, integrator, keys, solver,
+                   use_QobjEvo_matmul, time_dependent):
+        """
+        Add a new integrator to the set available to solvers.
+
+        Parameters
+        ----------
+
+        integrator : class derived from :obj:`Integrator`
+            New integrator to add.
+
+        keys : list of str
+            List of keys supported by the integrator.
+            When `options["methods"] in keys`, this integrator will be used.
+
+        solver : list of str
+            List of the [...]solve function that are supported by the
+            integrator.
+
+        use_QobjEvo_matmul : bool
+            Whether the Integrator use `QobjEvo.matmul` as the function of the
+            ODE. When `False`, rhs cannot be used.
+
+        time_dependent : bool
+            Whether integrator support time-dependent system.
+        """
+        if not isinstance(keys, list):
+            keys = [keys]
+        for key in keys:
+            if key in self.method2integrator:
+                raise ValueError("method '{}' already used".format(key))
+
+        integrator_data = self._complete_data(integrator, solver,
+                                              use_QobjEvo_matmul,
+                                              time_dependent)
+        for key in keys:
+            self.method2integrator[key] = integrator
+            self.method_data[key] = integrator_data
+        if use_QobjEvo_matmul:
+            self.base_methods += keys
+
+    def add_rhs(self, integrator, keys, solver, time_dependent):
+        """
+        Add a new rhs to the set available to solvers.
+
+        Parameters
+        ----------
+
+        integrator : callable
+            Function with the signature::
+
+                rhs(
+                    integrator: class,
+                    system: QobjEvo,
+                    options: SolverOptions
+                ) -> Integrator
+
+            that create the :obj:`Integrator` instance. The integrator can be
+            any integrator registered that has `"use_QobjEvo_matmul" == True`.
+            `system` is the :obj:`QobjEvo` driving the ODE: 'L', '-i*H', etc.
+            `options` is the :obj:`SolverOptions` of the solver.
+
+        keys : list of str
+            List of keys supported by the integrator.
+            When `options["methods"] in keys`, this integrator will be used.
+
+        solver : list of str
+            List of the [...]solve function that are supported by the
+            integrator.
+
+        time_dependent : bool
+            True if the integrator can solve time dependent systems.
+        """
+        if not isinstance(keys, list):
+            keys = [keys]
+        for key in keys:
+            if key in self.rhs2system:
+                raise ValueError("rhs keyword '{}' already used")
+        integrator_data = self._complete_data(integrator, solver,
+                                              True,
+                                              time_dependent)
+        for key in keys:
+            self.rhs2system[key] = integrator
+            self.rhs_data[key] = integrator_data
+
+    def _complete_data(self, integrator, solver, use_QobjEvo_matmul, td):
+        """
+        Get the information for the integrator.
+        """
+        integrator_data = {
+            "integrator": integrator,
+            "description": "",
+            # options used by the integrator, to add to the accepted option
+            # by the SolverOptions object.
+            "options": [],
+            # list of supported solver, sesolve, mesolve, etc.
+            "solver": [],
+            # The `method` use QobjEvo's matmul.
+            # If False, refuse `rhs` option.
+            "use_QobjEvo_matmul": use_QobjEvo_matmul,
+            # Support of time-dependent system
+            "time_dependent": td,
+        }
+        for sol in solver:
+            if sol not in self.known_solvers:
+                raise ValueError(f"Unknown solver '{sol}', known solver are"
+                                 + str(self.known_solvers))
+            integrator_data["solver"].append(sol)
+
+        if hasattr(integrator, 'description'):
+            integrator_data['description'] = integrator.description
+
+        if hasattr(integrator, 'used_options'):
+            integrator_data['options'] = integrator.used_options
+            for opt in integrator.used_options:
+                self.options_class.extra_options.add(opt)
+
+        return integrator_data
+
+    def __getitem__(self, key):
+        """
+        Obtain the integrator from the (method, rhs) key pair.
+        """
+        method, rhs = key
+        try:
+            integrator = self.method2integrator[method]
+        except KeyError:
+            raise KeyError(f"ode method {method} not found")
+        if rhs == "":
+            build_func = prepare_integrator
+        elif self.method_data[method]["use_QobjEvo_matmul"]:
+            try:
+                build_func = self.rhs2system[rhs]
+            except KeyError:
+                raise KeyError(f"ode rhs {rhs} not found")
+        else:
+            raise KeyError(f"ode method {method} does not support rhs")
+        return partial(build_func, integrator)
+
+    def _list_keys(self, keytype="methods", solver="",
+                   use_QobjEvo_matmul=None, time_dependent=None):
+        """
+        List integrators available corresponding to the conditions given.
+        Used in test.
+        """
+        if keytype == "methods":
+            names = [method for method in self.method2integrator
+                     if self._check_condition(method, "", solver,
+                                             use_QobjEvo_matmul,
+                                             time_dependent)]
+        elif keytype == "rhs":
+            names = [rhs for rhs in self.rhs2system
+                     if self._check_condition("", rhs, solver,
+                                             use_QobjEvo_matmul,
+                                             time_dependent)]
+        elif keytype == "pairs":
+            names = [(method, "") for method in self.method2integrator
+                     if self._check_condition(method, "", solver,
+                                             use_QobjEvo_matmul,
+                                             time_dependent)]
+            names += [(method, rhs)
+                for method, rhs in product(self.base_methods, self.rhs2system)
+                if rhs and self._check_condition(method, rhs, solver,
+                    use_QobjEvo_matmul, time_dependent)
+            ]
+        else:
+            raise ValueError("keytype must be one of "
+                             "'rhs', 'methods' or 'pairs'")
+        return names
+
+    def _check_condition(self, method, rhs, solver="",
+                         use_QobjEvo_matmul=None, time_dependent=None):
+        """
+        Verify if the pair (method, rhs) can be used for the given solver
+        and whether it support the desired capacities.
+        """
+        if method in self.method_data:
+            data = self.method_data[method]
+            if solver and solver not in data['solver']:
+                return False
+            if (
+                use_QobjEvo_matmul is not None and
+                use_QobjEvo_matmul != data['use_QobjEvo_matmul']
+            ):
+                return False
+            if (
+                time_dependent is not None and
+                time_dependent != data['time_dependent']
+            ):
+                return False
+
+        if rhs in self.rhs_data:
+            data = self.rhs_data[rhs]
+            if solver and solver not in data['solver']:
+                return False
+            if (
+                time_dependent is not None and
+                time_dependent != data['time_dependent']
+            ):
+                return False
+
+        return True
+
+
+integrator_collection = _IntegratorCollection(
+    ['sesolve', 'mesolve', 'mcsolve'],
+    SolverOdeOptions
+)
+
+def prepare_integrator(integrator, system, options):
+    """Default rhs function"""
+    return integrator(system, options)
+
+integrator_collection.add_rhs(prepare_integrator, "",
+                              ['sesolve', 'mesolve', 'mcsolve'], True)

--- a/qutip/solver/integrator.py
+++ b/qutip/solver/integrator.py
@@ -34,6 +34,9 @@ class Integrator:
 
     Class Attributes
     ----------------
+    name : str
+        The name of the integrator.
+
     supports_blackbox : bool
         If True, then the integrator calls only ``system.matmul``,
         ``system.matmul_data``, ``system.expect``, ``system.expect_data`` and
@@ -58,9 +61,10 @@ class Integrator:
     integrator_options = {}
     # Can evolve time dependent system
     support_time_dependant = None
-    # Use the QobjEvo's matmul_data method as the driving function
+    # Whether the integrator used the system QobjEvo as a blackbox
     supports_blackbox = None
-    name = ""
+    # The name of the integrator
+    name = None
 
     def __init__(self, system, options):
         self.system = system
@@ -151,8 +155,7 @@ class Integrator:
             differ from the input time only when ``step=True``.
 
         .. note:
-            Does not need to be implemented it the Integrator does not support
-            :func:`mcsolve`
+            The default implementation may be overridden by integrators that can provide a more efficient one.
         """
         t_last, state = self.get_state()
         if t > t_last:

--- a/qutip/solver/ode/__init__.py
+++ b/qutip/solver/ode/__init__.py
@@ -1,0 +1,1 @@
+from . scipy_integrator import *

--- a/qutip/solver/ode/__init__.py
+++ b/qutip/solver/ode/__init__.py
@@ -1,1 +1,1 @@
-from . scipy_integrator import *
+from .scipy_integrator import *

--- a/qutip/solver/ode/scipy_integrator.py
+++ b/qutip/solver/ode/scipy_integrator.py
@@ -32,7 +32,7 @@ class IntegratorScipyZvode(Integrator):
         'min_step': 0,
     }
     support_time_dependant = True
-    use_QobjEvo_matmul = True
+    supports_blackbox = True
 
     class qutip_zvode(zvode):
         """Overwrite the scipy's zvode to advance to max to ``t`` with step."""
@@ -145,7 +145,7 @@ class IntegratorScipyDop853(Integrator):
         'beta': 0.0,
     }
     support_time_dependant = True
-    use_QobjEvo_matmul = True
+    supports_blackbox = True
 
     def _prepare(self):
         """
@@ -244,7 +244,7 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
         'min_step': 0.0,
     }
     support_time_dependant = True
-    use_QobjEvo_matmul = True
+    supports_blackbox = True
 
     def _prepare(self):
         """

--- a/qutip/solver/ode/scipy_integrator.py
+++ b/qutip/solver/ode/scipy_integrator.py
@@ -63,7 +63,7 @@ class IntegratorScipyZvode(Integrator):
                 inplace=True)
         else:
             state = _data.dense.Dense(self._ode_solver._y, copy=False)
-        return t, state.copy() if copy else state
+        return t, (state.copy() if copy else state)
 
     def integrate(self, t, step=False, copy=True):
         if step:
@@ -199,7 +199,7 @@ class IntegratorScipyDop853(Integrator):
         else:
             state = _data.dense.Dense(self._ode_solver._y.view(np.complex128),
                                       copy=False)
-        return t, state.copy() if copy else state
+        return t, (state.copy() if copy else state)
 
     def set_state(self, t, state0):
         self._mat_state = state0.shape[1] > 1

--- a/qutip/solver/ode/scipy_integrator.py
+++ b/qutip/solver/ode/scipy_integrator.py
@@ -1,0 +1,320 @@
+"""ODE integrator from scipy."""
+
+__all__ = ['IntegratorScipyZvode', 'IntegratorScipyDop853',
+           'IntegratorScipylsoda']
+
+import numpy as np
+from scipy.integrate import ode
+from qutip.core import data as _data
+from qutip.core.data.reshape import column_unstack_dense, column_stack_dense
+from ..integrator import integrator_collection, IntegratorException, Integrator
+import warnings
+
+
+class IntegratorScipyZvode(Integrator):
+    """
+    Integrator using Scipy `ode` with zvode integrator. Ordinary Differential
+    Equation solver by netlib (http://www.netlib.org/odepack). Support 'Adams'
+    and 'BDF' methods for non-stiff and stiff systems respectively.
+    """
+    used_options = ['atol', 'rtol', 'nsteps', 'method', 'order',
+                    'first_step', 'max_step', 'min_step']
+    description = "scipy.integrate.ode using zvode integrator"
+
+    def _prepare(self):
+        """
+        Initialize the solver
+        """
+        self._ode_solver = ode(self._mul_np_vec)
+        opt = {key: self.options.ode[key]
+               for key in self.used_options
+               if key in self.options.ode}
+        self._ode_solver.set_integrator('zvode', **opt)
+        self.name = "scipy zvode " + opt["method"]
+
+    def _mul_np_vec(self, t, vec):
+        """
+        Interface between scipy which use numpy and the driver, which use data.
+        """
+        state = _data.dense.fast_from_numpy(vec)
+        column_unstack_dense(state, self._size, inplace=True)
+        out = _data.dense.zeros(state.shape[0], state.shape[1], state.fortran)
+        out = self.system.matmul_data(t, state, out)
+        column_stack_dense(out, inplace=True)
+        return out.as_ndarray().ravel()
+
+    def set_state(self, t, state0):
+        self._mat_state = state0.shape[1] > 1
+        self._size = state0.shape[0]
+        self._ode_solver.set_initial_value(
+            _data.column_stack(state0).to_array().ravel(),
+            t
+        )
+
+    def get_state(self, copy=True):
+        t = self._ode_solver.t
+        if self._mat_state:
+            state = _data.column_unstack_dense(
+                _data.dense.Dense(self._ode_solver._y, copy=False),
+                self._size,
+                inplace=True)
+        else:
+            state = _data.dense.Dense(self._ode_solver._y, copy=False)
+        return t, state.copy() if copy else state
+
+    def integrate(self, t, step=False, copy=True):
+        if step:
+            self._one_step(t)
+        elif self._ode_solver.t < t:
+            self._ode_solver.integrate(t)
+        elif self._ode_solver.t > t:
+            self._backstep(t)
+        self._check_failed_integration()
+        return self.get_state(copy)
+
+    def _one_step(self, t):
+        """
+        Advance up to t by one internal solver step.
+        Should be able to retreive the state at any time between the present
+        time and the resulting time using `backstep`.
+        """
+        # integrate(t, step=True) ignore the time and advance one step.
+        # Here we want to advance up to t doing maximum one step.
+        # So we check if a new step is really needed.
+        self.back = self.get_state(copy=True)
+        t_front = self._ode_solver._integrator.rwork[12]
+        t_ode = self._ode_solver.t
+        if t > t_front and t_ode >= t_front:
+            # The state is at t_front, do a step
+            self._ode_solver.integrate(t, step=True)
+            t_front = self._ode_solver._integrator.rwork[12]
+        elif t > t_front:
+            # The state is at a time before t_front, advance to t_front
+            t = t_front
+        else:
+            # t is inside the already computed integration range.
+            pass
+        if t_front >= t:
+            self._ode_solver.integrate(t)
+
+    def _backstep(self, t):
+        """
+        Retreive the state at time t, with t smaller than present ODE time.
+        The time t will always be between the last calls of `one_step`.
+        return the pair t, state.
+        """
+        # zvode can integrate with time lower than the most recent time
+        # but not over all the step interval.
+        # About 90% of the last step interval?
+        # Scipy raise a warning, not an Error.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self._ode_solver.integrate(t)
+        if not self._ode_solver.successful():
+            self.set_state(*self.back)
+            self._ode_solver.integrate(t)
+
+    def _check_failed_integration(self):
+        if self._ode_solver.successful():
+            return
+        messages = {
+            -1: 'Excess work done on this call. Try to increasing '
+                'the nsteps parameter in the Options class',
+            -2: 'Excess accuracy requested. (Tolerances too small.)',
+            -3: 'Illegal input detected.',
+            -4: 'Repeated error test failures. (Check all input.)',
+            -5: 'Repeated convergence failures. (Perhaps bad'
+                ' Jacobian supplied or wrong choice of MF or tolerances.)',
+            -6: 'Error weight became zero during problem. (Solution'
+                ' component i vanished, and ATOL or ATOL(i) = 0.)'
+        }
+        raise IntegratorException(messages[self._ode_solver._integrator.istate])
+
+
+class IntegratorScipyDop853(Integrator):
+    """
+    Integrator using Scipy `ode` with dop853 integrator. Eight order
+    runge-kutta method by Dormand & Prince. Use fortran implementation
+    from [E. Hairer, S.P. Norsett and G. Wanner, Solving Ordinary Differential
+    Equations i. Nonstiff Problems. 2nd edition. Springer Series in
+    Computational Mathematics, Springer-Verlag (1993)].
+    """
+    description = "scipy.integrate.ode using dop853 integrator"
+    used_options = ['atol', 'rtol', 'nsteps', 'first_step', 'max_step',
+                    'ifactor', 'dfactor', 'beta']
+
+    def _prepare(self):
+        """
+        Initialize the solver
+        """
+        self._ode_solver = ode(self._mul_np_vec)
+        opt = {key: self.options.ode[key]
+               for key in self.used_options
+               if key in self.options.ode}
+        self._ode_solver.set_integrator('dop853', **opt)
+        self.name = "scipy ode dop853"
+
+    def _mul_np_vec(self, t, vec):
+        """
+        Interface between scipy which use numpy and the driver, which use data.
+        """
+        state = _data.dense.fast_from_numpy(vec.view(np.complex128))
+        column_unstack_dense(state, self._size, inplace=True)
+        out = _data.dense.zeros(state.shape[0], state.shape[1], state.fortran)
+        out = self.system.matmul_data(t, state, out)
+        column_stack_dense(out, inplace=True)
+        return out.as_ndarray().ravel().view(np.float64)
+
+    def integrate(self, t, step=False, copy=True):
+        if step:
+            # Scipy's DOP853 does not have a step function.
+            # It has a safe step lengh, but can be 0 if unknown.
+            dt = self._ode_solver._integrator.work[6]
+            if dt:
+                t = min(self._ode_solver.t + dt, t)
+
+        if self._ode_solver.t > t:
+            # While DOP853 support changing the direction of the integration,
+            # it does not do so efficiently. We do it manually.
+            self._ode_solver._integrator.work[6] *= -1
+            self._ode_solver.integrate(t)
+            self._ode_solver._integrator.work[6] *= -1
+        elif self._ode_solver.t < t:
+            self._ode_solver.integrate(t)
+
+        self._check_failed_integration()
+        return self.get_state(copy)
+
+    def get_state(self, copy=True):
+        t = self._ode_solver.t
+        if self._mat_state:
+            state = _data.column_unstack_dense(
+                _data.dense.Dense(self._ode_solver._y.view(np.complex128),
+                                  copy=False),
+                self._size,
+                inplace=True)
+        else:
+            state = _data.dense.Dense(self._ode_solver._y.view(np.complex128),
+                                      copy=False)
+        return t, state.copy() if copy else state
+
+    def set_state(self, t, state0):
+        self._mat_state = state0.shape[1] > 1
+        self._size = state0.shape[0]
+        self._ode_solver.set_initial_value(
+            _data.column_stack(state0).to_array().ravel().view(np.float64),
+            t
+        )
+
+    def _check_failed_integration(self):
+        if self._ode_solver.successful():
+            return
+        messages = {
+            -1: 'input is not consistent',
+            -2: 'larger nsteps is needed, Try to increase the nsteps '
+                'parameter in the Options class.',
+            -3: 'step size becomes too small. Try increasing tolerance',
+            -4: 'problem is probably stiff (interrupted), try "bdf" '
+                'method instead',
+        }
+        raise IntegratorException(messages[self._ode_solver._integrator.istate])
+
+
+class IntegratorScipylsoda(IntegratorScipyDop853):
+    """
+    Integrator using Scipy `ode` with lsoda integrator. ODE solver by netlib
+    (http://www.netlib.org/odepack) Automatically choose between 'Adams' and
+    'BDF' methods to solve both stiff and non-stiff systems.
+    """
+    used_options = ['atol', 'rtol', 'nsteps', 'max_order_ns', 'max_order_s',
+                    'first_step', 'max_step', 'min_step']
+    description = "scipy.integrate.ode using lsoda integrator"
+
+    def _prepare(self):
+        """
+        Initialize the solver
+        """
+        self._ode_solver = ode(self._mul_np_vec)
+        opt = {key: self.options.ode[key]
+               for key in self.used_options
+               if key in self.options.ode}
+        self._ode_solver.set_integrator('lsoda', **opt)
+        self.name = "scipy lsoda"
+
+    def integrate(self, t, step=False, copy=True):
+        if step:
+            self._one_step(t)
+        elif self._ode_solver.t < t:
+            self._ode_solver.integrate(t)
+        elif self._ode_solver.t > t:
+            self._backstep(t)
+        self._check_failed_integration()
+        return self.get_state(copy)
+
+    def _one_step(self, t):
+        """
+        Advance up to t by one internal solver step.
+        Should be able to retreive the state at any time between the present
+        time and the resulting time using `backstep`.
+        """
+        # integrate(t, step=True) ignore the time and advance one step.
+        # Here we want to advance up to t doing maximum one step.
+        # So we check if a new step is really needed.
+        self.back = self.get_state(copy=True)
+        t_front = self._ode_solver._integrator.rwork[12]
+        t_ode = self._ode_solver.t
+        if t > t_front and t_ode >= t_front:
+            # The state is at t_front, do a step
+            self._ode_solver.integrate(t, step=True)
+            t_front = self._ode_solver._integrator.rwork[12]
+        elif t > t_front:
+            # The state is at a time before t_front, advance to t_front
+            t = t_front
+        else:
+            # t is inside the already computed integration range.
+            pass
+        if t_front >= t:
+            self._ode_solver.integrate(t)
+
+    def _backstep(self, t):
+        """
+        Retreive the state at time t, with t smaller than present ODE time.
+        The time t will always be between the last calls of `one_step`.
+        return the pair t, state.
+        """
+        # like zvode, lsoda can step with time lower than the most recent.
+        # But not all the step interval.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self._ode_solver.integrate(t)
+        if not self._ode_solver.successful():
+            self.set_state(*self.back)
+            self._ode_solver.integrate(t)
+
+    def _check_failed_integration(self):
+        if self._ode_solver.successful():
+            return
+        messages = {
+            -1: "Excess work done on this call."
+                "Try to increase the nsteps parameter in the Options class.",
+            -2: "Excess accuracy requested (tolerances too small).",
+            -3: "Illegal input detected (internal error).",
+            -4: "Repeated error test failures (internal error).",
+            -5: "Repeated convergence failures (perhaps bad Jacobian or tolerances).",
+            -6: "Error weight became zero during problem.",
+            -7: "Internal workspace insufficient to finish (internal error)."
+        }
+        raise IntegratorException(messages[self._ode_solver._integrator.istate])
+
+
+integrator_collection.add_method(IntegratorScipyZvode, keys=['adams', 'bdf'],
+                                 solver=['sesolve', 'mesolve', 'mcsolve'],
+                                 use_QobjEvo_matmul=True, time_dependent=True)
+
+integrator_collection.add_method(IntegratorScipyDop853, keys=['dop853'],
+                                 solver=['sesolve', 'mesolve', 'mcsolve'],
+                                 use_QobjEvo_matmul=True, time_dependent=True)
+
+integrator_collection.add_method(IntegratorScipylsoda, keys=['lsoda'],
+                                 solver=['sesolve', 'mesolve', 'mcsolve'],
+                                 use_QobjEvo_matmul=True, time_dependent=True)

--- a/qutip/solver/ode/scipy_integrator.py
+++ b/qutip/solver/ode/scipy_integrator.py
@@ -56,6 +56,7 @@ class IntegratorScipyZvode(Integrator):
     def get_state(self, copy=True):
         if not self._is_set:
             raise RuntimeError("The state is not initialted")
+        self._check_failed_integration()
         t = self._ode_solver.t
         if self._mat_state:
             state = _data.column_unstack_dense(
@@ -66,14 +67,22 @@ class IntegratorScipyZvode(Integrator):
             state = _data.dense.Dense(self._ode_solver._y, copy=copy)
         return t, state
 
-    def integrate(self, t, step=False, copy=True):
-        if step:
-            self._one_step(t)
-        elif self._ode_solver.t < t:
+    def integrate(self, t, copy=True):
+        if t != self._ode_solver.t:
             self._ode_solver.integrate(t)
-        elif self._ode_solver.t > t:
+        return self.get_state(copy)
+
+    def mcstep(self, t, copy=True):
+        if self._ode_solver.t < t:
+            self._back = self.get_state(copy=True)
+            self._one_step(t)
+        elif self._back[0] <= t:
             self._backstep(t)
-        self._check_failed_integration()
+        else:
+            raise IntegratorException(
+                "`t` is outside the integration range: "
+                f"{self._back[0]}..{self._ode_solver.t}."
+            )
         return self.get_state(copy)
 
     def _one_step(self, t):
@@ -82,10 +91,8 @@ class IntegratorScipyZvode(Integrator):
         Should be able to retreive the state at any time between the present
         time and the resulting time using `backstep`.
         """
-        # integrate(t, step=True) ignore the time and advance one step.
         # Here we want to advance up to t doing maximum one step.
-        # So we check if a new step is really needed.
-        self._back = self.get_state(copy=True)
+        # We check if a new step is needed.
         t_front = self._ode_solver._integrator.rwork[12]
         t_ode = self._ode_solver.t
         if t > t_front and t_ode >= t_front:
@@ -111,11 +118,6 @@ class IntegratorScipyZvode(Integrator):
         # but not over all the step interval.
         # About 90% of the last step interval?
         # Scipy raise a warning, not an Error.
-        t_prev, _ = self._back
-        if t < t_prev:
-            raise IntegratorException(
-                "Cannot integrate to previous times without using integrate "
-                "with step=True first.")
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self._ode_solver.integrate(t)
@@ -137,7 +139,9 @@ class IntegratorScipyZvode(Integrator):
             -6: 'Error weight became zero during problem. (Solution'
                 ' component i vanished, and ATOL or ATOL(i) = 0.)'
         }
-        raise IntegratorException(messages[self._ode_solver._integrator.istate])
+        raise IntegratorException(
+            messages[self._ode_solver._integrator.istate]
+        )
 
 
 class IntegratorScipyDop853(Integrator):
@@ -171,29 +175,31 @@ class IntegratorScipyDop853(Integrator):
         column_stack_dense(out, inplace=True)
         return out.as_ndarray().ravel().view(np.float64)
 
-    def integrate(self, t, step=False, copy=True):
-        if step:
+    def integrate(self, t, copy=True):
+        if t != self._ode_solver.t:
+            self._ode_solver.integrate(t)
+        return self.get_state(copy)
+
+    def mcstep(self, t, copy=True):
+        if self._ode_solver.t <= t:
             # Scipy's DOP853 does not have a step function.
             # It has a safe step lengh, but can be 0 if unknown.
             dt = self._ode_solver._integrator.work[6]
             if dt:
                 t = min(self._ode_solver.t + dt, t)
-
-        if self._ode_solver.t > t:
+            self._ode_solver.integrate(t)
+        else:
             # While DOP853 support changing the direction of the integration,
             # it does not do so efficiently. We do it manually.
             self._ode_solver._integrator.work[6] *= -1
             self._ode_solver.integrate(t)
             self._ode_solver._integrator.work[6] *= -1
-        elif self._ode_solver.t < t:
-            self._ode_solver.integrate(t)
-
-        self._check_failed_integration()
         return self.get_state(copy)
 
     def get_state(self, copy=True):
         if not self._is_set:
             raise RuntimeError("The state is not initialted")
+        self._check_failed_integration()
         t = self._ode_solver.t
         if self._mat_state:
             state = _data.column_unstack_dense(
@@ -229,7 +235,7 @@ class IntegratorScipyDop853(Integrator):
         raise IntegratorException(messages[self._ode_solver._integrator.istate])
 
 
-class IntegratorScipylsoda(IntegratorScipyDop853):
+class IntegratorScipylsoda(IntegratorScipyZvode):
     """
     Integrator using Scipy `ode` with lsoda integrator. ODE solver by netlib
     (http://www.netlib.org/odepack) Automatically choose between 'Adams' and
@@ -249,60 +255,40 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
         self.name = "scipy lsoda"
         self._back = (np.inf, None)
 
-    def integrate(self, t, step=False, copy=True):
-        if step:
-            self._one_step(t)
-        elif self._ode_solver.t < t:
-            self._ode_solver.integrate(t)
-        elif self._ode_solver.t > t:
-            self._backstep(t)
+    def _mul_np_vec(self, t, vec):
+        """
+        Interface between scipy which use numpy and the driver, which use data.
+        """
+        state = _data.dense.fast_from_numpy(vec.view(np.complex128))
+        column_unstack_dense(state, self._size, inplace=True)
+        out = self.system.matmul_data(t, state)
+        column_stack_dense(out, inplace=True)
+        return out.as_ndarray().ravel().view(np.float64)
+
+    def get_state(self, copy=True):
+        if not self._is_set:
+            raise RuntimeError("The state is not initialted")
         self._check_failed_integration()
-        return self.get_state(copy)
-
-    def _one_step(self, t):
-        """
-        Advance up to t by one internal solver step.
-        Should be able to retreive the state at any time between the present
-        time and the resulting time using `backstep`.
-        """
-        # integrate(t, step=True) ignore the time and advance one step.
-        # Here we want to advance up to t doing maximum one step.
-        # So we check if a new step is really needed.
-        self._back = self.get_state(copy=True)
-        t_front = self._ode_solver._integrator.rwork[12]
-        t_ode = self._ode_solver.t
-        if t > t_front and t_ode >= t_front:
-            # The state is at t_front, do a step
-            self._ode_solver.integrate(t, step=True)
-            t_front = self._ode_solver._integrator.rwork[12]
-        elif t > t_front:
-            # The state is at a time before t_front, advance to t_front
-            t = t_front
+        t = self._ode_solver.t
+        if self._mat_state:
+            state = _data.column_unstack_dense(
+                _data.dense.Dense(self._ode_solver._y.view(np.complex128),
+                                  copy=copy),
+                self._size,
+                inplace=True)
         else:
-            # t is inside the already computed integration range.
-            pass
-        if t_front >= t:
-            self._ode_solver.integrate(t)
+            state = _data.dense.Dense(self._ode_solver._y.view(np.complex128),
+                                      copy=copy)
+        return t, state
 
-    def _backstep(self, t):
-        """
-        Retreive the state at time t, with t smaller than present ODE time.
-        The time t will always be between the last calls of `one_step`.
-        return the pair t, state.
-        """
-        # like zvode, lsoda can step with time lower than the most recent.
-        # But not all the step interval.
-        t_prev, _ = self._back
-        if t < t_prev:
-            raise IntegratorException(
-                "Cannot integrate to previous times without using integrate "
-                "with step=True first.")
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            self._ode_solver.integrate(t)
-        if not self._ode_solver.successful():
-            self.set_state(*self._back)
-            self._ode_solver.integrate(t)
+    def set_state(self, t, state0):
+        self._is_set = True
+        self._mat_state = state0.shape[1] > 1
+        self._size = state0.shape[0]
+        self._ode_solver.set_initial_value(
+            _data.column_stack(state0).to_array().ravel().view(np.float64),
+            t
+        )
 
     def _check_failed_integration(self):
         if self._ode_solver.successful():
@@ -313,15 +299,21 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
             -2: "Excess accuracy requested (tolerances too small).",
             -3: "Illegal input detected (internal error).",
             -4: "Repeated error test failures (internal error).",
-            -5: "Repeated convergence failures (perhaps bad Jacobian or tolerances).",
+            -5: "Repeated convergence failures "
+                "(perhaps bad Jacobian or tolerances).",
             -6: "Error weight became zero during problem.",
             -7: "Internal workspace insufficient to finish (internal error)."
         }
-        raise IntegratorException(messages[self._ode_solver._integrator.istate])
+        raise IntegratorException(
+            messages[self._ode_solver._integrator.istate]
+        )
 
 
 sets = [sesolve_integrators, mesolve_integrators, mcsolve_integrators]
 for integrator_set in sets:
-    add_integrator(IntegratorScipyZvode, ['adams', 'bdf'], integrator_set, SolverOdeOptions)
-    add_integrator(IntegratorScipyDop853, ['dop853'], integrator_set, SolverOdeOptions)
-    add_integrator(IntegratorScipylsoda, ['lsoda'], integrator_set, SolverOdeOptions)
+    add_integrator(IntegratorScipyZvode, ['adams', 'bdf'],
+                   integrator_set, SolverOdeOptions)
+    add_integrator(IntegratorScipyDop853, ['dop853'],
+                   integrator_set, SolverOdeOptions)
+    add_integrator(IntegratorScipylsoda, ['lsoda'],
+                   integrator_set, SolverOdeOptions)

--- a/qutip/solver/ode/scipy_integrator.py
+++ b/qutip/solver/ode/scipy_integrator.py
@@ -30,11 +30,8 @@ class IntegratorScipyZvode(Integrator):
         Initialize the solver
         """
         self._ode_solver = ode(self._mul_np_vec)
-        opt = {key: self.options.ode[key]
-               for key in self.used_options
-               if key in self.options.ode}
-        self._ode_solver.set_integrator('zvode', **opt)
-        self.name = "scipy zvode " + opt["method"]
+        self._ode_solver.set_integrator('zvode', **self.options)
+        self.name = "scipy zvode " + self.options['method']
 
     def _mul_np_vec(self, t, vec):
         """
@@ -155,10 +152,7 @@ class IntegratorScipyDop853(Integrator):
         Initialize the solver
         """
         self._ode_solver = ode(self._mul_np_vec)
-        opt = {key: self.options.ode[key]
-               for key in self.used_options
-               if key in self.options.ode}
-        self._ode_solver.set_integrator('dop853', **opt)
+        self._ode_solver.set_integrator('dop853', **self.options)
         self.name = "scipy ode dop853"
 
     def _mul_np_vec(self, t, vec):
@@ -245,10 +239,7 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
         Initialize the solver
         """
         self._ode_solver = ode(self._mul_np_vec)
-        opt = {key: self.options.ode[key]
-               for key in self.used_options
-               if key in self.options.ode}
-        self._ode_solver.set_integrator('lsoda', **opt)
+        self._ode_solver.set_integrator('lsoda', **self.options)
         self.name = "scipy lsoda"
 
     def integrate(self, t, step=False, copy=True):

--- a/qutip/solver/ode/scipy_integrator.py
+++ b/qutip/solver/ode/scipy_integrator.py
@@ -47,6 +47,7 @@ class IntegratorScipyZvode(Integrator):
         return out.as_ndarray().ravel()
 
     def set_state(self, t, state0):
+        self._is_set = True
         self._mat_state = state0.shape[1] > 1
         self._size = state0.shape[0]
         self._ode_solver.set_initial_value(
@@ -55,6 +56,8 @@ class IntegratorScipyZvode(Integrator):
         )
 
     def get_state(self, copy=True):
+        if not self._is_set:
+            raise RuntimeError("The state is not initialted")
         t = self._ode_solver.t
         if self._mat_state:
             state = _data.column_unstack_dense(
@@ -189,6 +192,8 @@ class IntegratorScipyDop853(Integrator):
         return self.get_state(copy)
 
     def get_state(self, copy=True):
+        if not self._is_set:
+            raise RuntimeError("The state is not initialted")
         t = self._ode_solver.t
         if self._mat_state:
             state = _data.column_unstack_dense(
@@ -202,6 +207,7 @@ class IntegratorScipyDop853(Integrator):
         return t, (state.copy() if copy else state)
 
     def set_state(self, t, state0):
+        self._is_set = True
         self._mat_state = state0.shape[1] > 1
         self._size = state0.shape[0]
         self._ode_solver.set_initial_value(

--- a/qutip/solver/ode/scipy_integrator.py
+++ b/qutip/solver/ode/scipy_integrator.py
@@ -42,8 +42,7 @@ class IntegratorScipyZvode(Integrator):
         """
         state = _data.dense.fast_from_numpy(vec)
         column_unstack_dense(state, self._size, inplace=True)
-        out = _data.dense.zeros(state.shape[0], state.shape[1], state.fortran)
-        out = self.system.matmul_data(t, state, out)
+        out = self.system.matmul_data(t, state)
         column_stack_dense(out, inplace=True)
         return out.as_ndarray().ravel()
 
@@ -165,8 +164,7 @@ class IntegratorScipyDop853(Integrator):
         """
         state = _data.dense.fast_from_numpy(vec.view(np.complex128))
         column_unstack_dense(state, self._size, inplace=True)
-        out = _data.dense.zeros(state.shape[0], state.shape[1], state.fortran)
-        out = self.system.matmul_data(t, state, out)
+        out = self.system.matmul_data(t, state)
         column_stack_dense(out, inplace=True)
         return out.as_ndarray().ravel().view(np.float64)
 
@@ -311,6 +309,7 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
             -7: "Internal workspace insufficient to finish (internal error)."
         }
         raise IntegratorException(messages[self._ode_solver._integrator.istate])
+
 
 sets = [sesolve_integrators, mesolve_integrators, mcsolve_integrators]
 for integrator_set in sets:

--- a/qutip/solver/ode/scipy_integrator.py
+++ b/qutip/solver/ode/scipy_integrator.py
@@ -34,7 +34,7 @@ class IntegratorScipyZvode(Integrator):
     support_time_dependant = True
     supports_blackbox = True
 
-    class qutip_zvode(zvode):
+    class _zvode(zvode):
         """Overwrite the scipy's zvode to advance to max to ``t`` with step."""
         def step(self, *args):
             itask = self.call_args[2]
@@ -50,7 +50,7 @@ class IntegratorScipyZvode(Integrator):
         """
         self._ode_solver = ode(self._mul_np_vec)
         self._ode_solver.set_integrator('zvode')
-        self._ode_solver._integrator = self.qutip_zvode(**self.options)
+        self._ode_solver._integrator = self._zvode(**self.options)
         self.name = "scipy zvode " + self.options['method']
 
     def _mul_np_vec(self, t, vec):

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -1,7 +1,6 @@
 from qutip.solver.integrator import (sesolve_integrators,
                                      mesolve_integrators, mcsolve_integrators)
 from qutip.solver.options import SolverOptions
-from qutip.core import QobjEvo, liouvillian
 import qutip
 import numpy as np
 from numpy.testing import assert_allclose

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -1,0 +1,120 @@
+from qutip.solver.integrator import *
+from qutip.solver.options import SolverOptions
+from qutip.core import QobjEvo, liouvillian
+import qutip as qt
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+
+def id_from_keys(keys):
+    if keys[1] == "":
+        return keys[0]
+    else:
+        return keys[0] + "_" + keys[1]
+
+
+class TestIntegratorCte():
+    _analytical_se = lambda _, t: np.cos(t * np.pi)
+    se_system = QobjEvo(-1j * qt.sigmax() * np.pi)
+    _analytical_me = lambda _, t: 1 - np.exp(-t)
+    me_system = liouvillian(QobjEvo(qt.qeye(2)), c_ops=[qt.destroy(2)])
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="sesolve"),
+        ids=id_from_keys
+    )
+    def se_keys(self, request):
+        return request.param
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="mesolve"),
+        ids=id_from_keys
+    )
+    def me_keys(self, request):
+        return request.param
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="mcsolve"),
+        ids=id_from_keys
+    )
+    def mc_keys(self, request):
+        return request.param
+
+    def test_se_integration(self, se_keys):
+        method, rhs = se_keys
+        opt = SolverOptions(method=method, rhs=rhs)
+        evol = integrator_collection[method, rhs](self.se_system, opt)
+        state0 = qt.core.unstack_columns(qt.basis(6,0).data, (2, 3))
+        evol.set_state(0, state0)
+        for t, state in evol.run(np.linspace(0, 2, 21)):
+            assert_allclose(self._analytical_se(t),
+                            state.to_array()[0, 0], atol=2e-5)
+            assert state.shape == (2, 3)
+
+    def test_me_integration(self, me_keys):
+        method, rhs = me_keys
+        opt = SolverOptions(method=method, rhs=rhs)
+        evol = integrator_collection[method, rhs](self.me_system, opt)
+        state0 = qt.operator_to_vector(qt.fock_dm(2,1)).data
+        evol.set_state(0, state0)
+        for t in np.linspace(0, 2, 21):
+            t_, state = evol.integrate(t)
+            assert t_ == t
+            assert_allclose(self._analytical_me(t),
+                            state.to_array()[0, 0], atol=2e-5)
+
+    def test_mc_integration(self, mc_keys):
+        method, rhs = mc_keys
+        opt = SolverOptions(method=method, rhs=rhs)
+        evol = integrator_collection[method, rhs](self.se_system, opt)
+        state = qt.basis(2,0).data
+        evol.set_state(0, state)
+        t = 0
+        for i in range(1, 21):
+            t_target = i * 0.05
+            while t < t_target:
+                t_old, y_old = evol.get_state()
+                t, state = evol.integrate(t_target, step=True)
+                assert t <= t_target
+                assert t > t_old
+                assert_allclose(self._analytical_se(t),
+                                state.to_array()[0, 0], atol=2e-5)
+                t_back = (t + t_old) / 2
+                t_got, bstate = evol.integrate(t_back)
+                assert t_back == t_got
+                assert_allclose(self._analytical_se(t),
+                                state.to_array()[0, 0], atol=2e-5)
+                t, state = evol.integrate(t)
+
+
+class TestIntegrator(TestIntegratorCte):
+    _analytical_se = lambda _, t: np.cos(t**2/2 * np.pi)
+    se_system = QobjEvo([-1j * qt.sigmax() * np.pi, "t"])
+    _analytical_me = lambda _, t: 1 - np.exp(-(t**3) / 3)
+    me_system = liouvillian(QobjEvo(qt.qeye(2)),
+                            c_ops=[QobjEvo([qt.destroy(2), 't'])])
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="sesolve",
+                                                time_dependent=True),
+        ids=id_from_keys
+    )
+    def se_keys(self, request):
+        return request.param
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="mesolve",
+                                                time_dependent=True),
+        ids=id_from_keys
+    )
+    def me_keys(self, request):
+        return request.param
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="mcsolve",
+                                                time_dependent=True),
+        ids=id_from_keys
+    )
+    def mc_keys(self, request):
+        return request.param

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -1,6 +1,6 @@
 from qutip.solver.integrator import (sesolve_integrators,
                                      mesolve_integrators, mcsolve_integrators)
-from qutip.solver.options import SolverOptions
+from qutip.solver.options import SolverOdeOptions
 import qutip
 import numpy as np
 from numpy.testing import assert_allclose
@@ -27,7 +27,7 @@ class TestIntegratorCte():
         return request.param
 
     def test_se_integration(self, se_method):
-        opt = SolverOptions(method=se_method)
+        opt = SolverOdeOptions(method=se_method)
         evol = sesolve_integrators[se_method](self.se_system, opt)
         state0 = qutip.core.unstack_columns(qutip.basis(6,0).data, (2, 3))
         evol.set_state(0, state0)
@@ -37,7 +37,7 @@ class TestIntegratorCte():
             assert state.shape == (2, 3)
 
     def test_me_integration(self, me_method):
-        opt = SolverOptions(method=me_method)
+        opt = SolverOdeOptions(method=me_method)
         evol = mesolve_integrators[me_method](self.me_system, opt)
         state0 = qutip.operator_to_vector(qutip.fock_dm(2,1)).data
         evol.set_state(0, state0)
@@ -48,7 +48,7 @@ class TestIntegratorCte():
                             state.to_array()[0, 0], atol=2e-5)
 
     def test_mc_integration(self, mc_method):
-        opt = SolverOptions(method=mc_method)
+        opt = SolverOdeOptions(method=mc_method)
         evol = mcsolve_integrators[mc_method](self.se_system, opt)
         state = qutip.basis(2,0).data
         evol.set_state(0, state)

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -57,17 +57,17 @@ class TestIntegratorCte():
             t_target = i * 0.05
             while t < t_target:
                 t_old, y_old = evol.get_state()
-                t, state = evol.integrate(t_target, step=True)
+                t, state = evol.mcstep(t_target)
                 assert t <= t_target
                 assert t > t_old
                 assert_allclose(self._analytical_se(t),
                                 state.to_array()[0, 0], atol=2e-5)
                 t_back = (t + t_old) / 2
-                t_got, bstate = evol.integrate(t_back)
+                t_got, bstate = evol.mcstep(t_back)
                 assert t_back == t_got
                 assert_allclose(self._analytical_se(t),
                                 state.to_array()[0, 0], atol=2e-5)
-                t, state = evol.integrate(t)
+                t, state = evol.mcstep(t)
 
 
 class TestIntegrator(TestIntegratorCte):


### PR DESCRIPTION
Introduce a common ODE integrator interface for qutip's solver.

Presently qutip's solver use `scipy.integratre.ode`'s zvode ODE solver, which support `adams` and `bdf` methods.
These are great method in most case, but not always optimal.
This PR introduce, a common interface to allow other ODE method to be used by solvers.
It also add 2 new scipy ODE solvers: `lsoda` and `dop853`.
`lsoda` detect if the system is stiff and switch between `adams` and `bdf`.
`dop853` is a 8th order Runge-Kutta method.

The `Integrator` use `Data` as state and return the state as a pair `(t, state)`.
Often solver's run only compute the expectation values, so there is no need to create a `Qobj`.
Returning the time with the state is for `mcsolve` which have the integration advancing with one internal step and the run loop is cleaner in solver. 

I did some benchmark and `adams` method is often the best scipy method.
Sparse system: loglog plot of time in function of system size.
![image](https://user-images.githubusercontent.com/17770236/131005186-aa51aa86-8ecf-4c03-8ba4-eeddcd65af30.png)

Dense time-dependent system.
![image](https://user-images.githubusercontent.com/17770236/131005465-5c0a9e8e-9ec7-4409-8cda-70aab5129e1f.png)

*`vern7`, `vern9`, and `diag` method will be introduced in another PR.
