### PR TITLE
Handle change in configuration attributes for numpy 1.22.0

### DIFF
--- a/qutip/utilities.py
+++ b/qutip/utilities.py
@@ -334,7 +334,12 @@ def _version2int(version_string):
 
 def _blas_info():
     config = np.__config__
-    blas_info = config.blas_opt_info
+    if hasattr(config, 'blas_ilp64_opt_info'):
+        blas_info = config.blas_ilp64_opt_info
+    elif hasattr(config, 'blas_opt_info'):
+        blas_info = config.blas_opt_info
+    else:
+        blas_info = {}
     _has_lib_key = 'libraries' in blas_info.keys()
     blas = None
     if hasattr(config,'mkl_info') or \


### PR DESCRIPTION
**Description**

In the recently released numpy 1.22.0 the `__config__` attribute for the
published wheels (at least on the linux platforms I'm using) have
removed the `blas_opt_info` attribute and are instead publishing
identical information in the `blas_ilp64_opt_info` attribute. Running
qutip with the latest numpy release on these platforms was causing an
attribute error when `_blas_info()` is called as
`numpy.__config__.blas_opt_info` doesn't exist in the installed numpy.
This commit fixes this by first checking if the new name exists and
using that to get the blas opt info, and then trying the name available
in previous releases. This should maintain compatibility with older
numpy releases but fix the issue when running with 1.22.0.

**Changelog**

Fix compatibility with numpy configuration in numpy's 1.22.0 release