### PR TITLE
Initial draft of instrument support.

### DIFF
--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -132,6 +132,7 @@ from .partial_transpose import *
 from .continuous_variables import *
 from .distributions import *
 from .three_level_atom import *
+from .qinstrument import *
 
 ########################################################################
 # This section exists only for the deprecation warning of qip importation.

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -552,13 +552,13 @@ class Qobj:
     # The next few operator overload methods allow `A & B` to mean
     # 𝐴 ⊗ 𝐵 and `A ^ n` to mean ⊗ᵢ₌₁ⁿ 𝐴.
     def __and__(self, other):
-        return tensor.tensor(self, other)
+        return tensor(self, other)
 
     def __rand__(self, other):
-        return tensor.tensor(other, self)
+        return tensor(other, self)
 
     def __xor__(self, n):
-        return tensor.tensor([self] * n)
+        return tensor([self] * n)
 
     def __getitem__(self, ind):
         # TODO: should we require that data-layer types implement this?  This

--- a/qutip/qinstrument.py
+++ b/qutip/qinstrument.py
@@ -1,0 +1,393 @@
+"""The Quantum instrument (QInstrument) class, for representing the most
+general form of discrete-time evolution in open quantum systems.
+"""
+
+__all__ = ['QInstrument', 'Seq', 'Tens']
+
+# # Design notes
+#
+# Instruments are indexed sets of functions from normalized density operators 
+# to subnormalized (trace ∈ [0, 1]) density operators, with each index
+# corresponding to a given classical measurement outcome.
+#
+# We represent instruments in QuTiP as dictionaries from classical measurement
+# labels to Qobj instances for each quantum process making up an instrument.
+# In particular, measurement labels are always assumed to be _tuples_ of zero
+# or more different underlying labels, making it easy to compose instruments
+# together. A quantum process representing no measurement thus is indexed by
+# the zero-length (unit-like) tuple `()`, while a process representing a single
+# measurement may be represented by tuples such as `(0,)`, `(1,)`, and so
+# forth.
+
+import itertools
+import warnings
+import types
+import numbers
+from typing import Dict, Iterable, TypeVar, Union, Optional, Generic
+from dataclasses import dataclass
+from qutip.core import Qobj
+
+@dataclass
+class Outcome:
+    probability : float
+    output_state : Qobj
+
+    @classmethod
+    def _from_qobj(cls, qobj):
+        return cls(probability=qobj.tr(), output_state=qobj.unit())
+
+# TODO: Need better names for these two classes!
+def _flatten_nested(t, items):
+    return sum(
+        (
+            list(item) if isinstance(item, t) else [item]
+            for item in items
+        ),
+        []
+    )
+
+def _flatten_singletons(t, items):
+    return [
+        item[0] if isinstance(item, t) and len(item) == 1 else item
+        for item in items
+    ]
+
+class Seq(tuple):
+    """
+    A sequence of measurement outcomes.
+
+    Automatically flattens nested levels of `Seq`; e.g.: `Seq(Seq(1, 2), 3)`
+    is identical to `Seq(1, 2, 3)`. Nested singletons of `Tens` are implied;
+    e.g.: `Seq(Tens(1,), 2)` is identical to `Seq(1, 2)`.
+    """
+    def __new__(cls, *iterable):
+        return super().__new__(cls,
+            _flatten_singletons(Tens, _flatten_nested(Seq, iterable))
+        )
+
+    def __repr__(self) -> str:
+        return f"Seq{super().__repr__()}"
+
+    def __add__(self, other):
+        return Seq(*(super().__add__(other)))
+    def __radd__(self, other):
+        return Seq(*(super().__radd__(other)))
+
+class Tens(tuple):
+    """
+    A list of measurement outcomes extracted in parallel on distinct
+    subsystems.
+
+    Automatically flattens nested levels of `Tens`; e.g.: `Tens(Tens(1, 2), 3)`
+    is identical to `Tens(1, 2, 3)`. Nested singletons of `Seq` are implied;
+    e.g.: `Tens(Seq(1,), 2)` is identical to `Tens(1, 2)`.
+    """
+    def __new__(cls, *iterable):
+        return super().__new__(cls,
+            _flatten_singletons(Seq, _flatten_nested(Tens, iterable))
+        )
+
+    def __repr__(self) -> str:
+        return f"Tens{super().__repr__()}"
+
+    def __add__(self, other):
+        return Tens(*(super().__add__(other)))
+    def __radd__(self, other):
+        return Tens(*(super().__radd__(other)))
+
+
+
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
+
+import numpy as np
+import qutip.settings as settings
+from qutip import __version__
+
+def _is_iterable(value):
+    try:
+        _ = iter(value)
+        return True
+    except:
+        return False
+
+def _normalize_as_instrument(instrument_like):
+    """
+    """
+    # Is the input already literally an instrument? Then copy and return its
+    # data.
+    if isinstance(instrument_like, QInstrument):
+        return instrument_like._processes
+
+    # Is the instrument already in the right form (that is, dictionary from
+    # tuples to Qobj instances)?
+    elif isinstance(instrument_like, dict):
+        # Assume that the input is already a dict from measurement labels to
+        # Qobj instances, but that the labels may not be tuples, and the Qobj
+        # values may need to be promoted to super.
+        return {
+            label if isinstance(label, tuple) else (label, ):
+                value if value.type == "super" else sr.to_super(value)
+            for label, value in instrument_like.items()
+        }
+
+    # If we have a single Qobj, promote it to super if needed.
+    elif isinstance(instrument_like, Qobj):
+        return {
+            Seq():
+                instrument_like
+                if instrument_like.type == "super" else
+                sr.to_super(instrument_like)
+        }
+
+    # We may also have an iterable, in which case we try to promote each entry
+    # and return integer indices.
+    # TODO: Only go down this branch if an iterable of Qobj values!
+    elif _is_iterable(instrument_like):
+        values = list(instrument_like)
+        return {
+            Seq(idx, ):
+                value
+                if value.type == "super" else
+                sr.to_super(value)
+            for idx, value in enumerate(instrument_like)
+        }
+
+    # TODO: Try to promote anything else to a single Qobj.
+
+    else:
+        raise TypeError(f"Value {instrument_like} was not instrument-like.")
+
+def _require_consistant_dims(processes):
+    dims = None
+    for process in processes:
+        if dims is None:
+            dims = process.dims
+        else:
+            if process.dims != dims:
+                raise ValueError(f"Dimensions {process.dims} are not consistent with dimensions {dims}.")
+
+def _ensure_instrument(instrument_like):
+    return instrument_like if isinstance(instrument_like, QInstrument) else QInstrument(instrument_like)
+
+
+class QInstrument(object):
+    """TODO
+    """
+    __array_priority__ = 100  # sets Qobj priority above numpy arrays
+    # Disable ufuncs from acting directly on Qobj. This is necessary because we
+    # define __array__.
+    __array_ufunc__ = None
+
+    def __init__(self, input=None):
+        """
+        TODO
+        """
+        self._processes = _normalize_as_instrument(input)
+        _require_consistant_dims(self._processes.values())
+
+    @property
+    def dims(self):
+        # When constructing, we ensured that all dims are consistant, so we
+        # only need to check the first process.
+        return next(iter(self._processes.values())).dims
+
+    @property
+    def outcome_space(self):
+        return self._processes.keys()
+
+    @property
+    def n_outcomes(self):
+        return len(self._processes)
+
+    @property
+    def nonselective_process(self):
+        return sum(self._processes.values())
+
+    @property
+    def iscp(self):
+        return all(process.iscp for process in self._processes.values()) and self.nonselective_process.iscp
+
+    @property
+    def ishp(self):
+        return all(process.ishp for process in self._processes.values()) and self.nonselective_process.ishp
+
+    @property
+    def istp(self):
+        # Only check the combined channel!
+        return self.nonselective_process.istp
+    
+    @property
+    def iscptp(self):
+        # Don't check tp on constiuant channels!
+        return all(process.iscp for process in self._processes.values()) and self.nonselective_process.iscptp
+
+    def copy(self):
+        """Create identical copy"""
+        return (type(self))(input=self)
+
+    def __len__(self):
+        return self.n_outcomes
+
+    @staticmethod
+    def _compose(left, right):
+        # TODO: Check if scalars work?
+        try:
+            left = _ensure_instrument(left)
+            right = _ensure_instrument(right)
+        except TypeError:
+            return NotImplemented
+
+        return QInstrument({
+            # Reverse the ordering of labels, since 𝐵𝐴 means "𝐴 then 𝐵."
+            Seq(right_label, left_label): prod
+            for (left_label, left_process), (right_label, right_process)
+            in itertools.product(left._processes.items(), right._processes.items())
+            # Chop out trace-annhilating processes (those processes that
+            # correspond to measurement outcomes that cannot possibly occur).
+            if not (prod := (left_process * right_process)).is_trace_annhilating
+        })
+
+    def __mul__(self, other):
+        """
+        MULTIPLICATION with Qobj on LEFT [ ex. Qobj*4 ]
+        """
+        return self._compose(self, other)
+
+    def __rmul__(self, other):
+        """
+        MULTIPLICATION with Qobj on RIGHT [ ex. 4*Qobj ]
+        """
+        return self._compose(other, self)
+
+    def __getitem__(self, ind):
+        """
+        GET qobj elements.
+        """
+        return self._processes[ind]
+
+    def __eq__(self, other):
+        """
+        EQUALITY operator.
+        """
+        # TODO
+
+    def __ne__(self, other):
+        """
+        INEQUALITY operator.
+        """
+        return not (self == other)
+
+    def __pow__(self, n):  # calculates powers of Qobj
+        """
+        POWER operation.
+        """
+        # TODO: could optimize to use binary exponentiation.
+        acc = self
+        for _ in range(1, n):
+            acc *= self
+        return acc
+
+    # The next few operator overload methods allow `A & B` to mean
+    # 𝐴 ⊗ 𝐵 and `A ^ n` to mean ⊗ᵢ₌₁ⁿ 𝐴.
+    def __and__(self, other):
+        return tensor(self, other)
+
+    def __rand__(self, other):
+        return tensor(other, self)
+
+    def __xor__(self, n):
+        return tensor([self] * n)
+
+    def __str__(self):
+        return repr(self) # TODO
+
+    def __repr__(self):
+        return f"QInstrument id={id(self):0x} {{\n    dims {self.dims}\n    outcomes {' '.join(map(str, self.outcome_space))}\n}}"
+
+    def __call__(self, other):
+        # TODO: Confirm that other is type=ket or type=oper.
+        return {
+            label: Outcome._from_qobj(process(other))
+            for label, process in self._processes.items()
+        }
+
+    def sample(self, other):
+        pr_table = list(self(other).items())
+        idx_outcome = np.random.choice(len(pr_table), p=[outcome.probability for (label, outcome) in pr_table])
+        return pr_table[idx_outcome]
+
+    def __getstate__(self):
+        # defines what happens when Qobj object gets pickled
+        self.__dict__.update({'qutip_version': __version__[:5]})
+        return self.__dict__
+
+    def __setstate__(self, state):
+        # defines what happens when loading a pickled Qobj
+        if 'qutip_version' in state.keys():
+            del state['qutip_version']
+        (self.__dict__).update(state)
+
+    def _repr_latex_(self):
+        # TODO
+        pass
+
+    def __array__(self, *arg, **kwarg):
+        """Numpy array from Qobj
+        For compatibility with np.array
+        """
+        # TODO
+
+    def unit(self, inplace=False,
+             norm=None, sparse=False,
+             tol=0, maxiter=100000):
+       # TODO
+       pass
+
+    def tidyup(self, atol=settings.core['auto_tidyup_atol']):
+        """Removes small elements from the quantum object.
+
+        Parameters
+        ----------
+        atol : float
+            Absolute tolerance used by tidyup. Default is set
+            via qutip global settings parameters.
+
+        Returns
+        -------
+        oper : :class:`qutip.Qobj`
+            Quantum object with small elements removed.
+
+        """
+        # TODO
+
+    # CLASS METHODS
+    # Mostly factory methods to help quickly construct new instruments.
+
+    @classmethod
+    def basis_measurement(cls, N=2):
+        return cls([
+            qutip.states.projection(N, idx, idx)
+            for idx in range(N)
+        ])
+
+def _instrument_tensor(qlist):
+    terms = list(itertools.product(*[_ensure_instrument(q)._processes.items() for q in qlist]))
+
+    return QInstrument({
+        Tens(*labels): super_tensor(*processes)
+        for labels, processes in
+        itertools.starmap(zip, terms)
+    })
+
+# TRAILING IMPORTS
+# We do a few imports here to avoid circular dependencies.
+import qutip.core.superop_reps as sr
+import qutip.core.tensor as tensor
+from .core.tensor import super_tensor
+import qutip.core.operators as ops
+import qutip.core.metrics as mts
+import qutip.core.states
+import qutip.core.superoperator

