### PR TITLE
Add do_3d_projection to Arrow3D for matplotlib 3.5

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -41,6 +41,13 @@ try:
 
             self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
             FancyArrowPatch.draw(self, renderer)
+
+        def do_3d_projection(self, renderer=None):
+            # only called by matplotlib >= 3.5
+            xs3d, ys3d, zs3d = self._verts3d
+            xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
+            self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
+            return np.min(zs)
 except ImportError:
     pass
 
@@ -358,7 +365,7 @@ class Bloch:
         vectors : array_like
             Array with vectors of unit length or smaller.
         """
-        if isinstance(vectors[0], (list, ndarray)):
+        if isinstance(vectors[0], (list, tuple, ndarray)):
             for vec in vectors:
                 self.vectors.append(vec)
         else:

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -200,11 +200,11 @@ class TestBloch:
        pytest.param(
             np.array(0, 0, 1), id="single-vector-numpy"),
         pytest.param(
-            [(0, 0, 1), (0, 1, 0)], id="two-vectors"),
+            [(0, 0, 1), (0, 1, 0)], id="list-vectors-tuple"),
         pytest.param(
-            [[0, 0, 1]], id="list-vector"),
+            [[0, 0, 1]], id="list-vectors-list"),
         pytest.param(
-            [np.array([0, 0, 1])], id="nparray-vector"),
+            [np.array([0, 0, 1])], id="list-vectors-numpy"),
     ])
     @check_pngs_equal
     def test_vector(self, vectors, fig_test, fig_ref):

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -194,7 +194,11 @@ class TestBloch:
         "vectors",
     ], [
         pytest.param(
-            (0, 0, 1), id="single-vector"),
+            (0, 0, 1), id="single-vector-tuple"),
+        pytest.param(
+            [0, 0, 1], id="single-vector-list"),
+       pytest.param(
+            np.array(0, 0, 1), id="single-vector-numpy"),
         pytest.param(
             [(0, 0, 1), (0, 1, 0)], id="two-vectors"),
         pytest.param(

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -198,7 +198,7 @@ class TestBloch:
         pytest.param(
             [0, 0, 1], id="single-vector-list"),
        pytest.param(
-            np.array(0, 0, 1), id="single-vector-numpy"),
+            np.array([0, 0, 1]), id="single-vector-numpy"),
         pytest.param(
             [(0, 0, 1), (0, 1, 0)], id="list-vectors-tuple"),
         pytest.param(

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -156,3 +156,44 @@ class TestBloch:
     ):
         self.plot_line_test(fig_test, start_test, end_test, **kwargs)
         self.plot_line_ref(fig_ref, start_ref, end_ref, **kwargs)
+
+    def plot_vector_test(self, fig, vectors):
+        b = Bloch(fig=fig)
+        b.add_vectors(vectors)
+        b.render()
+
+    def plot_vector_ref(self, fig, vectors):
+        from qutip.bloch import Arrow3D
+        b = Bloch(fig=fig)
+        b.render()
+        colors = ['g', '#CC6600', 'b', 'r']
+
+        if not isinstance(vectors[0], (list, tuple, np.ndarray)):
+            vectors = [vectors]
+
+        for i, v in enumerate(vectors):
+            color = colors[i % len(colors)]
+            xs3d = v[1] * np.array([0, 1])
+            ys3d = -v[0] * np.array([0, 1])
+            zs3d = v[2] * np.array([0, 1])
+            a = Arrow3D(
+                xs3d, ys3d, zs3d,
+                mutation_scale=20, lw=3, arrowstyle="-|>", color=color)
+            b.axes.add_artist(a)
+
+    @pytest.mark.parametrize([
+        "vectors",
+    ], [
+        pytest.param(
+            (0, 0, 1), id="single-vector"),
+        pytest.param(
+            [(0, 0, 1), (0, 1, 0)], id="two-vectors"),
+        pytest.param(
+            [[0, 0, 1]], id="list-vector"),
+        pytest.param(
+            [np.array([0, 0, 1])], id="nparray-vector"),
+    ])
+    @check_pngs_equal
+    def test_vector(self, vectors, fig_test, fig_ref):
+        self.plot_vector_test(fig_test, vectors)
+        self.plot_vector_ref(fig_ref, vectors)


### PR DESCRIPTION
**Description**
Add do_3d_projection to Arrow3D for matplotlib 3.5 to fix the rendering of vectors on the Bloch sphere.

This PR also adds tests for rendering vectors and adds support for passing vectors as tuples.

**Related issues or PRs**
- fix #1817
- builds on #1690

**Changelog**
Fixed rendering of vectors on the Bloch sphere when using matplotlib 3.5 and above.
Allowed vectors to be passed as tuples to Bloch.add_vectors.
Added tests for rendering vectors on the Bloch sphere.
