### PR TITLE
Better handling of scipy ode in integrator

### DIFF
--- a/qutip/solver/ode/scipy_integrator.py
+++ b/qutip/solver/ode/scipy_integrator.py
@@ -91,13 +91,10 @@ class IntegratorScipyZvode(Integrator):
         Do the check for concurrent use of the integrator and reset if used
         elsewhere.
         """
-        if self._ode_solver._integrator.initialized:
-            if (
-                self._ode_solver._integrator.handle !=
-                self._ode_solver._integrator.__class__.active_global_handle
-            ):
-                self._ode_solver._integrator.reset(
-                    len(self._ode_solver._y), False)
+        integrator = self._ode_solver._integrator
+        if integrator.initialized:
+            if integrator.handle != integrator.__class__.active_global_handle:
+                integrator.reset(len(self._ode_solver._y), False)
 
     def integrate(self, t, copy=True):
         self._check_handle()
@@ -107,7 +104,7 @@ class IntegratorScipyZvode(Integrator):
 
     def mcstep(self, t, copy=True):
         self._check_handle()
-        if t == self._ode_solver.t:
+        if self._ode_solver.t == t:
             pass
         elif self._ode_solver.t < t:
             self._back = self._ode_solver.t
@@ -273,19 +270,14 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
         Do the check for concurrent use of the integrator and reset if used
         elsewhere.
         """
-        if self._ode_solver._integrator.initialized:
-            if (
-                self._ode_solver._integrator.handle !=
-                self._ode_solver._integrator.__class__.active_global_handle
-            ):
-                self._ode_solver._integrator.reset(
-                    len(self._ode_solver._y), False)
+        integrator = self._ode_solver._integrator
+        if integrator.initialized:
+            if integrator.handle != integrator.__class__.active_global_handle:
+                integrator.reset(len(self._ode_solver._y), False)
 
     def integrate(self, t, copy=True):
         self._check_handle()
-        if t != self._ode_solver.t:
-            self._ode_solver.integrate(t)
-        return self.get_state(copy)
+        return super().integrate(t, copy)
 
     def mcstep(self, t, copy=True):
         self._check_handle()

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -108,16 +108,18 @@ class TestIntegrator(TestIntegratorCte):
 @pytest.mark.parametrize('integrator',
     [IntegratorScipyZvode, IntegratorScipylsoda], ids=["zvode", "lsoda"])
 def test_concurent_usage(integrator):
-    sys = qutip.QobjEvo(qutip.qeye(1))
     opt = SolverOdeOptions()
-    sys = qutip.QobjEvo(0.5*qutip.qeye(1))
-    inter1 = integrator(sys, opt)
+
+    sys1 = qutip.QobjEvo(0.5*qutip.qeye(1))
+    inter1 = integrator(sys1, opt)
     inter1.set_state(0, qutip.basis(1,0).data)
-    sys = qutip.QobjEvo(-0.5*qutip.qeye(1))
-    inter2 = integrator(sys, opt)
+
+    sys2 = qutip.QobjEvo(-0.5*qutip.qeye(1))
+    inter2 = integrator(sys2, opt)
     inter2.set_state(0, qutip.basis(1,0).data)
+
     for t in np.linspace(0,1,6):
-        expected = pytest.approx(np.exp(t/2), abs=1e-5)
-        assert inter1.integrate(t)[1].to_array()[0, 0] == expected
-        expected = pytest.approx(np.exp(-t/2), abs=1e-5)
-        assert inter2.integrate(t)[1].to_array()[0, 0] == expected
+        expected1 = pytest.approx(np.exp(t/2), abs=1e-5)
+        assert inter1.integrate(t)[1].to_array()[0, 0] == expected1
+        expected2 = pytest.approx(np.exp(-t/2), abs=1e-5)
+        assert inter2.integrate(t)[1].to_array()[0, 0] == expected2

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -2,6 +2,8 @@ from qutip.solver.options import SolverOdeOptions
 from qutip.solver.sesolve import SeSolver
 from qutip.solver.mesolve import MeSolver
 from qutip.solver.solver_base import Solver
+from qutip.solver.ode.scipy_integrator import (IntegratorScipyZvode,
+                                               IntegratorScipylsoda)
 import qutip
 import numpy as np
 from numpy.testing import assert_allclose
@@ -101,3 +103,21 @@ class TestIntegrator(TestIntegratorCte):
     )
     def mc_method(self, request):
         return request.param
+
+
+@pytest.mark.parametrize('integrator',
+    [IntegratorScipyZvode, IntegratorScipylsoda], ids=["zvode", "lsoda"])
+def test_concurent_usage(integrator):
+    sys = qutip.QobjEvo(qutip.qeye(1))
+    opt = SolverOdeOptions()
+    sys = qutip.QobjEvo(0.5*qutip.qeye(1))
+    inter1 = integrator(sys, opt)
+    inter1.set_state(0, qutip.basis(1,0).data)
+    sys = qutip.QobjEvo(-0.5*qutip.qeye(1))
+    inter2 = integrator(sys, opt)
+    inter2.set_state(0, qutip.basis(1,0).data)
+    for t in np.linspace(0,1,6):
+        expected = pytest.approx(np.exp(t/2), abs=1e-5)
+        assert inter1.integrate(t)[1].to_array()[0, 0] == expected
+        expected = pytest.approx(np.exp(-t/2), abs=1e-5)
+        assert inter2.integrate(t)[1].to_array()[0, 0] == expected


### PR DESCRIPTION
**Description**
Make our integrator re-entrant. Scipy'ode is can only have one active instance active for some of the methods. This cuased no issue when the whole integration is done at once as when used in `mesolve`. But with solver as class, this mean using them will have side effect on other solver instances.  This PR make the check for concurrent integrator usage before scipy does and force a reset if needed. Switching between system will be inefficient, but will return the expected results.

In lsoda's integrator's `_backstep` we are catching a warning before acting on it, but catching the warnings still printed them at the end of tests, bloating the output. In this PR, I also do the check before scipy does so the warning is never raised.


**Related issues or PRs**
Point raised in discussion with @hodgestar and @AGaliciaMartinez on #1710 


**Changelog**
Front run some safety check in scipy.ode