### PR TITLE
Change test_utilities to pytest

### DIFF
--- a/doc/apidoc/functions.rst
+++ b/doc/apidoc/functions.rst
@@ -334,7 +334,7 @@ Utility Functions
 -----------------
 
 .. automodule:: qutip.utilities
-    :members: n_thermal, linspace_with, clebsch, convert_unit
+    :members: n_thermal, clebsch, convert_unit
 
 
 .. _functions-fileio:

--- a/qutip/tests/test_utilities.py
+++ b/qutip/tests/test_utilities.py
@@ -1,104 +1,107 @@
 import numpy as np
-from numpy.testing import assert_, run_module_suite
+from qutip import convert_unit, clebsch, n_thermal
+import qutip.utilities as utils
+from functools import partial
+import pytest
 
-from qutip import convert_unit, clebsch
+
+@pytest.mark.parametrize(['w', 'w_th', 'expected'], [
+    pytest.param(np.log(2), 1, 1, id='log(2)'),
+    pytest.param(np.log(2)*5, 5, 1, id='5*log(2)'),
+    pytest.param(0, 1, 0, id="0_energy"),
+    pytest.param(1, -1, 0, id="neg_temp"),
+    pytest.param(np.array([np.log(2), np.log(3), np.log(4)]), 1,
+                 np.array([1, 1/2, 1/3]), id="array"),
+])
+def test_n_thermal(w, w_th, expected):
+    np.testing.assert_allclose(n_thermal(w, w_th), expected)
 
 
-def test_unit_conversions():
-    "utilities: energy unit conversions"
+def _get_converter(orig, target):
+    """get funtion 'convert_{}_to_{}' when available for coverage """
+    try:
+        func = getattr(utils, f'convert_{orig}_to_{target}')
+    except AttributeError:
+        func = partial(convert_unit, orig=orig, to=target)
+    return func
 
+
+@pytest.mark.parametrize('orig', ["J", "eV", "meV", "GHz", "mK"])
+@pytest.mark.parametrize('target', ["J", "eV", "meV", "GHz", "mK"])
+def test_unit_conversions(orig, target):
     T = np.random.rand() * 100.0
+    T_converted = convert_unit(T, orig=orig, to=target)
+    T_back = convert_unit(T_converted, orig=target, to=orig)
 
-    diff = convert_unit(convert_unit(T, orig="mK", to="GHz"),
-                        orig="GHz", to="mK") - T
-    assert_(abs(diff) < 1e-6)
-    diff = convert_unit(convert_unit(T, orig="mK", to="meV"),
-                        orig="meV", to="mK") - T
-    assert_(abs(diff) < 1e-6)
+    assert T == pytest.approx(T_back)
 
-    diff = convert_unit(convert_unit(convert_unit(T, orig="mK", to="GHz"),
-                                     orig="GHz", to="meV"),
-                        orig="meV", to="mK") - T
-    assert_(abs(diff) < 1e-6)
+    T_converted = _get_converter(orig=orig, target=target)(T)
+    T_back = _get_converter(orig=target, target=orig)(T_converted)
 
-    w = np.random.rand() * 100.0
+    assert T == pytest.approx(T_back)
 
-    diff = convert_unit(convert_unit(w, orig="GHz", to="meV"),
-                        orig="meV", to="GHz") - w
-    assert_(abs(diff) < 1e-6)
 
-    diff = convert_unit(convert_unit(w, orig="GHz", to="mK"),
-                        orig="mK", to="GHz") - w
-    assert_(abs(diff) < 1e-6)
+@pytest.mark.parametrize('orig', ["J", "eV", "meV", "GHz", "mK"])
+@pytest.mark.parametrize('middle', ["J", "eV", "meV", "GHz", "mK"])
+@pytest.mark.parametrize('target', ["J", "eV", "meV", "GHz", "mK"])
+def test_unit_conversions_loop(orig, middle, target):
+    T = np.random.rand() * 100.0
+    T_middle = convert_unit(T, orig=orig, to=middle)
+    T_converted = convert_unit(T_middle, orig=middle, to=target)
+    T_back = convert_unit(T_converted, orig=target, to=orig)
 
-    diff = convert_unit(convert_unit(convert_unit(w, orig="GHz", to="mK"),
-                                     orig="mK", to="meV"),
-                        orig="meV", to="GHz") - w
-    assert_(abs(diff) < 1e-6)
+    assert T == pytest.approx(T_back)
 
