### PR TITLE
Improve weighting in steadystate solver.

### DIFF
--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -270,7 +270,8 @@ def steadystate(A, c_op_list=[], method='direct', solver=None, **kwargs):
 
     # Set weight parameter to avg abs val in L if not set explicitly
     if 'weight' not in kwargs.keys():
-        ss_args['weight'] = np.mean(np.abs(A.data.data.max()))
+        # set the weight to the mean of the non-zero absoluate values in A:
+        ss_args['weight'] = np.mean(np.abs(A.data.data))
         ss_args['info']['weight'] = ss_args['weight']
 
     if ss_args['method'] == 'direct':

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -345,7 +345,12 @@ def _steadystate_LU_liouvillian(L, ss_args, has_mkl=0):
         if settings.debug:
             logger.debug('Calculating Weighted Bipartite Matching ordering...')
         _wbm_start = time.time()
-        perm = weighted_bipartite_matching(L)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", "qutip graph functions are deprecated",
+                DeprecationWarning,
+            )
+            perm = weighted_bipartite_matching(L)
         _wbm_end = time.time()
         L = sp_permute(L, perm, [], form)
         ss_args['info']['perm'].append('wbm')
@@ -738,7 +743,12 @@ def _steadystate_power_liouvillian(L, ss_args, has_mkl=0):
         if settings.debug:
             logger.debug('Calculating Weighted Bipartite Matching ordering...')
         _wbm_start = time.time()
-        perm = weighted_bipartite_matching(L)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", "qutip graph functions are deprecated",
+                DeprecationWarning,
+            )
+            perm = weighted_bipartite_matching(L)
         _wbm_end = time.time()
         L = sp_permute(L, perm, [], kind)
         ss_args['info']['perm'].append('wbm')

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -482,7 +482,7 @@ def _steadystate_direct_dense(L, ss_args):
     b[0] = ss_args['weight']
 
     L = L.full()
-    L[0, :] = np.diag(ss_args['weight']*np.ones(n)).reshape((1, n ** 2))
+    L[0, :] += np.diag(ss_args['weight']*np.ones(n)).reshape(n ** 2)
     _dense_start = time.time()
     v = np.linalg.solve(L, b)
     _dense_end = time.time()

--- a/qutip/tests/test_steadystate.py
+++ b/qutip/tests/test_steadystate.py
@@ -193,11 +193,11 @@ def test_bad_options_steadystate():
     H = (a.dag() + a)
     c_ops = [a]
     with pytest.raises(ValueError):
-        rho_ss = qutip.steadystate(H, c_ops, method='not a method')
+        qutip.steadystate(H, c_ops, method='not a method')
     with pytest.raises(TypeError):
-        rho_ss = qutip.steadystate(H, c_ops, method='direct', bad_opt=True)
+        qutip.steadystate(H, c_ops, method='direct', bad_opt=True)
     with pytest.raises(ValueError):
-        rho_ss = qutip.steadystate(H, c_ops, method='direct', solver='Error')
+        qutip.steadystate(H, c_ops, method='direct', solver='Error')
 
 
 def test_bad_options_pseudo_inverse():
@@ -228,8 +228,7 @@ def test_bad_system():
     N = 4
     a = qutip.destroy(N)
     H = (a.dag() + a)
-    c_ops = [a]
-    with pytest.raises(TypeError) as err:
-        rho_ss = qutip.steadystate(H, [], method='direct')
-    with pytest.raises(TypeError) as err:
-        rho_ss = qutip.steadystate(qutip.basis(N, N-1), [], method='direct')
+    with pytest.raises(TypeError):
+        qutip.steadystate(H, [], method='direct')
+    with pytest.raises(TypeError):
+        qutip.steadystate(qutip.basis(N, N-1), [], method='direct')

--- a/qutip/tests/test_steadystate.py
+++ b/qutip/tests/test_steadystate.py
@@ -86,6 +86,7 @@ def test_exact_solution_for_simple_methods(method, kwargs):
         [0.e+00-0.j, 1.e+00+0.j],
     ])
     np.testing.assert_allclose(expected_rho_ss, rho_ss, atol=1e-16)
