### PR TITLE
Unify random qobj

### DIFF
--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -83,8 +83,8 @@ def randnz(shape, norm=1 / np.sqrt(2), seed=None):
 def rand_herm(N=None, density=0.75, dims=None, pos_def=False, seed=None):
     """Creates a random NxN sparse Hermitian quantum object.
 
-    If 'N' is an integer or None, uses :math:`H=0.5*(X+X^{+})` where :math:`X` is
-    a randomly generated quantum operator with a given `density`. Else uses
+    If 'N' is an integer or None, uses :math:`H=0.5*(X+X^{+})` where :math:`X`
+    is a randomly generated quantum operator with a given `density`. Else uses
     complex Jacobi rotations when 'N' is given by an array.
 
     Parameters
@@ -217,16 +217,8 @@ def rand_unitary(N=None, density=0.75, dims=None, seed=None):
         NxN Unitary quantum operator.
 
     """
-    if N is None and dims is None:
-        raise ValueError('Specify either the number of rows of unitary'
-                         ' operator (N) or dimensions of quantum object'
-                         ' (dims).')
-    elif N is None and dims:
-        N = np.prod(dims[0])
-    elif N and dims is None:
-        dims = [[N], [N]]
-    elif N and dims:
-        _check_dims(dims, N, N)
+    N, dims = _check_N_and_dims(dims, N, N, 'unitary operator')
+
 
     U = (-1.0j * rand_herm(N, density, seed=seed)).expm()
     U.data.sort_indices()
@@ -254,16 +246,7 @@ def rand_unitary_haar(N=None, dims=None, seed=None):
         Unitary of dims ``[[dim], [dim]]`` drawn from the Haar
         measure.
     """
-    if N is None and dims is None:
-        raise ValueError('Specify either the number of rows of unitary'
-                         ' operator (N) or dimensions of quantum object'
-                         ' (dims).')
-    elif N is None and dims:
-        N = np.prod(dims[0])
-    elif N and dims is None:
-        dims = [[N], [N]]
-    elif N and dims:
-        _check_dims(dims, N, N)
+    N, dims = _check_N_and_dims(dims, N, N, 'density operator')
 
     # Mez01 STEP 1: Generate an N × N matrix Z of complex standard
     #               normal random variates.
@@ -301,7 +284,7 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     N : int, optional
         Number of rows for output state vector. If None, N is deduced
          from dims.
-    density : float
+    density : float, default=1
         Density between [0,1] of output ket state.
     dims : list of lists of int, optional
         Dimensions of quantum object. Used for specifying tensor
@@ -322,15 +305,7 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     if seed is not None:
         np.random.seed(seed=seed)
 
-    if N is None and dims is None:
-        raise ValueError('Specify either the number of rows of state vector'
-                         ' (N) or dimensions of quantum object (dims).')
-    elif N is None and dims:
-        N = np.prod(dims[0])
-    elif N and dims is None:
-        dims = [[N], [1]]
-    elif N and dims:
-        _check_dims(dims, N, 1)
+    N, dims = _check_N_and_dims(dims, N, 1, 'state vector')
 
     X = sp.rand(N, 1, density, format='csr')
     while X.nnz == 0:
@@ -371,15 +346,7 @@ def rand_ket_haar(N=None, dims=None, seed=None):
     ValueError
         If neither `N` nor `dims` are specified.
     """
-    if N is None and dims is None:
-        raise ValueError('Specify either the number of rows of state vector'
-                         ' (N) or dimensions of quantum object (dims).')
-    elif N is None and dims:
-        N = np.prod(dims[0])
-    elif N and dims is None:
-        dims = [[N], [1]]
-    elif N and dims:
-        _check_dims(dims, N, 1)
+    N, dims = _check_N_and_dims(dims, N, 1, 'state vector')
 
     psi = rand_unitary_haar(N, seed=seed) * basis(N, 0)
     psi.dims = dims
@@ -491,16 +458,7 @@ def rand_dm_ginibre(N=None, rank=None, dims=None, seed=None):
     ValueError
         If neither `N` nor `dims` are specified.
     """
-    if N is None and dims is None:
-        raise ValueError('Specify either the number of rows of density'
-                         ' operator (N) or dimensions of quantum object'
-                         ' (dims).')
-    elif N is None and dims:
-        N = np.prod(dims[0])
-    elif N and dims is None:
-        dims = [[N], [N]]
-    elif N and dims:
-        _check_dims(dims, N, N)
+    N, dims = _check_N_and_dims(dims, N, N, 'density operator')
 
     if rank is None:
         rank = N
@@ -564,16 +522,7 @@ def rand_kraus_map(N=None, dims=None, seed=None):
         N^2 x N x N qobj operators.
 
     """
