### PR TITLE
Add dims check for e_ops in main solvers

### DIFF
--- a/qutip/mcsolve.py
+++ b/qutip/mcsolve.py
@@ -309,6 +309,8 @@ class _MC():
         else:
             self.e_ops = ExpectOps([])
 
+        self.e_ops.check_dims(self.ss.td_c_ops[0].cte.dims)
+
         ss = self.ss
         if ss is not None and ss.type == "Diagonal" and not self.e_ops.isfunc:
             e_ops = [

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -465,6 +465,9 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
                 if not isinstance(op, Qobj) and callable(op):
                     output.expect.append(np.zeros(n_tsteps, dtype=complex))
                     continue
+                if op.dims != rho0.dims:
+                    raise TypeError('e_ops dims are not compatible with '
+                                    'the state')
                 e_ops_data.append(spre(op).data)
                 if op.isherm and rho0.isherm:
                     output.expect.append(np.zeros(n_tsteps))

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -466,8 +466,9 @@ def _generic_ode_solve(func, ode_args, rho0, tlist, e_ops, opt,
                     output.expect.append(np.zeros(n_tsteps, dtype=complex))
                     continue
                 if op.dims != rho0.dims:
-                    raise TypeError('e_ops dims are not compatible with '
-                                    'the state')
+                    raise TypeError(f"e_ops dims ({op.dims}) are not "
+                                    f"compatible with the state's "
+                                    f"({rho0.dims})")
                 e_ops_data.append(spre(op).data)
                 if op.isherm and rho0.isherm:
                     output.expect.append(np.zeros(n_tsteps))

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -288,22 +288,22 @@ def _generic_ode_solve(func, ode_args, psi0, tlist, e_ops, opt,
                     output.expect.append(np.zeros(n_tsteps, dtype=complex))
         if oper_evo:
             for e in e_ops:
-                if isinstance(e, Qobj):
-                    if e.dims[1] != psi0b[0]:
-                        raise TypeError('e_ops dims are not compatible with '
-                                        'the state')
+                if not isinstance(e, Qobj):
+                    e_ops_data.append(e)
+                elif e.dims[1] != psi0.dims[0]:
+                    raise TypeError(f"e_ops dims ({e.dims}) are not compatible "
+                                    f"with the state's ({psi0.dims})")
+                else:
                     e_ops_data.append(e.dag().data)
-                    continue
-                e_ops_data.append(e)
         else:
             for e in e_ops:
-                if isinstance(e, Qobj):
-                    if e.dims[1] != psi0.dims[0]:
-                        raise TypeError('e_ops dims are not compatible with '
-                                        'the state')
+                if not isinstance(e, Qobj):
+                    e_ops_data.append(e)
+                elif e.dims[1] != psi0.dims[0]:
+                    raise TypeError(f"e_ops dims ({e.dims}) are not compatible "
+                                    f"with the state's ({psi0.dims})")
+                else:
                     e_ops_data.append(e.data)
-                    continue
-                e_ops_data.append(e)
     else:
         raise TypeError("Expectation parameter must be a list or a function")
 

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -289,12 +289,18 @@ def _generic_ode_solve(func, ode_args, psi0, tlist, e_ops, opt,
         if oper_evo:
             for e in e_ops:
                 if isinstance(e, Qobj):
+                    if e.dims[1] != psi0b[0]:
+                        raise TypeError('e_ops dims are not compatible with '
+                                        'the state')
                     e_ops_data.append(e.dag().data)
                     continue
                 e_ops_data.append(e)
         else:
             for e in e_ops:
                 if isinstance(e, Qobj):
+                    if e.dims[1] != psi0.dims[0]:
+                        raise TypeError('e_ops dims are not compatible with '
+                                        'the state')
                     e_ops_data.append(e.data)
                     continue
                 e_ops_data.append(e)

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -291,8 +291,8 @@ def _generic_ode_solve(func, ode_args, psi0, tlist, e_ops, opt,
                 if not isinstance(e, Qobj):
                     e_ops_data.append(e)
                 elif e.dims[1] != psi0.dims[0]:
-                    raise TypeError(f"e_ops dims ({e.dims}) are not compatible "
-                                    f"with the state's ({psi0.dims})")
+                    raise TypeError(f"e_ops dims ({e.dims}) are not compatible"
+                                    f" with the state's ({psi0.dims})")
                 else:
                     e_ops_data.append(e.dag().data)
         else:
@@ -300,8 +300,8 @@ def _generic_ode_solve(func, ode_args, psi0, tlist, e_ops, opt,
                 if not isinstance(e, Qobj):
                     e_ops_data.append(e)
                 elif e.dims[1] != psi0.dims[0]:
-                    raise TypeError(f"e_ops dims ({e.dims}) are not compatible "
-                                    f"with the state's ({psi0.dims})")
+                    raise TypeError(f"e_ops dims ({e.dims}) are not compatible"
+                                    f" with the state's ({psi0.dims})")
                 else:
                     e_ops_data.append(e.data)
     else:

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -78,8 +78,8 @@ class ExpectOps:
         if not self.isfunc:
             for op in self.e_ops_qoevo:
                 if isinstance(op, QobjEvo) and op.cte.dims[1] != dims[0]:
-                    raise TypeError('e_ops dims are not compatible with '
-                                    'the state')
+                    raise TypeError(f"e_ops dims ({op.cte.dims}) are not "
+                                    f"compatible with the system's ({dims})")
 
     def copy(self):
         out = ExpectOps.__new__(ExpectOps)

--- a/qutip/solver.py
+++ b/qutip/solver.py
@@ -74,6 +74,13 @@ class ExpectOps:
         else:
             self.raw_out = np.zeros((self.e_num, len(tlist)), dtype=complex)
 
+    def check_dims(self, dims):
+        if not self.isfunc:
+            for op in self.e_ops_qoevo:
+                if isinstance(op, QobjEvo) and op.cte.dims[1] != dims[0]:
+                    raise TypeError('e_ops dims are not compatible with '
+                                    'the state')
+
     def copy(self):
         out = ExpectOps.__new__(ExpectOps)
         out.isfunc = self.isfunc

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -345,6 +345,15 @@ class StochasticSolverOptions:
         self.rho0 = mat2vec(state0.full()).ravel()
 
         # Observation
+
+        for e_op in e_ops:
+            if (
+                isinstance(e_op, Qobj)
+                and self.H is not None
+                and e_op.dims[1] != self.H.cte.dims[0]
+            ):
+                raise TypeError('e_ops dims are not compatible with '
+                                'the state')
         self.e_ops = e_ops
         self.m_ops = m_ops
         self.store_measurement = store_measurement

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -352,8 +352,8 @@ class StochasticSolverOptions:
                 and self.H is not None
                 and e_op.dims[1] != self.H.cte.dims[0]
             ):
-                raise TypeError('e_ops dims are not compatible with '
-                                'the state')
+                raise TypeError(f"e_ops dims ({e_op.dims}) are not compatible "
+                                f"with the system's ({self.H.cte.dims})")
         self.e_ops = e_ops
         self.m_ops = m_ops
         self.store_measurement = store_measurement

--- a/qutip/tests/test_mcsolve.py
+++ b/qutip/tests/test_mcsolve.py
@@ -281,3 +281,12 @@ def test_regression_490():
     result_mc = qutip.mcsolve(h, state, times, ntraj=1)
     for state_me, state_mc in zip(result_me.states, result_mc.states):
         np.testing.assert_allclose(state_me.full(), state_mc.full(), atol=1e-8)
+
+
+def test_mcsolve_bad_e_ops():
+    H = qutip.sigmaz()
+    c_ops = [qutip.sigmax()]
+    psi0 = qutip.basis(2, 0)
+    tlist = np.linspace(0, 20, 200)
+    with pytest.raises(TypeError) as exc:
+        qutip.mcsolve(H, psi0, tlist=tlist, c_ops=c_ops, e_ops=[qutip.qeye(3)])

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -969,5 +969,10 @@ def test_tlist_h_with_other_tlist_c_ops_raises():
     assert str(exc.value) == "Time lists are not compatible"
 
 
-if __name__ == "__main__":
-    run_module_suite()
+def test_mesolve_bad_e_ops():
+    H = sigmaz()
+    c_ops = [sigmax()]
+    psi0 = basis(2, 0)
+    tlist = np.linspace(0, 20, 200)
+    with pytest.raises(TypeError) as exc:
+        mesolve(H, psi0, tlist=tlist, c_ops=c_ops, e_ops=[qeye(3)])

--- a/qutip/tests/test_sesolve.py
+++ b/qutip/tests/test_sesolve.py
@@ -10,6 +10,7 @@ from qutip import num, destroy, create
 from qutip.interpolate import Cubic_Spline
 from qutip import sesolve
 from qutip.solver import Options
+import pytest
 
 os.environ['QUTIP_GRAPHICS'] = "NO"
 
@@ -344,5 +345,10 @@ class TestSESolve:
         assert_(max(abs(res.expect[0][5:])) < tol,
                 msg="evolution with feedback not proceding as expected")
 
-if __name__ == "__main__":
-    run_module_suite()
+
+def test_sesolve_bad_e_ops():
+    H = sigmaz()
+    psi0 = basis(2, 0)
+    tlist = np.linspace(0, 20, 200)
+    with pytest.raises(TypeError) as exc:
+        sesolve(H, psi0, tlist=tlist, e_ops=[qeye(3)])

--- a/qutip/tests/test_stochastic_me.py
+++ b/qutip/tests/test_stochastic_me.py
@@ -277,8 +277,22 @@ def test_ssesolve_feedback():
                    ntraj=ntraj, nsubsteps=nsubsteps, method='homodyne',
                    map_func=parallel_map, args={"expect_op_3":qeye(N)})
 
-    print(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
-                 for idx in range(len(e_ops))]))
 
-if __name__ == "__main__":
-    run_module_suite()
+def test_smesolve_bad_e_ops():
+    "Stochastic: ssesolve: time-dependent H with feedback"
+    tol = 0.01
+    N = 4
+    ntraj = 10
+    nsubsteps = 100
+    a = destroy(N)
+
+    H = [num(N)]
+    psi0 = coherent(N, 2.5)
+    sc_ops = [a + a.dag()]
+    e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag()), qeye(N+1)]
+
+    times = np.linspace(0, 10, 101)
+    with pytest.raises(TypeError) as exc:
+        res = smesolve(H, psi0, times, sc_ops=sc_ops, e_ops=e_ops, noise=1,
+                       ntraj=ntraj, nsubsteps=nsubsteps, method='homodyne',
+                       map_func=parallel_map)