+    assert rho_ss.tr() == pytest.approx(1, abs=1e-14)
 
 
 @pytest.mark.parametrize(['method', 'kwargs'], [
@@ -151,6 +152,7 @@ def test_driven_cavity(method, kwargs):
     rho_ss_analytic = qutip.coherent_dm(N, -1.0j * (Omega)/(Gamma/2))
 
     np.testing.assert_allclose(rho_ss, rho_ss_analytic, atol=1e-4)
+    assert rho_ss.tr() == pytest.approx(1, abs=1e-12)
 
 
 @pytest.mark.parametrize(['method', 'kwargs'], [
@@ -169,6 +171,7 @@ def test_pseudo_inverse(method, kwargs):
     Lpinv = qutip.pseudo_inverse(L, rho, method=method, **kwargs)
     np.testing.assert_allclose((L * Lpinv * L).full(), L.full())
     np.testing.assert_allclose((Lpinv * L * Lpinv).full(), Lpinv.full())
+    assert rho.tr() == pytest.approx(1, abs=1e-15)
 
 
 @pytest.mark.parametrize('sparse', [True, False])
@@ -210,6 +213,7 @@ def test_steadystate_floquet(sparse):
     expect_ss = qutip.expect(a_d * a, rho_ss)
 
     np.testing.assert_allclose(expect_me[-20:], expect_ss, atol=1e-3)
+    assert rho_ss.tr() == pytest.approx(1, abs=1e-15)
 
 
 def test_bad_options_steadystate():

--- a/qutip/tests/test_steadystate.py
+++ b/qutip/tests/test_steadystate.py
@@ -65,6 +65,31 @@ def test_qubit(method, kwargs):
 
 @pytest.mark.parametrize(['method', 'kwargs'], [
     pytest.param('direct', {}, id="direct"),
+    pytest.param('direct', {'solver': 'mkl'}, id="direct_mkl",
+                 marks=pytest.mark.skipif(not qutip.settings.has_mkl,
+                                          reason='MKL extensions not found.')),
+    pytest.param('direct', {'sparse': False}, id="direct_dense"),
+    pytest.param('direct', {'use_rcm': True}, id="direct_rcm"),
+    pytest.param('direct', {'use_wbm': True}, id="direct_wbm"),
+    pytest.param('eigen', {}, id="eigen"),
+    pytest.param('eigen', {'use_rcm': True},  id="eigen_rcm"),
+    pytest.param('svd', {}, id="svd"),
+])
+def test_exact_solution_for_simple_methods(method, kwargs):
+    # this tests that simple methods correctly determine the steadystate
+    # with high accuracy for a small Liouvillian requiring correct weighting.
+    H = qutip.identity(2)
+    c_ops = [qutip.sigmam(), 1e-8 * qutip.sigmap()]
+    rho_ss = qutip.steadystate(H, c_ops, method=method, **kwargs)
+    expected_rho_ss = np.array([
+        [1.e-16+0.j, 0.e+00-0.j],
+        [0.e+00-0.j, 1.e+00+0.j],
+    ])
+    np.testing.assert_allclose(expected_rho_ss, rho_ss, atol=1e-16)
+
+
+@pytest.mark.parametrize(['method', 'kwargs'], [
+    pytest.param('direct', {}, id="direct"),
     pytest.param('direct', {'sparse':False}, id="direct_dense"),
     pytest.param('eigen', {}, id="eigen"),
     pytest.param('power', {'mtol':1e-5}, id="power"),


### PR DESCRIPTION
**Description**
Improve weighting in steadystate solver. Previously the default weighting did not match the documented behaviour and the sparse and dense solvers applied the weighting in different ways. Now the default matches the documentation and the sparse and dense solvers apply the weighting in the same manner.

**Related issues or PRs**
- Supersedes #1275
- Fixes #1512

**Changelog**
Improve the weighting in steadystate solver, so that the default weight matches the documented behaviour and the dense solver applies the weights in the same manner as the sparse solver.
