### PR TITLE
Fix test_interpolate mcsolve use.

### DIFF
--- a/qutip/tests/test_interpolate.py
+++ b/qutip/tests/test_interpolate.py
@@ -78,7 +78,7 @@ def _parametrize_solver_coefficients(metafunc):
     """
     size = 10
     times = np.linspace(0, 5, 50)
-    c_ops = [qutip.qzero(size)]
+    c_ops = [qutip.qeye(size)]
     solvers = [
         (qutip.sesolve, 'sesolve'),
         (functools.partial(qutip.mesolve, c_ops=c_ops), 'mesolve'),


### PR DESCRIPTION
In `test_interpolate`, `qzero` was used as `mcsolve`'s collapse operator. Due to numerical error in the interpolation method, `mcsolve` can detect a collapse, but a collapse for a null operator cause a a division by zero. This sometime made our tests fails.

By changing the collapse operator to `qeye`, the evolution, thus the test is unaffected, but it no longer randomly fail.
