### PR TITLE
implemented a possibility of mixing measurement operators and callback functions in e_ops list

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -79,7 +79,7 @@ Contributors
 - Louis Tessler
 - Lucas Verney
 - Marco David
-- Marek
+- Marek Narozniak
 - Markus Baden
 - Martín Sande
 - Mateo Laguna

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -460,7 +460,7 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
             opt.store_states = True
         else:
             for op in e_ops:
-                if not isinstance(op, (Qobj, QobjEvo)) and callable(op):
+                if not isinstance(op, Qobj) and callable(op):
                     output.expect.append(np.zeros(n_tsteps, dtype=complex))
                     continue
                 e_ops_data.append(spre(op).data)

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -127,9 +127,12 @@ def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None,
         single collapse operator, or list of collapse operators, or a list
         of Liouvillian superoperators.
 
-    e_ops : None / list of :class:`qutip.Qobj` and callback functions
-        single operator, list of operators and callable functions
-        for which to evaluate expectation values.
+    e_ops : None / list / callback function, optional
+        A list of operators as `Qobj` and/or callable functions (can be mixed)
+        or a single callable function. For operators, the result's expect will be  computed by :func:`qutip.expect`.
+        For callable functions, they are called as ``f(t, state)`` and return the expectation value.
+        A single callback's expectation value can be any type, but a callback part of a list must return
+        a number as the expectation value.
 
     args : None / *dictionary*
         dictionary of parameters for time-dependent Hamiltonians and
@@ -507,8 +510,7 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
             output.expect.append(e_ops(t, rho_t))
 
         for m in range(n_expt_op):
