### PR TITLE
Added ptrace specialisation tests and fixed a bug for ptrace_dense.

### DIFF
--- a/qutip/core/data/ptrace.pyx
+++ b/qutip/core/data/ptrace.pyx
@@ -147,10 +147,10 @@ cpdef Dense ptrace_dense(Dense matrix, object dims, object sel):
                       .reshape(dims + dims)
                       .transpose(qtrace + [nd + q for q in qtrace] +
                                  sel + [nd + q for q in sel])
-                      .reshape([np.prod(dtrace),
-                                np.prod(dtrace),
-                                np.prod(dkeep),
-                                np.prod(dkeep)]))
+                      .reshape([np.prod(dtrace, dtype=int),
+                                np.prod(dtrace, dtype=int),
+                                np.prod(dkeep, dtype=int),
+                                np.prod(dkeep, dtype=int)]))
     return dense.fast_from_numpy(rhomat)
 
 

--- a/qutip/tests/core/data/test_ptrace.py
+++ b/qutip/tests/core/data/test_ptrace.py
@@ -77,7 +77,7 @@ class TestPtrace(testing.UnaryOpMixin):
     # `generate_mathematically_correct` can be re-used.
     @pytest.mark.parametrize(
         "dims",
-        [[2], [0], [-2, -2] + [2] * 5, [1.2]],
+        [[2], [0], [-2, -2] + [2] * 5, [1.2, 2.2, 3.3]],
         ids=[
             "dims_different_to_shape",
             "dims_0",

--- a/qutip/tests/core/data/test_ptrace.py
+++ b/qutip/tests/core/data/test_ptrace.py
@@ -46,12 +46,6 @@ class TestPtrace(testing.UnaryOpMixin):
         expected = self.op_numpy(matrix.to_array(), self.dims, sel)
         test = op(matrix, self.dims, sel)
         assert isinstance(test, out_type)
-        if issubclass(out_type, data.Data):
-            assert test.shape == expected.shape
-            np.testing.assert_allclose(test.to_array(), expected,
-                                       atol=self.atol, rtol=self.rtol)
-        else:
-            np.testing.assert_allclose(test, expected, atol=self.atol,
-                                       rtol=self.rtol)
-
-
+        assert test.shape == expected.shape
+        np.testing.assert_allclose(test.to_array(), expected,
+                                   atol=self.atol, rtol=self.rtol)

--- a/qutip/tests/core/data/test_ptrace.py
+++ b/qutip/tests/core/data/test_ptrace.py
@@ -26,7 +26,7 @@ class TestPtrace(testing.UnaryOpMixin):
     # These values should not be changed.
     dims = [2]*7
     shapes = [(pytest.param((np.prod(dims), np.prod(dims))),)]
-    # bad_shapes = testing.shapes_not_square(np.prod(dims))
+    bad_shapes = testing.shapes_not_square(np.prod(dims))
 
     specialisations = [
         pytest.param(data.ptrace_csr, CSR, CSR),
@@ -49,3 +49,12 @@ class TestPtrace(testing.UnaryOpMixin):
         assert test.shape == expected.shape
         np.testing.assert_allclose(test.to_array(), expected,
                                    atol=self.atol, rtol=self.rtol)
+
+
+    def test_incorrect_shape_raises(self, op, data_m):
+        """
+        Test that the operation produces a suitable error if the shape of the
+        operand is not square.
+        """
+        with pytest.raises(ValueError):
+            op(data_m(), self.dims, sel=[0, 1])

--- a/qutip/tests/core/data/test_ptrace.py
+++ b/qutip/tests/core/data/test_ptrace.py
@@ -1,0 +1,57 @@
+from . import test_mathematics as testing
+import numpy as np
+import scipy.linalg
+import pytest
+from qutip import data
+from qutip.core.data import CSR, Dense
+
+
+class TestPtrace(testing.UnaryOpMixin):
+    def op_numpy(self, matrix, dims, sel):
+        ndims = len(dims)
+        dkeep = [dims[x] for x in sel]
+        qtrace = list(set(range(ndims)) - set(sel))
+        dtrace = [dims[x] for x in qtrace]
+
+        matrix = matrix.reshape(dims+dims)
+        matrix = matrix.transpose(qtrace + [ndims + i for i in qtrace] +
+                                  sel + [ndims + i for i in sel])
+        matrix = matrix.reshape([np.prod(dtrace, dtype=int),
+                                 np.prod(dtrace, dtype=int),
+                                 np.prod(dkeep, dtype=int),
+                                 np.prod(dkeep, dtype=int)])
+        return np.trace(matrix)
+
+    # Custom shapes to have also custom dims and sel arguments.
+    # These values should not be changed.
+    dims = [2]*7
+    shapes = [(pytest.param((np.prod(dims), np.prod(dims))),)]
+    # bad_shapes = testing.shapes_not_square(np.prod(dims))
+
+    specialisations = [
+        pytest.param(data.ptrace_csr, CSR, CSR),
+        pytest.param(data.ptrace_csr_dense, CSR, Dense),
+        pytest.param(data.ptrace_dense, Dense, Dense),
+    ]
+
+    @pytest.mark.parametrize('sel', [[0], [0, 3, 6], list(range(len(dims))), []],
+                             ids=['keep_one', 'keep_multiple',
+                                  'trace_none', 'trace_all'])
+    def test_mathematically_correct(self, op, data_m, out_type, sel):
+        """
+        Test that the unary operation is mathematically correct for all the
+        known type specialisations.
+        """
+        matrix = data_m()
+        expected = self.op_numpy(matrix.to_array(), self.dims, sel)
+        test = op(matrix, self.dims, sel)
+        assert isinstance(test, out_type)
+        if issubclass(out_type, data.Data):
+            assert test.shape == expected.shape
+            np.testing.assert_allclose(test.to_array(), expected,
+                                       atol=self.atol, rtol=self.rtol)
+        else:
+            np.testing.assert_allclose(test, expected, atol=self.atol,
+                                       rtol=self.rtol)
+
+

--- a/qutip/tests/core/data/test_ptrace.py
+++ b/qutip/tests/core/data/test_ptrace.py
@@ -14,18 +14,23 @@ class TestPtrace(testing.UnaryOpMixin):
         qtrace = list(set(range(ndims)) - set(sel))
         dtrace = [dims[x] for x in qtrace]
 
-        matrix = matrix.reshape(dims+dims)
-        matrix = matrix.transpose(qtrace + [ndims + i for i in qtrace] +
-                                  sel + [ndims + i for i in sel])
-        matrix = matrix.reshape([np.prod(dtrace, dtype=int),
-                                 np.prod(dtrace, dtype=int),
-                                 np.prod(dkeep, dtype=int),
-                                 np.prod(dkeep, dtype=int)])
+        matrix = matrix.reshape(dims + dims)
+        matrix = matrix.transpose(
+            qtrace + [ndims + i for i in qtrace] + sel + [ndims + i for i in sel]
+        )
+        matrix = matrix.reshape(
+            [
+                np.prod(dtrace, dtype=int),
+                np.prod(dtrace, dtype=int),
+                np.prod(dkeep, dtype=int),
+                np.prod(dkeep, dtype=int),
+            ]
+        )
         return np.trace(matrix)
 
     # Custom shapes to have also custom dims and sel arguments.
     # These values should not be changed.
-    dims = [2]*7
+    dims = [2] * 7
     shapes = [(pytest.param((np.prod(dims), np.prod(dims))),)]
     bad_shapes = testing.shapes_not_square(np.prod(dims))
 
@@ -35,16 +40,17 @@ class TestPtrace(testing.UnaryOpMixin):
         pytest.param(data.ptrace_dense, Dense, Dense),
     ]
 
-    @pytest.mark.parametrize('sel', [[0],
-                                     [0, 3, 6],
-                                     [0, 6, 3],
-                                     list(range(len(dims))),
-                                     []],
-                             ids=['keep_one',
-                                  'keep_multiple_sorted',
-                                  'keep_multiple_unsorted',
-                                  'trace_none',
-                                  'trace_all'])
+    @pytest.mark.parametrize(
+        "sel",
+        [[0], [0, 3, 6], [0, 6, 3], list(range(len(dims))), []],
+        ids=[
+            "keep_one",
+            "keep_multiple_sorted",
+            "keep_multiple_unsorted",
+            "trace_none",
+            "trace_all",
+        ],
+    )
     def test_mathematically_correct(self, op, data_m, out_type, sel):
         """
         Test that the unary operation is mathematically correct for all the
@@ -55,9 +61,9 @@ class TestPtrace(testing.UnaryOpMixin):
         test = op(matrix, self.dims, sel)
         assert isinstance(test, out_type)
         assert test.shape == expected.shape
-        np.testing.assert_allclose(test.to_array(), expected,
-                                   atol=self.atol, rtol=self.rtol)
-
+        np.testing.assert_allclose(
+            test.to_array(), expected, atol=self.atol, rtol=self.rtol
+        )
 
     def test_incorrect_shape_raises(self, op, data_m):
         """
@@ -69,25 +75,31 @@ class TestPtrace(testing.UnaryOpMixin):
 
     # `out_type` is included but not used so that
     # `generate_mathematically_correct` can be re-used.
-    @pytest.mark.parametrize('dims',
-                             [[2], [0], [-2, -2]+[2]*5, [1.2]],
-                             ids=['dims_different_to_shape',
-                                  'dims_0',
-                                  'dims_prod_is_shape_but_negative',
-                                  'dims_is_not_int',
-                                 ])
+    @pytest.mark.parametrize(
+        "dims",
+        [[2], [0], [-2, -2] + [2] * 5, [1.2]],
+        ids=[
+            "dims_different_to_shape",
+            "dims_0",
+            "dims_prod_is_shape_but_negative",
+            "dims_is_not_int",
+        ],
+    )
     def test_incorrect_dims_raises(self, op, data_m, out_type, dims):
         with pytest.raises(ValueError):
-            op(data_m(), dims, sel=[0,1])
+            op(data_m(), dims, sel=[0, 1])
 
     def generate_incorrect_dims_raises(self, metafunc):
         self.generate_mathematically_correct(metafunc)
 
-    @pytest.mark.parametrize('sel',
-                             [[2, 10], [-1, 2]],
-                             ids=['sel_value_larger_than_dims',
-                                  'sel_value_negative',
-                                 ])
+    @pytest.mark.parametrize(
+        "sel",
+        [[2, 10], [-1, 2]],
+        ids=[
+            "sel_value_larger_than_dims",
+            "sel_value_negative",
+        ],
+    )
     def test_incorrect_sel_raises(self, op, data_m, out_type, sel):
         with pytest.raises(IndexError):
             op(data_m(), dims=self.dims, sel=sel)

--- a/qutip/tests/core/test_ptrace.py
+++ b/qutip/tests/core/test_ptrace.py
@@ -120,11 +120,12 @@ def test_ptrace_fails_on_invalid_input(state, selection, exception):
     with pytest.raises(exception):
         state.ptrace(selection)
 
+
 @pytest.mark.parametrize('dims, sel',
                          [
-                             ([5, 2, 3], [2,1]),
-                             ([5, 2, 3], [0,2]),
-                             ([5, 2, 3], [0,1]),
+                             ([5, 2, 3], [2, 1]),
+                             ([5, 2, 3], [0, 2]),
+                             ([5, 2, 3], [0, 1]),
                              ([2]*6, [3, 2]),
                              ([2]*6, [0, 2]),
                              ([2]*6, [0, 1]),
@@ -135,25 +136,26 @@ def test_ptrace_rand_ket(dtype, dims, sel):
 
 
 @pytest.mark.parametrize('sel', [[], [0, 1, 2], [0], [1], [1, 0], [0, 2]],
-                        ids=['trace_all',
-                             'trace_none',
-                             'trace_one',
-                             'trace_one_2',
-                             'trace_multiple',
-                             'trace_multiple_not_sorted',
-                            ])
+                         ids=['trace_all',
+                              'trace_none',
+                              'trace_one',
+                              'trace_one_2',
+                              'trace_multiple',
+                              'trace_multiple_not_sorted',
+                              ])
 def test_ptrace_rand_dm(dtype, sel):
     A = qutip.rand_dm(64, 0.5, dims=[[4, 4, 4], [4, 4, 4]]).to(dtype)
     assert A.ptrace(sel) == expected(A, sel)
 
+
 @pytest.mark.parametrize('sel', [[], [0, 1, 2], [0], [1], [1, 0], [0, 2]],
-                        ids=['trace_all',
-                             'trace_none',
-                             'trace_one',
-                             'trace_one_2',
-                             'trace_multiple',
-                             'trace_multiple_not_sorted',
-                            ])
+                         ids=['trace_all',
+                              'trace_none',
+                              'trace_one',
+                              'trace_one_2',
+                              'trace_multiple',
+                              'trace_multiple_not_sorted',
+                              ])
 def test_ptrace_operator(dtype, sel):
     A = qutip.tensor(
         qutip.rand_dm(2), qutip.thermal_dm(10, 1), qutip.rand_unitary(3),

--- a/qutip/tests/core/test_ptrace.py
+++ b/qutip/tests/core/test_ptrace.py
@@ -144,5 +144,5 @@ def test_ptrace_rand(dtype):
             assert A.ptrace(sel) == expected(A, sel)
 
         A = qutip.rand_dm(64, 0.5, dims=[[4, 4, 4], [4, 4, 4]]).to(dtype)
-        for sel in ([0], [1], [0, 2]):
+        for sel in ([], [0], [1], [0, 2]):
             assert A.ptrace(sel) == expected(A, sel)

--- a/qutip/tests/core/test_ptrace.py
+++ b/qutip/tests/core/test_ptrace.py
@@ -142,7 +142,7 @@ def test_ptrace_rand_ket(dtype, dims, sel):
                              'trace_multiple',
                              'trace_multiple_not_sorted',
                             ])
-def test_ptrace_dm(dtype, sel):
+def test_ptrace_rand_dm(dtype, sel):
     A = qutip.rand_dm(64, 0.5, dims=[[4, 4, 4], [4, 4, 4]]).to(dtype)
     assert A.ptrace(sel) == expected(A, sel)
 

--- a/qutip/tests/core/test_ptrace.py
+++ b/qutip/tests/core/test_ptrace.py
@@ -120,29 +120,42 @@ def test_ptrace_fails_on_invalid_input(state, selection, exception):
     with pytest.raises(exception):
         state.ptrace(selection)
 
+@pytest.mark.parametrize('dims, sel',
+                         [
+                             ([5, 2, 3], [2,1]),
+                             ([5, 2, 3], [0,2]),
+                             ([5, 2, 3], [0,1]),
+                             ([2]*6, [3, 2]),
+                             ([2]*6, [0, 2]),
+                             ([2]*6, [0, 1]),
+                         ])
+def test_ptrace_rand_ket(dtype, dims, sel):
+    A = qutip.rand_ket(np.prod(dims), dims=[dims, [1]*len(dims)])
+    assert A.ptrace(sel) == expected(A, sel)
 
-def test_ptrace_rand(dtype):
-    'ptrace : randomized tests'
-    for _ in range(5):
-        A = qutip.tensor(
-            qutip.rand_ket(5), qutip.rand_ket(2), qutip.rand_ket(3),
-        ).to(dtype)
-        for sel in ([2, 1], [0, 2], [0, 1]):
-            assert A.ptrace(sel) == expected(A, sel)
 
-        A = qutip.tensor(
-            qutip.rand_dm(2), qutip.thermal_dm(10, 1), qutip.rand_unitary(3),
-        ).to(dtype)
-        for sel in ([1, 2], [0, 2], [0, 1]):
-            assert A.ptrace(sel) == expected(A, sel)
+@pytest.mark.parametrize('sel', [[], [0, 1, 2], [0], [1], [1, 0], [0, 2]],
+                        ids=['trace_all',
+                             'trace_none',
+                             'trace_one',
+                             'trace_one_2',
+                             'trace_multiple',
+                             'trace_multiple_not_sorted',
+                            ])
+def test_ptrace_dm(dtype, sel):
+    A = qutip.rand_dm(64, 0.5, dims=[[4, 4, 4], [4, 4, 4]]).to(dtype)
+    assert A.ptrace(sel) == expected(A, sel)
 
-        A = qutip.tensor(
-            qutip.rand_ket(2), qutip.rand_ket(2), qutip.rand_ket(2),
-            qutip.rand_ket(2), qutip.rand_ket(2), qutip.rand_ket(2),
-        ).to(dtype)
-        for sel in ([3, 2], [0, 2], [0, 1]):
-            assert A.ptrace(sel) == expected(A, sel)
-
-        A = qutip.rand_dm(64, 0.5, dims=[[4, 4, 4], [4, 4, 4]]).to(dtype)
-        for sel in ([], [0], [1], [0, 2]):
-            assert A.ptrace(sel) == expected(A, sel)
+@pytest.mark.parametrize('sel', [[], [0, 1, 2], [0], [1], [1, 0], [0, 2]],
+                        ids=['trace_all',
+                             'trace_none',
+                             'trace_one',
+                             'trace_one_2',
+                             'trace_multiple',
+                             'trace_multiple_not_sorted',
+                            ])
+def test_ptrace_operator(dtype, sel):
+    A = qutip.tensor(
+        qutip.rand_dm(2), qutip.thermal_dm(10, 1), qutip.rand_unitary(3),
+    ).to(dtype)
+    assert A.ptrace(sel) == expected(A, sel)

--- a/qutip/tests/core/test_ptrace.py
+++ b/qutip/tests/core/test_ptrace.py
@@ -45,7 +45,7 @@ def expected(qobj, sel):
         qobj = qobj.proj()
     sel = sorted(sel)
     dims = [[x for i, x in enumerate(qobj.dims[0]) if i in sel]]*2
-    new_shape = (np.prod(dims[0]),) * 2
+    new_shape = (np.prod(dims[0], dtype=int),) * 2
     out = qobj.full()
     before, after = 1, qobj.shape[0]
     for i, dim in enumerate(qobj.dims[0]):
@@ -55,7 +55,7 @@ def expected(qobj, sel):
             continue
         tmp_dims = (before, dim, after) * 2
         out = np.einsum('aibcid->abcd', out.reshape(tmp_dims))
-    return qutip.Qobj(out.reshape(new_shape), dims=dims)
+    return qutip.Qobj(out.reshape(new_shape), dims=dims, type='oper')
 
 
 @pytest.fixture(params=[_data.CSR, _data.Dense], ids=['CSR', 'Dense'])


### PR DESCRIPTION
**Checklist**
- [x] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).

**Description**
Added ptrace specialisation tests. While adding these tests a bug came out with `ptrace_dense` which is now fixed. The problem was it did not work for `sel=[]`, that is, no selection and hence the full trace was required. The bug comes from how `numpy` works as the output of np.prod([]) is float instead of integer. 

I wonder though what should be the behaviour for `qobj.ptrace([])`. Should it not be the same as `qobj.trace()`?  `qobj.ptrace([])` currently returns a `Qobj` of shape 1x1 whereas `qobj.trace()` returns a complex number.

**Changelog**
Fixed error with ptrace when the input and output are dense and `sel=[]`.
Added specialisations tests for ptrace.
Improved `ptrace` tests to test for edge cases (trace all and trace none).
Added a few more checks to catch invalid dims and raise ValueError.
 