### PR TITLE
add timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
             conda install nomkl "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
           fi
           python -m pip install -e .[$QUTIP_TARGET]
-          python -m pip install pytest-cov coveralls
+          python -m pip install pytest-cov coveralls pytest-timeout
 
       - name: Package information
         run: |
@@ -120,7 +120,7 @@ jobs:
             # truly being executed.
             export QUTIP_NUM_PROCESSES=2
           fi
-          pytest -Werror --strict-config --strict-markers --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes qutip/tests
+          pytest -Werror --strict-config --strict-markers --timeout=150 --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes qutip/tests
           # Above flags are:
           #  -Werror
           #     treat warnings as errors

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,7 +136,7 @@ jobs:
             # truly being executed.
             export QUTIP_NUM_PROCESSES=2
           fi
-          pytest -Werror --strict-config --strict-markers --timeout=150 --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes ${{ matrix.pytest-extra-options }} qutip/tests
+          pytest -Werror --strict-config --strict-markers --timeout=300 --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes ${{ matrix.pytest-extra-options }} qutip/tests
           # Above flags are:
           #  -Werror
           #     treat warnings as errors

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,7 +145,7 @@ jobs:
           #  --strict-markers
           #     error out if a marker is used but not defined in the
           #     configuration file
-          #  --timeout=150
+          #  --timeout=300
           #     error any individual test that goes longer than the given time
           #  --durations=0 --durations-min=1.0
           #     at the end, show a list of all the tests that took longer than a

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,6 +129,8 @@ jobs:
           #  --strict-markers
           #     error out if a marker is used but not defined in the
           #     configuration file
+          #  --timeout=150
+          #     error any individual test that goes longer than the given time
           #  --durations=0 --durations-min=1.0
           #     at the end, show a list of all the tests that took longer than a
           #     second to run


### PR DESCRIPTION
**Description**
Since yesterday, our tests hangs for both `master` and `dev.major` and never finish. It seen only a few tests are affected.
I am adding a timeout so the tests that hangs result in a localized error.