--- a/qutip/qinstrument.py
+++ b/qutip/qinstrument.py
@@ -516,32 +516,31 @@ class QInstrument(object):
             for label, process in self._processes.items()
         })
 
-    # CLASS METHODS
-    # Factory methods to help quickly construct new instruments.
+## FACTORY FUNCTIONS ##
 
-    @classmethod
-    def basis_measurement(cls, N=2):
-        return cls([
-            qutip.states.projection(N, idx, idx)
-            for idx in range(N)
-        ])
+def basis_measurement(N=2):
+    return QInstrument([
+        qutip.states.projection(N, idx, idx)
+        for idx in range(N)
+    ])
 
-    @classmethod
-    # TODO: Change to list[Pauli], use _ensure_pauli to promote to string.
-    def pauli_measurement(cls, pauli: Optional[Union[PauliString, str]] = None):
-        """
-        Returns an instrument that performs a half-space measurement on a
-        given Pauli operator.
-        """
-        # If pauli isn't an instance of PauliString, try to promote it.
-        pauli = PauliString(pauli) if isinstance(pauli, str) else pauli
-        pauli = replace(pauli if pauli is not None else PauliString("+Z"), phase=0)
-        op = (pauli).as_qobj()
-        eye = ops.qeye(op.dims[0])
-        return QInstrument({
-            Seq(pauli): (op + eye) / 2,
-            Seq(-pauli): (op - eye) / 2
-        })
+# TODO: Change to list[Pauli], use _ensure_pauli to promote to string.
+def pauli_measurement(pauli: Optional[Union[PauliString, str]] = None):
+    """
+    Returns an instrument that performs a half-space measurement on a
+    given Pauli operator.
+    """
+    # If pauli isn't an instance of PauliString, try to promote it.
+    pauli = PauliString(pauli) if isinstance(pauli, str) else pauli
+    pauli = replace(pauli if pauli is not None else PauliString("+Z"), phase=0)
+    op = (pauli).as_qobj()
+    eye = ops.qeye(op.dims[0])
+    return QInstrument({
+        Seq(pauli): (op + eye) / 2,
+        Seq(-pauli): (op - eye) / 2
+    })
+
+## INTERNAL UTILITY FUNCTIONS ##
 
 def _instrument_tensor(qlist):
     terms = list(itertools.product(*[_ensure_instrument(q)._processes.items() for q in qlist]))

