### PR TITLE
Close matplotlib figure windows cleanly in tests.

### DIFF
--- a/qutip/tests/test_processor.py
+++ b/qutip/tests/test_processor.py
@@ -142,8 +142,10 @@ class TestCircuitProcessor:
         processor.add_control(sigmaz())
         processor.pulses[0].tlist = tlist
         processor.pulses[0].coeff = np.array([np.sin(t) for t in tlist])
-        processor.plot_pulses()
-        plt.clf()
+        fig, _ = processor.plot_pulses()
+        # testing under Xvfb with pytest-xvfb complains if figure windows are
+        # left open, so we politely close it:
+        plt.close(fig)
 
         # cubic spline
         tlist = np.linspace(0., 2*np.pi, 20)
@@ -151,8 +153,10 @@ class TestCircuitProcessor:
         processor.add_control(sigmaz())
         processor.pulses[0].tlist = tlist
         processor.pulses[0].coeff = np.array([np.sin(t) for t in tlist])
-        processor.plot_pulses()
-        plt.clf()
+        fig, _ = processor.plot_pulses()
+        # testing under Xvfb with pytest-xvfb complains if figure windows are
+        # left open, so we politely close it:
+        plt.close(fig)
 
     def testSpline(self):
         """


### PR DESCRIPTION
Close figure plots explicitly during tests so that the test suite passes when run headless under Xvfb.

**Related issues or PRs**
* fixes #1639
* see https://github.com/The-Compiler/pytest-xvfb/issues/11 for the discussion of this situation when using pytest-xvfb

**Changelog**
Close figure plots explicitly during tests so that the test suite passes when run headless under Xvfb.
