### PR TITLE
Build with oldest supported numpy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
       # Set up wheels matrix.  This is CPython 3.6--3.9 for all OS targets.
-      CIBW_BUILD: "cp3[6-9]-*"
+      CIBW_BUILD: "cp3{6,7,8,9}-*"
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
@@ -120,8 +120,8 @@ jobs:
       - name: Install cibuildwheel
         run: |
           # cibuildwheel does the heavy lifting for us. Originally tested on
-          # 1.8.0, but should be fine at least up to any major new release.
-          python -m pip install 'cibuildwheel<2.0'
+          # 2.3.0, but should be fine at least up to any minor new release.
+          python -m pip install 'cibuildwheel==2.3.*'
 
       - name: Build wheels
         shell: bash

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -22,7 +22,9 @@ jobs:
 
       - name: Install QuTiP from GitHub
         run: |
-          python -mpip install -e .[full]
+          # Build without build isolation so that we use the build
+          # dependencies already installed from doc/requirements.txt.
+          python -m pip install -e .[full] --no-build-isolation
           # Install in editable mode so it doesn't matter if we import from
           # inside the installation directory, otherwise we can get some errors
           # because we're importing from the wrong location.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         # Test other versions of Python in special cases to avoid exploding the
         # matrix size; make sure to test all supported versions in some form.
-        python-version: [3.9]
+        python-version: ["3.9"]
         case-name: [defaults]
         numpy-requirement: [">=1.20,<1.21"]
         # Extra special cases.  In these, the new variable defined should always
@@ -37,7 +37,7 @@ jobs:
           # SciPy versions for Python 3.9.
           - case-name: old SciPy
             os: ubuntu-latest
-            python-version: 3.6
+            python-version: "3.6"
             scipy-requirement: ">=1.4,<1.5"
             # let the old SciPy version select an appropriate numpy version:
             numpy-requirement: ""
@@ -46,14 +46,14 @@ jobs:
           # not necessarily for pip.
           - case-name: no MKL
             os: ubuntu-latest
-            python-version: 3.7
+            python-version: "3.7"
             nomkl: 1
 
           # OpenMP runs.  We only really care about getting OpenMP working
           # properly on Linux at the moment.
           - case-name: OpenMP
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
             numpy-requirement: ">=1.20,<1.21"
             openmp: 1
 
@@ -61,7 +61,7 @@ jobs:
           # everything should be able to run this.
           - case-name: no Cython
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.8"
             nocython: 1
 
     steps:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -47,3 +47,4 @@ sphinxcontrib-serializinghtml==1.1.4
 traitlets==5.0.5
 urllib3==1.26.5
 wcwidth==0.2.5
+wheel==0.37.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,19 @@ requires = [
     "packaging",
     "wheel",
     "cython>=0.29.20",
-    "numpy>=1.16.6,<1.20",
+    "oldest-supported-numpy",
     "scipy>=1.0",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+# Change in future version to "build"
+build-frontend = "pip"
+
+[tool.cibuildwheel.override]
+# NumPy support manylinux2010 on CPython 3.6-3.9
+select = "cp3?-*"
+manylinux-x86_64-image = "manylinux2010"
+manylinux-i686-image = "manylinux2010"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ requires = [
     "packaging",
     "wheel",
     "cython>=0.29.20",
+    # See https://numpy.org/doc/stable/user/depending_on_numpy.html for
+    # the recommended way to build against numpy's C API:
     "oldest-supported-numpy",
     "scipy>=1.0",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     scipy>=1.0
     packaging
 setup_requires =
-    numpy>=1.16.6,<1.20
+    numpy>=1.13.3
     scipy>=1.0
     cython>=0.29.20
     packaging


### PR DESCRIPTION
**Description**

Currently QuTiP's build requirements specify `numpy>=1.16.6<1.20` but this was really a guess at the correct numpy to build with and importantly, is the wrong guess for Python 3.10 which is only supported by numpy 1.20 and later. Instead we now depend on the `oldest-supported-numpy` package, which is maintained by the numpy and SciPy folk and should always provide the correct version of numpy to build with on a given platform.

A previous version of this PR #1735 attempted to simultaneously add support for Python 3.10, but that turned out to be tricky because conda did not yet provide a pre-compiled SciPy for Python 3.10. This PR should allow QuTiP to be built locally for Python 3.10, but does not yet add official Python 3.10 builds.

- [x] Remove the restriction to `numpy<1.20` in `setup.cfg` (numpy >= 1.20 is required by Python 3.10)
- [x] Update the build process to explicitly build with the lowest supported numpy
- [x] While we're here, update to a more recent version of ciwheelbuild. 

**Related issues or PRs**
* Fixes #1732
* Fixes #1720
* Fixes #1740
* We also need to update our conda-forge feedstock -- https://github.com/conda-forge/qutip-feedstock/pull/72
* Alternative very similar implementation from @henryiii in #1738 (thank you!)
* Previous attempt in #1735 (that 

**Changelog**
* Updated the build process to support building on Python 3.10 by removing the build requirement for `numpy < 1.20` and replacing it with a requirement on `oldest-supported-numpy`.
* Update the version of cibuildwheel used to build wheels to 2.3.0.

