### PR TITLE
Implement and test new version of process fidelity

### DIFF
--- a/qutip/tests/test_scheduler.py
+++ b/qutip/tests/test_scheduler.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from qutip.qip.circuit import QubitCircuit
 from qutip.qip.compiler import Instruction, Scheduler
 from qutip.qip.operations.gates import gate_sequence_product
-from qutip import process_fidelity, qeye, tracedist
+from qutip import qeye, tracedist
 from qutip.qip.circuit import Gate
 
 


### PR DESCRIPTION
A re-implementation of `qutip.metrics.process_fidelity`. 
The definition implemented here follows Gilchrist, Langford, Nielsen, Phys. Rev. A 71, 062310 (2005), https://journals.aps.org/pra/abstract/10.1103/PhysRevA.71.062310 (https://arxiv.org/abs/quant-ph/0408063).
Depending on how the quantum channels passed to `process_fidelity` are represented (unitary, supermatrix, choi, chi, or Kraus), computational shortcuts are used. They are all tested against each other.

**Related issues or PRs**
Proposed in https://github.com/qutip/qutip/issues/1703

**Changelog**
Fixed implementation of qutip.metrics.process_fidelity and added tests