### PR TITLE
Added about() functionality for qutip_qip

### DIFF
--- a/doc/changes/1870.feature
+++ b/doc/changes/1870.feature
@@ -1,0 +1,1 @@
+Added about() functionality for qutip_qip

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -11,19 +11,13 @@ import scipy
 import inspect
 from qutip.utilities import _blas_info, available_cpu_count
 import qutip.settings
-import importlib
+import pkg_resources
 
 
-def about(caller="qutip"):
+def about():
     """
     About box for QuTiP. Gives version numbers for QuTiP, NumPy, SciPy, Cython,
     and MatPlotLib.
-
-    Parameters
-    ----------
-    caller: string
-            The library about which the information is needed.
-            Ex: 'qutip', 'qutip_qip'
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")
@@ -44,16 +38,6 @@ def about(caller="qutip"):
           "See https://github.com/qutip for details.")
     print("")
     print("QuTiP Version:      %s" % qutip.__version__)
-    install_path = os.path.dirname(inspect.getsourcefile(qutip))
-    if caller != "qutip":
-        try:
-            package = importlib.import_module(caller)
-            package_ver = package.__version__
-            install_path = os.path.dirname(inspect.getsourcefile(package))
-        except ImportError:
-            package_ver = 'None'
-            install_path = 'None'
-        print(f"{caller} Version:  %s" % package_ver)
     print("Numpy Version:      %s" % numpy.__version__)
     print("Scipy Version:      %s" % scipy.__version__)
     try:
@@ -75,7 +59,22 @@ def about(caller="qutip"):
     print("INTEL MKL Ext:      %s" % str(qutip.settings.has_mkl))
     print("Platform Info:      %s (%s)" % (platform.system(),
                                            platform.machine()))
-    print("Installation path:  %s" % install_path)
+    qutip_install_path = os.path.dirname(inspect.getsourcefile(qutip))
+    print("Installation path:  %s" % qutip_install_path)
+
+    # family packages
+    entrypoints = pkg_resources.iter_entry_points('qutip.about')
+    for ep in entrypoints:
+        about_func = ep.load()
+        try:
+            title, lines = about_func()
+        except Exception as exc:
+            title, lines = ep.name, [str(exc)]
+        print()
+        print(title)
+        for line in lines:
+            print(line)
+
     # citation
     longbar = "=" * 80
     cite_msg = "For your convenience a bibtex reference can be easily"

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -18,7 +18,10 @@ def about(caller="qutip"):
     About box for QuTiP. Gives version numbers for QuTiP, NumPy, SciPy, Cython,
     and MatPlotLib.
 
-    The caller argument indicates which libary called the function. 
+    Parameters
+    ----------
+    caller: string
+            The library about which the information is needed. Ex: 'qutip', 'qutip_qip' 
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -17,7 +17,8 @@ import pkg_resources
 def about():
     """
     About box for QuTiP. Gives version numbers for QuTiP, NumPy, SciPy, Cython,
-    and MatPlotLib. Also provides information about installed family packages like qutip-qip.
+    and MatPlotLib.
+    Also provides information about installed family packages like qutip-qip.
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -17,6 +17,8 @@ def about(caller="qutip"):
     """
     About box for QuTiP. Gives version numbers for QuTiP, NumPy, SciPy, Cython,
     and MatPlotLib.
+
+    The caller argument indicates which libary called the function. 
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")
@@ -72,7 +74,7 @@ def about(caller="qutip"):
     elif caller == "qutip_qip":
         try:
             install_path = os.path.dirname(inspect.getsourcefile(qutip_qip))
-        except:
+        except ImportError:
             pass
     print("Installation path:  %s" % install_path)
     # citation

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -21,7 +21,8 @@ def about(caller="qutip"):
     Parameters
     ----------
     caller: string
-            The library about which the information is needed. Ex: 'qutip', 'qutip_qip' 
+            The library about which the information is needed.
+            Ex: 'qutip', 'qutip_qip'
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -13,13 +13,15 @@ from qutip.utilities import _blas_info, available_cpu_count
 import qutip.settings
 
 
-def about():
+def about(caller="qutip"):
     """
     About box for QuTiP. Gives version numbers for QuTiP, NumPy, SciPy, Cython,
     and MatPlotLib.
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")
+    if caller == "qutip_qip":
+        print("Quantum Information Processing Module")
     print("================================")
     print("Copyright (c) QuTiP team 2011 and later.")
     print(
@@ -37,6 +39,13 @@ def about():
           "See https://github.com/qutip for details.")
     print("")
     print("QuTiP Version:      %s" % qutip.__version__)
