### PR TITLE
Rtol for tests

### DIFF
--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -297,7 +297,7 @@ class _GenericOpMixin:
         but with all data arguments numpy arrays, and returns the expected
         result.
 
-    tol: float
+    atol: float
         The absolute tolerance to use when comparing the test value with the
         expected value.  If the output is a Data type, the tolerance is
         per-element of the output.
@@ -327,7 +327,7 @@ class _GenericOpMixin:
     # addition not being associative; the maths on full numpy arrays will often
     # produce slightly different results to sparse algebra, since the order of
     # multiplications and additions will be different.
-    tol = 1e-10
+    atol = 1e-10
     rtol = 1e-7  # Same default as numpy
     shapes = []
     bad_shapes = []
@@ -406,16 +406,16 @@ class UnaryOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol,
+                                       atol=self.atol,
                                        rtol=self.rtol)
         elif out_type is list:
             for test_, expected_ in zip(test, expected):
                 assert test_.shape == expected_.shape
                 np.testing.assert_allclose(test_.to_array(),
-                                           expected_, atol=self.tol,
+                                           expected_, atol=self.atol,
                                            rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
+            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
 
     def test_incorrect_shape_raises(self, op, data_m):
         """
@@ -449,10 +449,10 @@ class UnaryScalarOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol,
+                                       atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
+            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
 
 
 class BinaryOpMixin(_GenericOpMixin):
@@ -472,10 +472,10 @@ class BinaryOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol,
+                                       atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
+            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
 
     def test_incorrect_shape_raises(self, op, data_l, data_r):
         """
@@ -507,10 +507,10 @@ class TernaryOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol,
+                                       atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
+            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
 
     def test_incorrect_shape_raises(self, op, data_l, data_m, data_r):
         """
@@ -555,10 +555,10 @@ class TestAdd(BinaryOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol,
+                                       atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
+            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
 
 
 class TestAdjoint(UnaryOpMixin):
@@ -645,10 +645,10 @@ class TestInner(BinaryOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol,
+                                       atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
+            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
 
 
 class TestInnerOp(TernaryOpMixin):
@@ -713,10 +713,10 @@ class TestInnerOp(TernaryOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol,
+                                       atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
+            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
 
 
 class TestKron(BinaryOpMixin):
@@ -819,7 +819,7 @@ class TestPow(UnaryOpMixin):
         assert isinstance(test, out_type)
         assert test.shape == expected.shape
         np.testing.assert_allclose(test.to_array(), expected,
-                                   atol=self.tol,
+                                   atol=self.atol,
                                    rtol=self.rtol)
 
     # Pow actually does have bad shape, so we put that in too.

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -416,7 +416,7 @@ class UnaryOpMixin(_GenericOpMixin):
                                            rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
-                                              rtol=self.rtol)
+                                       rtol=self.rtol)
 
     def test_incorrect_shape_raises(self, op, data_m):
         """
@@ -454,7 +454,7 @@ class UnaryScalarOpMixin(_GenericOpMixin):
                                        rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
-                                              rtol=self.rtol)
+                                       rtol=self.rtol)
 
 
 class BinaryOpMixin(_GenericOpMixin):
@@ -478,7 +478,7 @@ class BinaryOpMixin(_GenericOpMixin):
                                        rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
-                                              rtol=self.rtol)
+                                       rtol=self.rtol)
 
     def test_incorrect_shape_raises(self, op, data_l, data_r):
         """
@@ -514,7 +514,7 @@ class TernaryOpMixin(_GenericOpMixin):
                                        rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
-                                              rtol=self.rtol)
+                                       rtol=self.rtol)
 
     def test_incorrect_shape_raises(self, op, data_l, data_m, data_r):
         """
@@ -563,7 +563,7 @@ class TestAdd(BinaryOpMixin):
                                        rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
-                                              rtol=self.rtol)
+                                       rtol=self.rtol)
 
 
 class TestAdjoint(UnaryOpMixin):
@@ -654,7 +654,7 @@ class TestInner(BinaryOpMixin):
                                        rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
-                                              rtol=self.rtol)
+                                       rtol=self.rtol)
 
 
 class TestInnerOp(TernaryOpMixin):
