### PR TITLE
Fix bug in eigen solver

### DIFF
--- a/qutip/core/data/eigen.py
+++ b/qutip/core/data/eigen.py
@@ -101,11 +101,11 @@ def _eigs_csr(data, isherm, vecs, eigvals, num_large, num_small, tol, maxiter):
     small_vals = np.array([])
     evecs = None
 
-    remove_one = False
+    remove_one = 0  # 0: remove none, 1: remove smallest, -1: remove largest
     if eigvals == (N - 1):
         # calculate all eigenvalues and remove one at output if using sparse
         # 1: remove the smallest, -1, remove the largest
-        remove_one = bool(num_small) or -1
+        remove_one = 1 if (num_small > 0) else -1
         eigvals = 0
         num_small = num_large = N // 2
         num_small += N % 2

--- a/qutip/core/data/eigen.py
+++ b/qutip/core/data/eigen.py
@@ -172,11 +172,11 @@ def _eigs_csr(data, isherm, vecs, eigvals, num_large, num_small, tol, maxiter):
     if remove_one == 1:
         evals = evals[:-1]
         if vecs:
-            evecs = evecs[:,:-1]
+            evecs = evecs[:, :-1]
     elif remove_one == -1:
         evals = evals[1:]
         if vecs:
-            evecs = evecs[:,1:]
+            evecs = evecs[:, 1:]
 
     return np.array(evals), evecs
 

--- a/qutip/tests/core/test_eigen.py
+++ b/qutip/tests/core/test_eigen.py
@@ -1,13 +1,21 @@
 import scipy
 import numpy as np
 import pytest
+<<<<<<< HEAD
 import qutip
+=======
+from qutip import num, rand_herm, expect, rand_unitary
+>>>>>>> 5cc05631 (parametrize eigen tests)
 
 
 def is_eigen_set(oper, vals, vecs):
     for val, vec in zip(vals, vecs):
         assert abs(vec.norm() - 1) < 1e-13
+<<<<<<< HEAD
         assert abs(qutip.expect(oper, vec) - val) < 1e-13
+=======
+        assert abs(expect(oper, vec) - val) < 1e-13
+>>>>>>> 5cc05631 (parametrize eigen tests)
 
 
 @pytest.mark.parametrize(["sparse", 'dtype'], [
@@ -16,7 +24,11 @@ def is_eigen_set(oper, vals, vecs):
     pytest.param(False, 'dense', id="dense"),
 ])
 def test_eigen_known_oper(sparse, dtype):
+<<<<<<< HEAD
     N = qutip.num(10, dtype=dtype)
+=======
+    N = num(10, dtype=dtype)
+>>>>>>> 5cc05631 (parametrize eigen tests)
     spvals, spvecs = N.eigenstates(sparse=sparse)
     expected = np.arange(10)
     is_eigen_set(N, spvals, spvecs)
@@ -29,20 +41,31 @@ def test_eigen_known_oper(sparse, dtype):
     pytest.param(False, 'dense', id="dense"),
 ])
 @pytest.mark.parametrize(["rand"], [
+<<<<<<< HEAD
     pytest.param(qutip.rand_herm, id="hermitian"),
     pytest.param(qutip.rand_unitary, id="non-hermitian"),
+=======
+    pytest.param(rand_herm, id="hermitian"),
+    pytest.param(rand_unitary, id="non-hermitian"),
+>>>>>>> 5cc05631 (parametrize eigen tests)
 ])
 @pytest.mark.parametrize("order", ['low', 'high'])
 def test_eigen_rand_oper(rand, sparse, dtype, order):
     H = rand(10, dtype=dtype)
     spvals, spvecs = H.eigenstates(sparse=sparse, sort=order)
+<<<<<<< HEAD
     sp_energies = H.eigenenergies(sparse=sparse, sort=order)
