### PR TITLE
quantum circuits inherit user gates from `add_circuit`

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -601,7 +601,6 @@ class QubitCircuit:
         for circuit_op in qc.gates:
 
             if isinstance(circuit_op, Gate):
-                # gate = circuit_op
 
                 if circuit_op.targets is not None:
                     tar = [target + start for target in circuit_op.targets]
@@ -617,11 +616,12 @@ class QubitCircuit:
                     arg_value=circuit_op.arg_value)
             elif isinstance(circuit_op, Measurement):
                 self.add_measurement(
-                                circuit_op.name,
-                                targets=[target + start for target in circuit_op.targets],
-                                classical_store=circuit_op.classical_store)
+                    circuit_op.name,
+                    targets=[target + start for target in circuit_op.targets],
+                    classical_store=circuit_op.classical_store)
             else:
-                raise TypeError("The circuit to be added contains unknown operator {}".format(circuit_op))
+                raise TypeError("The circuit to be added contains unknown \
+                    operator {}".format(circuit_op))
 
     def remove_gate_or_measurement(self, index=None, end=None,
                                    name=None, remove="first"):

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -50,7 +50,7 @@ _fredkin_like = ["FREDKIN"]
 
 class Gate:
     """
-    Representation of a quantum gate, with its required parametrs, and target
+    Representation of a quantum gate, with its required parameters, and target
     and control qubits.
 
     Parameters
@@ -442,7 +442,7 @@ class QubitCircuit:
 
         Parameters
         ----------
-        name: string
+        measurement: string
             Measurement name. If name is an instance of `Measuremnent`,
             parameters are unpacked and added.
         targets: list
@@ -578,7 +578,7 @@ class QubitCircuit:
                             control_value=control_value)
                 self.gates.append(gate)
 
-    def add_circuit(self, qc, start=0):
+    def add_circuit(self, qc, start=0,overwrite_user_gates=False):
         """
         Adds a block of a qubit circuit to the main circuit.
         Globalphase gates are not added.
@@ -592,6 +592,13 @@ class QubitCircuit:
         """
         if self.N - start < qc.N:
             raise NotImplementedError("Targets exceed number of qubits.")
+        
+        # Inherit the user gates
+        for user_gate in qc.user_gates:
+            if user_gate in self.user_gates and overwrite_user_gates:
+                self.user_gates[user_gate] = qc.user_gates[user_gate]
+            else:
+                self.user_gates[user_gate] = qc.user_gates[user_gate]
 
         for circuit_op in qc.gates:
 
@@ -1624,7 +1631,7 @@ class QubitCircuit:
             elif gate.name == "TOFFOLI":
                 self.U_list.append(toffoli())
             elif gate.name == "GLOBALPHASE":
-                self.U_list.append(globalphase(gate.arg_value, n))
+                self.U_list.append(globalphase(gate.arg_value))
             elif gate.name in self.user_gates:
                 if gate.controls is not None:
                     raise ValueError("A user defined gate {} takes only  "

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -578,7 +578,7 @@ class QubitCircuit:
                             control_value=control_value)
                 self.gates.append(gate)
 
-    def add_circuit(self, qc, start=0,overwrite_user_gates=False):
+    def add_circuit(self, qc, start=0, overwrite_user_gates=False):
         """
         Adds a block of a qubit circuit to the main circuit.
         Globalphase gates are not added.
@@ -592,7 +592,7 @@ class QubitCircuit:
         """
         if self.N - start < qc.N:
             raise NotImplementedError("Targets exceed number of qubits.")
-        
+
         # Inherit the user gates
         for user_gate in qc.user_gates:
             if user_gate in self.user_gates and overwrite_user_gates:


### PR DESCRIPTION
**Description**
The `add_circuit` function in `QuantumCircuit` class used to copy the names of all gates without add the definition of user gates to the target circuit. Hence the user gates cannot be recognized by the new circuit. I made the copy of the definition automatic.
