### PR TITLE
fix failing circuit test

### DIFF
--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -584,4 +584,5 @@ class TestQubitCircuit:
             for i, final_state in enumerate(final_states):
                 _, probs_final = fourth.measurement_comp_basis(final_state)
                 np.testing.assert_allclose(probs_initial, probs_final)
-                assert sum(result_cbits[i]) == 1
+                if result.get_probabilities(i) > 1e-30:
+                    assert sum(result_cbits[i]) == 1


### PR DESCRIPTION
Fix the test breaking dev.major by adding the tolerance in the test itself.
This is an alternative to #1656, merge only one.
