### PR TITLE
Added Asier Galicia to the qutip admin team list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ QuTiP: Quantum Toolbox in Python
 [B. Li](https://github.com/boxili),
 [J. Lishman](https://github.com/jakelishman),
 [S. Cross](https://github.com/hodgestar),
+[A. Galicia](https://github.com/AGaliciaMartinez),
 [P. D. Nation](https://github.com/nonhermitian),
 and [J. R. Johansson](https://github.com/jrjohansson)
 

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -25,7 +25,7 @@ def about():
     print(
         "Current admin team: Alexander Pitchford, "
         "Nathan Shammah, Shahnawaz Ahmed, Neill Lambert, Eric Giguère, "
-        "Boxi Li, Jake Lishman and Simon Cross."
+        "Boxi Li, Jake Lishman, Simon Cross and Asier Galicia."
     )
     print(
         "Board members: Daniel Burgarth, Robert Johansson, Anton F. Kockum, "


### PR DESCRIPTION
**Description**
Added Asier Galicia to the QuTiP adim team list.

**Changelog**
Added Asier Galicia to the QuTiP adim team list.
