### PR TITLE
refactor process_fidelity using new function _hilbert_space_dims

### DIFF
--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -129,9 +129,12 @@ def _hilbert_space_dims(oper):
     """
     if isinstance(oper, list):
         return oper[0].dims
-    if oper.type == 'oper':
+    elif oper.type == 'oper':  # interpret as unitary quantum channel
         return oper.dims
-    return [oper.dims[0][1], oper.dims[1][0]]  # for Choi, chi, or super
+    elif oper.type=='super' and oper.superrep in ['choi', 'chi', 'super']:
+        return [oper.dims[0][1], oper.dims[1][0]]
+    else:
+        raise TypeError('oper is not a valid quantum channel!')
 
 
 def _process_fidelity_to_id(oper):

--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -131,7 +131,7 @@ def _hilbert_space_dims(oper):
         return oper[0].dims
     elif oper.type == 'oper':  # interpret as unitary quantum channel
         return oper.dims
-    elif oper.type=='super' and oper.superrep in ['choi', 'chi', 'super']:
+    elif oper.type == 'super' and oper.superrep in ['choi', 'chi', 'super']:
         return [oper.dims[0][1], oper.dims[1][0]]
     else:
         raise TypeError('oper is not a valid quantum channel!')

--- a/qutip/tests/core/test_metrics.py
+++ b/qutip/tests/core/test_metrics.py
@@ -56,6 +56,7 @@ from qutip import (
     identity, qdiags, sigmax, sigmay, sigmaz, qeye, fock_dm, basis,
 )
 from qutip.core.metrics import *
+from qutip.core.metrics import _hilbert_space_dims
 from qutip.qip.operations.gates import hadamard_transform, swap
 
 from qutip.settings import settings
@@ -394,6 +395,26 @@ def rand_super():
     return propagator(h_5, rand(), [
         create(5), destroy(5), jmat(2, 'z')
     ])
+
+
+@pytest.mark.parametrize('superrep_conversion',
+                         [lambda x: x, to_super, to_choi, to_kraus])
+def test__hilbert_space_dims(superrep_conversion):
+    """
+    Metrics: check _hilbert_space_dims
+    """
+    dims = [[2, 3], [4, 5]]
+    u = Qobj(np.ones((np.prod(dims[0]), np.prod(dims[1]))), dims=dims)
+    assert_(_hilbert_space_dims(superrep_conversion(u)) == dims)
+
+
+def test__hilbert_space_dims_chi():
+    """
+    Metrics: check _hilbert_space_dims for a chi channel
+    """
+    dims = [[2, 2], [2, 2]]
+    u = Qobj(np.ones((np.prod(dims[0]), np.prod(dims[1]))), dims=dims)
+    assert_(_hilbert_space_dims(to_chi(u)) == dims)
 
 
 @avg_gate_fidelity_test

--- a/qutip/tests/core/test_metrics.py
+++ b/qutip/tests/core/test_metrics.py
@@ -399,7 +399,7 @@ def rand_super():
 
 @pytest.mark.parametrize('superrep_conversion',
                          [lambda x: x, to_super, to_choi, to_kraus])
-def test__hilbert_space_dims(superrep_conversion):
+def test_hilbert_space_dims(superrep_conversion):
     """
     Metrics: check _hilbert_space_dims
     """
@@ -408,7 +408,7 @@ def test__hilbert_space_dims(superrep_conversion):
     assert_(_hilbert_space_dims(superrep_conversion(u)) == dims)
 
 
-def test__hilbert_space_dims_chi():
+def test_hilbert_space_dims_chi():
     """
     Metrics: check _hilbert_space_dims for a chi channel
     """


### PR DESCRIPTION
**Description**
This is a refactor of the changes from https://github.com/qutip/qutip/pull/1712. Previously, the logic which extracts the dimensions of the input and output Hilbert spaces of the involved quantum channels was spread out throughout `process_fidelity` and `_process_fidelity_to_id`. This PR collects it in a new private function `core.metrics._hilbert_space_dims`.

This will also allow reducing `average_gate_fidelity` to `process_fidelity` (in a future PR) as explained in https://qiskit.org/documentation/stubs/qiskit.quantum_info.average_gate_fidelity.html, without having to re-implement extracting the dimensions.

**Related issues or PRs**
Part of the work on https://github.com/qutip/qutip/issues/1703.

**Changelog**
refactor process_fidelity using new function _hilbert_space_dims