### PR TITLE
Cy.shape.check

### DIFF
--- a/qutip/cy/cqobjevo.pyx
+++ b/qutip/cy/cqobjevo.pyx
@@ -206,7 +206,7 @@ cdef class CQobjEvo:
     def mul_vec(self, double t, complex[::1] vec):
         if vec.shape[0] != self.shape1:
             raise ValueError(f"Shapes don't match: ({self.shape0}, "
-                             f"{self.shape1}) @ ({vec.shape[0]}, 1) ")
+                             f"{self.shape1}) @ ({vec.shape[0]}, 1)")
         cdef np.ndarray[complex, ndim=1] out = np.zeros(self.shape0,
                                                         dtype=complex)
         self._mul_vec(t, &vec[0], &out[0])
@@ -234,28 +234,28 @@ cdef class CQobjEvo:
         if self.super:
             if self.shape1 != vec.shape[0]:
                 raise ValueError(f"Shapes don't match: ({self.shape0}, "
-                                 f"{self.shape1}) @ ({vec.shape[0]}, 1) ")
+                                 f"{self.shape1}), ({vec.shape[0]}, 1)")
             return self._expect_super(t, &vec[0])
         else:
             if self.shape1 != vec.shape[0] and self.shape0 != self.shape1:
-                raise ValueError(f"Shape don't match: ({self.shape0}, "
-                                 f"{self.shape1}) @ ({vec.shape[0]}, 1) ")
+                raise ValueError(f"Shapes don't match: ({self.shape0}, "
+                                 f"{self.shape1}), ({vec.shape[0]}, 1)")
             return self._expect(t, &vec[0])
 
-    def overlapse(self, double t, complex[::1] oper):
+    def overlap(self, double t, complex[::1] oper):
         """
-        Compute the overlapse of operator as tr(this @ oper)
+        Compute the overlap of operator as tr(this @ oper)
         """
         if self.shape0 * self.shape1 != oper.shape[0]:
-            raise ValueError(f"Shape don't match: ({self.shape0}, "
-                             f"{self.shape1}) @ ({oper.shape[0]}, 1) ")
+            raise ValueError(f"Shapes don't match: ({self.shape0}, "
+                             f"{self.shape1}), ({oper.shape[0]}, 1)")
         cdef complex* vec = &oper[0]
         return self._overlapse(t, vec)
 
     def ode_mul_mat_f_vec(self, double t, complex[::1] mat):
         if mat.shape[0] != self.shape1*self.shape1:
-            raise ValueError(f"Shape don't match: ({self.shape0}, "
-                             f"{self.shape1}) @ ({mat.shape[0]}, 1) ")
+            raise ValueError(f"Shapes don't match: ({self.shape0}, "
+                             f"{self.shape1}) @ ({mat.shape[0]}, 1)")
         cdef np.ndarray[complex, ndim=1] out = np.zeros(self.shape1*self.shape1,
                                                         dtype=complex)
         self._mul_matf(t, &mat[0], &out[0], self.shape1, self.shape1)

--- a/qutip/cy/cqobjevo.pyx
+++ b/qutip/cy/cqobjevo.pyx
@@ -205,7 +205,7 @@ cdef class CQobjEvo:
 
     def mul_vec(self, double t, complex[::1] vec):
         if vec.shape[0] != self.shape1:
-            raise ValueError(f"Shape don't match: ({self.shape0}, "
+            raise ValueError(f"Shapes don't match: ({self.shape0}, "
                              f"{self.shape1}) @ ({vec.shape[0]}, 1) ")
         cdef np.ndarray[complex, ndim=1] out = np.zeros(self.shape0,
                                                         dtype=complex)
@@ -218,7 +218,7 @@ cdef class CQobjEvo:
         cdef unsigned int nrows = mat.shape[0]
         cdef unsigned int ncols = mat.shape[1]
         if mat.shape[0] != self.shape1:
-            raise ValueError("Shape don't match: "
+            raise ValueError("Shapes don't match: "
                 f"({self.shape0}, {self.shape1}) "
                 f"@ ({mat.shape[0]}, {mat.shape[1]})")
 
@@ -233,7 +233,7 @@ cdef class CQobjEvo:
     cpdef complex expect(self, double t, complex[::1] vec):
         if self.super:
             if self.shape1 != vec.shape[0]:
-                raise ValueError(f"Shape don't match: ({self.shape0}, "
+                raise ValueError(f"Shapes don't match: ({self.shape0}, "
                                  f"{self.shape1}) @ ({vec.shape[0]}, 1) ")
             return self._expect_super(t, &vec[0])
         else:

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -1399,7 +1399,7 @@ class QobjEvo:
                 exp = cy_expect_psi(self.__call__(t, data=True), vec, 0)
         elif vec.shape[0] == self.cte.shape[1]**2:
             if self.compiled:
-                exp = self.compiled_qobjevo.overlapse(t, vec)
+                exp = self.compiled_qobjevo.overlap(t, vec)
             else:
                 self._dynamics_args_update(t, state)
                 exp = (self.__call__(t, data=True) *

--- a/qutip/tests/test_qobjevo.py
+++ b/qutip/tests/test_qobjevo.py
@@ -488,6 +488,8 @@ def test_QobjEvo_mul_vec():
         assert_allclose(spmv(op(t,data=1), vec), op.mul_vec(t, vec))
         op.compile()
         assert_allclose(spmv(op(t,data=1), vec), op.mul_vec(t, vec))
+        with pytest.raises(ValueError):
+            op.mul_vec(t, vec[:-1])
 
 
 @pytest.mark.slow
@@ -530,6 +532,10 @@ def test_QobjEvo_mul_mat():
         assert_allclose(Qo1.data * matF, op.mul_mat(t,matF))
         assert_allclose(mat2vec(Qo1.data * mat).flatten(),
                         op.compiled_qobjevo.ode_mul_mat_f_vec(t,matV))
+        with pytest.raises(ValueError):
+            op.mul_mat(t, mat[:-1, :-1])
+        with pytest.raises(ValueError):
+            op.compiled_qobjevo.ode_mul_mat_f_vec(t,matV[:(N-1)**2])
 
 
 @pytest.mark.slow
@@ -581,6 +587,8 @@ def test_QobjEvo_expect_psi():
         assert_allclose(cy_expect_psi(Qo1.data, vec, 0), op.expect(t,vec,0))
         op.compile()
         assert_allclose(cy_expect_psi(Qo1.data, vec, 0), op.expect(t,vec,0))
+        with pytest.raises(ValueError):
+            op.expect(t, vec[:-1], 0)
 
 
 @pytest.mark.slow
@@ -632,6 +640,8 @@ def test_QobjEvo_expect_rho():
                         op.expect(t,mat,0), atol=1e-14)
         assert_allclose(cy_expect_rho_vec(Qo1.data, vec, 0),
                         op.expect(t,qobj,0), atol=1e-14)
+        with pytest.raises(ValueError):
+            op.expect(t, mat[:-1, :-1], 0)
 
     tlist = np.linspace(0,1,300)
     args={"w1":1, "w2":2, "w3":3}


### PR DESCRIPTION
**Description**
Add check for shape at the cython level. While these checks should be done before entering cython in QobjEvo or the solvers, as seen in #1782, some bad shape can slip through. 

**Changelog**
Add check for shape in cython qobjevo.