--- a/qutip/qinstrument.py
+++ b/qutip/qinstrument.py
@@ -358,11 +358,15 @@ class QInstrument(object):
         return QInstrument({
             # Reverse the ordering of labels, since 𝐵𝐴 means "𝐴 then 𝐵."
             Seq(right_label, left_label): prod
-            for (left_label, left_process), (right_label, right_process)
-            in itertools.product(left._processes.items(), right._processes.items())
+            for (left_label, right_label, prod)
+            in (
+                (left_label, right_label, left_process * right_process)
+                for (left_label, left_process), (right_label, right_process) in
+                itertools.product(left._processes.items(), right._processes.items())
+            )
             # Chop out trace-annhilating processes (those processes that
             # correspond to measurement outcomes that cannot possibly occur).
-            if not (prod := (left_process * right_process)).is_trace_annhilating
+            if not prod.is_trace_annhilating
         })
 
     def __mul__(self, other):

--- a/qutip/qinstrument.py
+++ b/qutip/qinstrument.py
@@ -297,7 +297,8 @@ class QInstrument(object):
 
     @property
     def nonselective_process(self):
-        return sum(self._processes.values())
+        values = list(self._processes.values())
+        return sum(values[1:], values[0])
 
     @property
     def iscp(self):

--- a/qutip/tests/test_qinstrument.py
+++ b/qutip/tests/test_qinstrument.py
@@ -1,0 +1,131 @@
+from qutip import (
+    QInstrument,
+    Seq, Par,
+    Pauli, PauliString
+)
+
+class TestSeqPar:
+    """
+    Unit tests that exercise the Seq/Par interface for instrument labels.
+    """
+    def test_seq_in_seq_is_flattened(self):
+        s = Seq(Seq(1, 2), Seq(3, 4), 5)
+        assert s == Seq(1, 2, 3, 4, 5)
+
+    def test_par_in_par_is_flattened(self):
+        s = Par(Par(1, 2), Par(3, 4), 5)
+        assert s == Par(1, 2, 3, 4, 5)
+
+    def test_seq_in_par_is_implied(self):
+        s = Par(1, 2, Seq(3,), 4)
+        assert s == Par(1, 2, 3, 4)
+
+    def test_par_in_seq_is_implied(self):
+        s = Seq(1, 2, Par(3,), 4)
+        assert s == Seq(1, 2, 3, 4)
+
+    def test_seq_parses_simple_case(self):
+        s = Seq.parse("1,2,3,4")
+        assert s == Seq(1, 2, 3, 4)
+
+    def test_seq_parses_noninteger_labels(self):
+        s = Seq.parse("⊥,a,3") # Only "3" should get converted to an int!
+        assert s == Seq("⊥", "a", 3)
+
+    def test_seq_parses_par(self):
+        s = Seq.parse("0,1,2;3,4")
+        assert s == Seq(Par(Seq(0, 1, 2), Seq(3, 4)))
+
+    def test_seq_parses_and_trims(self):
+        s = Seq.parse("0, 1, 2 ; 3, 4")
+        assert s == Seq.parse("0,1,2;3,4")
+
+    def test_repr(self):
+        raise NotImplementedError("test not yet written")
+
+
+class TestPauliString:
+    """
+    Unit tests that exercise the PauliSTring class used for labeling Pauli
+    measurements.
+    """
+
+    def test_init_takes_mod(self):
+        p = PauliString(2, "XY")
+        q = PauliString(6, "XY")
+        assert p == q
+
+    def test_init_assumes_default_phase(self):
+        p = PauliString("IXYZ")
+        q = PauliString(0, "IXYZ")
+        assert p == q
+
+    def test_as_qobj(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_neg(self):
+        p = PauliString(3, "ZZYZX")
+        q = PauliString(1, "ZZYZX")
+        assert p == -q
+        assert -p == q
+
+    def test_parse_without_sign(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_parse_with_sign(self):
+        raise NotImplementedError("test not yet written")
+
+
+class TestQInstrument:
+    """
+    Unit tests that exercise the QInstrument type for representing quantum
+    instruments.
+    """
+
+    def test_init_from_qobj(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_init_from_dict_with_str_labels(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_init_from_dict_with_seq_labels(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_nonselective_process_is_channel(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_lmul(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_rmul(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_pow(self):
+        raise NotImplementedError("test not yet written")    
+
+    def test_tensor(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_propagate(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_sample(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_mul_eliminates_impossible_outcomes(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_finite_visibility(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_complete(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_reindex(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_conditional_instruments(self):
+        raise NotImplementedError("test not yet written")
+
+    def test_ptrace(self):
+        raise NotImplementedError("test not yet written")


### PR DESCRIPTION
As discussed in #1673, this PR is an initial draft of what instrument support could look like to get feedback and discussion going on the API and functionality. As such, code style, documentation, unit testing and so forth still need to be addressed (see check list below).

**Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to QuTiP Development](http://qutip.org/docs/latest/development/contributing.html)
- [ ] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
- [ ] Please add tests to cover your changes if applicable.
- [ ] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-notebooks). Feel free to ask if you are not sure.

Delete this checklist after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.

**Description**
This PR adds a new class, `QInstrument`, that wraps a decomposition of a quantum instrument into completely positive trace non-increasing maps (subnormalized channels). This new class can be used to predict measurement outcomes and post-measurement states for a variety of different quantum systems:

```python
>>> import qutip
>>> H = qutip.operations.hadamard_transform()
>>> ket_plus = H * qutip.basis(2, 0)
>>> z_instrument = qutip.QInstrument.basis_measurement(2)
>>> (H * z_instrument)(ket_plus)
{Seq(0,): Outcome(probability=0.5000000000000002, output_state=Quantum object: dims = [[2], [2]], shape = (2, 2), type = oper, isherm = True
Qobj data =
[[0.5 0.5]
 [0.5 0.5]]), Seq(1,): Outcome(probability=0.5000000000000002, output_state=Quantum object: dims = [[2], [2]], shape = (2, 2), type = oper, isherm = True
Qobj data =
[[ 0.5 -0.5]
 [-0.5  0.5]])}
>>> z_instrument.sample(ket_plus)
(Seq(1,), Outcome(probability=0.5000000000000001, output_state=Quantum object: dims = [[2], [2]], shape = (2, 2), type = oper, isherm = True
Qobj data =
[[0. 0.]
 [0. 1.]]))
```

Instruments can be combined through composition and tensor products (corresponding to `Seq` and `Par` outcome labels, respectively):

```python
>>> z_instrument * z_instrument
QInstrument id=2e7d878ab80 {
    dims [[[2], [2]], [[2], [2]]]
    outcomes Seq(0, 0) Seq(1, 1)
}
>>> qutip.tensor([z_instrument] * 2)
QInstrument id=2e7d8a1dcd0 {
    dims [[[2, 2], [2, 2]], [[2, 2], [2, 2]]]
    outcomes Par(0, 0) Par(0, 1) Par(1, 0) Par(1, 1)
}
```

Impossible outcomes are detected and truncated automatically:

```python
>>> z_instrument * z_instrument
QInstrument id=2e7d8a6e130 {
    dims [[[2], [2]], [[2], [2]]]
    outcomes Seq(0, 0) Seq(1, 1)
}
>>> z_instrument.with_finite_visibility(0.95) ** 2
QInstrument id=2e7d8a6ef10 {
    dims [[[2], [2]], [[2], [2]]]
    outcomes Seq(0, 0) Seq(1, 0) Seq(0, 1) Seq(1, 1)
}
```

Arbitrary subsystem dims are supported:

```python
>>> qutip.QInstrument.basis_measurement(3)
QInstrument id=2e7d5ca4eb0 {
    dims [[[3], [3]], [[3], [3]]]
    outcomes Seq(0,) Seq(1,) Seq(2,)
}
```

Incomplete instruments (that is, where the probability of obtaining any result is less than 1, as in the erasure channel case) can be completed:

```python
>>> qutip.QInstrument(qutip.projection(4, 0, 0)).complete()
QInstrument id=1f9735f3f10 {
    dims [[[4], [4]], [[4], [4]]]
    outcomes Seq() Seq('⊥',)
}
```

Measurement outcome labels can be re-indexed onto integer labels according to lexographical sorting of original labels:

```python
>>> qutip.QInstrument(qutip.projection(4, 0, 0)).complete().reindex()
QInstrument id=1f96e774970 {
    dims [[[4], [4]], [[4], [4]]]
    outcomes Seq(0,) Seq(1,)
}
```

Composition and tensor products can be combined:

```python
>>> qutip.tensor(z_instrument.with_finite_visibility(0.95) ** 2, z_instrument)
QInstrument id=2e7d89a19a0 {
    dims [[[2, 2], [2, 2]], [[2, 2], [2, 2]]]
    outcomes Par(Seq(0, 0), 0) Par(Seq(0, 0), 1) Par(Seq(1, 0), 0) Par(Seq(1, 0), 1) Par(Seq(0, 1), 0) Par(Seq(0, 1), 1) Par(Seq(1, 1), 0) Par(Seq(1, 1), 1)
}
```

Outcomes can be labeled by arbitrary hashable types:

```python
>>> qutip.QInstrument.pauli_measurement("ZZ") * qutip.QInstrument.pauli_measurement("XX")
QInstrument id=2e7d89d5dc0 {
    dims [[[2, 2], [2, 2]], [[2, 2], [2, 2]]]
    outcomes Seq(+XX, +ZZ) Seq(-XX, +ZZ) Seq(+XX, -ZZ) Seq(-XX, -ZZ)
}
>>> (qutip.QInstrument.pauli_measurement("ZZ") * qutip.QInstrument.pauli_measurement("XX")) ** 2
QInstrument id=2e7d89a44c0 {
    dims [[[2, 2], [2, 2]], [[2, 2], [2, 2]]]
    outcomes Seq(+XX, +ZZ, +XX, +ZZ) Seq(-XX, +ZZ, -XX, +ZZ) Seq(+XX, -ZZ, +XX, -ZZ) Seq(-XX, -ZZ, -XX, -ZZ)
}
>>> (qutip.QInstrument.pauli_measurement("ZZ") * qutip.QInstrument.pauli_measurement("XX")).with_finite_visibility(0.95) ** 2
QInstrument id=2e7d6654520 {
    dims [[[2, 2], [2, 2]], [[2, 2], [2, 2]]]
    outcomes Seq(+XX, +ZZ, +XX, +ZZ) Seq(-XX, +ZZ, +XX, +ZZ) Seq(+XX, -ZZ, +XX, +ZZ) Seq(-XX, -ZZ, +XX, +ZZ) Seq(+XX, +ZZ, -XX, +ZZ) Seq(-XX, +ZZ, -XX, +ZZ) Seq(+XX, -ZZ, -XX, +ZZ) Seq(-XX, -ZZ, 
-XX, +ZZ) Seq(+XX, +ZZ, +XX, -ZZ) Seq(-XX, +ZZ, +XX, -ZZ) Seq(+XX, -ZZ, +XX, -ZZ) Seq(-XX, -ZZ, +XX, -ZZ) Seq(+XX, +ZZ, -XX, -ZZ) Seq(-XX, +ZZ, -XX, -ZZ) Seq(+XX, -ZZ, -XX, -ZZ) Seq(-XX, -ZZ, -XX, -ZZ)
}
```

Nonselective channels (that is, the channel resulting from discarding all measurement outcomes) can be efficiently obtained using the `nonselective_process` property:

```python
>>> ins = (qutip.QInstrument.pauli_measurement("ZZ") * qutip.QInstrument.pauli_measurement("XX")).with_finite_visibility(0.95) ** 2
>>> ins.nonselective_process
Quantum object: dims = [[[2, 2], [2, 2]], [[2, 2], [2, 2]]], shape = (16, 16), type = super, isherm = True
Qobj data =
[[0.50125 0.      0.      0.      0.      0.      0.      0.      0.
  0.      0.      0.      0.      0.      0.      0.49875]
 [0.      0.0025  0.      0.      0.      0.      0.      0.      0.
  0.      0.      0.      0.      0.      0.      0.     ]
 [0.      0.      0.0025  0.      0.      0.      0.      0.      0.
  0.      0.      0.      0.      0.      0.      0.     ]
 [0.      0.      0.      0.50125 0.      0.      0.      0.      0.
  0.      0.      0.      0.49875 0.      0.      0.     ]
 [0.      0.      0.      0.      0.0025  0.      0.      0.      0.
  0.      0.      0.      0.      0.      0.      0.     ]
 [0.      0.      0.      0.      0.      0.50125 0.      0.      0.
  0.      0.49875 0.      0.      0.      0.      0.     ]
 [0.      0.      0.      0.      0.      0.      0.50125 0.      0.
  0.49875 0.      0.      0.      0.      0.      0.     ]
 [0.      0.      0.      0.      0.      0.      0.      0.0025  0.
  0.      0.      0.      0.      0.      0.      0.     ]
 [0.      0.      0.      0.      0.      0.      0.      0.      0.0025
  0.      0.      0.      0.      0.      0.      0.     ]
 [0.      0.      0.      0.      0.      0.      0.49875 0.      0.
  0.50125 0.      0.      0.      0.      0.      0.     ]
 [0.      0.      0.      0.      0.      0.49875 0.      0.      0.
  0.      0.50125 0.      0.      0.      0.      0.     ]
 [0.      0.      0.      0.      0.      0.      0.      0.      0.
  0.      0.      0.0025  0.      0.      0.      0.     ]
 [0.      0.      0.      0.49875 0.      0.      0.      0.      0.
  0.      0.      0.      0.50125 0.      0.      0.     ]
 [0.      0.      0.      0.      0.      0.      0.      0.      0.
  0.      0.      0.      0.      0.0025  0.      0.     ]
 [0.      0.      0.      0.      0.      0.      0.      0.      0.
  0.      0.      0.      0.      0.      0.0025  0.     ]
 [0.49875 0.      0.      0.      0.      0.      0.      0.      0.
  0.      0.      0.      0.      0.      0.      0.50125]]
```

Trace preserving and complete positivity conditions can be checked in a similar way to `Qobj` instances:

```python
>>> ins.iscptp
True
>>> ins.ishp
True
>>> ins.istp
True
>>> ins.iscp
True
```

Finally, for convienence, this PR also proposes QuaEC-style shorthand for tensor products of quantum objects and instruments:

```python
>>> z_instrument & z_instrument.with_finite_visibility(0.95)
QInstrument id=2e7d5ca4d30 {
    dims [[[2, 2], [2, 2]], [[2, 2], [2, 2]]]
    outcomes Par(0, 0) Par(0, 1) Par(1, 0) Par(1, 1)
}
>>> z_instrument ^ 3
QInstrument id=2e7d8017e80 {
    dims [[[2, 2, 2], [2, 2, 2]], [[2, 2, 2], [2, 2, 2]]]
    outcomes Par(0, 0, 0) Par(0, 0, 1) Par(0, 1, 0) Par(0, 1, 1) Par(1, 0, 0) Par(1, 0, 1) Par(1, 1, 0) Par(1, 1, 1)
}
```

**Related issues or PRs**
- #1673

**Changelog**
Adds support for quantum instruments, a generalization of measurements and channels.
