### PR TITLE
Arcs and lines

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -3,7 +3,7 @@ __all__ = ['Bloch']
 import os
 
 from numpy import (ndarray, array, linspace, pi, outer, cos, sin, ones, size,
-                   sqrt, real, mod, append, ceil, arange)
+                   sqrt, real, mod, append, ceil, arange, arccos, arctan,arcsin)
 
 from packaging.version import parse as parse_version
 


### PR DESCRIPTION
**Description**

I have mainly added two features: 
1. Add an arc between any two points on the Bloch sphere: While calling `add_arc`, the user needs to provide the cartesian coordinates of the initial and the final points. 

2. Add a line segment connecting two points on the Bloch sphere: While calling `add_line`, the user needs to provide the cartesian coordinates of the two points.

I have attached an image where I constructed arcs and line segments in the Bloch sphere.
![Bloch_sphere_poss_2](https://user-images.githubusercontent.com/33507538/135909890-541e104e-7233-4702-83b6-c1d68bcbcc34.png)

#### Idea behind the arc code: 
1. Convert the two points to spherical coordinates.
2. Apply appropriate rotations along the z- and the y-axis on both the points so that the first point is now located at the north pole. 
3. Construct a latitude from the north pole to the (transformed) second point.
4. Apply reverse transformations on the points of the arc.
5. We now have the desired arc.

Other minor changes:
1. in `def show(self)`, the plot was not being displayed using the previous lines of code in the function, so I have commented them out and changed it to
```
if self.fig:
    plt.show(self.fig)
```

**Related issues:** #1683

**Changelog**
Added option for visualizing an arc on a Bloch sphere.
Added option for visualizing a line segment connecting two points on a Bloch sphere.