-    if N is None and dims is None:
-        raise ValueError('Specify either the number of rows of'
-                         ' operator (N) or dimensions of quantum object'
-                         ' (dims).')
-    elif N is None and dims:
-        N = np.prod(dims[0])
-    elif N and dims is None:
-        dims = [[N], [N]]
-    elif N and dims:
-        _check_dims(dims, N, N)
+    N, dims = _check_N_and_dims(dims, N, N, 'operator')
 
     # Random unitary (Stinespring Dilation)
     orthog_cols = rand_unitary(N ** 3, seed=seed).full()[:, :N]
@@ -712,7 +661,7 @@ def rand_stochastic(N=None, density=0.75, kind='left', dims=None, seed=None):
     ----------
     N : int, optional
         Dimension of matrix.
-    density : float
+    density : float (Default = 0.75)
         Density between [0,1] of output density matrix.
     kind : str (Default = 'left')
         Generate 'left' or 'right' stochastic matrix.
@@ -727,16 +676,7 @@ def rand_stochastic(N=None, density=0.75, kind='left', dims=None, seed=None):
     oper : qobj
         Quantum operator form of stochastic matrix.
     """
-    if N is None and dims is None:
-        raise ValueError('Specify either the number of rows of matrix'
-                         ' (N) or dimensions of quantum object'
-                         ' (dims).')
-    elif N is None and dims:
-        N = np.prod(dims[0])
-    elif N and dims is None:
-        dims = [[N], [N]]
-    elif N and dims:
-        _check_dims(dims, N, N)
+    N, dims = _check_N_and_dims(dims, N, N, 'matrix')
 
     if seed is not None:
         np.random.seed(seed=seed)
@@ -763,7 +703,6 @@ def rand_stochastic(N=None, density=0.75, kind='left', dims=None, seed=None):
 
 
 def _check_dims(dims, N1, N2):
-
     if len(dims) != 2:
         raise Exception("Qobj dimensions must be list of length 2.")
     if (not isinstance(dims[0], list)) or (not isinstance(dims[1], list)):
@@ -773,3 +712,34 @@ def _check_dims(dims, N1, N2):
         raise ValueError("Qobj dimensions must match matrix shape.")
     if len(dims[0]) != len(dims[1]):
         raise TypeError("Qobj dimension components must have same length.")
+
+def _check_N_and_dims(dims, N1, N2, error_type):
+    """
+
+    Parameters
+    ----------
+    dims : list of lists of int, optional
+        Dimensions of quantum object.
+    N1 : int
+        Dimension of matrix.
+    N1 : int
+        Dimension of matrix.
+    error_type : str
+        Indicates the type of quantum object.
+
+    Returns
+    -------
+    (N1, dims) : tuple
+
+    """
+    if N1 is None and dims is None:
+        raise ValueError(f'Specify either the number of rows of'
+                         f' {error_type} (N) or dimensions of '
+                         f'quantum object (dims).')
+    elif N1 is None and dims:
+        N1 = np.prod(dims[0])
+    elif N1 and dims is None:
+        dims = [[N1], [N2]]
+    elif N1 and dims:
+        _check_dims(dims, N1, N2)
+    return N1, dims

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -60,8 +60,7 @@ def rand_jacobi_rotation(A, seed=None):
     return A
 
 
-def randnz(shape, norm=1 / np.sqrt(2), seed=None):
-    # This function is intended for internal use.
+def _randnz(shape, norm=1 / np.sqrt(2), seed=None):
     """
     Returns an array of standard normal complex random variates.
     The Ginibre ensemble corresponds to setting ``norm = 1`` [Mis12]_.
@@ -267,15 +266,14 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
 
     Parameters
     ----------
-    N : int, None
-        Number of rows for output quantum vector.
-        If None, N is deduced from dims.
+    N : int, optional
+        Number of rows for output state vector. If None, N is deduced
+         from dims.
     density : float
         Density between [0,1] of output ket state.
-    dims : list, None
-        Dimensions of quantum object.
-        Used for specifying tensor structure.
-        If None, dims = [[N], [1]].
+    dims : list, optional
+        Dimensions of quantum object. Used for specifying tensor
+        structure. If None, dims = [[N], [1]].
     seed : int
         Seed for the random number generator.
 
@@ -288,7 +286,6 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     -------
     ValueError
         If neither `N` or `dims` are specified.