-            if not isinstance(e_ops[m], (Qobj, QobjEvo)) \
-               and callable(e_ops[m]):
+            if not isinstance(e_ops[m], Qobj) and callable(e_ops[m]):
                 output.expect[m][t_idx] = e_ops[m](t, rho_t)
                 continue
             output.expect[m][t_idx] = expect_rho_vec(e_ops_data[m], r.y,

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -127,11 +127,9 @@ def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None,
         single collapse operator, or list of collapse operators, or a list
         of Liouvillian superoperators.
 
-    e_ops : None / list of :class:`qutip.Qobj` / list of callback functions
-    / callback function
-        single operator, list of operators or list of callable functions
-        for which to evaluate
-        expectation values.
+    e_ops : None / list of :class:`qutip.Qobj` and callback functions
+        single operator, list of operators and callable functions
+        for which to evaluate expectation values.
 
     args : None / *dictionary*
         dictionary of parameters for time-dependent Hamiltonians and

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -509,7 +509,8 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
             output.expect.append(e_ops(t, rho_t))
 
         for m in range(n_expt_op):
-            if not isinstance(e_ops[m], (Qobj, QobjEvo)) and callable(e_ops[m]):
+            if not isinstance(e_ops[m], (Qobj, QobjEvo)) \
+               and callable(e_ops[m]):
                 output.expect[m][t_idx] = e_ops[m](t, rho_t)
                 continue
             output.expect[m][t_idx] = expect_rho_vec(e_ops_data[m], r.y,

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -127,8 +127,10 @@ def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None,
         single collapse operator, or list of collapse operators, or a list
         of Liouvillian superoperators.
 
-    e_ops : None / list of :class:`qutip.Qobj` / callback function single
-        single operator or list of operators for which to evaluate
+    e_ops : None / list of :class:`qutip.Qobj` / list of callback functions
+    / callback function
+        single operator, list of operators or list of callable functions
+        for which to evaluate
         expectation values.
 
     args : None / *dictionary*

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -458,6 +458,9 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
             opt.store_states = True
         else:
             for op in e_ops:
+                if not isinstance(op, (Qobj, QobjEvo)) and callable(op):
+                    output.expect.append(np.zeros(n_tsteps, dtype=complex))
+                    continue
                 e_ops_data.append(spre(op).data)
                 if op.isherm and rho0.isherm:
                     output.expect.append(np.zeros(n_tsteps))
@@ -504,6 +507,9 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
             output.expect.append(e_ops(t, rho_t))
 
         for m in range(n_expt_op):
+            if not isinstance(e_ops[m], (Qobj, QobjEvo)) and callable(e_ops[m]):
+                output.expect[m][t_idx] = e_ops[m](t, rho_t)
+                continue
             output.expect[m][t_idx] = expect_rho_vec(e_ops_data[m], r.y,
                                                      e_ops[m].isherm
                                                      and rho0.isherm)

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -129,10 +129,11 @@ def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None,
 
     e_ops : None / list / callback function, optional
         A list of operators as `Qobj` and/or callable functions (can be mixed)
-        or a single callable function. For operators, the result's expect will be  computed by :func:`qutip.expect`.
-        For callable functions, they are called as ``f(t, state)`` and return the expectation value.
-        A single callback's expectation value can be any type, but a callback part of a list must return
-        a number as the expectation value.
+        or a single callable function. For operators, the result's expect will
+        be  computed by :func:`qutip.expect`. For callable functions, they are
+        called as ``f(t, state)`` and return the expectation value.
+        A single callback's expectation value can be any type, but a callback
+        part of a list must return a number as the expectation value.
 
     args : None / *dictionary*
         dictionary of parameters for time-dependent Hamiltonians and

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -56,11 +56,12 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
 
     e_ops : None / list / callback function, optional
         A list of operators as `Qobj` and/or callable functions (can be mixed)
-        or a single callable function. For callable functions, they are called as ``f(t, state)`` 
-        and return the expectation value. A single callback's expectation value can be any type, 
-        but a callback part of a list must return a number as the expectation value. For operators, 
-        the result's expect will be  computed by :func:`qutip.expect` when the state is a ``ket``.
-        For operator evolution, the overlap is computed by: ::
+        or a single callable function. For callable functions, they are called
+        as ``f(t, state)`` and return the expectation value. A single
+        callback's expectation value can be any type, but a callback part of a
+        list must return a number as the expectation value. For operators, the
+        result's expect will be computed by :func:`qutip.expect` when the state
+        is a ``ket``. For operator evolution, the overlap is computed by: ::
 
             (e_ops[i].dag() * op(t)).tr()
 

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -322,7 +322,8 @@ def _generic_ode_solve(func, ode_args, psi0, tlist, e_ops, opt,
                             "the allowed number of substeps by increasing "
                             "the nsteps parameter in the Options class.")
         # get the current state / oper data if needed
-        if opt.store_states or opt.normalize_output or n_expt_op > 0 or expt_callback:
+        if opt.store_states or opt.normalize_output \
+           or n_expt_op > 0 or expt_callback:
             cdata = get_curr_state_data(r)
 
         if opt.normalize_output:
@@ -355,13 +356,15 @@ def _generic_ode_solve(func, ode_args, psi0, tlist, e_ops, opt,
         if oper_evo:
             for m in range(n_expt_op):
                 if callable(e_ops_data[m]):
-                    output.expect[m][t_idx] = e_ops_data[m](t, Qobj(cdata, dims=dims))
+                    func = e_ops_data[m]
+                    output.expect[m][t_idx] = func(t, Qobj(cdata, dims=dims))
                     continue
                 output.expect[m][t_idx] = (e_ops_data[m] * cdata).trace()
         else:
             for m in range(n_expt_op):
                 if callable(e_ops_data[m]):
-                    output.expect[m][t_idx] = e_ops_data[m](t, Qobj(cdata, dims=dims))
+                    func = e_ops_data[m]
+                    output.expect[m][t_idx] = func(t, Qobj(cdata, dims=dims))
                     continue
                 output.expect[m][t_idx] = cy_expect_psi(e_ops_data[m], cdata,
                                                         e_ops[m].isherm)

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -54,10 +54,13 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
     tlist : array_like of float
         List of times for :math:`t`.
 
-    e_ops : None / list of :class:`qutip.Qobj` and callback functions, optional
-        single operator, list of operators and callable functions
-        for which to evaluate expectation values. For operator evolution,
-        the overlap is computed: ::
+    e_ops : None / list / callback function, optional
+        A list of operators as `Qobj` and/or callable functions (can be mixed)
+        or a single callable function. For callable functions, they are called as ``f(t, state)`` 
+        and return the expectation value. A single callback's expectation value can be any type, 
+        but a callback part of a list must return a number as the expectation value. For operators, 
+        the result's expect will be  computed by :func:`qutip.expect` when the state is a ``ket``.
+        For operator evolution, the overlap is computed by: ::
 
             (e_ops[i].dag() * op(t)).tr()
 
@@ -276,7 +279,7 @@ def _generic_ode_solve(func, ode_args, psi0, tlist, e_ops, opt,
             opt.store_states = True
         else:
             for op in e_ops:
-                if not isinstance(op, (Qobj, QobjEvo)) and callable(op):
+                if not isinstance(op, Qobj) and callable(op):
                     output.expect.append(np.zeros(n_tsteps, dtype=complex))
                     continue
                 if op.isherm:
@@ -285,13 +288,13 @@ def _generic_ode_solve(func, ode_args, psi0, tlist, e_ops, opt,
                     output.expect.append(np.zeros(n_tsteps, dtype=complex))
         if oper_evo:
             for e in e_ops:
-                if isinstance(e, (Qobj, QobjEvo)):
+                if isinstance(e, Qobj):
                     e_ops_data.append(e.dag().data)
                     continue
                 e_ops_data.append(e)
         else:
             for e in e_ops:
-                if isinstance(e, (Qobj, QobjEvo)):
+                if isinstance(e, Qobj):
                     e_ops_data.append(e.data)
                     continue
                 e_ops_data.append(e)

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -54,8 +54,10 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
     tlist : array_like of float
         List of times for :math:`t`.
 
-    e_ops : list of :class:`~Qobj` or callback function, optional
-        Single operator or list of operators for which to evaluate expectation
+    e_ops : list of :class:`~Qobj` or list of callback functions or
+    a single callback function, optional
+        Single operator, list of operators or list of callable functions
+        for which to evaluate expectation
         values.  For operator evolution, the overlap is computed: ::
 
             (e_ops[i].dag() * op(t)).tr()

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -54,11 +54,10 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
     tlist : array_like of float
         List of times for :math:`t`.
 
-    e_ops : list of :class:`~Qobj` or list of callback functions or
-    a single callback function, optional
-        Single operator, list of operators or list of callable functions
-        for which to evaluate expectation
-        values.  For operator evolution, the overlap is computed: ::
+    e_ops : None / list of :class:`qutip.Qobj` and callback functions, optional
+        single operator, list of operators and callable functions
+        for which to evaluate expectation values. For operator evolution,
+        the overlap is computed: ::
 
             (e_ops[i].dag() * op(t)).tr()
 

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -90,7 +90,7 @@ class ExpectOps:
         else:
             t = self.tlist[iter_]
             for ii in range(self.e_num):
-                if isinstance(ii, (Qobj, QobjEvo)):
+                if isinstance(ii, (Qobj, QobjEvo, int)):
                     self.raw_out[ii, iter_] = \
                         self.e_ops_qoevo[ii].compiled_qobjevo.expect(t, state)
                 elif callable(ii):

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -59,7 +59,8 @@ class ExpectOps:
                     e_ops_isherm.append(None)
                     e_ops_qoevo.append(e)
                 else:
-                    raise TypeError("Expectation value list entry needs to be either a function either an operator")
+                    raise TypeError("Expectation value list entry needs to be "
+                                    "either a function either an operator")
             self.e_ops_isherm = e_ops_isherm
             self.e_ops_qoevo = np.array(e_ops_qoevo, dtype=object)
         elif callable(e_ops):
@@ -96,6 +97,7 @@ class ExpectOps:
                 elif callable(ii):
                     self.raw_out[ii, iter_] = \
                         self.e_ops_qoevo[ii](t, state)
+
     def finish(self):
         if self.isfunc:
             result = self.raw_out

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -90,7 +90,7 @@ class ExpectOps:
         else:
             t = self.tlist[iter_]
             for ii in range(self.e_num):
-                if isinstance(ii, (Qobj, QobjEvo, int)):
+                if isinstance(self.e_ops_qoevo[ii], QobjEvo):
                     self.raw_out[ii, iter_] = \
                         self.e_ops_qoevo[ii].compiled_qobjevo.expect(t, state)
                 elif callable(ii):

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -94,7 +94,7 @@ class ExpectOps:
                 if isinstance(self.e_ops_qoevo[ii], QobjEvo):
                     self.raw_out[ii, iter_] = \
                         self.e_ops_qoevo[ii].compiled_qobjevo.expect(t, state)
-                elif callable(ii):
+                elif callable(self.e_ops_qoevo[ii]):
                     self.raw_out[ii, iter_] = \
                         self.e_ops_qoevo[ii](t, state)
 

--- a/qutip/tests/test_expect.py
+++ b/qutip/tests/test_expect.py
@@ -132,7 +132,7 @@ def test_equivalent_to_matrix_element(hermitian):
 ])
 def test_compatibility_with_solver(solve):
     e_ops = [getattr(qutip, 'sigma'+x)() for x in 'xyzmp']
-    e_ops += [lambda t, psi: qutip.basis(2, 0).overlap(psi)]
+    e_ops += [lambda t, psi: np.sin(t)]
     h = qutip.sigmax()
     state = qutip.basis(2, 0)
     times = np.linspace(0, 10, 101)
@@ -147,12 +147,14 @@ def test_compatibility_with_solver(solve):
         assert isinstance(direct_, np.ndarray)
         assert isinstance(indirect_, np.ndarray)
         assert direct_.dtype == indirect_.dtype
+        np.testing.assert_allclose(direct_, indirect_, atol=1e-12)
     # test measurement operators based on lambda functions
     direct_ = direct[-1]
-    indirect_ = np.sin(times)
+    # by design, lambda measurements are of complex type
+    indirect_ = np.sin(times, dtype=complex)
     assert len(direct_) == len(indirect_)
     assert isinstance(direct_, np.ndarray)
     assert isinstance(indirect_, np.ndarray)
-    # by design, lambda measurements are of complex type
-    assert direct_.dtype != indirect_.dtype
+    assert direct_.dtype == indirect_.dtype
+    np.testing.assert_allclose(direct_, indirect_, atol=1e-12)
 


### PR DESCRIPTION
**Description**

I propose to make it possible to have callable functions inside of the `e_ops` list, not only operators. This becomes useful if we want to measure energy or if we want to have time-dependent measurements just like time-dependent Hamiltonian.

Changes are pretty straightforwards, mostly making sure types match. Important design choice is, if measurement is not an operator but a function, the data type is complex by default (to handle the general case).

Feedback and suggestions for changes are welcome. I will be happy to contribute more!

**Related issues or PRs**

Suggested in https://github.com/qutip/qutip/issues/1238

**Changelog**

1. Modified `mesolve` and `sesolve` objects to handle callable function inside of the `e_ops` list.
2. Prepared `solver` to create empty measured data if list of `e_ops` contains a callable function.
3. Modified one of the high level tests, `test_compatibility_with_solver` by adding an additional measurement which is not an operator but a lambda expression.
