### PR TITLE
Documenation-Bibliography: Watrous link updated

### DIFF
--- a/doc/biblio.rst
+++ b/doc/biblio.rst
@@ -16,7 +16,7 @@ Bibliography
     Docutils FAQ at https://docutils.sourceforge.net/FAQ.html#is-nested-inline-markup-possible.
     
 .. |theory-qi| replace:: *Theory of Quantum Information*
-.. _theory-qi: https://cs.uwaterloo.ca/~watrous/CS766/
+.. _theory-qi: https://cs.uwaterloo.ca/~watrous/TQI-notes/
 
 .. [Mez07]
     F. Mezzadri, *How to generate random matrices from the classical compact groups*, Notices of the AMS **54** 592-604 (2007). :arxiv:`math-ph/0609050`.


### PR DESCRIPTION
**Description**
Documenation-Bibliography: Watrous (Theory of Quantum Information) link updated, as the old one is not working anymore.


**Changelog**
Documenation-Bibliography: Watrous link (Theory of Quantum Information) updated