-
     """
     if seed is not None:
         np.random.seed(seed=seed)
@@ -322,13 +319,12 @@ def rand_ket_haar(N=None, dims=None, seed=None):
 
     Parameters
     ----------
-    N : int
-        Dimension of the state vector to be returned.
-        If None, N is deduced from dims.
-    dims : list, None
-        Dimensions of quantum object.
-        Used for specifying tensor structure.
-        If None, dims = [[N], [1]].
+    N : int, optional
+        Number of rows for output state vector. If None, N is deduced
+        from dims.
+    dims : list, optional
+        Dimensions of quantum object. Used for specifying tensor
+        structure. If None, dims = [[N], [1]].
     seed : int
         Seed for the random number generator.
 
@@ -349,6 +345,7 @@ def rand_ket_haar(N=None, dims=None, seed=None):
         N = np.prod(dims[0])
     elif N and dims is None:
         dims = [[N], [1]]
+    elif N and dims:
     _check_dims(dims, N, 1)
 
     psi = rand_unitary_haar(N, seed=seed) * basis(N, 0)
@@ -381,7 +378,6 @@ def rand_dm(N, density=0.75, pure=False, dims=None, seed=None):
     -----
     For small density matrices., choosing a low density will result in an error
     as no diagonal elements will be generated such that :math:`Tr(\rho)=1`.
-
     """
     if isinstance(N, (np.ndarray, list)):
         if np.abs(np.sum(N)-1.0) > 1e-15:
@@ -422,22 +418,25 @@ def rand_dm(N, density=0.75, pure=False, dims=None, seed=None):
     return Qobj(H, dims=dims)
 
 
-def rand_dm_ginibre(N=2, rank=None, dims=None, seed=None):
+def rand_dm_ginibre(N=None, rank=None, dims=None, seed=None):
     """
-    Returns a Ginibre random density operator of dimension
-    ``dim`` and rank ``rank`` by using the algorithm of
-    [BCSZ08]_. If ``rank`` is `None`, a full-rank
-    (Hilbert-Schmidt ensemble) random density operator will be
-    returned.
+    Returns a Ginibre random density operator.
+
+    The operator has dimension ``dim`` and rank ``rank`` and is
+    obtained by using the algorithm of [BCSZ08]_. If ``rank`` is
+    `None`, a full-rank (Hilbert-Schmidt ensemble) random density
+    operator will be returned.
 
     Parameters
     ----------
-    N : int
-        Dimension of the density operator to be returned.
-    dims : list
-        Dimensions of quantum object.  Used for specifying
-        tensor structure. Default is dims=[[N],[N]].
-
+    N : int, optional
+        Dimension of the density operator to be returned. If None, N is
+        deduced from dims.
+    dims : list, optional
+        Dimensions of quantum object. Used for specifying tensor
+        structure. If None, dims = [[N], [N]].
+    seed : int
+        Seed for the random number generator.
     rank : int or None
         Rank of the sampled density operator. If None, a full-rank
         density operator is generated.
@@ -447,7 +446,23 @@ def rand_dm_ginibre(N=2, rank=None, dims=None, seed=None):
     rho : Qobj
         An N × N density operator sampled from the Ginibre
         or Hilbert-Schmidt distribution.
+
+    Raises
+    -------
+    ValueError
+        If neither `N` or `dims` are specified.
     """
+    if N is None and dims is None:
+        raise ValueError('Specify either the number of rows of density'
+                         ' operator (N) or dimensions of quantum object'
+                         ' (dims).')
+    elif N is None and dims:
+        N = np.prod(dims[0])
+    elif N and dims is None:
+        dims = [[N], [N]]
+    elif N and dims:
+        _check_dims(dims, N, N)
+
     if rank is None:
         rank = N
     if rank > N:
@@ -460,20 +475,24 @@ def rand_dm_ginibre(N=2, rank=None, dims=None, seed=None):
     return Qobj(rho, dims=dims)
 
 
