### PR TITLE
Add new color_style argument to hinton() (#1595).

### DIFF
--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -175,7 +175,7 @@ def _cb_labels(left_dims):
 
 # Adopted from the SciPy Cookbook.
 def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
-           label_top=True, color_style="threshold"):
+           label_top=True, color_style="scaled"):
     """Draws a Hinton diagram for visualizing a density matrix or superoperator.
 
     Parameters
@@ -203,13 +203,16 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
         they will appear below the plot.
 
     color_style : string
-        Determines how colors are assigned to each square. If set to
-        `"threshold"` (default), each square is plotted as the maximum of
-        `cmap` for positive numbers and as the minimum for minimum. If set to
-        `"scaled"`, each color is chosen by passing the magnitude of the
-        corresponding matrix element into `cmap`. If set to `"phase"`, each
-        color is chosen according to the argument of the corresponding matrix
-        element; note that this generalizes `"threshold"` to complex numbers.
+        Determines how colors are assigned to each square:
+        - If set to `"scaled"` (default), each color is chosen by
+          passing the absolute value of the corresponding matrix
+          element into `cmap` with the sign of the real part.
+        - If set to `"threshold"`, each square is plotted as
+          the maximum of `cmap` for the positive real part and as
+          the minimum for the negative part of the matrix element;
+          note that this generalizes `"threshold"` to complex numbers.
+        - If set to `"phase"`, each color is chosen according to
+          the angle of the corresponding matrix element.
 
     Returns
     -------

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -290,13 +290,15 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
     # Set color_fn here.
     if color_style == "scaled":
         def color_fn(w):
+            w = np.abs(w) * np.sign(np.real(w))
             return cmap(int((w + w_max) * 256 / (2 * w_max)))
     elif color_style == "threshold":
         def color_fn(w):
+            w = np.real(w)
             return cmap(255 if w > 0 else 0)
     elif color_style == "phase":
         def color_fn(w):
-            return cmap(int(255 * np.mod(1 - np.angle(w) / np.pi, 2)))
+            return cmap(int(255 * (np.angle(w) / 2 / np.pi + 0.5)))
     else:
         raise ValueError(
             "Unknown color style {} for Hinton diagrams.".format(color_style)
@@ -308,18 +310,12 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
         for y in range(height):
             _x = x + 1
             _y = y + 1
-            if np.real(W[x, y]) > 0.0:
-                _blob(_x - 0.5, height - _y + 0.5, abs(W[x, y]), w_max,
-                      min(1, abs(W[x, y]) / w_max), color_fn=color_fn, ax=ax)
-            else:
-                _blob(
-                    _x - 0.5, height - _y + 0.5,
-                    -abs(W[x, y]), w_max,
-                    min(1, abs(W[x, y]) / w_max), color_fn=color_fn, ax=ax
-                )
+            _blob(_x - 0.5, height - _y + 0.5, W[x, y], w_max,
+                    min(1, abs(W[x, y]) / w_max), color_fn=color_fn, ax=ax)
 
     # color axis
-    norm = mpl.colors.Normalize(-abs(W).max(), abs(W).max())
+    vmax = np.pi if color_style == "phase" else abs(W).max()
+    norm = mpl.colors.Normalize(-vmax, vmax)
     cax, kw = mpl.colorbar.make_axes(ax, shrink=0.75, pad=.1)
     mpl.colorbar.ColorbarBase(cax, norm=norm, cmap=cmap)
 

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -289,13 +289,18 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
 
     # Set color_fn here.
     if color_style == "scaled":
-        color_fn = lambda w: cmap(int((w + w_max) * 256 / (2 * w_max)))
+        def color_fn(w):
+            return cmap(int((w + w_max) * 256 / (2 * w_max)))
     elif color_style == "threshold":
-        color_fn = lambda w: cmap(255 if w > 0 else 0)
+        def color_fn(w):
+            return cmap(255 if w > 0 else 0)
     elif color_style == "phase":
-        color_fn = lambda w: cmap(int(255 * np.mod(1 - np.angle(w) / np.pi, 2)))
+        def color_fn(w):
+            return cmap(int(255 * np.mod(1 - np.angle(w) / np.pi, 2)))
     else:
-        raise ValueError("Unknown color style {} for Hinton diagrams.".format(color_style))
+        raise ValueError(
+            "Unknown color style {} for Hinton diagrams.".format(color_style)
+        )
 
     ax.fill(array([0, width, width, 0]), array([0, 0, height, height]),
             color=cmap(128))
@@ -307,8 +312,11 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
                 _blob(_x - 0.5, height - _y + 0.5, abs(W[x, y]), w_max,
                       min(1, abs(W[x, y]) / w_max), color_fn=color_fn, ax=ax)
             else:
-                _blob(_x - 0.5, height - _y + 0.5, -abs(W[
-                      x, y]), w_max, min(1, abs(W[x, y]) / w_max), color_fn=color_fn, ax=ax)
+                _blob(
+                    _x - 0.5, height - _y + 0.5,
+                    -abs(W[x, y]), w_max,
+                    min(1, abs(W[x, y]) / w_max), color_fn=color_fn, ax=ax
+                )
 
     # color axis
     norm = mpl.colors.Normalize(-abs(W).max(), abs(W).max())

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -204,6 +204,7 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
 
     color_style : string
         Determines how colors are assigned to each square:
+
         -  If set to ``"scaled"`` (default), each color is chosen by
            passing the absolute value of the corresponding matrix
            element into `cmap` with the sign of the real part.

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -226,6 +226,21 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
     ValueError
         Input argument is not a quantum object.
 
+    Examples
+    --------
+    >>> import qutip
+    >>>
+    >>> dm = qutip.rand_dm(4)
+    >>> fig, ax = qutip.hinton(dm)
+    >>> fig.show()
+    >>>
+    >>> qutip.settings.colorblind_safe = True
+    >>> fig, ax = qutip.hinton(dm, color_style="threshold")
+    >>> fig.show()
+    >>> qutip.settings.colorblind_safe = False
+    >>>
+    >>> fig, ax = qutip.hinton(dm, color_style="phase")
+    >>> fig.show()
     """
 
     # Apply default colormaps.

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -204,14 +204,14 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
 
     color_style : string
         Determines how colors are assigned to each square:
