### PR TITLE
Extra check for shape in Qobj to fix #1782

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -310,11 +310,6 @@ class Qobj(object):
             )
             self.dims = [[int(inpt.shape[0])], [int(inpt.shape[1])]]
 
-        if self._data.shape[0] > np.prod(self.dims[0]) or \
-           self._data.shape[1] > np.prod(self.dims[1]):
-            raise ValueError(f"Qobj has smaller dims {self.dims} " +
-                             f"than underlying shape {self._data.shape}")
-
         if type == 'super':
             # Type is not super, i.e. dims not explicitly passed, but oper-like
             # shape.
@@ -332,6 +327,13 @@ class Qobj(object):
         else:
             if self.type == 'super' and self.superrep is None:
                 self.superrep = 'super'
+
+        if (self._data.shape[0] > np.prod(np.hstack(self.dims[0])) or
+           self._data.shape[1] > np.prod(np.hstack(self.dims[1]))) and \
+           self.type != 'super':
+
+            raise ValueError(f"Qobj has smaller dims {self.dims} " +
+                             f"than underlying shape {self._data.shape}")
 
         # clear type cache
         self._type = None

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -328,6 +328,10 @@ class Qobj(object):
             if self.type == 'super' and self.superrep is None:
                 self.superrep = 'super'
 
+        # While the obvious check would be != that would fail valid
+        # use cases such as enr_fock and other enr_ functions.
+        # This does leave open the possibility of data still being
+        # misused such as Qobj(complex[n**2][1], dims = [[n],[n]])
         if (self._data.shape[0] > np.prod(np.hstack(self.dims[0])) or
            self._data.shape[1] > np.prod(np.hstack(self.dims[1]))) and \
            self.type != 'super':

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -310,6 +310,11 @@ class Qobj(object):
             )
             self.dims = [[int(inpt.shape[0])], [int(inpt.shape[1])]]
 
+        if self._data.shape[0] > np.prod(self.dims[0]) or \
+           self._data.shape[1] > np.prod(self.dims[1]):
+            raise ValueError(f"Qobj has smaller dims {self.dims} " +
+                             f"than underlying shape {self._data.shape}")
+
         if type == 'super':
             # Type is not super, i.e. dims not explicitly passed, but oper-like
             # shape.

--- a/qutip/tests/test_bofin_solvers.py
+++ b/qutip/tests/test_bofin_solvers.py
@@ -179,13 +179,13 @@ class TestHierarchyADOsState:
 
     def mk_rho_and_soln(self, ados, rho_dims):
         n_ados = len(ados.labels)
-        ado_soln = np.random.rand(n_ados, *[2**d for d in rho_dims])
-        rho = Qobj(ado_soln[0, :], dims=[2, 2])
+        ado_soln = np.random.rand(n_ados, *[np.product(d) for d in rho_dims])
+        rho = Qobj(ado_soln[0, :], dims=rho_dims)
         return rho, ado_soln
 
     def test_create(self):
         ados = self.mk_ados([2, 3], max_depth=2)
-        rho, ado_soln = self.mk_rho_and_soln(ados, [2, 2])
+        rho, ado_soln = self.mk_rho_and_soln(ados, [[2], [2]])
         ado_state = HierarchyADOsState(rho, ados, ado_soln)
         assert ado_state.rho == rho
         assert ado_state.labels == ados.labels
@@ -195,7 +195,7 @@ class TestHierarchyADOsState:
 
     def test_extract(self):
         ados = self.mk_ados([2, 3], max_depth=2)
-        rho, ado_soln = self.mk_rho_and_soln(ados, [2, 2])
+        rho, ado_soln = self.mk_rho_and_soln(ados, [[2], [2]])
         ado_state = HierarchyADOsState(rho, ados, ado_soln)
         ado_state.extract((0, 0)) == rho
         ado_state.extract(0) == rho


### PR DESCRIPTION
**Description**
Extra check in `Qobj` constructor to make sure that the underlying data behaves as expected.

**Related issues or PRs**
The PR is a fix to #1782, where the `Qobj` would be constructed in a way subsequent code (i.e. `mesolve`) did not expect causing a segmentation fault.

**Changelog**
Added a check in `Qobj` constructor that the respective members of `data.shape` cannot be larger than what the corresponding `dims` could contain.
