### PR TITLE
Add a tolerance for measurement.

### DIFF
--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -29,6 +29,10 @@ class CoreOptions:
         The absolute tolerance used in automatic tidyup (see the ``auto_tidyup``
         parameter above) and the default value of ``atol`` used in
         :method:`Qobj.tidyup`.
+
+    min_probability : float {1e-30}
+        The minimun probability for measurement considered to be possible in
+        :func:`measurement_statistics_povm`.
     """
     options = {
         # use auto tidyup
@@ -42,5 +46,7 @@ class CoreOptions:
         # general relative tolerance
         "rtol": 1e-12,
         # use auto tidyup absolute tolerance
-        "auto_tidyup_atol": 1e-14
+        "auto_tidyup_atol": 1e-14,
+        # cutoff for impossible collapse in measurment
+        "min_probability": 1e-30
     }

--- a/qutip/measurement.py
+++ b/qutip/measurement.py
@@ -38,6 +38,7 @@ import numpy as np
 
 from . import Qobj, expect, identity
 from .qip.operations.gates import expand_operator
+from .settings import settings
 
 
 def _verify_input(op, state):
@@ -93,7 +94,7 @@ def _measurement_statistics_povm_ket(state, ops):
     for i, op in enumerate(ops):
         p = np.absolute((state.dag() * op.dag() * op * state))
         probabilities.append(p)
-        if p != 0:
+        if p >= settings.core['min_probability']:
             collapsed_states.append((op * state) / np.sqrt(p))
         else:
             collapsed_states.append(None)
@@ -135,7 +136,7 @@ def _measurement_statistics_povm_dm(density_mat, ops):
         st = op * density_mat * op.dag()
         p = st.tr()
         probabilities.append(p)
-        if p != 0:
+        if p >= settings.core['min_probability']:
             collapsed_states.append(st/p)
         else:
             collapsed_states.append(None)


### PR DESCRIPTION
Measurements would return a `None` state when the probability is 0.
Due to recent changes which affected operation order, a test for `CircuitSimulator` would result in a probability of `~1e-33`. Not being 0, this resulted in an unexpected possible result of the circuit simulation, breaking tests for `dev.major`

I changed the test from `p != 0` to `p >= tol` with `tol` being set in core's settings.