### PR TITLE
Support Pathlike objects in fileio

### DIFF
--- a/qutip/fileio.py
+++ b/qutip/fileio.py
@@ -225,7 +225,7 @@ def qsave(data, name='qutip_data'):
     if file.suffix != '.qu':
         file.with_suffix('.qu')
 
-    with open(name, "rb") as fileObject:
+    with open(name, "wb") as fileObject:
         # this writes the object a to the file named 'filename.qu'
         pickle.dump(data, fileObject)
 

--- a/qutip/fileio.py
+++ b/qutip/fileio.py
@@ -222,8 +222,7 @@ def qsave(data, name='qutip_data'):
     """
     # open the file for writing
     file = Path(name)
-    if file.suffix != '.qu':
-        file.with_suffix('.qu')
+    file = file.with_suffix(file.suffix + ".qu")
 
     with open(name, "wb") as fileObject:
         # this writes the object a to the file named 'filename.qu'
@@ -246,8 +245,7 @@ def qload(name):
 
     """
     file = Path(name)
-    if file.suffix != '.qu':
-        file.with_suffix('.qu')
+    file = file.with_suffix(file.suffix + ".qu")
 
     with open(name, "rb") as fileObject:
         if sys.version_info >= (3, 0):

--- a/qutip/fileio.py
+++ b/qutip/fileio.py
@@ -3,8 +3,7 @@ __all__ = ['file_data_store', 'file_data_read', 'qsave', 'qload']
 import pickle
 import numpy as np
 import sys
-from qutip.qobj import Qobj
-from qutip.solver import Result
+from pathlib import Path
 
 
 # -----------------------------------------------------------------------------
@@ -16,7 +15,7 @@ def file_data_store(filename, data, numtype="complex", numformat="decimal",
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         Name of data file to be stored, including extension.
     data: array_like
         Data to be written to file.
@@ -112,7 +111,7 @@ def file_data_read(filename, sep=None):
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         Name of file containing reqested data.
     sep : str
         Seperator used to store data.
@@ -217,15 +216,18 @@ def qsave(data, name='qutip_data'):
     ----------
     data : instance/array_like
         Input Python object to be stored.
-    filename : str
+    filename : str or pathlib.Path
         Name of output data file.
 
     """
     # open the file for writing
-    fileObject = open(name + '.qu', 'wb')
-    # this writes the object a to the file named 'filename.qu'
-    pickle.dump(data, fileObject)
-    fileObject.close()
+    file = Path(name)
+    if file.suffix != '.qu':
+        file.with_suffix('.qu')
+
+    with open(name, "rb") as fileObject:
+        # this writes the object a to the file named 'filename.qu'
+        pickle.dump(data, fileObject)
 
 
 def qload(name):
@@ -234,7 +236,7 @@ def qload(name):
 
     Parameters
     ----------
-    name : str
+    name : str or pathlib.Path
         Name of data file to be loaded.
 
     Returns
@@ -243,23 +245,14 @@ def qload(name):
         Object retrieved from requested file.
 
     """
-    with open(name + ".qu", "rb") as fileObject:
+    file = Path(name)
+    if file.suffix != '.qu':
+        file.with_suffix('.qu')
+
+    with open(name, "rb") as fileObject:
         if sys.version_info >= (3, 0):
             out = pickle.load(fileObject, encoding='latin1')
         else:
             out = pickle.load(fileObject)
-    if isinstance(out, Qobj):  # for quantum objects
-        print('Loaded Qobj object:')
-        str1 = "Quantum object: " + "dims = " + str(out.dims) \
-            + ", shape = " + str(out.shape) + ", type = " + out.type
-        if out.type == 'oper' or out.type == 'super':
-            str1 += ", isHerm = " + str(out.isherm) + "\n"
-        else:
-            str1 += "\n"
-        print(str1)
-    elif isinstance(out, Result):
-        print('Loaded Result object:')
-        print(out)
-    else:
-        print("Loaded " + str(type(out).__name__) + " object.")
+
     return out

--- a/qutip/tests/test_fileio.py
+++ b/qutip/tests/test_fileio.py
@@ -45,8 +45,9 @@ class Test_file_data_store_file_data_read:
         return self.case(_random_file_name(), kwargs)
 
 
-@pytest.mark.parametrize('use_path' [True, False], ids=['Path', 'str'])
-@pytest.mark.parametrize('include_suffix' [True, False], ids=['yes', 'no'])
+@pytest.mark.parametrize('use_path', [True, False], ids=['Path', 'str'])
+@pytest.mark.parametrize('include_suffix', [True, False],
+                         ids=['with_suffix', 'no_suffix'])
 def test_qsave_qload(use_path, include_suffix):
     ops_in = [qutip.sigmax(),
               qutip.num(_dimension),

--- a/qutip/tests/test_fileio.py
+++ b/qutip/tests/test_fileio.py
@@ -46,15 +46,12 @@ class Test_file_data_store_file_data_read:
 
 
 @pytest.mark.parametrize('use_path', [True, False], ids=['Path', 'str'])
-@pytest.mark.parametrize('include_suffix', [True, False],
-                         ids=['with_suffix', 'no_suffix'])
-def test_qsave_qload(use_path, include_suffix):
+@pytest.mark.parametrize('suffix', ['', '.qu', '.dat'])
+def test_qsave_qload(use_path, suffix):
     ops_in = [qutip.sigmax(),
               qutip.num(_dimension),
               qutip.coherent_dm(_dimension, 1j)]
-    filename = _random_file_name()
-    if include_suffix:
-        filename += '.qu'
+    filename = _random_file_name() + suffix
     if use_path:
         filename = Path.cwd() / filename
     qutip.qsave(ops_in, filename)

--- a/qutip/tests/test_fileio.py
+++ b/qutip/tests/test_fileio.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import uuid
 import qutip
+from pathlib import Path
 
 # qsave _always_ appends a suffix to the file name at the time of writing, but
 # in case this changes in the future, to ensure that we never leak a temporary
@@ -44,11 +45,17 @@ class Test_file_data_store_file_data_read:
         return self.case(_random_file_name(), kwargs)
 
 
-def test_qsave_qload():
+@pytest.mark.parametrize('use_path' [True, False], ids=['Path', 'str'])
+@pytest.mark.parametrize('include_suffix' [True, False], ids=['yes', 'no'])
+def test_qsave_qload(use_path, include_suffix):
     ops_in = [qutip.sigmax(),
               qutip.num(_dimension),
               qutip.coherent_dm(_dimension, 1j)]
     filename = _random_file_name()
+    if include_suffix:
+        filename += '.qu'
+    if use_path:
+        filename = Path.cwd() / filename
     qutip.qsave(ops_in, filename)
     ops_out = qutip.qload(filename)
     assert ops_in == ops_out


### PR DESCRIPTION
**Description**
- Adds support for pathlib.Path objects in qsave/qload.
- Adds tests for those functions.
- Suffix is optional, if given it won't be appended again.
- Removes prints in qload

**Related issues or PRs**
fix #1184

**Changelog**
`qsave` and `qload` now support `pathlib.Path` objects.
