### PR TITLE
Add Matsubara and Padé expansion Lorentzian baths for the HEOM solver.

### DIFF
--- a/qutip/nonmarkov/bofin_baths.py
+++ b/qutip/nonmarkov/bofin_baths.py
@@ -800,12 +800,12 @@ class LorentzianBath(FermionicBath):
             Q, ck_plus, vk_plus, ck_minus, vk_minus, tag=tag,
         )
 
-    def _corr(self, gamma, w, T, lmax, sigma, mu):
+    def _corr(self, gamma, w, T, Nk, sigma, mu):
         beta = 1. / T
         kappa = [0.]
-        kappa.extend([1. for _ in range(1, lmax + 1)])
+        kappa.extend([1. for _ in range(1, Nk + 1)])
         epsilon = [0]
-        epsilon.extend([(2 * ll - 1) * np.pi for ll in range(1, lmax + 1)])
+        epsilon.extend([(2 * ll - 1) * np.pi for ll in range(1, Nk + 1)])
 
         def f(x):
             # kB = 1.0
@@ -814,7 +814,7 @@ class LorentzianBath(FermionicBath):
         eta_list = [0.5 * gamma * w * f(1.0j * beta * w)]
         gamma_list = [w - sigma * 1.0j * mu]
 
-        for ll in range(1, lmax + 1):
+        for ll in range(1, Nk + 1):
             eta_list.append(
                 -1.0j * (kappa[ll] / beta) * gamma * w**2 /
                 (-(epsilon[ll]**2 / beta**2) + w**2)
@@ -879,20 +879,20 @@ class LorentzianPadeBath(FermionicBath):
             Q, ck_plus, vk_plus, ck_minus, vk_minus, tag=tag,
         )
 
-    def _corr(self, gamma, w, T, lmax, sigma, mu):
+    def _corr(self, gamma, w, T, Nk, sigma, mu):
         beta = 1. / T
-        kappa, epsilon = self._kappa_epsilon(lmax)
+        kappa, epsilon = self._kappa_epsilon(Nk)
 
         def f_approx(x):
             f = 0.5
-            for ll in range(1, lmax + 1):
+            for ll in range(1, Nk + 1):
                 f = f - 2 * kappa[ll] * x / (x**2 + epsilon[ll]**2)
             return f
 
         eta_list = [0.5 * gamma * w * f_approx(1.0j * beta * w)]
         gamma_list = [w - sigma * 1.0j * mu]
 
