### PR TITLE
Add operator support between Data types

### DIFF
--- a/qutip/core/data/base.pyx
+++ b/qutip/core/data/base.pyx
@@ -2,6 +2,7 @@
 
 import numpy as np
 cimport numpy as cnp
+import qutip.core.data as _data
 
 __all__ = [
     'idxint_dtype', 'Data', 'EfficiencyWarning',
@@ -33,6 +34,50 @@ cdef class Data:
 
     cpdef Data copy(self):
         raise NotImplementedError
+
+    def __add__(left, right):
+        if isinstance(left, Data) and isinstance(right, Data):
+            return _data.add(left, right)
+        return NotImplemented
+
+    def __sub__(left, right):
+        if isinstance(left, Data) and isinstance(right, Data):
+            return _data.sub(left, right)
+        return NotImplemented
+
+    def __matmul__(left, right):
+        if isinstance(left, Data) and isinstance(right, Data):
+            return _data.matmul(left, right)
+        return NotImplemented
+
+    def __mul__(left, right):
+        data, number = (left, right) if isinstance(left, Data) else (right, left)
+        try:
+            return _data.mul(data, number)
+        except TypeError:
+            return NotImplemented
+
+    def __imul__(self, other):
+        try:
+            return _data.imul(self, other)
+        except TypeError:
+            return NotImplemented
+
+    def __truediv__(left, right):
+        data, number = (left, right) if isinstance(left, Data) else (right, left)
+        try:
+            return _data.mul(data, 1/number)
+        except TypeError:
+            return NotImplemented
+
+    def __itruediv__(self, other):
+        try:
+            return _data.imul(self, 1/other)
+        except TypeError:
+            return NotImplemented
+
+    def __neg__(self):
+        return _data.neg(self)
 
 
 class EfficiencyWarning(Warning):

--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -232,12 +232,12 @@ cdef class CSR(base.Data):
 
     def __add__(left, right):
         if not isinstance(left, CSR) or not isinstance(right, CSR):
-            return NotImplemented
+            return base.Data.__add__(left, right)
         return add_csr(left, right)
 
     def __matmul__(left, right):
         if not isinstance(left, CSR) or not isinstance(right, CSR):
-            return NotImplemented
+            return base.Data.__matmul__(left, right)
         return matmul_csr(left, right)
 
     def __mul__(left, right):
@@ -276,7 +276,7 @@ cdef class CSR(base.Data):
 
     def __sub__(left, right):
         if not isinstance(left, CSR) or not isinstance(right, CSR):
-            return NotImplemented
+            return base.Data.__sub__(left, right)
         return sub_csr(left, right)
 
     cpdef double complex trace(self):

--- a/qutip/core/data/dense.pyx
+++ b/qutip/core/data/dense.pyx
@@ -209,12 +209,12 @@ cdef class Dense(base.Data):
 
     def __add__(left, right):
         if not isinstance(left, Dense) or not isinstance(right, Dense):
-            return NotImplemented
+            return base.Data.__add__(left, right)
         return add_dense(left, right)
 
     def __matmul__(left, right):
         if not isinstance(left, Dense) or not isinstance(right, Dense):
-            return NotImplemented
+            return base.Data.__matmul__(left, right)
         return matmul_dense(left, right)
 
     def __mul__(left, right):
@@ -253,7 +253,7 @@ cdef class Dense(base.Data):
 
     def __sub__(left, right):
         if not isinstance(left, Dense) or not isinstance(right, Dense):
-            return NotImplemented
+            return base.Data.__sub__(left, right)
         return sub_dense(left, right)
 
     def __dealloc__(self):

--- a/qutip/tests/core/data/test_operators.py
+++ b/qutip/tests/core/data/test_operators.py
@@ -1,0 +1,71 @@
+import pytest
+import numpy
+import qutip
+from qutip.core import data as _data
+
+
+@pytest.mark.parametrize('type_left', _data.to.dtypes)
+@pytest.mark.parametrize('type_right', _data.to.dtypes)
+@pytest.mark.parametrize(['operator', 'dispatch'], [
+    pytest.param(lambda left, right: left + right, _data.add, id="add"),
+    pytest.param(lambda left, right: left - right, _data.sub, id="sub"),
+    pytest.param(lambda left, right: left @ right, _data.matmul, id="matmul"),
+])
+def test_data_binary_operator(type_left, type_right, operator, dispatch):
+    left = qutip.rand_dm(5, dtype=type_left).data
+    right = qutip.rand_dm(5, dtype=type_right).data
+    numpy.testing.assert_allclose(
+        operator(left, right).to_array(),
+        dispatch(left, right).to_array(),
+        rtol=1e-15
+    )
+
+
+@pytest.mark.parametrize('type_', _data.to.dtypes)
+@pytest.mark.parametrize(['operator', 'dispatch'], [
+    pytest.param(lambda data, number: data * number, _data.mul, id="mul"),
+    pytest.param(lambda data, number: number * data, _data.mul, id="rmul"),
+    pytest.param(lambda data, number: data / number,
+                 lambda data, number: _data.mul(data, 1/number), id="div"),
+])
+def test_data_unitary_operator(type_, operator, dispatch):
+    data = qutip.qeye(2, dtype=type_).data
+    number = 3
+    numpy.testing.assert_allclose(
+        operator(data, number).to_array(),
+        dispatch(data, number).to_array(),
+        rtol=1e-15
+    )
+
+
+def imul(data, number):
+    data *= number
+
+
+def idiv(data, number):
+    data /= number
+
+
+@pytest.mark.parametrize('type_', _data.to.dtypes)
+@pytest.mark.parametrize(['operator', 'dispatch'], [
+    pytest.param(imul, _data.mul, id="imul"),
+    pytest.param(idiv, lambda data, num: _data.mul(data, 1/num), id="idiv"),
+])
+def test_data_inplace_operator(type_, operator, dispatch):
+    data = qutip.qeye(2, dtype=type_).data
+    data_copy = data.copy()
+    number = 3
+    operator(data, number)
+    numpy.testing.assert_allclose(
+        data.to_array(),
+        dispatch(data_copy, number).to_array(),
+        rtol=1e-15
+    )
+
+
+@pytest.mark.parametrize('type_', _data.to.dtypes)
+def test_data_neg_operator(type_):
+    data = qutip.qeye(2, dtype=type_).data
+    numpy.testing.assert_allclose(
+        (-data).to_array(), -data.to_array(), rtol=1e-15
+    )


### PR DESCRIPTION
Doing  #1646, I saw that we use operator between data object in code where types are not strictly checked. We may have other test working only because we do test mostly in `CSR`... 

This PR add operators support between data-layer. This will help clean the code:
`_data.matmul(_data.matmul(A, B), C)` vs `A @ B @ C`.
and it will reduce the risk of them being used in functions where we expect, but don't check, that all data object are of the same type. 

It is added in `base.Data` so any new data-layer will have operators working without having to create them. It use the dispatched function of `add`, `sub`, `matmul`, `mul`, `imul`, and `neg`. But it has the side effect that operators can change the type if the specialization does not exist.

@jakelishman, is this something you though of but choose not to do?