+=======
+>>>>>>> 5cc05631 (parametrize eigen tests)
     if order == 'low':
         assert np.all(np.diff(spvals).real >= 0)
     else:
         assert np.all(np.diff(spvals).real <= 0)
     is_eigen_set(H, spvals, spvecs)
+<<<<<<< HEAD
     np.testing.assert_allclose(spvals, sp_energies)
+=======
+>>>>>>> 5cc05631 (parametrize eigen tests)
 
 
 @pytest.mark.parametrize(["sparse", 'dtype'], [
@@ -51,8 +74,13 @@ def test_eigen_rand_oper(rand, sparse, dtype, order):
     pytest.param(False, 'dense', id="dense"),
 ])
 @pytest.mark.parametrize("rand", [
+<<<<<<< HEAD
     pytest.param(qutip.rand_herm, id="hermitian"),
     pytest.param(qutip.rand_unitary, id="non-hermitian"),
+=======
+    pytest.param(rand_herm, id="hermitian"),
+    pytest.param(rand_unitary, id="non-hermitian"),
+>>>>>>> 5cc05631 (parametrize eigen tests)
 ])
 @pytest.mark.parametrize("order", ['low', 'high'])
 @pytest.mark.parametrize("N", [1, 5, 8, 9])
@@ -74,8 +102,13 @@ def test_FewState(rand, sparse, dtype, order, N):
     pytest.param(False, 'dense', id="dense"),
 ])
 @pytest.mark.parametrize(["rand"], [
+<<<<<<< HEAD
     pytest.param(qutip.rand_herm, id="hermitian"),
     pytest.param(qutip.rand_unitary, id="non-hermitian"),
+=======
+    pytest.param(rand_herm, id="hermitian"),
+    pytest.param(rand_unitary, id="non-hermitian"),
+>>>>>>> 5cc05631 (parametrize eigen tests)
 ])
 @pytest.mark.parametrize("order", ['low', 'high'])
 @pytest.mark.parametrize("N", [1, 5, 8, 9])
@@ -88,6 +121,7 @@ def test_ValsOnly(rand, sparse, dtype, order, N):
         assert np.all(np.diff(spvals).real >= 0)
     else:
         assert np.all(np.diff(spvals).real <= 0)
+<<<<<<< HEAD
 
 
 @pytest.mark.parametrize(["sparse", 'dtype'], [
@@ -116,3 +150,5 @@ def test_BigDenseValsOnly():
     H = qutip.rand_herm(dimension, density=1e-2)
     spvals = H.eigenenergies()
     assert abs(H.tr() - spvals.sum()) < tol
+=======
+>>>>>>> 5cc05631 (parametrize eigen tests)

--- a/qutip/tests/core/test_eigen.py
+++ b/qutip/tests/core/test_eigen.py
@@ -1,21 +1,13 @@
 import scipy
 import numpy as np
 import pytest
-<<<<<<< HEAD
 import qutip
-=======
-from qutip import num, rand_herm, expect, rand_unitary
->>>>>>> 5cc05631 (parametrize eigen tests)
 
 
 def is_eigen_set(oper, vals, vecs):
     for val, vec in zip(vals, vecs):
         assert abs(vec.norm() - 1) < 1e-13
-<<<<<<< HEAD
         assert abs(qutip.expect(oper, vec) - val) < 1e-13
-=======
-        assert abs(expect(oper, vec) - val) < 1e-13
->>>>>>> 5cc05631 (parametrize eigen tests)
 
 
 @pytest.mark.parametrize(["sparse", 'dtype'], [
@@ -24,11 +16,7 @@ def is_eigen_set(oper, vals, vecs):
     pytest.param(False, 'dense', id="dense"),
 ])
 def test_eigen_known_oper(sparse, dtype):
-<<<<<<< HEAD
     N = qutip.num(10, dtype=dtype)
-=======
-    N = num(10, dtype=dtype)
->>>>>>> 5cc05631 (parametrize eigen tests)
     spvals, spvecs = N.eigenstates(sparse=sparse)
     expected = np.arange(10)
     is_eigen_set(N, spvals, spvecs)
@@ -41,31 +29,20 @@ def test_eigen_known_oper(sparse, dtype):
     pytest.param(False, 'dense', id="dense"),
 ])
 @pytest.mark.parametrize(["rand"], [
-<<<<<<< HEAD
     pytest.param(qutip.rand_herm, id="hermitian"),
     pytest.param(qutip.rand_unitary, id="non-hermitian"),
-=======
-    pytest.param(rand_herm, id="hermitian"),
-    pytest.param(rand_unitary, id="non-hermitian"),
->>>>>>> 5cc05631 (parametrize eigen tests)
 ])
 @pytest.mark.parametrize("order", ['low', 'high'])
 def test_eigen_rand_oper(rand, sparse, dtype, order):
     H = rand(10, dtype=dtype)
     spvals, spvecs = H.eigenstates(sparse=sparse, sort=order)