@@ -723,7 +723,7 @@ class TestInnerOp(TernaryOpMixin):
                                        rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
-                                              rtol=self.rtol)
+                                       rtol=self.rtol)
 
 
 class TestKron(BinaryOpMixin):

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -415,7 +415,8 @@ class UnaryOpMixin(_GenericOpMixin):
                                            expected_, atol=self.atol,
                                            rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
+            np.testing.assert_allclose(test, expected, atol=self.atol,
+                                              rtol=self.rtol)
 
     def test_incorrect_shape_raises(self, op, data_m):
         """
@@ -452,7 +453,8 @@ class UnaryScalarOpMixin(_GenericOpMixin):
                                        atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
+            np.testing.assert_allclose(test, expected, atol=self.atol,
+                                              rtol=self.rtol)
 
 
 class BinaryOpMixin(_GenericOpMixin):
@@ -475,7 +477,8 @@ class BinaryOpMixin(_GenericOpMixin):
                                        atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
+            np.testing.assert_allclose(test, expected, atol=self.atol,
+                                              rtol=self.rtol)
 
     def test_incorrect_shape_raises(self, op, data_l, data_r):
         """
@@ -510,7 +513,8 @@ class TernaryOpMixin(_GenericOpMixin):
                                        atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
+            np.testing.assert_allclose(test, expected, atol=self.atol,
+                                              rtol=self.rtol)
 
     def test_incorrect_shape_raises(self, op, data_l, data_m, data_r):
         """
@@ -558,7 +562,8 @@ class TestAdd(BinaryOpMixin):
                                        atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
+            np.testing.assert_allclose(test, expected, atol=self.atol,
+                                              rtol=self.rtol)
 
 
 class TestAdjoint(UnaryOpMixin):
@@ -648,7 +653,8 @@ class TestInner(BinaryOpMixin):
                                        atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
+            np.testing.assert_allclose(test, expected, atol=self.atol,
+                                              rtol=self.rtol)
 
 
 class TestInnerOp(TernaryOpMixin):
@@ -716,7 +722,8 @@ class TestInnerOp(TernaryOpMixin):
                                        atol=self.atol,
                                        rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.atol + self.rtol*abs(expected)
+            np.testing.assert_allclose(test, expected, atol=self.atol,
+                                              rtol=self.rtol)
 
 
 class TestKron(BinaryOpMixin):

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -302,6 +302,11 @@ class _GenericOpMixin:
         expected value.  If the output is a Data type, the tolerance is
         per-element of the output.
 
+    rtol: float
+        The relative tolerance to use when comparing the test value with the
+        expected value.  If the output is a Data type, the tolerance is
+        per-element of the output.
+
     shapes: list of (list of shapes)
         A list of the sets of shapes which should be used for the tests of
         mathematical correctness.  Each element of the list is a set of shapes,
@@ -323,6 +328,7 @@ class _GenericOpMixin:
     # produce slightly different results to sparse algebra, since the order of
     # multiplications and additions will be different.
     tol = 1e-10
+    rtol = 1e-7 # Same default as numpy
     shapes = []
     bad_shapes = []
     specialisations = []
@@ -400,14 +406,16 @@ class UnaryOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol)
+                                       atol=self.tol,
+                                       rtol=self.rtol)
         elif out_type is list:
             for test_, expected_ in zip(test, expected):
                 assert test_.shape == expected_.shape
                 np.testing.assert_allclose(test_.to_array(),
-                                           expected_, atol=self.tol)
+                                           expected_, atol=self.tol,
+                                           rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol
+            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
 
     def test_incorrect_shape_raises(self, op, data_m):
         """
@@ -441,9 +449,10 @@ class UnaryScalarOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol)
+                                       atol=self.tol,
+                                       rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol
+            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
 
 
 class BinaryOpMixin(_GenericOpMixin):
@@ -463,9 +472,10 @@ class BinaryOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol)
+                                       atol=self.tol,
+                                       rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol
+            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
 
     def test_incorrect_shape_raises(self, op, data_l, data_r):
         """
@@ -497,9 +507,10 @@ class TernaryOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol)
+                                       atol=self.tol,
+                                       rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol
+            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
 
     def test_incorrect_shape_raises(self, op, data_l, data_m, data_r):
         """
