### PR TITLE
Fix scipy.sparse deprecation warnings raised by qutip.fast_csr_matrix.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,13 +69,13 @@ jobs:
           # Ignore ImportWarning because pyximport registered an importer
           # PyxImporter that does not have a find_spec method and this raises
           # a warning on Python 3.10
-          # Ignore DeprecationWarnings raised by importing scipy.sparse.X
+          # Ignore DeprecationWarnings raised by cvxpy importing scipy.sparse.X
           # under SciPy 1.8.0+.
           - case-name: Python 3.10
             os: ubuntu-latest
             python-version: "3.10"
             condaforge: 1
-            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:qutip.fastsparse -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper"
+            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper"
 
     steps:
       - uses: actions/checkout@v2

--- a/qutip/fastsparse.py
+++ b/qutip/fastsparse.py
@@ -8,10 +8,18 @@ from scipy.sparse import (
 
 # fast_csr_matrix extends the internals of csr_matrix, and we need to
 # import parts of the internals of scipy.sparse to do that:
+import scipy.sparse
 import scipy.sparse._sparsetools as _sparsetools
-from scipy.sparse._sputils import (
-    isdense, isscalarlike, upcast, get_index_dtype,
-)
+if hasattr(scipy.sparse, "_sputils"):
+    # SciPy 1.8.0 deprecated the public scipy.sparse.sputils interface and
+    # moved it to _sputils
+    from scipy.sparse._sputils import (
+        isdense, isscalarlike, upcast, get_index_dtype,
+    )
+else:
+    from scipy.sparse.sputils import (
+        isdense, isscalarlike, upcast, get_index_dtype,
+    )
 
 
 class fast_csr_matrix(csr_matrix):

--- a/qutip/fastsparse.py
+++ b/qutip/fastsparse.py
@@ -1,10 +1,17 @@
-import numpy as np
-import operator
-from scipy.sparse import (
-    _sparsetools, csr_matrix, dia_matrix, isspmatrix, SparseEfficiencyWarning,
-)
-from scipy.sparse.sputils import upcast, isdense, isscalarlike, get_index_dtype
 from warnings import warn
+import operator
+
+import numpy as np
+from scipy.sparse import (
+    csr_matrix, dia_matrix, isspmatrix, SparseEfficiencyWarning,
+)
+
+# fast_csr_matrix extends the internals of csr_matrix, and we need to
+# import parts of the internals of scipy.sparse to do that:
+import scipy.sparse._sparsetools as _sparsetools
+from scipy.sparse._sputils import (
+    isdense, isscalarlike, upcast, get_index_dtype,
+)
 
 
 class fast_csr_matrix(csr_matrix):

--- a/qutip/fastsparse.py
+++ b/qutip/fastsparse.py
@@ -1,11 +1,11 @@
 import numpy as np
 import operator
-from scipy.sparse import (_sparsetools, isspmatrix, isspmatrix_csr,
-                          csr_matrix, coo_matrix, csc_matrix, dia_matrix)
-from scipy.sparse.sputils import (upcast, upcast_char, to_native, isdense, isshape,
-                      getdtype, isscalarlike, get_index_dtype)
-from scipy.sparse.base import spmatrix, isspmatrix, SparseEfficiencyWarning
+from scipy.sparse import (
+    _sparsetools, csr_matrix, dia_matrix, isspmatrix, SparseEfficiencyWarning,
+)
+from scipy.sparse.sputils import upcast, isdense, isscalarlike, get_index_dtype
 from warnings import warn
+
 
 class fast_csr_matrix(csr_matrix):
     """


### PR DESCRIPTION
**Description**
Fix scipy.sparse deprecation warnings raised by qutip.fast_csr_matrix by:

- importing functions from the public interface where we can (i.e. from the `scipy.sparse` module)
- explicitly importing functions from the internal interface otherwise (i.e. from `_sputils`)

We already import methods from `_sparsetools` so our reliance on the internal interfaces is not a new thing.

This PR ensures we don't implicitly rely on the internal interfaces via the deprecated public interfaces.

**Related issues or PRs**
- fixes #1823

**Changelog**
Fix scipy.sparse deprecation warnings raised by qutip.fast_csr_matrix.
