### PR TITLE
Fix reading the CPU frequency on Apple M1.

### DIFF
--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -8,11 +8,15 @@ import numpy as np
 
 
 def _mac_hardware_info():
-    info = dict()
-    results = dict()
-    for l in [l.split(':') for l in os.popen('sysctl hw').readlines()[1:]]:
-        info[l[0].strip(' "').replace(' ', '_').lower().strip('hw.')] = \
-            l[1].strip('.\n ')
+    info = {}
+    results = {}
+    with os.popen('sysctl hw') as f:
+        lines = f.readlines()
+    for line in lines[1:]:
+        key, _, value = line.partition(':')
+        key = key.strip(' "').replace(' ', '_').lower().strip('hw.')
+        value = value.strip('.\n ')
+        info[key] = value
     results.update({'cpus': int(info['physicalcpu'])})
     # Mac OS currently doesn't not provide hw.cpufrequency on the M1
     with os.popen('sysctl hw.cpufrequency') as f:

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -15,7 +15,8 @@ def _mac_hardware_info():
             l[1].strip('.\n ')
     results.update({'cpus': int(info['physicalcpu'])})
     # Mac OS currently doesn't not provide hw.cpufrequency on the M1
-    cpu_freq_lines = os.popen('sysctl hw.cpufrequency').readlines()
+    with os.popen('sysctl hw.cpufrequency') as f:
+        cpu_freq_lines = f.readlines()
     if cpu_freq_lines:
         # Yay, hw.cpufrequency present
         results.update({

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -18,8 +18,8 @@ def _mac_hardware_info():
     cpu_freq_lines = os.popen('sysctl hw.cpufrequency').readlines()
     if cpu_freq_lines:
         # Yay, hw.cpufrequency present
-        results.update({'cpu_freq': int(float(
-            cpu_freq_lines[0].split(':')[1]) / 1000000)
+        results.update({
+            'cpu_freq': float(cpu_freq_lines[0].split(':')[1]) / 1000000,
         })
     else:
         # No hw.cpufrequency, assume Apple M1 CPU (all are 3.2 GHz currently)
@@ -39,19 +39,19 @@ def _linux_hardware_info():
     with open("/proc/cpuinfo") as f:
         for l in [l.split(':') for l in f.readlines()]:
             if (l[0].strip() == "physical id"):
-                sockets = np.maximum(sockets,int(l[1].strip())+1)
+                sockets = np.maximum(sockets, int(l[1].strip()) + 1)
             if (l[0].strip() == "cpu cores"):
                 cores_per_socket = int(l[1].strip())
             if (l[0].strip() == "cpu MHz"):
                 frequency = float(l[1].strip()) / 1000.
-    results.update({'cpus': sockets * cores_per_socket})
+    results.update({'cpus': int(sockets * cores_per_socket)})
     # get cpu frequency directly (bypasses freq scaling)
     try:
         with open(
                 "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq") as f:
             line = f.readlines()[0]
         frequency = float(line.strip('\n')) / 1000000.
-    except:
+    except Exception:
         pass
     results.update({'cpu_freq': frequency})
 
@@ -85,7 +85,7 @@ def _win_hardware_info():
         ncpus = 0
         for cpu in cpus:
             ncpus += int(cpu.Properties_['NumberOfCores'].Value)
-    except:
+    except Exception:
         ncpus = int(multiprocessing.cpu_count())
     return {'os': 'Windows', 'cpus': ncpus}
 

--- a/qutip/hardware_info.py
+++ b/qutip/hardware_info.py
@@ -14,9 +14,16 @@ def _mac_hardware_info():
         info[l[0].strip(' "').replace(' ', '_').lower().strip('hw.')] = \
             l[1].strip('.\n ')
     results.update({'cpus': int(info['physicalcpu'])})
-    results.update({'cpu_freq': int(float(os.popen('sysctl hw.cpufrequency')
-                                          .readlines()[0].split(':')[
-                                              1]) / 1000000)})
+    # Mac OS currently doesn't not provide hw.cpufrequency on the M1
+    cpu_freq_lines = os.popen('sysctl hw.cpufrequency').readlines()
+    if cpu_freq_lines:
+        # Yay, hw.cpufrequency present
+        results.update({'cpu_freq': int(float(
+            cpu_freq_lines[0].split(':')[1]) / 1000000)
+        })
+    else:
+        # No hw.cpufrequency, assume Apple M1 CPU (all are 3.2 GHz currently)
+        results['cpu_freq'] = 3.2
     results.update({'memsize': int(int(info['memsize']) / (1024 ** 2))})
     # add OS information
     results.update({'os': 'Mac OSX'})

--- a/qutip/tests/test_hardware_info.py
+++ b/qutip/tests/test_hardware_info.py
@@ -1,0 +1,15 @@
+"""
+Tests for qutip.hardware_info.
+"""
+
+from qutip.hardware_info import hardware_info
+
+
+def test_hardware_info():
+    info = hardware_info()
+    assert info["os"] in ("Windows", "FreeBSD", "Linux", "Mac OSX")
+    assert info["cpus"] > 0
+    assert isinstance(info["cpus"], int)
+    cpu_freq = info.get("cpu_freq", 0.0)
+    assert cpu_freq >= 0.
+    assert isinstance(cpu_freq, float)


### PR DESCRIPTION
**Description**
Fix reading the CPU frequency on Apple M1.

Currently Mac OS does not provide the CPU frequency via sysctl (see discussion in this psutils bug -- https://github.com/giampaolo/psutil/issues/1892).

It seems that the only way to obtain the CPU frequency currently is to measure it -- see https://github.com/BitesPotatoBacks/osx-cpufreq/blob/fb82fd7afcffe9d76d98ad7af76217d7a9d34f38/M1cpufreq/M1cpufreq/main.cpp#L7-L35. I don't know what this measures exactly (e.g. is there clock scaling of some sort so that the measured CPU frequency might not be the maximum CPU frequency?) and it seems a lot of work to get a piece of information that isn't used directly by QuTiP, so I just fixed the result to 3.2 GHz for now (which according to Wikipedia is the clock speed for current M1s).

Hopefully sysctl will support CPU frequency on the M1 before we have to worry about this again.

**Related issues or PRs**
- Fixes #1606

**Changelog**
Fixed reading the CPU frequency on Apple M1.