### PR TITLE
Fix ttmsolve bug with addition of Qobj and None

### DIFF
--- a/qutip/nonmarkov/transfertensor.py
+++ b/qutip/nonmarkov/transfertensor.py
@@ -14,7 +14,7 @@ import numpy as np
 
 
 from qutip import (Options, spre, vector_to_operator, operator_to_vector,
-                   ket2dm, isket)
+                   ket2dm, isket, Qobj)
 from qutip.solver import Result
 from qutip.expect import expect_rho_vec
 
@@ -148,7 +148,7 @@ def ttmsolve(dynmaps, rho0, times, e_ops=[], learningtimes=None, tensors=None,
     K = len(tensors)
     states = [rho0vec]
     for n in range(1, len(times)):
-        states.append(None)
+        states.append(Qobj())
         for k in range(n):
             if n-k < K:
                 states[-1] += tensors[n-k]*states[k]

--- a/qutip/nonmarkov/transfertensor.py
+++ b/qutip/nonmarkov/transfertensor.py
@@ -146,12 +146,13 @@ def ttmsolve(dynmaps, rho0, times, e_ops=[], learningtimes=None, tensors=None,
     K = len(tensors)
     states = [rho0vec]
     for n in range(1, len(times)):
-        # Append empty state
-        states.append(None)
-        for k in range(n):
-            if n - k < K:
-                tmp = tensors[n - k] * states[k]
-                states[-1] = tmp if states[-1] is None else tmp + states[-1]
+        # Set current state
+        state = None
+        for j in range(1, min(K, n + 1)):
+            tmp = tensors[j] * states[n - j]
+            state = tmp if state is None else tmp + state
+        # Append state to all states
+        states.append(state)
     for i, r in enumerate(states):
         if opt.store_states or expt_callback:
             if r.type == 'operator-ket':

--- a/qutip/nonmarkov/transfertensor.py
+++ b/qutip/nonmarkov/transfertensor.py
@@ -11,10 +11,9 @@ method (TTM), introduced in [1].
 """
 
 import numpy as np
-from attr import validate
 
 from qutip import (Options, spre, vector_to_operator, operator_to_vector,
-                   ket2dm, isket, Qobj)
+                   ket2dm, isket)
 from qutip.solver import Result
 from qutip.expect import expect_rho_vec
 

--- a/qutip/tests/test_transfertensor.py
+++ b/qutip/tests/test_transfertensor.py
@@ -1,7 +1,7 @@
 import pytest
 import qutip as qt
 import numpy as np
-from qutip.nonmarkov.transfertensor import *
+from qutip.nonmarkov.transfertensor import ttmsolve
 
 
 def test_ttmsolve_jc_model():

--- a/qutip/tests/test_transfertensor.py
+++ b/qutip/tests/test_transfertensor.py
@@ -1,0 +1,49 @@
+import pytest
+import qutip as qt
+import numpy as np
+from qutip.nonmarkov.transfertensor import *
+
+
+def test_ttmsolve_jc_model():
+    """
+    Checks the output of ttmsolve using an example from Jaynes-Cumming model,
+    which can also be found in the qutip-notebooks repository.
+    """
+    # Define Hamiltonian and states
+    N, kappa = 3, 1.0
+    a = qt.tensor(qt.qeye(2), qt.destroy(N))
+    sm = qt.tensor(qt.sigmam(), qt.qeye(N))
+    sz = qt.tensor(qt.sigmaz(), qt.qeye(N))
+    H = kappa * (a.dag() * sm + a * sm.dag())
+    c_ops = [np.sqrt(kappa) * a]
+    # identity superoperator
+    Id = qt.tensor(qt.qeye(2), qt.qeye(N))
+    E0 = qt.sprepost(Id, Id)
+    # partial trace superoperator
+    ptracesuper = qt.tensor_contract(E0, (1, N))
+    # initial states
+    rho0a = qt.ket2dm(qt.basis(2, 0))
+    psi0c = qt.basis(N, 0)
+    rho0c = qt.ket2dm(psi0c)
+    rho0 = qt.tensor(rho0a, rho0c)
+    superrho0cav = qt.sprepost(qt.tensor(qt.qeye(2), psi0c),
+                               qt.tensor(qt.qeye(2), psi0c.dag()))
+
+    # calculate exact solution using mesolve
+    times = np.arange(0, 5, 0.1)
+    exactsol = qt.mesolve(H, rho0, times, c_ops, [])
+    exact_z = qt.expect(sz, exactsol.states)
+
+    # dynamical map
+    def dynmap(t):
+        # reduced dynamical map for the qubit at time t
+        Et = qt.mesolve(H, E0, [0., t], c_ops, []).states[-1]
+        return ptracesuper * (Et * superrho0cav)
+
+    # solve using transfer method
+    learning_times = np.arange(0, 10.0, 0.1)
+    learning_maps = [dynmap(t) for t in learning_times]
+    ttmsol = ttmsolve(learning_maps, rho0a, times)
+    ttm_z = qt.expect(qt.sigmaz(), ttmsol.states)
+    # check that ttm result and exact solution are close
+    assert np.allclose(ttm_z, exact_z, atol=0.01)


### PR DESCRIPTION
**Description**
The nonmarkov transfer tensor method (TTM) fails in an example notebook (see below). I tracked down the error to the *ttmsolve* method, where None is used to fill an array. I replaced None with an empty Qobj to fix the bug occuring from adding a Qobj and None.

**Related issues or PRs**
The related issue is in the qutip-notebooks repo: https://github.com/qutip/qutip-notebooks/issues/122

**Changelog**
Replace placeholder in ttmsolve with empty Qobj