### PR TITLE
insert sign for plotting with non reversed states

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -1734,11 +1734,11 @@ class QubitCircuit:
                 measurement = op
                 col = []
                 for n in range(self.N+self.num_cbits):
-
                     if n in measurement.targets:
                         col.append(r" \meter")
                     elif (n-self.N) == measurement.classical_store:
-                        store_tag = n - measurement.targets[0]
+                        sgn = 1 if self.reverse_states else -1
+                        store_tag = sgn * (n - measurement.targets[0])
                         col.append(r" \qw \cwx[%d] " % store_tag)
                     else:
                         col.append(r" \qw ")

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -614,6 +614,20 @@ class TestQubitCircuit:
                 np.testing.assert_allclose(probs_initial, probs_final)
                 assert sum(result_cbits[i]) == 1
 
+    def test_latex_code(self):
+        qc = QubitCircuit(1, num_cbits=1, reverse_states=True)
+        qc.add_measurement("M0", targets=0, classical_store=0)
+        exp = \
+            ' &  &  \\qw \\cwx[1]  & \\qw \\\\ \n &  &  \\meter & \\qw \\\\ \n'
+        assert qc.latex_code() == exp
+
+    def test_latex_code_non_reversed(self):
+        qc = QubitCircuit(1, num_cbits=1, reverse_states=False)
+        qc.add_measurement("M0", targets=0, classical_store=0)
+        exp = ' &  &  \\meter & \\qw \\\\ \n &  ' + \
+              '&  \\qw \\cwx[-1]  & \\qw \\\\ \n'
+        assert qc.latex_code() == exp
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
**Description**
There was a bug for plotting a QC with `reversed_states = False`, that caused a problem when plotting a measurement with classical storage. This PR fixes this bug.

**Related issues or PRs**
#1842 

**Changelog**
Fix circuit index used when plotting circuits with non-reversed states.