-        for ll in range(1, lmax + 1):
+        for ll in range(1, Nk + 1):
             eta_list.append(
                 -1.0j * (kappa[ll] / beta) * gamma * w**2
                 / (-(epsilon[ll]**2 / beta**2) + w**2)

--- a/qutip/nonmarkov/bofin_baths.py
+++ b/qutip/nonmarkov/bofin_baths.py
@@ -755,9 +755,46 @@ class FermionicBath(Bath):
 
 
 class LorentzianBath(FermionicBath):
-    def __init__(self, Q, gamma, w, T, mu, lmax, tag=None):
-        ck_plus, vk_plus = self._corr(gamma, w, T, lmax, 1.0, mu)
-        ck_minus, vk_minus = self._corr(gamma, w, T, lmax, -1.0, mu)
+    """
+    A helper class for constructing a Lorentzian fermionic bath from the
+    bath parameters (see parameters below).
+
+    .. note::
+
+        This Matsubara expansion used in this bath converges very slowly
+        and ``Nk > 20`` may be required to get good convergence. The
+        Padé expansion used by :class:`LorentzianPadeBath` converges much
+        more quickly.
+
+    Parameters
+    ----------
+    Q : Qobj
+        Operator describing the coupling between system and bath.
+
+    gamma : float
+        The coupling strength between the system and the bath.
+
+    w : float
+        The width of the environment.
+
+    T : float
+        Bath temperature.
+
+    mu : float
+        The chemical potential of the bath.
+
+    Nk : int
+        Number of exponential terms used to approximate the bath correlation
+        functions.
+
+    tag : optional, str, tuple or any other object
+        A label for the bath exponents (for example, the name of the
+        bath). It defaults to None but can be set to help identify which
+        bath an exponent is from.
+    """
+    def __init__(self, Q, gamma, w, T, mu, Nk, tag=None):
+        ck_plus, vk_plus = self._corr(gamma, w, T, Nk, 1.0, mu)
+        ck_minus, vk_minus = self._corr(gamma, w, T, Nk, -1.0, mu)
 
         super().__init__(
             Q, ck_plus, vk_plus, ck_minus, vk_minus, tag=tag,
@@ -788,9 +825,55 @@ class LorentzianBath(FermionicBath):
 
 
 class LorentzianPadeBath(FermionicBath):
-    def __init__(self, Q, gamma, w, T, mu, lmax, tag=None):
-        ck_plus, vk_plus = self._corr(gamma, w, T, lmax, 1.0, mu)
-        ck_minus, vk_minus = self._corr(gamma, w, T, lmax, -1.0, mu)
+    """
+    A helper class for constructing a Padé expansion for Lorentzian fermionic
+    bath from the bath parameters (see parameters below).
+
+    A Padé approximant is a sum-over-poles expansion (
+    see https://en.wikipedia.org/wiki/Pad%C3%A9_approximant).
+
+    The application of the Padé method to spectrum decompoisitions is described
+    in "Padé spectrum decompositions of quantum distribution functions and
+    optimal hierarchical equations of motion construction for quantum open
+    systems" [1].
+
+    The implementation here follows the approach in the paper.
+
+    [1] J. Chem. Phys. 134, 244106 (2011); https://doi.org/10.1063/1.3602466
+
+    This is an alternative to the :class:`LorentzianBath` which constructs
+    a simpler exponential expansion that converges much more slowly in
+    this particular case.
+
+    Parameters
+    ----------
+    Q : Qobj
+        Operator describing the coupling between system and bath.
+
+    gamma : float
+        The coupling strength between the system and the bath.
+
+    w : float
+        The width of the environment.
+
+    T : float
+        Bath temperature.
+
+    mu : float
+        The chemical potential of the bath.
+
+    Nk : int
+        Number of exponential terms used to approximate the bath correlation
+        functions.
+
+    tag : optional, str, tuple or any other object
+        A label for the bath exponents (for example, the name of the
+        bath). It defaults to None but can be set to help identify which
+        bath an exponent is from.
+    """
+    def __init__(self, Q, gamma, w, T, mu, Nk, tag=None):
+        ck_plus, vk_plus = self._corr(gamma, w, T, Nk, 1.0, mu)
+        ck_minus, vk_minus = self._corr(gamma, w, T, Nk, -1.0, mu)
 
         super().__init__(
             Q, ck_plus, vk_plus, ck_minus, vk_minus, tag=tag,

--- a/qutip/nonmarkov/bofin_baths.py
+++ b/qutip/nonmarkov/bofin_baths.py
@@ -755,19 +755,9 @@ class FermionicBath(Bath):
 
 
 class LorentzianBath(FermionicBath):
-    def __init__(self, Q, gamma, w, T, theta, lmax, tag=None):
-        mu_l = theta / 2.0
-        mu_r = - theta / 2.0
-
-        etapL, gampL = self._corr(gamma, w, T, lmax, 1.0, mu_l)
-        etamL, gammL = self._corr(gamma, w, T, lmax, -1.0, mu_l)
-        etapR, gampR = self._corr(gamma, w, T, lmax, 1.0, mu_r)
-        etamR, gammR = self._corr(gamma, w, T, lmax, -1.0, mu_r)
-
-        ck_plus = etapR + etapL
-        vk_plus = gampR + gampL
-        ck_minus = etamR + etamL
-        vk_minus = gammR + gammL
+    def __init__(self, Q, gamma, w, T, mu, lmax, tag=None):
+        ck_plus, vk_plus = self._corr(gamma, w, T, lmax, 1.0, mu)
+        ck_minus, vk_minus = self._corr(gamma, w, T, lmax, -1.0, mu)
 
         super().__init__(
             Q, ck_plus, vk_plus, ck_minus, vk_minus, tag=tag,
@@ -798,19 +788,9 @@ class LorentzianBath(FermionicBath):
 
 
 class LorentzianPadeBath(FermionicBath):
-    def __init__(self, Q, gamma, w, T, theta, lmax, tag=None):
-        mu_l = theta / 2.0
-        mu_r = - theta / 2.0
-
-        etapL, gampL = self._corr(gamma, w, T, lmax, 1.0, mu_l)
-        etamL, gammL = self._corr(gamma, w, T, lmax, -1.0, mu_l)
-        etapR, gampR = self._corr(gamma, w, T, lmax, 1.0, mu_r)
-        etamR, gammR = self._corr(gamma, w, T, lmax, -1.0, mu_r)
-
-        ck_plus = etapR + etapL
-        vk_plus = gampR + gampL
-        ck_minus = etamR + etamL
-        vk_minus = gammR + gammL
+    def __init__(self, Q, gamma, w, T, mu, lmax, tag=None):
+        ck_plus, vk_plus = self._corr(gamma, w, T, lmax, 1.0, mu)
+        ck_minus, vk_minus = self._corr(gamma, w, T, lmax, -1.0, mu)
 
         super().__init__(
             Q, ck_plus, vk_plus, ck_minus, vk_minus, tag=tag,

--- a/qutip/nonmarkov/bofin_solvers.py
+++ b/qutip/nonmarkov/bofin_solvers.py
@@ -1037,7 +1037,6 @@ class HSolverDL(HEOMSolver):
             Nk=N_exp - 1,
             T=temperature,
             combine=combine,
-            terminator=bnd_cut_approx,
         )
 
         if bnd_cut_approx:
@@ -1049,7 +1048,8 @@ class HSolverDL(HEOMSolver):
             is_hamiltonian = H0.type == "oper"
             if is_hamiltonian:
                 H_sys = liouvillian(H_sys)
-            H_sys = H_sys + bath.terminator
+            _, terminator = bath.terminator()
+            H_sys = H_sys + terminator
 
         super().__init__(
             H_sys, bath=bath, max_depth=N_cut, options=options,

--- a/qutip/nonmarkov/heom.py
+++ b/qutip/nonmarkov/heom.py
@@ -28,6 +28,8 @@ __all__ = [
     "DrudeLorentzPadeBath",
     "UnderDampedBath",
     "FermionicBath",
+    "LorentzianBath",
+    "LorentzianPadeBath",
     "HEOMSolver",
     "HSolverDL",
 ]
@@ -40,6 +42,8 @@ from .bofin_baths import (
     DrudeLorentzPadeBath,
     UnderDampedBath,
     FermionicBath,
+    LorentzianBath,
+    LorentzianPadeBath,
 )
 
 from .bofin_solvers import (

--- a/qutip/tests/test_bofin_baths.py
+++ b/qutip/tests/test_bofin_baths.py
@@ -202,8 +202,6 @@ class TestDrudeLorentzBath:
             ck=ck_real[1], vk=vk_real[1],
             tag="bath1",
         )
-        assert bath.delta is None
-        assert bath.terminator is None
 
         bath = DrudeLorentzBath(
             Q=Q, lam=0.025, T=1 / 0.95, Nk=1, gamma=0.05, combine=False,
@@ -213,20 +211,21 @@ class TestDrudeLorentzBath:
         check_exponent(exp2, "R", dim=None, Q=Q, ck=ck_real[1], vk=vk_real[1])
         check_exponent(exp3, "I", dim=None, Q=Q, ck=ck_imag[0], vk=vk_imag[0])
 
-        bath = DrudeLorentzBath(
-            Q=Q, lam=0.025, T=1 / 0.95, Nk=1, gamma=0.05, terminator=True,
-        )
-        bath2 = DrudeLorentzBath(
-            Q=Q, lam=0.025, T=1 / 0.95, Nk=1, gamma=0.05, terminator=True,
-            combine=False,
-        )
+    @pytest.mark.parametrize(['combine'], [
+        pytest.param(True, id="combine"),
+        pytest.param(False, id="no-combine"),
+    ])
+    def test_terminator(self, combine):
+        Q = sigmaz()
         op = -2*spre(Q)*spost(Q.dag()) + spre(Q.dag()*Q) + spost(Q.dag()*Q)
 
-        assert np.abs(bath.delta - (0.00031039 / 4.0)) < 1e-8
-        assert np.abs(bath2.delta - (0.00031039 / 4.0)) < 1e-8
+        bath = DrudeLorentzBath(
+            Q=Q, lam=0.025, T=1 / 0.95, Nk=1, gamma=0.05, combine=combine,
+        )
+        delta, terminator = bath.terminator()
 
-        assert isequal(bath.terminator, - (0.00031039 / 4.0) * op, tol=1e-8)
-        assert isequal(bath2.terminator, - (0.00031039 / 4.0) * op, tol=1e-8)
+        assert np.abs(delta - (0.00031039 / 4.0)) < 1e-8
+        assert isequal(terminator, - (0.00031039 / 4.0) * op, tol=1e-8)
 
 
 class TestDrudeLorentzPadeBath:
@@ -259,6 +258,22 @@ class TestDrudeLorentzPadeBath:
         check_exponent(exp1, "R", dim=None, Q=Q, ck=ck_real[0], vk=vk_real[0])
         check_exponent(exp2, "R", dim=None, Q=Q, ck=ck_real[1], vk=vk_real[1])
         check_exponent(exp3, "I", dim=None, Q=Q, ck=ck_imag[0], vk=vk_imag[0])
+
+    @pytest.mark.parametrize(['combine'], [
+        pytest.param(True, id="combine"),
+        pytest.param(False, id="no-combine"),
+    ])
+    def test_terminator(self, combine):
+        Q = sigmaz()
+        op = -2*spre(Q)*spost(Q.dag()) + spre(Q.dag()*Q) + spost(Q.dag()*Q)
+
+        bath = DrudeLorentzPadeBath(
+            Q=Q, lam=0.025, T=1 / 0.95, Nk=1, gamma=0.05, combine=combine,
+        )
+        delta, terminator = bath.terminator()
+
+        assert np.abs(delta - (0.0 / 4.0)) < 1e-8
+        assert isequal(terminator, - (0.0 / 4.0) * op, tol=1e-8)
 
 
 class TestUnderDampedBath:

--- a/qutip/tests/test_bofin_baths.py
+++ b/qutip/tests/test_bofin_baths.py
@@ -14,6 +14,8 @@ from qutip.nonmarkov.bofin_baths import (
     DrudeLorentzPadeBath,
     UnderDampedBath,
     FermionicBath,
+    LorentzianBath,
+    LorentzianPadeBath,
 )
 
 
@@ -349,3 +351,93 @@ class TestFermionicBath:
             "The bath exponent lists ck_plus and vk_plus, and ck_minus and"
             " vk_minus must be the same length."
         )
+
+
+class TestLorentzianBath:
+    def test_create(self):
+        Q = sigmaz()
+        ck_plus = [
+            0.0025-0.0013376935246402686j,
+            -0.00026023645770006167j,
+            -0.0002748355116913478j,
+        ]
+        vk_plus = [
+            1+1j,
+            0.08121642500626945+1j,
+            0.24364927501880834+1j,
+        ]
+        ck_minus = [
+            0.0025-0.0013376935246402686j,
+            -0.00026023645770006167j,
+            -0.0002748355116913478j,
+        ]
+        vk_minus = [
+            1-1j,
+            0.08121642500626945-1j,
+            0.24364927501880834-1j,
+        ]
+
+        bath = LorentzianBath(
+            Q=Q, gamma=0.01, w=1, mu=-1, T=0.025851991, Nk=2, tag="bath1",
+        )
+        assert len(bath.exponents) == 6
+        for i in range(len(ck_plus)):
+            exp_p = bath.exponents[2 * i]
+            exp_m = bath.exponents[2 * i + 1]
+            check_exponent(
+                exp_p, "+", dim=2, Q=Q,
+                ck=ck_plus[i], vk=vk_plus[i],
+                sigma_bar_k_offset=1,
+                tag="bath1",
+            )
+            check_exponent(
+                exp_m, "-", dim=2, Q=Q,
+                ck=ck_minus[i], vk=vk_minus[i],
+                sigma_bar_k_offset=-1,
+                tag="bath1",
+            )
+
+
+class TestLorentzianPadeBath:
+    def test_create(self):
+        Q = sigmaz()
+        ck_plus = [
+            0.0025+0.0014269000277373958j,
+            -0.0002608459250597002j,
+            -0.0011660541026776957j,
+        ]
+        vk_plus = [
+            1+1j,
+            0.08123902308117874+1j,
+            0.3371925267385835+1j,
+        ]
+        ck_minus = [
+            0.0025+0.0014269000277373958j,
+            -0.0002608459250597002j,
+            -0.0011660541026776957j,
+        ]
+        vk_minus = [
+            1-1j,
+            0.08123902308117874-1j,
+            0.3371925267385835-1j,
+        ]
+
+        bath = LorentzianPadeBath(
+            Q=Q, gamma=0.01, w=1, mu=-1, T=0.025851991, Nk=2, tag="bath1",
+        )
+        assert len(bath.exponents) == 6
+        for i in range(len(ck_plus)):
+            exp_p = bath.exponents[2 * i]
+            exp_m = bath.exponents[2 * i + 1]
+            check_exponent(
+                exp_p, "+", dim=2, Q=Q,
+                ck=ck_plus[i], vk=vk_plus[i],
+                sigma_bar_k_offset=1,
+                tag="bath1",
+            )
+            check_exponent(
+                exp_m, "-", dim=2, Q=Q,
+                ck=ck_minus[i], vk=vk_minus[i],
+                sigma_bar_k_offset=-1,
+                tag="bath1",
+            )

--- a/qutip/tests/test_bofin_solvers.py
+++ b/qutip/tests/test_bofin_solvers.py
@@ -722,11 +722,11 @@ class TestHEOMSolver:
         )
         bath_l = bath_cls(
             dlm.Q, gamma=dlm.gamma, w=dlm.W, T=dlm.T, mu=dlm.theta / 2,
-            lmax=dlm.lmax,
+            Nk=dlm.lmax,
         )
         bath_r = bath_cls(
             dlm.Q, gamma=dlm.gamma, w=dlm.W, T=dlm.T, mu=- dlm.theta / 2,
-            lmax=dlm.lmax,
+            Nk=dlm.lmax,
         )
         # for a single impurity we converge with max_depth = 2
         hsolver = HEOMSolver(dlm.H, [bath_r, bath_l], 2, options=options)

--- a/qutip/tests/test_bofin_solvers.py
+++ b/qutip/tests/test_bofin_solvers.py
@@ -21,6 +21,8 @@ from qutip.nonmarkov.bofin_baths import (
     DrudeLorentzPadeBath,
     UnderDampedBath,
     FermionicBath,
+    LorentzianBath,
+    LorentzianPadeBath,
 )
 from qutip.nonmarkov.bofin_solvers import (
     HierarchyADOs,
@@ -386,10 +388,7 @@ class DiscreteLevelCurrentModel:
         mu_r = - self.theta / 2.
 
         def deltafun(j, k):
-            if j == k:
-                return 1.
-            else:
-                return 0.
+            return 1. if j == k else 0.
 
         Alpha = np.zeros((2 * lmax, 2 * lmax))
         for j in range(2*lmax):
@@ -705,6 +704,38 @@ class TestHEOMSolver:
         rho_final, ado_state = hsolver.steady_state()
         current = dlm.state_current(ado_state)
         analytic_current = dlm.analytic_current()
+        np.testing.assert_allclose(analytic_current, current, rtol=1e-3)
+
+    @pytest.mark.parametrize(['bath_cls', 'analytic_current'], [
+        pytest.param(LorentzianBath, 0.001101, id="matsubara"),
+        pytest.param(LorentzianPadeBath, 0.000813, id="pade"),
+    ])
+    def test_discrete_level_model_lorentzian_baths(
+        self, bath_cls, analytic_current, atol=1e-3
+    ):
+        dlm = DiscreteLevelCurrentModel(
+            gamma=0.01, W=1, T=0.025851991, lmax=10,
+        )
+
+        options = Options(
+            nsteps=15_000, store_states=True, rtol=1e-7, atol=1e-7,
+        )
+        bath = bath_cls(
+            dlm.Q, gamma=dlm.gamma, w=dlm.W, T=dlm.T, theta=dlm.theta,
+            lmax=dlm.lmax,
+        )
+        # for a single impurity we converge with max_depth = 2
+        hsolver = HEOMSolver(dlm.H, bath, 2, options=options)
+
+        tlist = [0, 600]
+        result = hsolver.run(dlm.rho(), tlist, ado_return=True)
+        current = dlm.state_current(result.ado_states[-1])
+        # analytic_current = dlm.analytic_current()
+        np.testing.assert_allclose(analytic_current, current, rtol=1e-3)
+
+        rho_final, ado_state = hsolver.steady_state()
+        current = dlm.state_current(ado_state)
+        # analytic_current = dlm.analytic_current()
         np.testing.assert_allclose(analytic_current, current, rtol=1e-3)
 
 

--- a/qutip/tests/test_bofin_solvers.py
+++ b/qutip/tests/test_bofin_solvers.py
@@ -622,10 +622,10 @@ class TestHEOMSolver:
         )
         bath = bath_cls(
             Q=dlm.Q, lam=dlm.lam, gamma=dlm.gamma, T=dlm.T, Nk=dlm.Nk,
-            terminator=terminator,
         )
         if terminator:
-            H_sys = liouvillian(dlm.H) + bath.terminator
+            _, terminator_op = bath.terminator()
+            H_sys = liouvillian(dlm.H) + terminator_op
         else:
             H_sys = dlm.H
 

--- a/qutip/tests/test_bofin_solvers.py
+++ b/qutip/tests/test_bofin_solvers.py
@@ -720,12 +720,16 @@ class TestHEOMSolver:
         options = Options(
             nsteps=15_000, store_states=True, rtol=1e-7, atol=1e-7,
         )
-        bath = bath_cls(
-            dlm.Q, gamma=dlm.gamma, w=dlm.W, T=dlm.T, theta=dlm.theta,
+        bath_l = bath_cls(
+            dlm.Q, gamma=dlm.gamma, w=dlm.W, T=dlm.T, mu=dlm.theta / 2,
+            lmax=dlm.lmax,
+        )
+        bath_r = bath_cls(
+            dlm.Q, gamma=dlm.gamma, w=dlm.W, T=dlm.T, mu=- dlm.theta / 2,
             lmax=dlm.lmax,
         )
         # for a single impurity we converge with max_depth = 2
-        hsolver = HEOMSolver(dlm.H, bath, 2, options=options)
+        hsolver = HEOMSolver(dlm.H, [bath_r, bath_l], 2, options=options)
 
         tlist = [0, 600]
         result = hsolver.run(dlm.rho(), tlist, ado_return=True)

--- a/qutip/tests/test_heom.py
+++ b/qutip/tests/test_heom.py
@@ -10,6 +10,8 @@ from qutip.nonmarkov.heom import (
     DrudeLorentzPadeBath,
     UnderDampedBath,
     FermionicBath,
+    LorentzianBath,
+    LorentzianPadeBath,
     HEOMSolver,
     HSolverDL,
 )
@@ -25,6 +27,8 @@ class TestBathAPI:
         assert DrudeLorentzPadeBath
         assert UnderDampedBath
         assert FermionicBath
+        assert LorentzianBath
+        assert LorentzianPadeBath
 
 
 class TestSolverAPI:


### PR DESCRIPTION
**Description**
Add Matsubara and Padé expansion Lorentzian baths for the HEOM solver.

**Todo**
- [x] Clean-up the Pade expansion code.
- [x] ~~Somehow get the Matsubara and Pade results for the current to match.~~ (These are not supposed to match!)
- [x] Add solver tests for the Lorentzian baths.
- [x] Add bath tests for the Lorentzian baths.
- [x] Add tests for the DrudeLorentzPadeBath terminator.
- [x] Convert the slightly awkward terminator= argument for Drude-Lorentz baths to a terminator method.

**Related issues or PRs**
* #1601
* #1724

**Changelog**
Add Matsubara and Padé expansion Lorentzian baths for the HEOM solver.
