### PR TITLE
Remove operator in data-layers

### DIFF
--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -224,61 +224,6 @@ cdef class CSR(base.Data):
             sort.inplace(self, ptr, diff)
         return self
 
-    # Beware: before Cython 3, mathematical operator overrides follow the C
-    # API, _not_ the Python one.  This means the first argument is _not_
-    # guaranteed to be `self`, and methods like `__rmul__` don't exist.  This
-    # does not affect in place operations like `__imul__`, since we can always
-    # guarantee the one on the left is `self`.
-
-    def __add__(left, right):
-        if not isinstance(left, CSR) or not isinstance(right, CSR):
-            return NotImplemented
-        return add_csr(left, right)
-
-    def __matmul__(left, right):
-        if not isinstance(left, CSR) or not isinstance(right, CSR):
-            return NotImplemented
-        return matmul_csr(left, right)
-
-    def __mul__(left, right):
-        csr, number = (left, right) if isinstance(left, CSR) else (right, left)
-        if not isinstance(number, numbers.Number):
-            return NotImplemented
-        return mul_csr(csr, complex(number))
-
-    def __imul__(self, other):
-        if not isinstance(other, numbers.Number):
-            return NotImplemented
-        cdef int nnz_ = nnz(self)
-        cdef double complex mul = other
-        blas.zscal(&nnz_, &mul, self.data, &_ONE)
-        return self
-
-    def __truediv__(left, right):
-        csr, number = (left, right) if isinstance(left, CSR) else (right, left)
-        if not isinstance(number, numbers.Number):
-            return NotImplemented
-        # Technically `(1 / x) * y` doesn't necessarily equal `y / x` in
-        # floating point, but multiplication is faster than division, and we
-        # don't really care _that_ much anyway.
-        return mul_csr(csr, 1 / complex(number))
-
-    def __itruediv__(self, other):
-        if not isinstance(other, numbers.Number):
-            return NotImplemented
-        cdef int nnz_ = nnz(self)
-        cdef double complex mul = 1 / other
-        blas.zscal(&nnz_, &mul, self.data, &_ONE)
-        return self
-
-    def __neg__(self):
-        return neg_csr(self)
-
-    def __sub__(left, right):
-        if not isinstance(left, CSR) or not isinstance(right, CSR):
-            return NotImplemented
-        return sub_csr(left, right)
-
     cpdef double complex trace(self):
         return trace_csr(self)
 

--- a/qutip/core/data/dense.pyx
+++ b/qutip/core/data/dense.pyx
@@ -207,55 +207,6 @@ cdef class Dense(base.Data):
     cpdef Dense transpose(self):
         return transpose_dense(self)
 
-    def __add__(left, right):
-        if not isinstance(left, Dense) or not isinstance(right, Dense):
-            return NotImplemented
-        return add_dense(left, right)
-
-    def __matmul__(left, right):
-        if not isinstance(left, Dense) or not isinstance(right, Dense):
-            return NotImplemented
-        return matmul_dense(left, right)
-
-    def __mul__(left, right):
-        dense, number = (left, right) if isinstance(left, Dense) else (right, left)
-        if not isinstance(number, numbers.Number):
-            return NotImplemented
-        return mul_dense(dense, complex(number))
-
-    def __imul__(self, other):
-        if not isinstance(other, numbers.Number):
-            return NotImplemented
-        cdef int size = self.shape[0]*self.shape[1]
-        cdef double complex mul = complex(other)
-        blas.zscal(&size, &mul, self.data, &_ONE)
-        return self
-
-    def __truediv__(left, right):
-        dense, number = (left, right) if isinstance(left, Dense) else (right, left)
-        if not isinstance(number, numbers.Number):
-            return NotImplemented
-        # Technically `(1 / x) * y` doesn't necessarily equal `y / x` in
-        # floating point, but multiplication is faster than division, and we
-        # don't really care _that_ much anyway.
-        return mul_dense(dense, 1 / complex(number))
-
-    def __itruediv__(self, other):
-        if not isinstance(other, numbers.Number):
-            return NotImplemented
-        cdef int size = self.shape[0]*self.shape[1]
-        cdef double complex mul = 1 / complex(other)
-        blas.zscal(&size, &mul, self.data, &_ONE)
-        return self
-
-    def __neg__(self):
-        return neg_dense(self)
-
-    def __sub__(left, right):
-        if not isinstance(left, Dense) or not isinstance(right, Dense):
-            return NotImplemented
-        return sub_dense(left, right)
-
     def __dealloc__(self):
         if self._deallocate and self.data != NULL:
             PyDataMem_FREE(self.data)

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -161,12 +161,12 @@ shape = [3, 3], type = oper, isHerm = True
         return Qobj(_jplus(j, dtype=dtype).adjoint(), dims=dims, type='oper',
                     isherm=False, isunitary=False, copy=False)
     if which == 'x':
