### PR TITLE
fix seeds in stochastic tests 

### DIFF
--- a/qutip/tests/solve/test_stochastic_me.py
+++ b/qutip/tests/solve/test_stochastic_me.py
@@ -92,6 +92,8 @@ def test_smesolve_homodyne_methods():
                         ['explicit1.5', 1e-4],
                         ['taylor2.0', 1e-4]]
     for n_method in list_methods_tol:
+        # Comparisons of error between sol and sol3 depend on the stochastic
+        # noise, thus the seed, fixing the seed remove random fails.
         np.random.seed(1)
         sol = smesolve(H, rho0, tlist, c_op, sc_op, e_op,
                        nsubsteps=Nsub, method='homodyne', solver = n_method[0])

--- a/qutip/tests/solve/test_stochastic_me.py
+++ b/qutip/tests/solve/test_stochastic_me.py
@@ -92,6 +92,7 @@ def test_smesolve_homodyne_methods():
                         ['explicit1.5', 1e-4],
                         ['taylor2.0', 1e-4]]
     for n_method in list_methods_tol:
+        np.random.seed(1)
         sol = smesolve(H, rho0, tlist, c_op, sc_op, e_op,
                        nsubsteps=Nsub, method='homodyne', solver = n_method[0])
         sol2 = smesolve(H, rho0, tlist, c_op, sc_op, e_op, store_measurement=0,

--- a/qutip/tests/solve/test_stochastic_se.py
+++ b/qutip/tests/solve/test_stochastic_se.py
@@ -90,6 +90,7 @@ def test_ssesolve_homodyne_methods():
                         ['explicit1.5', 5e-4],
                         ['taylor2.0', 5e-4]]
     for n_method in list_methods_tol:
+        np.random.seed(1)
         sol = ssesolve(H, rho0, tlist, sc_op, e_op,
                        nsubsteps=Nsub, method='homodyne', solver=n_method[0])
         sol2 = ssesolve(H, rho0, tlist, sc_op, e_op, store_measurement=0,

--- a/qutip/tests/solve/test_stochastic_se.py
+++ b/qutip/tests/solve/test_stochastic_se.py
@@ -90,6 +90,8 @@ def test_ssesolve_homodyne_methods():
                         ['explicit1.5', 5e-4],
                         ['taylor2.0', 5e-4]]
     for n_method in list_methods_tol:
+        # Comparisons of error between sol and sol3 depend on the stochastic
+        # noise, thus the seed, fixing the seed remove random fails.
         np.random.seed(1)
         sol = ssesolve(H, rho0, tlist, sc_op, e_op,
                        nsubsteps=Nsub, method='homodyne', solver=n_method[0])


### PR DESCRIPTION
Some tests in stochastic evolution passes only most of the time.
The problematic tests are comparison of different step length, normally error should be smaller with smaller step length. Since the evolution use random number, this is not true for all seeds.

By fixing the test, we should not have the tests randomly failing.
I am adding _improving stochastic tests and having them use pytest_ to my to-do.

Ps. tests fail due to the error fixed in #1656
