### PR TITLE
Disable mcsolve tests on windows.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,10 +78,14 @@ jobs:
             pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper"
 
           # Windows. Once all tests pass without special options needed, this
-          # can be moved to the main os list in the test matrix.
+          # can be moved to the main os list in the test matrix. All the tests
+          # that fail currently seem to do so because mcsolve uses
+          # multiprocessing under the hood. Windows does not support fork()
+          # well, which makes transfering objects to the child processes
+          # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
           - case-name: Windows Latest
             os: windows-latest
-            pytest-extra-options: "-k 'not (test_correlation or test_interpolate)'"
+            pytest-extra-options: "-k 'not (test_correlation or test_interpolate or test_mcsolve)'"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**Description**
Disable mcsolve tests on windows.

**Related issues or PRs**
- See #1202

**Changelog**
Disable mcsolve tests on windows. The mcsolve solver uses multprocessing under the hood to simulate many trajectories at once and this can deadlock on Windows.