### PR TITLE
Remove the check on the initial state dimension

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -2080,8 +2080,6 @@ class CircuitSimulator:
         self.state = None
 
         if state is not None:
-            if state.shape[0] != 2 ** self.qc.N:
-                raise ValueError("dimension of state is incorrect")
             if self.mode == "density_matrix_simulator" and state.isket:
                 self.state = ket2dm(state)
             else:


### PR DESCRIPTION
**Description**
Remove the wrong check on the initial state dimension. It assumes a qubit state. However, we also support multilevel systems such as qudits.

**Related issues or PRs**
fix #1803 

**Changelog**
Remove the wrong check on the initial state dimension in QubitCircuit.