-def rand_dm_hs(N=2, dims=None, seed=None):
+def rand_dm_hs(N=None, dims=None, seed=None):
     """
-    Returns a Hilbert-Schmidt random density operator of dimension
-    ``dim`` and rank ``rank`` by using the algorithm of
-    [BCSZ08]_.
+    Returns a Hilbert-Schmidt random density operator.
+
+    The operator has dimensions ``dim`` and rank ``rank`` and
+    is obtained using the algorithm of [BCSZ08]_.
 
 
     Parameters
     ----------
-    N : int
-        Dimension of the density operator to be returned.
-    dims : list
-        Dimensions of quantum object.  Used for specifying
-        tensor structure. Default is dims=[[N],[N]].
+    N : int, optional
+        Dimension of the density operator to be returned. If None, N is
+        deduced from dims.
+    dims : list, optional
+        Dimensions of quantum object. Used for specifying tensor
+        structure. If None, dims = [[N], [N]].
+    seed : int
+        Seed for the random number generator.
 
     Returns
     -------

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 This module is a collection of random state and operator generators.
-The sparsity of the ouput Qobj's is controlled by varing the
+The sparsity of the output Qobj's is controlled by varying the
 `density` parameter.
 """
 
@@ -267,14 +267,15 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
 
     Parameters
     ----------
-    N : int
+    N : int, None
         Number of rows for output quantum vector.
         If None, N is deduced from dims.
     density : float
         Density between [0,1] of output ket state.
-    dims : list
-        Dimensions of quantum object.  Used for specifying
-        tensor structure. Default is dims=[[N],[1]].
+    dims : list, None
+        Dimensions of quantum object.
+        Used for specifying tensor structure.
+        If None, dims = [[N], [1]].
     seed : int
         Seed for the random number generator.
 
@@ -291,16 +292,16 @@ def rand_ket(N=None, density=1, dims=None, seed=None):
     """
     if seed is not None:
         np.random.seed(seed=seed)
+
     if N is None and dims is None:
         raise ValueError('Specify either the number of rows of state vector'
-                         '(N) or dimensions of quantum object (dims)')
-    if N is not None and dims:
-        _check_dims(dims, N, 1)
-    elif dims:
+                         ' (N) or dimensions of quantum object (dims).')
+    elif N is None and dims:
         N = np.prod(dims[0])
-        _check_dims(dims, N, 1)
-    else:
+    elif N and dims is None:
         dims = [[N], [1]]
+    _check_dims(dims, N, 1)
+
     X = sp.rand(N, 1, density, format='csr')
     while X.nnz == 0:
         # ensure that the ket is not all zeros.
@@ -324,9 +325,12 @@ def rand_ket_haar(N=None, dims=None, seed=None):
     N : int
         Dimension of the state vector to be returned.
         If None, N is deduced from dims.
-    dims : list of ints, or None
-        Dimensions of the resultant quantum object.
-        If None, [[N],[1]] is used.
+    dims : list, None
+        Dimensions of quantum object.
+        Used for specifying tensor structure.
+        If None, dims = [[N], [1]].
+    seed : int
+        Seed for the random number generator.
 
     Returns
     -------
@@ -340,14 +344,13 @@ def rand_ket_haar(N=None, dims=None, seed=None):
     """
     if N is None and dims is None:
         raise ValueError('Specify either the number of rows of state vector'
-                         '(N) or dimensions of quantum object (dims)')
-    if N and dims:
-        _check_dims(dims, N, 1)
-    elif dims:
+                         ' (N) or dimensions of quantum object (dims).')
+    elif N is None and dims:
         N = np.prod(dims[0])
-        _check_dims(dims, N, 1)
-    else:
+    elif N and dims is None:
         dims = [[N], [1]]
+    _check_dims(dims, N, 1)
+
     psi = rand_unitary_haar(N, seed=seed) * basis(N, 0)
     psi.dims = dims
     return psi
@@ -482,7 +485,7 @@ def rand_dm_hs(N=2, dims=None, seed=None):
     return rand_dm_ginibre(N, rank=None, dims=dims, seed=seed)
 
 
-def rand_kraus_map(N, dims=None, seed=None):
+def rand_kraus_map(N=None, dims=None, seed=None):
     """
     Creates a random CPTP map on an N-dimensional Hilbert space in Kraus
     form.
@@ -495,7 +498,6 @@ def rand_kraus_map(N, dims=None, seed=None):
         Dimensions of quantum object.  Used for specifying
         tensor structure. Default is dims=[[N],[N]].
 
-
     Returns
     -------
     oper_list : list of qobj
@@ -503,7 +505,7 @@ def rand_kraus_map(N, dims=None, seed=None):
 
     """
 
-    if dims:
+    if N is not None and dims is not None:
         _check_dims(dims, N, N)
 
     # Random unitary (Stinespring Dilation)
@@ -678,11 +680,12 @@ def rand_stochastic(N, density=0.75, kind='left', dims=None, seed=None):
 
 
 def _check_dims(dims, N1, N2):