-<<<<<<< HEAD
     sp_energies = H.eigenenergies(sparse=sparse, sort=order)
-=======
->>>>>>> 5cc05631 (parametrize eigen tests)
     if order == 'low':
         assert np.all(np.diff(spvals).real >= 0)
     else:
         assert np.all(np.diff(spvals).real <= 0)
     is_eigen_set(H, spvals, spvecs)
-<<<<<<< HEAD
     np.testing.assert_allclose(spvals, sp_energies)
-=======
->>>>>>> 5cc05631 (parametrize eigen tests)
 
 
 @pytest.mark.parametrize(["sparse", 'dtype'], [
@@ -74,13 +51,8 @@ def test_eigen_rand_oper(rand, sparse, dtype, order):
     pytest.param(False, 'dense', id="dense"),
 ])
 @pytest.mark.parametrize("rand", [
-<<<<<<< HEAD
     pytest.param(qutip.rand_herm, id="hermitian"),
     pytest.param(qutip.rand_unitary, id="non-hermitian"),
-=======
-    pytest.param(rand_herm, id="hermitian"),
-    pytest.param(rand_unitary, id="non-hermitian"),
->>>>>>> 5cc05631 (parametrize eigen tests)
 ])
 @pytest.mark.parametrize("order", ['low', 'high'])
 @pytest.mark.parametrize("N", [1, 5, 8, 9])
@@ -102,13 +74,8 @@ def test_FewState(rand, sparse, dtype, order, N):
     pytest.param(False, 'dense', id="dense"),
 ])
 @pytest.mark.parametrize(["rand"], [
-<<<<<<< HEAD
     pytest.param(qutip.rand_herm, id="hermitian"),
     pytest.param(qutip.rand_unitary, id="non-hermitian"),
-=======
-    pytest.param(rand_herm, id="hermitian"),
-    pytest.param(rand_unitary, id="non-hermitian"),
->>>>>>> 5cc05631 (parametrize eigen tests)
 ])
 @pytest.mark.parametrize("order", ['low', 'high'])
 @pytest.mark.parametrize("N", [1, 5, 8, 9])
@@ -121,7 +88,6 @@ def test_ValsOnly(rand, sparse, dtype, order, N):
         assert np.all(np.diff(spvals).real >= 0)
     else:
         assert np.all(np.diff(spvals).real <= 0)
