### PR TITLE
Fix `isherm_csr` wrongly detecting structure

### DIFF
--- a/qutip/core/data/properties.pyx
+++ b/qutip/core/data/properties.pyx
@@ -135,6 +135,8 @@ cpdef bint isherm_csr(CSR matrix, double tol=-1):
                 # Pointer into the "transposed" matrix.
                 ptr_t = out_row_index[col]
                 out_row_index[col] += 1
+                if nrows != matrix.row_index[ptr_t]:
+                    return _isherm_csr_full(matrix, tol)
                 # We tested the structure already, so we can guarantee that
                 # these two elements correspond.
                 if not _conj_feq(matrix.data[ptr], matrix.data[ptr_t], tol):

--- a/qutip/core/data/properties.pyx
+++ b/qutip/core/data/properties.pyx
@@ -137,8 +137,6 @@ cpdef bint isherm_csr(CSR matrix, double tol=-1):
                 out_row_index[col] += 1
                 if row != matrix.col_index[ptr_t]:
                     return _isherm_csr_full(matrix, tol)
-                # We tested the structure already, so we can guarantee that
-                # these two elements correspond.
                 if not _conj_feq(matrix.data[ptr], matrix.data[ptr_t], tol):
                     return False
         return True

--- a/qutip/core/data/properties.pyx
+++ b/qutip/core/data/properties.pyx
@@ -135,7 +135,7 @@ cpdef bint isherm_csr(CSR matrix, double tol=-1):
                 # Pointer into the "transposed" matrix.
                 ptr_t = out_row_index[col]
                 out_row_index[col] += 1
-                if nrows != matrix.row_index[ptr_t]:
+                if row != matrix.col_index[ptr_t]:
                     return _isherm_csr_full(matrix, tol)
                 # We tested the structure already, so we can guarantee that
                 # these two elements correspond.

--- a/qutip/tests/core/data/test_properties.py
+++ b/qutip/tests/core/data/test_properties.py
@@ -110,7 +110,6 @@ class Test_isherm:
         assert not _data.isherm(base.transpose(), tol=self.tol)
 
     @pytest.mark.parametrize("density", np.linspace(0.2, 1, 17))
-    @pytest.mark.parametrize("n", [3, 10])
     def test_compare_implicit_zero_random(self, datatype, density):
         """
         Regression test of gh-1350.
@@ -122,6 +121,7 @@ class Test_isherm:
         so it should appear so.  We also set the diagonal to be larger to the
         tolerance to ensure isherm can't just compare everything to zero.
         """
+        n = 10
         base = self.tol * 1e-2 * (np.random.rand(n, n) + 1j * np.random.rand(n, n))
         # Mask some values out to zero.
         base[np.random.rand(n, n) > density] = 0
@@ -147,3 +147,10 @@ class Test_isherm:
         assert np.count_nonzero(base.to_array()) == nnz
         assert not _data.isherm(base, tol=self.tol)
         assert not _data.isherm(base.transpose(), tol=self.tol)
+
+    def test_structure_detection(self, datatype):
+        base = np.array([[1,1,0],
+                         [0,1,1],
+                         [1,0,1]])
+        base = _data.to(datatype, _data.create(base))
+        assert not _data.isherm(base, tol=self.tol)

--- a/qutip/tests/core/data/test_properties.py
+++ b/qutip/tests/core/data/test_properties.py
@@ -110,6 +110,7 @@ class Test_isherm:
         assert not _data.isherm(base.transpose(), tol=self.tol)
 
     @pytest.mark.parametrize("density", np.linspace(0.2, 1, 17))
+    @pytest.mark.parametrize("n", [3, 10])
     def test_compare_implicit_zero_random(self, datatype, density):
         """
         Regression test of gh-1350.
@@ -121,7 +122,6 @@ class Test_isherm:
         so it should appear so.  We also set the diagonal to be larger to the
         tolerance to ensure isherm can't just compare everything to zero.
         """
-        n = 10
         base = self.tol * 1e-2 * (np.random.rand(n, n) + 1j * np.random.rand(n, n))
         # Mask some values out to zero.
         base[np.random.rand(n, n) > density] = 0


### PR DESCRIPTION
**Description**
`isherm_csr` did not fully tested the structure, it only checked that each line had as many elements in it than the corresponding column. So 
```
[[1, 1, 0],
 [0, 1, 1],
 [1, 0, 1]]
```
was seen as hermician.

This added a second layer of structure check for such cases and a test that would previously fail.


**Related issues or PRs**
Fixes #1865
