### PR TITLE
Minor doc fix in QubitCircuit

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -364,6 +364,8 @@ class QubitCircuit:
         A list of integer for the dimension of each composite system.
         e.g [2,2,2,2,2] for 5 qubits system. If None, qubits system
         will be the default option.
+    num_cbits : int
+        Number of classical bits in the system.
 
     Examples
     --------


### PR DESCRIPTION
**Description**

The `num_cbits` wasn't documented in the QubitCircuit docstring. This adds it.

Took me a second to figure out what it was (as a novice in quantum computing), so I figured I'd save some other novice that second.

FWIW: `reverse_states` isn't documented either, but I'm not confident I can write an accurate description of what that is, otherwise I would have put it here too.

This library is really neat! Thanks to all who are developing and maintaining it! 

**Changelog**

Add docs for `num_cbits` in QubitCircuit docstring
