### PR TITLE
Fix parameters in call to fsesolve.

### DIFF
--- a/doc/guide/dynamics/dynamics-floquet.rst
+++ b/doc/guide/dynamics/dynamics-floquet.rst
@@ -206,7 +206,7 @@ For convenience, all the steps described above for calculating the evolution of 
 
 .. code-block:: python
 
-    output = fsesolve(H, psi0, times, [num(2)], args)
+    output = fsesolve(H, psi0=psi0, tlist=tlist, e_ops=[qutip.num(2)], args=args)
     p_ex = output.expect[0]
 
 .. _floquet-dissipative:


### PR DESCRIPTION
**Description**
Fix the parameters in the call to fsesolve in the floquet guide. The fsesolve parameters were updated at some point, but the guide wasn't.

**Related issues or PRs**
Fixes #1663 

**Changelog**
Fixed the parameters in the call to fsesolve in the floquet guide.