+
     if len(dims) != 2:
         raise Exception("Qobj dimensions must be list of length 2.")
     if (not isinstance(dims[0], list)) or (not isinstance(dims[1], list)):
         raise TypeError(
-            "Qobj dimension components must be lists. i.e. dims=[[N],[N]]")
+            "Qobj dimension components must be lists. i.e. dims=[[N],[N]].")
     if np.prod(dims[0]) != N1 or np.prod(dims[1]) != N2:
         raise ValueError("Qobj dimensions must match matrix shape.")
     if len(dims[0]) != len(dims[1]):

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -531,7 +531,7 @@ def rand_kraus_map(N=None, dims=None, seed=None):
 
     Parameters
     ----------
-    N : int
+    N : int, optional
         Length of input/output density matrix.
     dims : list of lists of int, optional
         Dimensions of quantum object.  Used for specifying
@@ -545,8 +545,15 @@ def rand_kraus_map(N=None, dims=None, seed=None):
         N^2 x N x N qobj operators.
 
     """
-
-    if N is not None and dims is not None:
+    if N is None and dims is None:
+        raise ValueError('Specify either the number of rows of'
+                         ' operator (N) or dimensions of quantum object'
+                         ' (dims).')
+    elif N is None and dims:
+        N = np.prod(dims[0])
+    elif N and dims is None:
+        dims = [[N], [N]]
+    elif N and dims:
         _check_dims(dims, N, N)
 
     # Random unitary (Stinespring Dilation)
@@ -567,6 +574,8 @@ def rand_super(N=5, dims=None, seed=None):
     dims : list of lists of int, optional
         Dimensions of quantum object.  Used for specifying
         tensor structure. Default is dims=[[[N],[N]], [[N],[N]]].
+    seed : int, optional
+        Seed for the random number generator.
     """
     from .propagator import propagator
     if dims is not None:
@@ -604,6 +613,8 @@ def rand_super_bcsz(N=2, enforce_tp=True, rank=None, dims=None, seed=None):
     dims : list of lists of int, optional
         Dimensions of quantum object.  Used for specifying
         tensor structure. Default is dims=[[[N],[N]], [[N],[N]]].
+    seed : int, optional
+        Seed for the random number generator.
 
     Returns
     -------
@@ -675,12 +686,12 @@ def rand_super_bcsz(N=2, enforce_tp=True, rank=None, dims=None, seed=None):
     return sr.to_super(D)
 
 
-def rand_stochastic(N, density=0.75, kind='left', dims=None, seed=None):
+def rand_stochastic(N=None, density=0.75, kind='left', dims=None, seed=None):
     """Generates a random stochastic matrix.
 
     Parameters
     ----------
-    N : int
+    N : int, optional
         Dimension of matrix.
     density : float
         Density between [0,1] of output density matrix.
@@ -689,16 +700,28 @@ def rand_stochastic(N, density=0.75, kind='left', dims=None, seed=None):
     dims : list of lists of int, optional
         Dimensions of quantum object.  Used for specifying
         tensor structure. Default is dims=[[N],[N]].
+    seed : int, optional
+        Seed for the random number generator.
 
     Returns
     -------
     oper : qobj
         Quantum operator form of stochastic matrix.
     """
+    if N is None and dims is None:
+        raise ValueError('Specify either the number of rows of matrix'
+                         ' (N) or dimensions of quantum object'
+                         ' (dims).')
+    elif N is None and dims:
+        N = np.prod(dims[0])
+    elif N and dims is None:
+        dims = [[N], [N]]
+    elif N and dims:
+        _check_dims(dims, N, N)
+
     if seed is not None:
         np.random.seed(seed=seed)
-    if dims:
-        _check_dims(dims, N, N)
+
     num_elems = max([int(np.ceil(N*(N+1)*density)/2), N])
     data = np.random.rand(num_elems)
     # Ensure an element on every row and column


### PR DESCRIPTION
**Description**

Functions in `random_objects.py` deal with the parameters `N` and `dims` in different ways. Here I unify their interface implementing the following changes:

1) Both `N` and `dims` parameters are now optional, with default value `None` for all functions.
2) If both are given, we check if they match. An error is raised if they don't.
3) If only one of them is given, the other one receives an appropriate value.
4) If none of them are given, an error is raised requesting one of them.

Functions `rand_super` and `rand_super_bcsz` were left unchanged. I believe it's better to leave their changes for v5.0, when the parameters `N` and `dims` will be substituted by `dimensions`.

**Related issues or PRs**
Fix #1838.

**Changelog**
Unify interface from random_objects.py module.