-        A = 0.5 * _jplus(j, dtype=dtype)
-        return Qobj(A + A.adjoint(), dims=dims, type='oper',
-                    isherm=True, isunitary=False, copy=False)
+        A =  _jplus(j, dtype=dtype)
+        return Qobj(_data.add(A, A.adjoint()), dims=dims, type='oper',
+                    isherm=True, isunitary=False, copy=False) * 0.5
     if which == 'y':
-        A = -0.5j * _jplus(j, dtype=dtype)
-        return Qobj(A + A.adjoint(), dims=dims, type='oper',
+        A =  _data.mul(_jplus(j, dtype=dtype), -0.5j)
+        return Qobj(_data.add(A, A.adjoint()), dims=dims, type='oper',
                     isherm=True, isunitary=False, copy=False)
     if which == 'z':
         return Qobj(_jz(j, dtype=dtype), dims=dims, type='oper',

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -482,8 +482,8 @@ class Qobj:
         if isinstance(other, Qobj):
             return self.__matmul__(other)
 
-        # We send other to mul instead of complex(other) to be more flexible. 
-        # The dispatcher can then decide how to handle other and return 
+        # We send other to mul instead of complex(other) to be more flexible.
+        # The dispatcher can then decide how to handle other and return
         # TypeError if it does not know what to do with the type of other.
         try:
             out = _data.mul(self._data, other)
@@ -847,7 +847,7 @@ class Qobj:
             raise TypeError('purity is only defined for states.')
         if self.isket or self.isbra:
             return _data.norm.l2(self.data)**2
-        return _data.trace(self.data @ self.data).real
+        return _data.trace(_data.matmul(self.data, self.data)).real
 
     def full(self, order='C', squeeze=False):
         """Dense array from quantum object.
@@ -1075,7 +1075,7 @@ class Qobj:
         """
         norm = self.norm(norm=norm, kwargs=kwargs)
         if inplace:
-            self.data /= norm
+            self.data = _data.mul(self.data, 1 / norm)
             self._isherm = self._isherm if norm.imag == 0 else None
             self._isunitary = (self._isunitary
                                if abs(norm) - 1 < settings.core['atol']
@@ -1416,7 +1416,7 @@ class Qobj:
                 out_data = _data.add(out_data,
                                      _data.project(state.data),
                                      value)
-        out_data /= _data.norm.trace(out_data)
+        out_data = _data.mul(out_data, 1/_data.norm.trace(out_data))
         return Qobj(out_data,
                     dims=self.dims.copy(),
                     type=self.type,

--- a/qutip/core/superoperator.py
+++ b/qutip/core/superoperator.py
@@ -132,7 +132,7 @@ def liouvillian(H=None, c_ops=None, data_only=False, chi=None):
     sop_shape = [np.prod(op_dims), np.prod(op_dims)]
     spI = _data.identity(op_shape[0])
 
-    data = -1j * _data.kron(spI, H.data)
+    data = _data.mul(_data.kron(spI, H.data), -1j)
     data = _data.add(data, _data.kron(H.data.transpose(), spI), scale=1j)
 
     for c_op, chi_ in zip(c_ops, chi):
@@ -183,7 +183,7 @@ def lindblad_dissipator(a, b=None, data_only=False, chi=None):
 
     data_only :  bool [False]
         Return the data object instead of a Qobj
-        
+
     Returns
     -------
     D : qobj, QobjEvo

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -382,7 +382,7 @@ def rand_ket(N=0, density=1, dims=None, *, seed=None, dtype=_data.Dense):
     Y = X.copy()
     Y.data = 1.0j * (np.random.random(len(X.data)) - 0.5)
     X = _data.csr.CSR(X + Y)
-    return Qobj(X / _data.norm.l2(X),
+    return Qobj(_data.mul(X, 1 / _data.norm.l2(X)),
                 dims=dims,
                 copy=False,
                 type='ket',
@@ -495,8 +495,9 @@ def rand_dm(N, density=0.75, pure=False, dims=None, *,
             if tries >= 10:
                 raise ValueError(
                     "Requested density is too low to generate density matrix.")
-            H = H.data
             H /= trace
+            H = H.data
+
     else:
         raise TypeError('Input N must be an integer or array_like.')
     return Qobj(H, dims=dims, type='oper', isherm=True, copy=False).to(dtype)

--- a/qutip/solve/_mcsolve.pyx
+++ b/qutip/solve/_mcsolve.pyx
@@ -283,7 +283,7 @@ cdef class CyMcOde:
         cdef Dense state
         cobj = <QobjEvo> self.c_ops[j]
         state = cobj.matmul_data(t, _data.dense.fast_from_numpy(y.base))
-        state /= l2_dense(state)
+        state = _data.mul(state, 1/l2_dense(state))
         return state.as_ndarray()[:, 0]
 
 

--- a/qutip/solve/countstat.py
+++ b/qutip/solve/countstat.py
@@ -205,7 +205,7 @@ def countstat_current_noise(L, c_ops, wlist=None, rhoss=None, J_ops=None,
 
             Pop = _data.kron(rhoss_vec.data, tr_op_vec.data.transpose())
             Iop = _data.identity(N*N)
-            Q = Iop - Pop
+            Q = _data.sub(Iop, Pop)
 
             for k, w in enumerate(wlist):
 
@@ -259,8 +259,8 @@ def countstat_current_noise(L, c_ops, wlist=None, rhoss=None, J_ops=None,
 
                         X_rho_vec_i = _data.dense.fast_from_numpy(X_rho_vec_i)
                         S[j, i, k] -= (
-                            _data.expect_super(Jj @ Q, X_rho_vec_i)
-                            + _data.expect_super(Ji @ Q, X_rho_vec_j)
+                            _data.expect_super(_data.matmul(Jj, Q), X_rho_vec_i)
+                            + _data.expect_super(_data.matmul(Jj, Q), X_rho_vec_j)
                         ).real
 
         else:

--- a/qutip/solve/mcsolve.py
+++ b/qutip/solve/mcsolve.py
@@ -714,10 +714,7 @@ def _mc_dm_avg(psi_list):
     over all trajectories for a single time using parfor.
     """
     ln = len(psi_list)
-    dims = psi_list[0].dims
-    shape = psi_list[0].shape
-    out_data = sum([psi.data for psi in psi_list]) / ln
-    return Qobj(out_data, dims=dims, shape=shape, fast='mc-dm')
+    return sum(psi_list) / ln
 
 def _collapse_args(args):
     for key in args:

--- a/qutip/solve/mesolve.py
+++ b/qutip/solve/mesolve.py
@@ -331,29 +331,29 @@ class _LiouvillianFromFunc:
 
     def H2L(self, t, rho, args):
         Ht = self.f(t, args)
-        Lt = -1.0j * (spre(Ht) - spost(Ht)).data
+        Lt = -1.0j * (spre(Ht) - spost(Ht))
         for op in self.c_ops:
-            Lt += op(t).data
-        return Lt
+            Lt += op(t)
+        return Lt.data
 
     def H2L_with_state(self, t, rho, args):
         Ht = self.f(t, rho, args)
-        Lt = -1.0j * (spre(Ht) - spost(Ht)).data
+        Lt = -1.0j * (spre(Ht) - spost(Ht))
         for op in self.c_ops:
-            Lt += op(t).data
-        return Lt
+            Lt += op(t)
+        return Lt.data
 
     def L(self, t, rho, args):
-        Lt = self.f(t, args).data
+        Lt = self.f(t, args)
         for op in self.c_ops:
-            Lt += op(t).data
-        return Lt
+            Lt += op(t)
+        return Lt.data
 
     def L_with_state(self, t, rho, args):
-        Lt = self.f(t, rho, args).data
+        Lt = self.f(t, rho, args)
         for op in self.c_ops:
-            Lt += op(t).data
-        return Lt
+            Lt += op(t)
+        return Lt.data
 
 
 def _mesolve_func_td(L_func, c_op_list, rho0, tlist, args, opt):

--- a/qutip/solve/sesolve.py
+++ b/qutip/solve/sesolve.py
@@ -351,7 +351,7 @@ def _generic_ode_solve(func, ode_args, psi0, tlist, e_ops, opt,
                 norm = _data.norm.l2(cdata)
                 if abs(norm - 1) > 1e-12:
                     # only reset the solver if state changed
-                    cdata /= norm
+                    cdata = _data.mul(cdata, 1/norm)
                     r.set_initial_value(cdata.as_ndarray(), r.t)
                 else:
                     r._y = cdata.as_ndarray()
@@ -379,8 +379,8 @@ def _generic_ode_solve(func, ode_args, psi0, tlist, e_ops, opt,
     if opt['store_final_state']:
         cdata = get_curr_state_data(r)
         if opt['normalize_output']:
-            cdata_nd = cdata.as_ndarray()
-            cdata_nd /= la_norm(cdata_nd, axis=0)
+            cdata = cdata.as_ndarray()
+            cdata /= la_norm(cdata, axis=0)
         output.final_state = Qobj(cdata, dims=dims)
 
     return output

--- a/qutip/solve/steadystate.py
+++ b/qutip/solve/steadystate.py
@@ -826,7 +826,7 @@ def _steadystate_power_liouvillian(L, ss_args, has_mkl=0):
     perm2 = None
     rev_perm = None
     n = L.shape[0]
-    L = _data.to(_data.CSR, L.data) - _data.identity(n, 1e-15, dtype=_data.CSR)
+    L = _data.sub(L.data, _data.identity(n, 1e-15))
     if ss_args['solver'] == 'mkl':
         kind = 'csr'
     else:

--- a/qutip/tests/core/data/test_properties.py
+++ b/qutip/tests/core/data/test_properties.py
@@ -64,7 +64,7 @@ class Test_isherm:
         n = 10
         base = _data.to(datatype, _data.create(np.diag(np.random.rand(n))))
         assert _data.isherm(base, tol=self.tol)
-        assert not _data.isherm(base * 1j, tol=self.tol)
+        assert not _data.isherm(_data.mul(base, 1j), tol=self.tol)
 
     def test_compare_implicit_zero_structure(self, datatype):
         """


### PR DESCRIPTION
We presently support operator in data layer including binary operators with themselves (`CSR + CSR`). But we use them sometime without confirming that both data object are of the same type, which will eventually cause bugs.

Here I remove this support and fixed many places were we used them, but there are probably some uses remaining in place not covered by tests.

This is an alternative solution to the issue from #1647.