-def test_unit_clebsch():
-    "utilities: Clebsch–Gordan coefficients "
-    N = 15
-    for _ in range(100):
-        "sum_m1 sum_m2 C(j1,j2,j3,m1,m2,m3)*C(j1,j2,j3',m1,m2,m3') ="
-        "delta j3,j3' delta m3,m3'"
-        j1 = np.random.randint(0, N+1)
-        j2 = np.random.randint(0, N+1)
-        j3 = np.random.randint(abs(j1-j2), j1+j2+1)
-        j3p = np.random.randint(abs(j1-j2), j1+j2+1)
-        m3 = np.random.randint(-j3, j3+1)
-        m3p = np.random.randint(-j3p, j3p+1)
-        if np.random.rand() < 0.25:
-            j1 += 0.5
-            j3 += 0.5
-            j3p += 0.5
-            m3 += np.random.choice([-0.5, 0.5])
-            m3p += np.random.choice([-0.5, 0.5])
-        if np.random.rand() < 0.25:
-            j2 += 0.5
-            j3 += 0.5
-            j3p += 0.5
-            m3 += np.random.choice([-0.5, 0.5])
-            m3p += np.random.choice([-0.5, 0.5])
-        sum_match = -1
-        sum_differ = -int(j3 == j3p and m3 == m3p)
-        for m1 in np.arange(-j1,j1+1):
-            for m2 in np.arange(-j2,j2+1):
+
+def test_unit_conversions_bad_unit():
+    with pytest.raises(TypeError):
+        convert_unit(10, orig="bad", to="J")
+    with pytest.raises(TypeError):
+        convert_unit(10, orig="J", to="bad")
+
+
+
+@pytest.mark.parametrize('j1', [0.5, 1.0, 1.5, 2.0, 5, 7.5, 10, 12.5])
+@pytest.mark.parametrize('j2', [0.5, 1.0, 1.5, 2.0, 5, 7.5, 10, 12.5])
+def test_unit_clebsch_delta_j(j1, j2):
+    """sum_m1 sum_m2 C(j1,j2,j3,m1,m2,m3) * C(j1,j2,j3',m1,m2,m3') =
+    delta j3,j3' delta m3,m3'"""
+    for _ in range(10):
+        j3 = np.random.choice(np.arange(abs(j1-j2), j1+j2+1))
+        j3p = np.random.choice(np.arange(abs(j1-j2), j1+j2+1))
+        m3 = np.random.choice(np.arange(-j3, j3+1))
+        m3p = np.random.choice(np.arange(-j3p, j3p+1))
+
+        sum_match = 0
+        sum_differ = 0
+        for m1 in np.arange(-j1, j1+1):
+            for m2 in np.arange(-j2, j2+1):
                 c1 = clebsch(j1, j2, j3, m1, m2, m3)
                 c2 = clebsch(j1, j2, j3p, m1, m2, m3p)
                 sum_match += c1**2
                 sum_differ += c1*c2
-        assert_(abs(sum_match) < 1e-6)
-        assert_(abs(sum_differ) < 1e-6)
+        assert sum_match == pytest.approx(1)
+        assert sum_differ == pytest.approx(int(j3 == j3p and m3 == m3p))
 
-    for _ in range(100):
-        "sum_j3 sum_m3 C(j1,j2,j3,m1,m2,m3)*C(j1,j2,j3,m1',m2',m3) ="
-        "delta m1,m1' delta m2,m2'"
-        j1 = np.random.randint(0,N+1)
-        j2 = np.random.randint(0,N+1)
-        m1 = np.random.randint(-j1,j1+1)
-        m1p = np.random.randint(-j1,j1+1)
-        m2 = np.random.randint(-j2,j2+1)
-        m2p = np.random.randint(-j2,j2+1)
-        if np.random.rand() < 0.25:
-            j1 += 0.5
-            m1 += np.random.choice([-0.5, 0.5])
-            m1p += np.random.choice([-0.5, 0.5])
-        if np.random.rand() < 0.25:
-            j2 += 0.5
-            m2 += np.random.choice([-0.5, 0.5])
-            m2p += np.random.choice([-0.5, 0.5])
-        sum_match = -1
-        sum_differ = -int(m1 == m1p and m2 == m2p)
-        for j3 in np.arange(abs(j1-j2),j1+j2+1):
-            for m3 in np.arange(-j3,j3+1):
+
+@pytest.mark.parametrize('j1', [0.5, 1.0, 1.5, 2.0, 5, 7.5, 10, 12.5])
+@pytest.mark.parametrize('j2', [0.5, 1.0, 1.5, 2.0, 5, 7.5, 10, 12.5])
+def test_unit_clebsch_delta_m(j1, j2):
+    """sum_j3 sum_m3 C(j1,j2,j3,m1,m2,m3)*C(j1,j2,j3,m1',m2',m3) =
+    delta m1,m1' delta m2,m2'"""
+    for _ in range(10):
+        m1 = np.random.choice(np.arange(-j1, j1+1))
+        m1p = np.random.choice(np.arange(-j1, j1+1))
+        m2 = np.random.choice(np.arange(-j2, j2+1))
+        m2p = np.random.choice(np.arange(-j2, j2+1))
+
+        sum_match = 0
+        sum_differ = 0
+        for j3 in np.arange(abs(j1-j2), j1+j2+1):
+            for m3 in np.arange(-j3, j3+1):
                 c1 = clebsch(j1, j2, j3, m1, m2, m3)
                 c2 = clebsch(j1, j2, j3, m1p, m2p, m3)
                 sum_match += c1**2
                 sum_differ += c1*c2
