### PR TITLE
No parallel map

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
         # If our tests are running for longer than an hour, _something_ is wrong
         # somewhere.  The GitHub default is 6 hours, which is a bit long to wait
         # to see if something hung.
-        timeout-minutes: 60
+        timeout-minutes: 300
         run: |
           if [[ -n "${{ matrix.openmp }}" ]]; then
             # Force OpenMP runs to use more threads, even if there aren't

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
             conda install nomkl "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
           fi
           python -m pip install -e .[$QUTIP_TARGET]
-          python -m pip install pytest-cov coveralls
+          python -m pip install pytest-cov coveralls pytest-timeout
 
       - name: Package information
         run: |
@@ -120,7 +120,7 @@ jobs:
             # truly being executed.
             export QUTIP_NUM_PROCESSES=2
           fi
-          pytest -Werror --strict-config --strict-markers --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes qutip/tests
+          pytest -Werror --strict-config --strict-markers --timeout=300 --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes qutip/tests
           # Above flags are:
           #  -Werror
           #     treat warnings as errors

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
             # truly being executed.
             export QUTIP_NUM_PROCESSES=2
           fi
-          pytest -Werror --strict-config --strict-markers --timeout=300 --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes qutip/tests
+          pytest -Werror --strict-config --strict-markers --timeout=120 --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes qutip/tests
           # Above flags are:
           #  -Werror
           #     treat warnings as errors

--- a/qutip/parallel.py
+++ b/qutip/parallel.py
@@ -237,3 +237,7 @@ def parallel_map(task, values, task_args=tuple(), task_kwargs={}, **kwargs):
 def _default_kwargs():
     settings = {'num_cpus': qset.num_cpus}
     return settings
+
+# skip multiprocessing as a check for hanging github action run
+parallel_map = serial_map
+parfor = serial_map


### PR DESCRIPTION
**Description**
A test for hanging github's action.
To see if it could be caused by multiprocessing, it over with `parallel_map` with `serial_map` so all test are forced to run in one process.