-<<<<<<< HEAD
 
 
 @pytest.mark.parametrize(["sparse", 'dtype'], [
@@ -150,5 +116,3 @@ def test_BigDenseValsOnly():
     H = qutip.rand_herm(dimension, density=1e-2)
     spvals = H.eigenenergies()
     assert abs(H.tr() - spvals.sum()) < tol
-=======
->>>>>>> 5cc05631 (parametrize eigen tests)

--- a/qutip/tests/core/test_eigen.py
+++ b/qutip/tests/core/test_eigen.py
@@ -1,204 +1,106 @@
 import scipy
 import numpy as np
-from numpy.testing import assert_equal, run_module_suite, assert_
-import unittest
-
-from qutip import num, rand_herm, expect, rand_unitary
+import pytest
+import qutip
 
 
-def test_SparseHermValsVecs():
-    """
-    Sparse eigs Hermitian
-    """
-
-    # check using number operator
-    N = num(10)
-    spvals, spvecs = N.eigenstates(sparse=True)
-    for k in range(10):
-        # check that eigvals are in proper order
-        assert_equal(abs(spvals[k] - k) <= 1e-13, True)
-        # check that eigenvectors are right and in right order
-        assert_equal(abs(expect(N, spvecs[k]) - spvals[k]) < 5e-14, True)
-
-    # check ouput of only a few eigenvals/vecs
-    spvals, spvecs = N.eigenstates(sparse=True, eigvals=7)
-    assert_equal(len(spvals), 7)
-    assert_equal(spvals[0] <= spvals[-1], True)
-    for k in range(7):
-        assert_equal(abs(spvals[k] - k) < 1e-12, True)
-
-    spvals, spvecs = N.eigenstates(sparse=True, sort='high', eigvals=5)
-    assert_equal(len(spvals), 5)
-    assert_equal(spvals[0] >= spvals[-1], True)
-    vals = np.arange(9, 4, -1)
-    for k in range(5):
-        # check that eigvals are ordered from high to low
-        assert_equal(abs(spvals[k] - vals[k]) < 5e-14, True)
-        assert_equal(abs(expect(N, spvecs[k]) - vals[k]) < 1e-14, True)
-    # check using random Hermitian
-    H = rand_herm(10)
-    spvals, spvecs = H.eigenstates(sparse=True)
-    # check that sorting is lowest eigval first
-    assert_equal(spvals[0] <= spvals[-1], True)
-    # check that spvals equal expect vals
-    for k in range(10):
-        assert_equal(abs(expect(H, spvecs[k]) - spvals[k]) < 5e-14, True)
-        # check that ouput is real for Hermitian operator
-        assert_equal(np.isreal(spvals[k]), True)
+def is_eigen_set(oper, vals, vecs):
+    for val, vec in zip(vals, vecs):
+        assert abs(vec.norm() - 1) < 1e-13
+        assert abs(qutip.expect(oper, vec) - val) < 1e-13
 
 
-def test_SparseValsVecs():
-    """
-    Sparse eigs non-Hermitian
-    """
-    U = rand_unitary(10)
-    spvals, spvecs = U.eigenstates(sparse=True)
-    assert_equal(np.real(spvals[0]) <= np.real(spvals[-1]), True)
-    for k in range(10):
-        # check that eigenvectors are right and in right order
-        assert_equal(abs(expect(U, spvecs[k]) - spvals[k]) < 5e-14, True)
-        assert_equal(np.iscomplex(spvals[k]), True)
-
-    # check sorting
-    spvals, spvecs = U.eigenstates(sparse=True, sort='high')
-    assert_equal(np.real(spvals[0]) >= np.real(spvals[-1]), True)
-
-    # check for N-1 eigenvals
-    U = rand_unitary(10)
-    spvals, spvecs = U.eigenstates(sparse=True, eigvals=9)
-    assert_equal(len(spvals), 9)
+@pytest.mark.parametrize(["sparse", 'dtype'], [
+    pytest.param(True, 'csr', id="sparse"),
+    pytest.param(False, 'csr', id="sparse2dense"),
+    pytest.param(False, 'dense', id="dense"),
+])
+def test_eigen_known_oper(sparse, dtype):
+    N = qutip.num(10, dtype=dtype)
+    spvals, spvecs = N.eigenstates(sparse=sparse)
+    expected = np.arange(10)
+    is_eigen_set(N, spvals, spvecs)
+    np.testing.assert_allclose(spvals, expected, atol=1e-13)
 
 
-def test_SparseValsOnly():
-    """
-    Sparse eigvals only Hermitian.
-    """
-    H = rand_herm(10)
-    spvals = H.eigenenergies(sparse=True)
-    assert_equal(len(spvals), 10)
-    # check that sorting is lowest eigval first
-    assert_equal(spvals[0] <= spvals[-1], True)
-    # check that spvals equal expect vals
-    for k in range(10):
-        # check that ouput is real for Hermitian operator
-        assert_equal(np.isreal(spvals[k]), True)
-    spvals = H.eigenenergies(sparse=True, sort='high')
-    # check that sorting is lowest eigval first
-    assert_equal(spvals[0] >= spvals[-1], True)
-    spvals = H.eigenenergies(sparse=True, sort='high', eigvals=4)
-    assert_equal(len(spvals), 4)
-
-    U = rand_unitary(10)
-    spvals = U.eigenenergies(sparse=True)
-    assert_equal(len(spvals), 10)
-    # check that sorting is lowest eigval first
-    assert_equal(spvals[0] <= spvals[-1], True)
-    # check that spvals equal expect vals
-    for k in range(10):
-        # check that ouput is real for Hermitian operator
-        assert_equal(np.iscomplex(spvals[k]), True)
-    spvals = U.eigenenergies(sparse=True, sort='high')
-    # check that sorting is lowest eigval first
-    assert_equal(spvals[0] >= spvals[-1], True)
-    spvals = U.eigenenergies(sparse=True, sort='high', eigvals=4)
-    assert_equal(len(spvals), 4)
+@pytest.mark.parametrize(["sparse", 'dtype'], [
+    pytest.param(True, 'csr', id="sparse"),
+    pytest.param(False, 'csr', id="sparse2dense"),
+    pytest.param(False, 'dense', id="dense"),
+])
+@pytest.mark.parametrize(["rand"], [
+    pytest.param(qutip.rand_herm, id="hermitian"),
+    pytest.param(qutip.rand_unitary, id="non-hermitian"),
+])
+@pytest.mark.parametrize("order", ['low', 'high'])
+def test_eigen_rand_oper(rand, sparse, dtype, order):
+    H = rand(10, dtype=dtype)
+    spvals, spvecs = H.eigenstates(sparse=sparse, sort=order)
+    sp_energies = H.eigenenergies(sparse=sparse, sort=order)
+    if order == 'low':
+        assert np.all(np.diff(spvals).real >= 0)
+    else:
+        assert np.all(np.diff(spvals).real <= 0)
+    is_eigen_set(H, spvals, spvecs)
+    np.testing.assert_allclose(spvals, sp_energies)
 
 
-def test_DenseHermValsVecs():
-    """
-    Dense eigs Hermitian.
-    """
-    # check using number operator
-    N = num(10)
-    spvals, spvecs = N.eigenstates(sparse=False)
-    for k in range(10):
-        # check that eigvals are in proper order
-        assert_equal(abs(spvals[k] - k) < 1e-14, True)
-        # check that eigenvectors are right and in right order
-        assert_equal(abs(expect(N, spvecs[k]) - spvals[k]) < 5e-14, True)
-
-    # check ouput of only a few eigenvals/vecs
-    spvals, spvecs = N.eigenstates(sparse=False, eigvals=7)
-    assert_equal(len(spvals), 7)
-    assert_equal(spvals[0] <= spvals[-1], True)
-    for k in range(7):
-        assert_equal(abs(spvals[k] - k) < 1e-14, True)
-
-    spvals, spvecs = N.eigenstates(sparse=False, sort='high', eigvals=5)
-    assert_equal(len(spvals), 5)
-    assert_equal(spvals[0] >= spvals[-1], True)
-    vals = np.arange(9, 4, -1)
-    for k in range(5):
-        # check that eigvals are ordered from high to low
-        assert_equal(abs(spvals[k] - vals[k]) < 5e-14, True)
-        assert_equal(abs(expect(N, spvecs[k]) - vals[k]) < 5e-14, True)
-    # check using random Hermitian
-    H = rand_herm(10)
-    spvals, spvecs = H.eigenstates(sparse=False)
-    # check that sorting is lowest eigval first
-    assert_equal(spvals[0] <= spvals[-1], True)
-    # check that spvals equal expect vals
-    for k in range(10):
-        assert_equal(abs(expect(H, spvecs[k]) - spvals[k]) < 5e-14, True)
-        # check that ouput is real for Hermitian operator
-        assert_equal(np.isreal(spvals[k]), True)
+@pytest.mark.parametrize(["sparse", 'dtype'], [
+    pytest.param(True, 'csr', id="sparse"),
+    pytest.param(False, 'csr', id="sparse2dense"),
+    pytest.param(False, 'dense', id="dense"),
+])
+@pytest.mark.parametrize("rand", [
+    pytest.param(qutip.rand_herm, id="hermitian"),
+    pytest.param(qutip.rand_unitary, id="non-hermitian"),
+])
+@pytest.mark.parametrize("order", ['low', 'high'])
+@pytest.mark.parametrize("N", [1, 5, 8, 9])
+def test_FewState(rand, sparse, dtype, order, N):
+    H = rand(10, dtype=dtype)
+    all_spvals = H.eigenenergies(sparse=sparse, sort=order)
+    spvals, spvecs = H.eigenstates(sparse=sparse, sort=order, eigvals=N)
+    assert np.allclose(all_spvals[:N], spvals)
+    is_eigen_set(H, spvals, spvecs)
+    if order == 'low':
+        assert np.all(np.diff(spvals).real >= 0)
+    else:
+        assert np.all(np.diff(spvals).real <= 0)
 
 
-def test_DenseValsVecs():
-    """
-    Dense eigs non-Hermitian
-    """
-    W = rand_herm(10,0.5) + 1j*rand_herm(10,0.5)
-    spvals, spvecs = W.eigenstates(sparse=False)
-    assert_equal(np.real(spvals[0]) <= np.real(spvals[-1]), True)
-    for k in range(10):
-        # check that eigenvectors are right and in right order
-        assert_equal(abs(expect(W, spvecs[k]) - spvals[k]) < 1e-14, True)
-        assert_(np.iscomplex(spvals[k]))
+@pytest.mark.parametrize(["sparse", 'dtype'], [
+    pytest.param(True, 'csr', id="sparse"),
+    pytest.param(False, 'csr', id="sparse2dense"),
+    pytest.param(False, 'dense', id="dense"),
+])
+@pytest.mark.parametrize(["rand"], [
+    pytest.param(qutip.rand_herm, id="hermitian"),
+    pytest.param(qutip.rand_unitary, id="non-hermitian"),
+])
+@pytest.mark.parametrize("order", ['low', 'high'])
+@pytest.mark.parametrize("N", [1, 5, 8, 9])
+def test_ValsOnly(rand, sparse, dtype, order, N):
+    H = rand(10, dtype=dtype)
+    all_spvals = H.eigenenergies(sparse=sparse, sort=order)
+    spvals = H.eigenenergies(sparse=sparse, sort=order, eigvals=N)
+    assert np.allclose(all_spvals[:N], spvals)
+    if order == 'low':
+        assert np.all(np.diff(spvals).real >= 0)
+    else:
+        assert np.all(np.diff(spvals).real <= 0)
 
-    # check sorting
-    spvals, spvecs = W.eigenstates(sparse=False, sort='high')
-    assert_equal(np.real(spvals[0]) >= np.real(spvals[-1]), True)
 
-    # check for N-1 eigenvals
-    W = rand_unitary(10)
-    spvals, spvecs = W.eigenstates(sparse=False, eigvals=9)
-    assert_equal(len(spvals), 9)
-
-
-def test_DenseValsOnly():
-    """
-    Dense eigvals only Hermitian
-    """
-    H = rand_herm(10)
-    spvals = H.eigenenergies(sparse=False)
-    assert_equal(len(spvals), 10)
-    # check that sorting is lowest eigval first
-    assert_equal(spvals[0] <= spvals[-1], True)
-    # check that spvals equal expect vals
-    for k in range(10):
-        # check that ouput is real for Hermitian operator
-        assert_equal(np.isreal(spvals[k]), True)
-    spvals = H.eigenenergies(sparse=False, sort='high')
-    # check that sorting is lowest eigval first
-    assert_equal(spvals[0] >= spvals[-1], True)
-    spvals = H.eigenenergies(sparse=False, sort='high', eigvals=4)
-    assert_equal(len(spvals), 4)
-
-    U = rand_unitary(10)
-    spvals = U.eigenenergies(sparse=False)
-    assert_equal(len(spvals), 10)
-    # check that sorting is lowest eigval first
-    assert_equal(spvals[0] <= spvals[-1], True)
-    # check that spvals equal expect vals
-    for k in range(10):
-        # check that ouput is real for Hermitian operator
-        assert_equal(np.iscomplex(spvals[k]), True)
-    spvals = U.eigenenergies(sparse=False, sort='high')
-    # check that sorting is lowest eigval first
-    assert_equal(spvals[0] >= spvals[-1], True)
-    spvals = U.eigenenergies(sparse=False, sort='high', eigvals=4)
-    assert_equal(len(spvals), 4)
+@pytest.mark.parametrize(["sparse", 'dtype'], [
+    pytest.param(True, 'csr', id="sparse"),
+    pytest.param(False, 'csr', id="sparse2dense"),
+    pytest.param(False, 'dense', id="dense"),
+])
+def test_eigen_small(sparse, dtype):
+    H = (qutip.sigmax() + qutip.sigmaz()).to(dtype)
+    all_spvals = H.eigenenergies(sparse=sparse)
+    spvals, spvecs = H.eigenstates(sparse=sparse, eigvals=1)
+    assert np.abs(all_spvals[0] - spvals[0]) <= 1e-14
+    is_eigen_set(H, spvals, spvecs)
 
 
 def test_BigDenseValsOnly():
@@ -211,6 +113,6 @@ def test_BigDenseValsOnly():
     # Allow an average absolute tolerance for each eigenvalue; we expect
     # uncertainty in the sum to add in quadrature.
     tol = 1e-12 * np.sqrt(dimension)
-    H = rand_herm(dimension, density=1e-2)
+    H = qutip.rand_herm(dimension, density=1e-2)
     spvals = H.eigenenergies()
     assert abs(H.tr() - spvals.sum()) < tol

--- a/qutip/tests/core/test_eigenstates.py
+++ b/qutip/tests/core/test_eigenstates.py
@@ -88,5 +88,6 @@ def test_satisfy_eigenvalue_equation(random_hamiltonian, sparse, dtype):
                                    (eigenvalue * eigenstate).full(),
                                    atol=1e-10)
         assert eigenstate.norm() == pytest.approx(1., abs=1e-10)
-    for evec1, evec2 in combinations(eigenstates, 2):
-        assert evec1.overlap(evec2) == pytest.approx(0., abs=1e-10)
+    errors = [evec1.overlap(evec2)
+              for evec1, evec2 in combinations(eigenstates, 2)]
+    assert np.max(np.abs(errors)) == pytest.approx(0., abs=1e-8)


### PR DESCRIPTION
**Description**
There are some edge cases with the eigen solver that are bugged in `dev.major` that tests missed:
- `_eigs_dense` : It would not compute the proper eigen states when not all eigen states are required and the matrix is non-Hermitian.
- `_eigs_csr` : When all but one eigen values / vectors are needed: the smallest eigen values would always be removed, even when `sort='high'`. Also one element of the eigen vector matrix was removed, not one column.

I rewrote the tests with pytest to catch more cases.

**Changelog**
Fix some edges cases in `eigs`.
