### PR TITLE
Fix silent ignoring of offset in coherent and coherent_dm when offset is non-zero.

### DIFF
--- a/qutip/states.py
+++ b/qutip/states.py
@@ -9,7 +9,7 @@ __all__ = ['basis', 'qutrit_basis', 'coherent', 'coherent_dm', 'fock_dm',
 
 import numbers
 import numpy as np
-from numpy import arange, conj, prod
+from numpy import arange, conj
 import scipy.sparse as sp
 import itertools
 
@@ -948,7 +948,7 @@ def enr_fock(dims, excitations, state):
 
     try:
         data[state2idx[tuple(state)], 0] = 1
-    except:
+    except Exception:
         raise ValueError("The state tuple %s is not in the restricted "
                          "state space" % str(tuple(state)))
 

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -193,6 +193,11 @@ def coherent(N, alpha, offset=0, method=None):
         method = "operator" if offset == 0 else "analytic"
 
     if method == "operator":
+        if offset != 0:
+            raise ValueError(
+                "The method 'operator' does not support offset != 0. Please"
+                " select another method or set the offset to zero."
+            )
         x = basis(N, 0)
         a = destroy(N)
         D = (alpha * a.dag() - conj(alpha) * a).expm()

--- a/qutip/tests/test_states.py
+++ b/qutip/tests/test_states.py
@@ -126,8 +126,14 @@ def test_CoherentState():
     with pytest.raises(ValueError) as e:
         qutip.coherent(N, alpha, offset=-1)
     assert str(e.value) == ("Offset must be non-negative")
+    with pytest.raises(ValueError) as e:
+        qutip.coherent(N, alpha, offset=1, method="operator")
+    assert str(e.value) == (
+        "The method 'operator' does not support offset != 0. Please"
+        " select another method or set the offset to zero."
+    )
 
-    
+
 def test_CoherentDensityMatrix():
     N = 10
     rho = qutip.coherent_dm(N, 1)
@@ -139,6 +145,12 @@ def test_CoherentDensityMatrix():
     with pytest.raises(ValueError) as e:
         qutip.coherent_dm(N, 1, offset=-1)
     assert str(e.value) == ("Offset must be non-negative")
+    with pytest.raises(ValueError) as e:
+        qutip.coherent_dm(N, 1, offset=1, method="operator")
+    assert str(e.value) == (
+        "The method 'operator' does not support offset != 0. Please"
+        " select another method or set the offset to zero."
+    )
 
 
 def test_thermal():


### PR DESCRIPTION
**Description**
Raise an error instead of silently ignoring the offset when attempting to generate coherent states or density matrices with method 'operator' and non-zero offset.

**Related issues or PRs**
* Small fix post #1469

**Changelog**
Fix silent ignoring of offset in coherent and coherent_dm when offset is non-zero. A ValueError is now raised instead.