-        - If set to `"scaled"` (default), each color is chosen by
+        - If set to ``"scaled"`` (default), each color is chosen by
           passing the absolute value of the corresponding matrix
           element into `cmap` with the sign of the real part.
-        - If set to `"threshold"`, each square is plotted as
+        - If set to ``"threshold"``, each square is plotted as
           the maximum of `cmap` for the positive real part and as
           the minimum for the negative part of the matrix element;
           note that this generalizes `"threshold"` to complex numbers.
-        - If set to `"phase"`, each color is chosen according to
+        - If set to ``"phase"``, each color is chosen according to
           the angle of the corresponding matrix element.
 
     Returns
@@ -313,8 +313,9 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
         for y in range(height):
             _x = x + 1
             _y = y + 1
-            _blob(_x - 0.5, height - _y + 0.5, W[x, y], w_max,
-                    min(1, abs(W[x, y]) / w_max), color_fn=color_fn, ax=ax)
+            _blob(
+                _x - 0.5, height - _y + 0.5, W[x, y], w_max,
+                min(1, abs(W[x, y]) / w_max), color_fn=color_fn, ax=ax)
 
     # color axis
     vmax = np.pi if color_style == "phase" else abs(W).max()

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -204,15 +204,15 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
 
     color_style : string
         Determines how colors are assigned to each square:
-        - If set to ``"scaled"`` (default), each color is chosen by
-          passing the absolute value of the corresponding matrix
-          element into `cmap` with the sign of the real part.
-        - If set to ``"threshold"``, each square is plotted as
-          the maximum of `cmap` for the positive real part and as
-          the minimum for the negative part of the matrix element;
-          note that this generalizes `"threshold"` to complex numbers.
-        - If set to ``"phase"``, each color is chosen according to
-          the angle of the corresponding matrix element.
+        -  If set to ``"scaled"`` (default), each color is chosen by
+           passing the absolute value of the corresponding matrix
+           element into `cmap` with the sign of the real part.
+        -  If set to ``"threshold"``, each square is plotted as
+           the maximum of `cmap` for the positive real part and as
+           the minimum for the negative part of the matrix element;
+           note that this generalizes `"threshold"` to complex numbers.
+        -  If set to ``"phase"``, each color is chosen according to
+           the angle of the corresponding matrix element.
 
     Returns
     -------


### PR DESCRIPTION
**Description**
This PR adds thresholding and phase color styles to `qutip.visualization.hinton`.

**Related issues or PRs**
- #1595

**Changelog**
Hinton diagrams now support threshold, scaled, and phase color styles.