@@ -544,9 +555,10 @@ class TestAdd(BinaryOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol)
+                                       atol=self.tol,
+                                       rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol
+            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
 
 
 class TestAdjoint(UnaryOpMixin):
@@ -633,10 +645,10 @@ class TestInner(BinaryOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol)
+                                       atol=self.tol,
+                                       rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol
-
+            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
 
 class TestInnerOp(TernaryOpMixin):
     # This is very very similar to TestInner.
@@ -700,9 +712,10 @@ class TestInnerOp(TernaryOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.tol)
+                                       atol=self.tol,
+                                       rtol=self.rtol)
         else:
-            assert abs(test - expected) < self.tol
+            assert abs(test - expected) < self.tol + self.rtol*abs(expected)
 
 
 class TestKron(BinaryOpMixin):
@@ -805,7 +818,8 @@ class TestPow(UnaryOpMixin):
         assert isinstance(test, out_type)
         assert test.shape == expected.shape
         np.testing.assert_allclose(test.to_array(), expected,
-                                   atol=self.tol)
+                                   atol=self.tol,
+                                   rtol=self.rtol)
 
     # Pow actually does have bad shape, so we put that in too.
     def test_incorrect_shape_raises(self, op, data_m):

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -406,14 +406,12 @@ class UnaryOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.atol,
-                                       rtol=self.rtol)
+                                       atol=self.atol, rtol=self.rtol)
         elif out_type is list:
             for test_, expected_ in zip(test, expected):
                 assert test_.shape == expected_.shape
-                np.testing.assert_allclose(test_.to_array(),
-                                           expected_, atol=self.atol,
-                                           rtol=self.rtol)
+                np.testing.assert_allclose(test_.to_array(), expected_,
+                                           atol=self.atol, rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
                                        rtol=self.rtol)
@@ -474,8 +472,7 @@ class BinaryOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.atol,
-                                       rtol=self.rtol)
+                                       atol=self.atol, rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
                                        rtol=self.rtol)
@@ -510,8 +507,7 @@ class TernaryOpMixin(_GenericOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.atol,
-                                       rtol=self.rtol)
+                                       atol=self.atol, rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
                                        rtol=self.rtol)
@@ -559,8 +555,7 @@ class TestAdd(BinaryOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.atol,
-                                       rtol=self.rtol)
+                                       atol=self.atol, rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
                                        rtol=self.rtol)
@@ -650,8 +645,7 @@ class TestInner(BinaryOpMixin):
         if issubclass(out_type, Data):
             assert test.shape == expected.shape
             np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.atol,
-                                       rtol=self.rtol)
+                                       atol=self.atol, rtol=self.rtol)
         else:
             np.testing.assert_allclose(test, expected, atol=self.atol,
                                        rtol=self.rtol)
@@ -825,8 +819,7 @@ class TestPow(UnaryOpMixin):
         test = op(matrix, n)
         assert isinstance(test, out_type)
         assert test.shape == expected.shape
-        np.testing.assert_allclose(test.to_array(), expected,
-                                   atol=self.atol,
+        np.testing.assert_allclose(test.to_array(), expected, atol=self.atol,
                                    rtol=self.rtol)
 
     # Pow actually does have bad shape, so we put that in too.

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -328,7 +328,7 @@ class _GenericOpMixin:
     # produce slightly different results to sparse algebra, since the order of
     # multiplications and additions will be different.
     tol = 1e-10
-    rtol = 1e-7 # Same default as numpy
+    rtol = 1e-7  # Same default as numpy
     shapes = []
     bad_shapes = []
     specialisations = []
@@ -649,6 +649,7 @@ class TestInner(BinaryOpMixin):
                                        rtol=self.rtol)
         else:
             assert abs(test - expected) < self.tol + self.rtol*abs(expected)
+
 
 class TestInnerOp(TernaryOpMixin):
     # This is very very similar to TestInner.

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -63,9 +63,6 @@ class TestTraceNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):
         return np.linalg.svd(matrix)[1].sum()
 
