### PR TITLE
Added Test classes to the be importable from tests/core/data

### DIFF
--- a/qutip/tests/core/data/__init__.py
+++ b/qutip/tests/core/data/__init__.py
@@ -1,0 +1,4 @@
+from .test_expect import *
+from .test_mathematics import *
+from .test_norm import *
+from .test_reshape import *

--- a/qutip/tests/core/data/test_expect.py
+++ b/qutip/tests/core/data/test_expect.py
@@ -10,6 +10,7 @@ from itertools import product
 
 __all__ = ['TestExpect', 'TestExpectSuper']
 
+
 class TestExpect(BinaryOpMixin):
     def op_numpy(self, op, state):
         is_ket = state.shape[1] == 1

--- a/qutip/tests/core/data/test_expect.py
+++ b/qutip/tests/core/data/test_expect.py
@@ -8,6 +8,7 @@ from qutip import data
 from qutip.core.data import CSR, Dense
 from itertools import product
 
+__all__ = ['TestExpect', 'TestExpectSuper']
 
 class TestExpect(BinaryOpMixin):
     def op_numpy(self, op, state):

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -8,10 +8,12 @@ from qutip.core.data import Data, Dense, CSR
 
 from . import conftest
 
-__all__ = ['TestAdd', 'TestAdjoint', 'TestConj', 'TestExpm', 'TestInner',
-          'TestTranspose', 'TestInnerOp', 'TestInv', 'TestKron', 'TestMatmul',
-          'TestMul', 'TestTrace', 'TestSub', 'TestProject', 'TestPow',
-          'TestNeg', 'TestMultiply', 'TestMultiply']
+__all__ = [
+    'TestAdd', 'TestAdjoint', 'TestConj', 'TestExpm', 'TestInner',
+    'TestTranspose', 'TestInnerOp', 'TestInv', 'TestKron', 'TestMatmul',
+    'TestMul', 'TestTrace', 'TestSub', 'TestProject', 'TestPow', 'TestNeg',
+    'TestMultiply', 'TestMultiply',
+]
 
 # The ParameterSet is actually a pretty hidden type, so it's easiest to access
 # it like this.

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -8,6 +8,11 @@ from qutip.core.data import Data, Dense, CSR
 
 from . import conftest
 
+__all__ = ['TestAdd', 'TestAdjoint', 'TestConj', 'TestExpm', 'TestInner',
+          'TestTranspose', 'TestInnerOp', 'TestInv', 'TestKron', 'TestMatmul',
+          'TestMul', 'TestTrace', 'TestSub', 'TestProject', 'TestPow',
+          'TestNeg', 'TestMultiply', 'TestMultiply']
+
 # The ParameterSet is actually a pretty hidden type, so it's easiest to access
 # it like this.
 _ParameterSet = type(pytest.param())

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -6,6 +6,8 @@ from qutip import data
 from qutip.core.data import CSR, Dense
 import numbers
 
+__all__ = ['TestOneNorm', 'TestFrobeniusNorm', 'TestMaxNorm', 'TestL2Norm',
+          'TestTraceNorm']
 
 class TestOneNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):

--- a/qutip/tests/core/data/test_norm.py
+++ b/qutip/tests/core/data/test_norm.py
@@ -7,7 +7,8 @@ from qutip.core.data import CSR, Dense
 import numbers
 
 __all__ = ['TestOneNorm', 'TestFrobeniusNorm', 'TestMaxNorm', 'TestL2Norm',
-          'TestTraceNorm']
+           'TestTraceNorm', ]
+
 
 class TestOneNorm(testing.UnaryOpMixin):
     def op_numpy(self, matrix):

--- a/qutip/tests/core/data/test_reshape.py
+++ b/qutip/tests/core/data/test_reshape.py
@@ -5,7 +5,8 @@ from qutip import data
 from qutip.core.data import CSR, Dense
 
 __all__ = ['TestSplitColumns', 'TestColumnStack', 'TestColumnUnstack',
-           'TestReshape']
+           'TestReshape', ]
+
 
 class TestSplitColumns(UnaryOpMixin):
     def op_numpy(self, matrix):

--- a/qutip/tests/core/data/test_reshape.py
+++ b/qutip/tests/core/data/test_reshape.py
@@ -4,6 +4,8 @@ import numpy as np
 from qutip import data
 from qutip.core.data import CSR, Dense
 
+__all__ = ['TestSplitColumns', 'TestColumnStack', 'TestColumnUnstack',
+           'TestReshape']
 
 class TestSplitColumns(UnaryOpMixin):
     def op_numpy(self, matrix):


### PR DESCRIPTION
**Description**

Previously I was using (in qutip-tensorflow):
```python
import qutip.tests.core.data.test_mathematics
import qutip.tests.core.data.test_reshape

class TestAdd_2(test_mathematic.TestAdd):
	pass

class TestReshape_2(test_reshape.TestReshape):
	pass
```

This PR allows using instead:
```python
import qutip.tests.core.data as testing

class TestAdd_2(testing.TestAdd):
	pass

class TestReshape_2(testing.TestReshape):
	pass
```
which is more convenient, specially because there are multiple  modules that need to be imported in this way. Importing the classes individually is not a valid option as it will run qutip's tests also in qutip-tensorflow. 

**Related issues or PRs**
This is currently planned to be used in qutip/qutip-tensorflow#34.