### PR TITLE
Linblad fix

### DIFF
--- a/qutip/core/superoperator.py
+++ b/qutip/core/superoperator.py
@@ -130,7 +130,7 @@ def liouvillian(H=None, c_ops=None, data_only=False, chi=None):
     op_shape = H.shape
     sop_dims = [[op_dims[0], op_dims[0]], [op_dims[1], op_dims[1]]]
     sop_shape = [np.prod(op_dims), np.prod(op_dims)]
-    spI = _data.identity(op_shape[0])
+    spI = _data.identity(op_shape[0], dtype=type(H.data))
 
     data = _data.mul(_data.kron(spI, H.data), -1j)
     data = _data.add(data, _data.kron(H.data.transpose(), spI), scale=1j)

--- a/qutip/tests/core/test_superoper.py
+++ b/qutip/tests/core/test_superoper.py
@@ -198,6 +198,28 @@ class TestMatVec:
         S2 = qutip.sprepost(U1, U2)
         assert S1 == S2
 
+    @pytest.mark.parametrize("dtype", [_data.CSR, _data.Dense])
+    @pytest.mark.parametrize("operation", [qutip.spre,
+                                           qutip.spost,
+                                           qutip.liouvillian,
+                                           qutip.lindblad_dissipator])
+    def test_operation_dtype(self, dtype, operation):
+        """This test checks that the dtype is properly kept with the
+        `operation` function."""
+        U1 = qutip.rand_unitary(3).to(dtype)
+        result = operation(U1)
+        assert type(result.data) == dtype
+
+
+    @pytest.mark.parametrize("dtype", [_data.CSR, _data.Dense])
+    def test_sprepost_dtype(self, dtype):
+        """This test checks that the dtype is properly kept with `sprepost`
+        function."""
+        U1 = qutip.rand_unitary(3).to(dtype)
+        result = qutip.sprepost(U1, U1)
+        assert type(result.data) == dtype
+
+
     def testLiouvillianImplem(self):
         """
         Superoperator: Randomized comparison of standard and reference

--- a/qutip/tests/core/test_superoper.py
+++ b/qutip/tests/core/test_superoper.py
@@ -86,10 +86,10 @@ class TestMatVec:
         assert err.value.args[0] == ("Cannot convert object already "
                                      "in super representation")
 
-
     def testOperatorVectorTensor(self):
         """
-        Superoperator: Operator - vector - operator conversion with a tensor product state.
+        Superoperator: Operator - vector - operator conversion with a tensor
+        product state.
         """
         Na = 3
         Nb = 2
@@ -101,7 +101,8 @@ class TestMatVec:
 
     def testOperatorVectorNotSquare(self):
         """
-        Superoperator: Operator - vector - operator conversion for non-square matrix.
+        Superoperator: Operator - vector - operator conversion for non-square
+        matrix.
         """
         op1 = qutip.Qobj(np.random.rand(6).reshape((3, 2)))
         op2 = qutip.vector_to_operator(qutip.operator_to_vector(op1))
@@ -210,7 +211,6 @@ class TestMatVec:
         result = operation(U1)
         assert type(result.data) == dtype
 
-
     @pytest.mark.parametrize("dtype", [_data.CSR, _data.Dense])
     def test_sprepost_dtype(self, dtype):
         """This test checks that the dtype is properly kept with `sprepost`
@@ -218,7 +218,6 @@ class TestMatVec:
         U1 = qutip.rand_unitary(3).to(dtype)
         result = qutip.sprepost(U1, U1)
         assert type(result.data) == dtype
-
 
     def testLiouvillianImplem(self):
         """


### PR DESCRIPTION
**Checklist**
- [x] PEP8

**Description**
The behaviour of the `liouvillian` seemed to be wrong. For a `TfTensor` as input it returned a `Dense` as oupu. This is mainly because the identity matrix created within the function was not a `TfTensor`. 

_Testing The tests that I included where would pass without the fix!_ 

Reproducing this behaviour within QuTiP seems to be challenging. This is because of how things are automatically converted from one data type to another. In particular, `liouvillian` worked as expected for both `Dense` and `CSR` but not for `TfTensor`. However, since `TfTensor` is not part of qutip I am not sure how to make it to reproduce this error. 

The issue seems in fact to be related to an inconsistency in how data is automatically transformed. The following code summarises the problem:
```
H = qt.rand_herm(5)
csr = H.to('csr').data
dense = H.to('dense').data
tftensor = H.to('tftensor').data

qutip.data.kron(csr, dense) # output: dense
qutip.data.kron(csr, csr) # output: csr
qutip.data.kron(csr, tftensor) # output: dense?? this is what causes problems!
qutip.data.kron(tftensor, tftensor) # output: tftensor
```


**Changelog**
Fixed liouvillian to not generate dense output when used with TfTensor.