-    # CSR[square,sparse] fails if tol is larger.
-    tol = 3.7e-8
-
     specialisations = [
         pytest.param(data.norm.trace_csr, CSR, numbers.Number),
         pytest.param(data.norm.trace_dense, Dense, numbers.Number),

--- a/qutip/tests/core/data/test_reshape.py
+++ b/qutip/tests/core/data/test_reshape.py
@@ -7,7 +7,7 @@ from qutip.core.data import CSR, Dense
 
 class TestSplitColumns(UnaryOpMixin):
     def op_numpy(self, matrix):
-       return [column[:, np.newaxis] for column in matrix.T]
+        return [column[:, np.newaxis] for column in matrix.T]
 
     specialisations = [
         pytest.param(data.split_columns_csr, CSR, list),
@@ -112,7 +112,7 @@ class TestReshape(UnaryOpMixin):
                                    rtol=self.rtol)
 
     @pytest.mark.parametrize('rows, columns', [(-2, -50), (-50, -2), (3, 10)],
-                            ids=["negative1","negative2","invalid"])
+                             ids=["negative1", "negative2", "invalid"])
     def test_incorrect_rows_raises(self, op, data_m, out_type, rows, columns):
         with pytest.raises(ValueError):
             op(data_m(), rows, columns)

--- a/qutip/tests/core/data/test_reshape.py
+++ b/qutip/tests/core/data/test_reshape.py
@@ -57,7 +57,7 @@ class TestColumnUnstack(UnaryOpMixin):
         test = op(matrix, rows)
         assert isinstance(test, out_type)
         assert test.shape == expected.shape
-        np.testing.assert_allclose(test.to_array(), expected, atol=self.tol,
+        np.testing.assert_allclose(test.to_array(), expected, atol=self.atol,
                                    rtol=self.rtol)
 
     def test_incorrect_shape_raises(self, op, data_m):
@@ -108,7 +108,7 @@ class TestReshape(UnaryOpMixin):
         test = op(matrix, rows, columns)
         assert isinstance(test, out_type)
         assert test.shape == expected.shape
-        np.testing.assert_allclose(test.to_array(), expected, atol=self.tol,
+        np.testing.assert_allclose(test.to_array(), expected, atol=self.atol,
                                    rtol=self.rtol)
 
     @pytest.mark.parametrize('rows, columns', [(-2, -50), (-50, -2), (3, 10)],

--- a/qutip/tests/core/data/test_reshape.py
+++ b/qutip/tests/core/data/test_reshape.py
@@ -57,7 +57,8 @@ class TestColumnUnstack(UnaryOpMixin):
         test = op(matrix, rows)
         assert isinstance(test, out_type)
         assert test.shape == expected.shape
-        np.testing.assert_allclose(test.to_array(), expected, atol=self.tol)
+        np.testing.assert_allclose(test.to_array(), expected, atol=self.tol,
+                                   rtol=self.rtol)
 
     def test_incorrect_shape_raises(self, op, data_m):
         with pytest.raises(ValueError):
@@ -107,7 +108,8 @@ class TestReshape(UnaryOpMixin):
         test = op(matrix, rows, columns)
         assert isinstance(test, out_type)
         assert test.shape == expected.shape
-        np.testing.assert_allclose(test.to_array(), expected, atol=self.tol)
+        np.testing.assert_allclose(test.to_array(), expected, atol=self.tol,
+                                   rtol=self.rtol)
 
     @pytest.mark.parametrize('rows, columns', [(-2, -50), (-50, -2), (3, 10)],
                             ids=["negative1","negative2","invalid"])


### PR DESCRIPTION
**Description**
I added the option to specify `rtol` in the tests. The default value is the same as for `numpy.testing.all_close` which was being used 'silently' (tests for the exponential pretty much ignored the absolute tolerance specified by us). I also made the tests more consistent. Now the assertion for scalar outputs also use `rtol` in the same way `numpy.testing.all_close` does. 

**Related issues or PRs**
This is useful for qutip/qutip-tensorflow#34 where I plan to add support for complex64.

**Changelog**
Aded rtol for specialisation tests.
Changed comparison of scalars to be consistent with `numpy.testing.all_close`
