### PR TITLE
Fix specifying of wheel to install during post build verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp37-cp37m-manylinux2010_x86_64.whl
+          python -m pip install wheels/*-cp37-cp37m-*.manylinux2010_x86_64.whl
           python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on


### PR DESCRIPTION

**Description**
Fix specifying of wheel to install during post build verification.

When we switched to a newer cibuildwheel the tags of the built Linux wheels changed and broke the pre-upload to PyPI verification step. This fixes the name of the wheel to match that of the ones built by the newer cibuildwheel. 

**Related issues or PRs**
- None

**Changelog**
Fix specifying of wheel to install during post build verification.