### PR TITLE
QobjEvo tidyup use settings.auto_tidyup_atol

### DIFF
--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -1012,7 +1012,7 @@ class QobjEvo:
         return res
 
     # Unitary function of Qobj
-    def tidyup(self, atol=1e-12):
+    def tidyup(self, atol=None):
         """Removes small elements from this quantum object inplace."""
         self.cte = self.cte.tidyup(atol)
         for op in self.ops:


### PR DESCRIPTION
**Description**
`QobjEvo` do not use settings value when using tidyup, thus solver do not respond to changes in settings as seen in #1831.
With this, `QobjEvo` will use `settings.auto_tidyup_atol` as the default tolerance. However it will not respond to `settings.auto_tidyup` since cython support for CSR is v4 is flacky and matrix with `0` stored can cause errors. 
Jake's implementation of CSR in v5 solves this.

**Related issues or PRs**
Close #1831

**Changelog**
QobjEvo.tidyup use settings.auto_tidyup_atol