### PR TITLE
Change tests/test_metrics.py so that only dnorm tests are skipped if cvxpy is not installed

### DIFF
--- a/qutip/tests/test_metrics.py
+++ b/qutip/tests/test_metrics.py
@@ -291,8 +291,6 @@ def adc_choi(x):
 # 
 # Skip dnorm tests if we don't have cvxpy or cvxopt available, since dnorm 
 # depends on them.
-
-
 @pytest.mark.skipif(cvxpy is None or cvxopt is None,
                     reason="Skipping dnorm tests because dnorm requires cvxpy"
                     " and cvxopt which are not installed.")

--- a/qutip/tests/test_metrics.py
+++ b/qutip/tests/test_metrics.py
@@ -13,6 +13,13 @@ from qutip import (
 from qutip.qip.operations import (
     hadamard_transform, swap,
 )
+
+try:
+    import cvxpy
+    import cvxopt
+except ImportError:
+    cvxpy, cvxopt = None, None
+
 # These ones are the metrics functions that we actually want to test.
 from qutip import (
     fidelity, tracedist, hellinger_dist, dnorm, average_gate_fidelity,
@@ -281,16 +288,19 @@ def adc_choi(x):
 #
 # The warning filter is to account for cvxpy < 1.1.10 which uses np.complex,
 # which is deprecated as of numpy 1.20.
+# 
+# Skip dnorm tests if we don't have cvxpy or cvxopt available, since dnorm 
+# depends on them.
+
+
+@pytest.mark.skipif(cvxpy is None or cvxopt is None,
+                    reason="Skipping dnorm tests because dnorm requires cvxpy"
+                    " and cvxopt which are not installed.")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.filterwarnings(
     "ignore:`np.complex` is a deprecated alias:DeprecationWarning:cvxpy"
 )
 class Test_dnorm:
-    # Skip dnorm tests if we don't have cvxpy or cvxopt available, since it
-    # depends on them.
-    cvxpy = pytest.importorskip("cvxpy")
-    cvxopt = pytest.importorskip("cvxopt")
-
     @pytest.fixture(params=[2, 3])
     def dimension(self, request):
         return request.param


### PR DESCRIPTION
Previously, all tests in `test_metrics.py` were skipped if cvxpy or cvxopt were not installed.

Addresses part 1 of https://github.com/qutip/qutip/issues/1703.

**Changelog**
Only skip the dnorm tests if cvxpy is not installed (previously all metrics tests were skipped).