-        assert_(abs(sum_match) < 1e-6)
-        assert_(abs(sum_differ) < 1e-6)
-
-
-if __name__ == "__main__":
-    run_module_suite()
+        assert sum_match == pytest.approx(1)
+        assert sum_differ == pytest.approx(int(m1 == m1p and m2 == m2p))

--- a/qutip/utilities.py
+++ b/qutip/utilities.py
@@ -3,8 +3,7 @@ This module contains utility functions that are commonly needed in other
 qutip modules.
 """
 
-__all__ = ['n_thermal', 'linspace_with', 'clebsch', 'convert_unit',
-           'view_methods']
+__all__ = ['n_thermal', 'clebsch', 'convert_unit']
 
 import numpy as np
 
@@ -43,39 +42,6 @@ def n_thermal(w, w_th):
             return 1.0 / (np.exp(w / w_th) - 1.0)
         else:
             return 0.0
-
-
-def linspace_with(start, stop, num=50, elems=[]):
-    """
-    Return an array of numbers sampled over specified interval
-    with additional elements added.
-
-    Returns `num` spaced array with elements from `elems` inserted
-    if not already included in set.
-
-    Returned sample array is not evenly spaced if addtional elements
-    are added.
-
-    Parameters
-    ----------
-    start : int
-        The starting value of the sequence.
-    stop : int
-        The stoping values of the sequence.
-    num : int, optional
-        Number of samples to generate.
-    elems : list/ndarray, optional
-        Requested elements to include in array
-
-    Returns
-    -------
-    samples : ndadrray
-        Original equally spaced sample array with additional
-        elements added.
-    """
-    elems = np.array(elems)
-    lspace = np.linspace(start, stop, num)
-    return np.union1d(lspace, elems)
 
 
 def _factorial_prod(N, arr):
@@ -356,32 +322,6 @@ def convert_mK_to_GHz(w):
     """
     w_GHz = w * 1.0e-12 * (_kB / _h)
     return w_GHz
-
-
-def view_methods(Q):
-    """
-    View the methods and corresponding doc strings
-    for a Qobj class.
-
-    Parameters
-    ----------
-    Q : Qobj
-        Input Quantum object.
-
-    """
-    meth = dir(Q)
-    qobj_props = ['data', 'dims', 'isherm', 'shape', 'type']
-    pub_meth = [x for x in meth if x.find('_') and x not in qobj_props]
-    ml = max([len(x) for x in pub_meth])
-    nl = len(Q.__class__.__name__ + 'Class Methods:')
-    print(Q.__class__.__name__ + ' Class Methods:')
-    print('-' * nl)
-    for ii in range(len(pub_meth)):
-        m = getattr(Q, pub_meth[ii])
-        meth_str = m.__doc__
-        ind = meth_str.find('\n')
-        pub_len = len(pub_meth[ii] + ': ')
-        print(pub_meth[ii] + ':' + ' ' * (ml+3-pub_len) + meth_str[:ind])
 
 
 def _version2int(version_string):


### PR DESCRIPTION
**Description**
Update tests in `test_utilities.py` to `pytest` and add test for previouly untested function.
I removed 2 functions:
`linspace_with`: never used, almost equivalent to `np.linspace`.
`view_methods`: supposed to print methods of a `Qobj`, but broken...

**Changelog**
Update tests in test_utilities.py to pytest.
Remove broken qutip.utilities.view_methods.
Remove qutip.utilities.linspace_with (use numpy.linspace instead).
