### PR TITLE
Add a numpy 1.22 and Python 3.10 build to the CI test matrix.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,8 +106,7 @@ jobs:
           else
             conda install nomkl "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
           fi
-          python -m pip install packaging
-          python -m pip install --no-build-isolation -e .[$QUTIP_TARGET]
+          python -m pip install -e .[$QUTIP_TARGET]
           python -m pip install pytest-cov coveralls
 
       - name: Package information

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
           else
             conda install nomkl "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
           fi
-          python -m pip install -e --no-build-isolation .[$QUTIP_TARGET]
+          python -m pip install --no-build-isolation -e .[$QUTIP_TARGET]
           python -m pip install pytest-cov coveralls
 
       - name: Package information

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,6 +107,7 @@ jobs:
             conda install nomkl "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
           fi
           python -m pip install -e .[$QUTIP_TARGET]
+          python -m pip install coverage==6.2
           python -m pip install pytest-cov coveralls
 
       - name: Package information

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
             os: ubuntu-latest
             python-version: "3.10"
             condaforge: 1
-            pytest-extra-options: "-W ignore::ImportWarnng"
+            pytest-extra-options: "-W ignore::ImportWarning"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.9"]
         case-name: [defaults]
-        numpy-requirement: ["=1.22"]
+        numpy-requirement: ["==1.22"]
         # Extra special cases.  In these, the new variable defined should always
         # be a truth-y value (hence 'nomkl: 1' rather than 'mkl: 0'), because
         # the lack of a variable is _always_ false-y, and the defaults lack all
@@ -71,6 +71,11 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+
+      - name: Add conda-forge
+        run: |
+          conda config --prepend channels conda-forge
+          conda config --set channel_priority strict
 
       - name: Install QuTiP and dependencies
         # In the run, first we handle any special cases.  We do this in bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.9"]
         case-name: [defaults]
-        numpy-requirement: ["==1.22"]
+        numpy-requirement: [">=1.20,<1.21"]
         # Extra special cases.  In these, the new variable defined should always
         # be a truth-y value (hence 'nomkl: 1' rather than 'mkl: 0'), because
         # the lack of a variable is _always_ false-y, and the defaults lack all
@@ -64,6 +64,13 @@ jobs:
             python-version: "3.8"
             nocython: 1
 
+          # Python 3.10 and numpy 1.22
+          # Use conda-forge to provide numpy 1.22
+          - case-name: Python 3.10
+            os: ubuntu-latest
+            python-version: "3.10"
+            condaforge: 1
+
     steps:
       - uses: actions/checkout@v2
 
@@ -71,11 +78,6 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-
-      - name: Add conda-forge
-        run: |
-          conda config --prepend channels conda-forge
-          conda config --set channel_priority strict
 
       - name: Install QuTiP and dependencies
         # In the run, first we handle any special cases.  We do this in bash
@@ -87,6 +89,10 @@ jobs:
             QUTIP_TARGET="$QUTIP_TARGET,runtime_compilation"
           fi
           export CI_QUTIP_WITH_OPENMP=${{ matrix.openmp }}
+          if [[ -n "${{ matrix.condaforge }}" ]]; then
+            conda config --prepend channels conda-forge
+            conda config --set channel_priority strict
+          fi
           if [[ -z "${{ matrix.nomkl }}" ]]; then
             conda install blas=*=mkl "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
           elif [[ "${{ matrix.os }}" =~ ^windows.*$ ]]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.9"]
         case-name: [defaults]
-        numpy-requirement: [">=1.20,<1.21"]
+        numpy-requirement: ["1.22"]
         # Extra special cases.  In these, the new variable defined should always
         # be a truth-y value (hence 'nomkl: 1' rather than 'mkl: 0'), because
         # the lack of a variable is _always_ false-y, and the defaults lack all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,10 +66,14 @@ jobs:
 
           # Python 3.10 and numpy 1.22
           # Use conda-forge to provide numpy 1.22
+          # Ignore ImportWarning because pyximport registered an importer
+          # PyxImporter that does not have a find_spec method and this raises
+          # a warning on Python 3.10
           - case-name: Python 3.10
             os: ubuntu-latest
             python-version: "3.10"
             condaforge: 1
+            pytest-extra-options: "-W ignore::ImportWarnng"
 
     steps:
       - uses: actions/checkout@v2
@@ -131,7 +135,7 @@ jobs:
             # truly being executed.
             export QUTIP_NUM_PROCESSES=2
           fi
-          pytest -Werror --strict-config --strict-markers --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes qutip/tests
+          pytest -Werror --strict-config --strict-markers --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes ${{ matrix.pytest-extra-options }} qutip/tests
           # Above flags are:
           #  -Werror
           #     treat warnings as errors

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,7 @@ jobs:
           else
             conda install nomkl "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
           fi
+          python -m pip install packaging
           python -m pip install --no-build-isolation -e .[$QUTIP_TARGET]
           python -m pip install pytest-cov coveralls
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.9"]
         case-name: [defaults]
-        numpy-requirement: ["1.22"]
+        numpy-requirement: ["=1.22"]
         # Extra special cases.  In these, the new variable defined should always
         # be a truth-y value (hence 'nomkl: 1' rather than 'mkl: 0'), because
         # the lack of a variable is _always_ false-y, and the defaults lack all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
           else
             conda install nomkl "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
           fi
-          python -m pip install -e .[$QUTIP_TARGET]
+          python -m pip install -e --no-build-isolation .[$QUTIP_TARGET]
           python -m pip install pytest-cov coveralls
 
       - name: Package information

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -81,7 +81,7 @@ def _default_steadystate_args():
     def_args = {'sparse': True, 'use_rcm': False,
                 'use_wbm': False, 'use_precond': False,
                 'all_states': False, 'M': None, 'x0': None, 'drop_tol': 1e-4,
-                'fill_factor': 100, 'diag_pivot_thresh': None, 'maxiter': 1000,
+                'fill_factor': 100, 'diag_pivot_thresh': 0.1, 'maxiter': 1000,
                 'permc_spec': 'COLAMD', 'ILU_MILU': 'smilu_2',
                 'restart': 20,
                 'max_iter_refine': 10,
@@ -1218,7 +1218,7 @@ def _pseudo_inverse_sparse(L, rhoss, w=None, **pseudo_args):
         LIQ = lu.solve(Q.toarray())
 
     else:
-        raise ValueError("unsupported method '%s'" % method)
+        raise ValueError("unsupported method '%s'" % pseudo_args['method'])
 
     R = sp.csr_matrix(Q * LIQ)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown; variant=GFM
 keywords = quantum, physics, dynamics
 license = BSD 3-Clause License
-license_file = LICENSE.txt
+license_files = LICENSE.txt
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Intended Audience :: Science/Research


### PR DESCRIPTION
**Description**
Add a numpy 1.22 and Python 3.10 build to the CI test matrix.

**Related issues or PRs**
* If test pass consistently with numpy 1.22, we can close #1694

**Changelog**
Add a numpy 1.22 and Python 3.10 build to the CI test matrix.