### PR TITLE
Add support for specifying the numpy version in the CI test matrix.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
           - case-name: OpenMP
             os: ubuntu-latest
             python-version: 3.9
-            numpy-requirement: [">=1.20,<1.21"]
+            numpy-requirement: ">=1.20,<1.21"
             openmp: 1
 
           # Builds without Cython at runtime.  This is a core feature;


### PR DESCRIPTION
**Description**
Add support for setting the numpy version in test runs.

**Related issues or PRs**
* See #1694 for the strange steadystate test failures on Python 3.9, numpy 1.21.2 and on certain Azure VMs.
* See #1689 for earlier discussion of the above failures in an unrelated PR.

**Changelog**
* Add support for specifying the numpy version in the CI test matrix and pin numpy to the latest 1.20.X by default.