--- a/qutip/tests/test_stochastic_se.py
+++ b/qutip/tests/test_stochastic_se.py
@@ -211,9 +211,21 @@ def test_ssesolve_feedback():
                    ntraj=ntraj, nsubsteps=nsubsteps, method='homodyne',
                    map_func=parallel_map, args={"expect_op_3":qeye(N)})
 
-    print(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
-                 for idx in range(len(e_ops))]))
 
+def test_ssesolve_bad_e_ops():
+    tol = 0.01
+    N = 4
+    ntraj = 10
+    nsubsteps = 100
+    a = destroy(N)
+    b = destroy(N-1)
 
-if __name__ == "__main__":
-    run_module_suite()
+    H = [num(N)]
+    psi0 = coherent(N, 2.5)
+    sc_ops = [a + a.dag()]
+    e_ops = [a.dag() * a, a + a.dag(), (-1j)*(b - b.dag()), qeye(N+1)]
+    times = np.linspace(0, 10, 101)
+    with pytest.raises(TypeError) as exc:
+        res = ssesolve(H, psi0, times, sc_ops, e_ops, solver=None, noise=1,
+                       ntraj=ntraj, nsubsteps=nsubsteps, method='homodyne',
+                       map_func=parallel_map)


### PR DESCRIPTION
**Description**
Dimension checks was not done for `e_ops` for most solvers, which could result in segfault, (#1776).
Add checks and tests for these checks for `sesolve`, `mesolve`, `mcsolve`, stochastic solvers. 
`brmesolve` and `floquet` are safe.

**Related issues or PRs**
fixes #1776

**Changelog**
Add dims check for e_ops in main solvers