+    if caller == "qutip_qip":
+        try:
+            import qutip_qip
+            qutip_qip_ver = qutip_qip.__version__
+        except ImportError:
+            qutip_qip_ver = 'None'
+        print("QuTiP QIP Version:  %s" % qutip_qip_ver)
     print("Numpy Version:      %s" % numpy.__version__)
     print("Scipy Version:      %s" % scipy.__version__)
     try:
@@ -58,9 +67,14 @@ def about():
     print("INTEL MKL Ext:      %s" % str(qutip.settings.has_mkl))
     print("Platform Info:      %s (%s)" % (platform.system(),
                                            platform.machine()))
-    qutip_install_path = os.path.dirname(inspect.getsourcefile(qutip))
-    print("Installation path:  %s" % qutip_install_path)
-
+    if caller == "qutip":
+        install_path = os.path.dirname(inspect.getsourcefile(qutip))
+    elif caller == "qutip_qip":
+        try:
+            install_path = os.path.dirname(inspect.getsourcefile(qutip_qip))
+        except:
+            pass
+    print("Installation path:  %s" % install_path)
     # citation
     longbar = "=" * 80
     cite_msg = "For your convenience a bibtex reference can be easily"

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -17,7 +17,7 @@ import pkg_resources
 def about():
     """
     About box for QuTiP. Gives version numbers for QuTiP, NumPy, SciPy, Cython,
-    and MatPlotLib.
+    and MatPlotLib. Also provides information about installed family packages like qutip-qip.
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -11,6 +11,7 @@ import scipy
 import inspect
 from qutip.utilities import _blas_info, available_cpu_count
 import qutip.settings
+import importlib
 
 
 def about(caller="qutip"):
@@ -26,8 +27,6 @@ def about(caller="qutip"):
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")
-    if caller == "qutip_qip":
-        print("Quantum Information Processing Module")
     print("================================")
     print("Copyright (c) QuTiP team 2011 and later.")
     print(
@@ -45,13 +44,16 @@ def about(caller="qutip"):
           "See https://github.com/qutip for details.")
     print("")
     print("QuTiP Version:      %s" % qutip.__version__)
-    if caller == "qutip_qip":
+    install_path = os.path.dirname(inspect.getsourcefile(qutip))
+    if caller != "qutip":
         try:
-            import qutip_qip
-            qutip_qip_ver = qutip_qip.__version__
+            package = importlib.import_module(caller)
+            package_ver = package.__version__
+            install_path = os.path.dirname(inspect.getsourcefile(package))
         except ImportError:
-            qutip_qip_ver = 'None'
-        print("QuTiP QIP Version:  %s" % qutip_qip_ver)
+            package_ver = 'None'
+            install_path = 'None'
+        print(f"{caller} Version:  %s" % package_ver)
     print("Numpy Version:      %s" % numpy.__version__)
     print("Scipy Version:      %s" % scipy.__version__)
     try:
@@ -73,13 +75,6 @@ def about(caller="qutip"):
     print("INTEL MKL Ext:      %s" % str(qutip.settings.has_mkl))
     print("Platform Info:      %s (%s)" % (platform.system(),
                                            platform.machine()))
-    if caller == "qutip":
-        install_path = os.path.dirname(inspect.getsourcefile(qutip))
-    elif caller == "qutip_qip":
-        try:
-            install_path = os.path.dirname(inspect.getsourcefile(qutip_qip))
-        except ImportError:
-            pass
     print("Installation path:  %s" % install_path)
     # citation
     longbar = "=" * 80


### PR DESCRIPTION
**Description**
For solving issue qutip/qutip-qip#51, I have added an `about` functionality for `qutip_qip`. Will also make the necessary PR in the qutip-qip repository for completing this issue.

**Related issues or PRs**
fixes qutip/qutip-qip#51

**Changelog**
 Added a parameter to `qutip`'s about function which defaults to "qutip". `qutip`'s about can be called from `qutip_qip` with the argument of "qutip_qip" which will display information about `qutip_qip`.
Displaying `qutip_qip`'s version and installation path.