### PR TITLE
Solver contain unique integrator 

### DIFF
--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -27,7 +27,6 @@ class Solver:
     name = "generic"
 
     # State, time and Integrator of the stepper functionnality
-    is_set = False
     _integrator = None
     _avail_integrators = {}
 
@@ -125,7 +124,6 @@ class Solver:
         _time_start = time()
         _data0 = self._prepare_state(state0)
         self._integrator.set_state(tlist[0], _data0)
-        self.is_set = True
         self._argument(args)
         self.stats["preparation time"] += time() - _time_start
 
@@ -163,7 +161,6 @@ class Solver:
         """
         _time_start = time()
         self._integrator.set_state(t0, self._prepare_state(state0))
-        self.is_set = True
         self.stats["preparation time"] += time() - _time_start
 
     def step(self, t, *, args=None, copy=True):
@@ -188,7 +185,7 @@ class Solver:
             ``run``. If ``run`` is called, ``step`` will continue from the last
             time and state obtained.
         """
-        if not self.is_set:
+        if not self._integrator._is_set:
             raise RuntimeError("The `start` method must called first")
         _time_start = time()
         self._argument(args)
@@ -226,12 +223,14 @@ class Solver:
             raise TypeError("options must be an instance of" +
                             str(self.optionsclass))
         self._options = new
-        if self.is_set:
+        if self._integrator is None:
+            pass
+        elif self._integrator._is_set:
             # The integrator was already used: continue where it is.
             state = self._integrator.get_state()
             self._integrator = self._get_integrator()
             self._integrator.set_state(*state)
-        elif self._integrator is not None:
+        else:
             # The integrator was never used, but after it's creation in init.
             self._integrator = self._get_integrator()
 

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -6,7 +6,6 @@ from ..core import stack_columns, unstack_columns
 from .result import Result
 from .integrator import Integrator
 from ..ui.progressbar import progess_bars
-from ..core.data import to
 from time import time
 
 
@@ -24,25 +23,12 @@ class Solver:
 
     options : SolverOptions
         Options for the solver
-
-    attributes
-    ----------
-    rhs : Qobj, QobjEvo
-        Right hand side of the evolution::
-            d state / dt = rhs @ state
-
-    options : SolverOptions
-        Options for the solver
-
-    stats: dict
-        Diverse statistics of the evolution.
     """
     name = "generic"
 
     # State, time and Integrator of the stepper functionnality
-    _t = 0
-    _state = None
-    _integrator = False
+    is_set = False
+    _integrator = None
     _avail_integrators = {}
 
     # Class of option used by the solver
@@ -55,7 +41,9 @@ class Solver:
         else:
             TypeError("The rhs must be a QobjEvo")
         self.options = options
-        self.stats = {"preparation time": 0}
+        _time_start = time()
+        self._integrator = self._get_integrator()
+        self.stats = {"preparation time": time() - _time_start}
         self._state_metadata = {}
 
     def _prepare_state(self, state):
@@ -99,7 +87,7 @@ class Solver:
         else:
             return Qobj(state, **self._state_metadata, copy=copy)
 
-    def run(self, state0, tlist, *, args=None, e_ops=None, options=None):
+    def run(self, state0, tlist, *, args=None, e_ops=None):
         """
         Do the evolution of the Quantum system.
 
@@ -127,31 +115,27 @@ class Solver:
             values. Function[s] must have the signature
             f(t : float, state : Qobj) -> expect.
 
-        options : SolverOptions {None}
-            Options for the solver
-
         Return
         ------
         results : :class:`qutip.solver.Result`
             Results of the evolution. States and/or expect will be saved. You
             can control the saved data in the options.
         """
-        _data0 = self._prepare_state(state0)
-        _integrator = self._get_integrator()
-        if options is not None:
-            self.options = options
-        if args:
-            _integrator.arguments(args)
+
         _time_start = time()
-        _integrator.set_state(tlist[0], _data0)
+        _data0 = self._prepare_state(state0)
+        self._integrator.set_state(tlist[0], _data0)
+        self.is_set = True
+        self._argument(args)
         self.stats["preparation time"] += time() - _time_start
+
         results = Result(e_ops, self.options.results,
                          self.rhs.issuper, _data0.shape[1]!=1)
         results.add(tlist[0], state0)
 
         progress_bar = progess_bars[self.options['progress_bar']]()
         progress_bar.start(len(tlist)-1, **self.options['progress_kwargs'])
-        for t, state in _integrator.run(tlist):
+        for t, state in self._integrator.run(tlist):
             progress_bar.update()
             results.add(t, self._restore_state(state, copy=False))
         progress_bar.finished()
@@ -159,7 +143,7 @@ class Solver:
         self.stats['run time'] = progress_bar.total_time()
         # TODO: It would be nice if integrator could give evolution statistics
         # self.stats.update(_integrator.stats)
-        self.stats["method"] = _integrator.name
+        self.stats["method"] = self._integrator.name
         results.stats = self.stats.copy()
         results.solver = self.name
         return results
@@ -178,13 +162,11 @@ class Solver:
             Initial time of the evolution.
         """
         _time_start = time()
-        self._t = t0
-        self._state = self._prepare_state(state0)
-        self._integrator = self._get_integrator()
-        self._integrator.set_state(self._t, self._state)
+        self._integrator.set_state(t0, self._prepare_state(state0))
+        self.is_set = True
         self.stats["preparation time"] += time() - _time_start
 
-    def step(self, t, *, args=None, options=None, copy=True):
+    def step(self, t, *, args=None, copy=True):
         """
         Evolve the state to ``t`` and return the state as a :class:`Qobj`.
 
@@ -198,27 +180,21 @@ class Solver:
             The change is effective from the beginning of the interval.
             Changing ``args`` can slow the evolution.
 
-        options : SolverOptions, optional {None}
-            Update the ``options`` of the system.
-            The change is effective from the beginning of the interval.
-            Changing ``options`` can slow the evolution.
-
         copy : bool, optional {True}
             Whether to return a copy of the data or the data in the ODE solver.
+
+        .. note :
+            The state must be initialized first by calling ``start`` or
+            ``run``. If ``run`` is called, ``step`` will continue from the last
+            time and state obtained.
         """
-        if not self._integrator:
+        if not self.is_set:
             raise RuntimeError("The `start` method must called first")
-        if options is not None:
-            self.options = options
-            self._integrator = self._get_integrator()
-            self._integrator.set_state(self._t, self._state)
-        if args:
-            self._integrator.arguments(args)
-            self._integrator.reset()
         _time_start = time()
-        self._t, self._state = self._integrator.integrate(t, copy=False)
+        self._argument(args)
+        _, state = self._integrator.integrate(t, copy=False)
         self.stats["run time"] += time() - _time_start
-        return self._restore_state(self._state, copy=copy)
+        return self._restore_state(state, copy=copy)
 
     def _get_integrator(self):
         """ Return the initialted integrator. """
@@ -250,6 +226,20 @@ class Solver:
             raise TypeError("options must be an instance of" +
                             str(self.optionsclass))
         self._options = new
+        if self.is_set:
+            # The integrator was already used: continue where it is.
+            state = self._integrator.get_state()
+            self._integrator = self._get_integrator()
+            self._integrator.set_state(*state)
+        elif self._integrator is not None:
+            # The integrator was never used, but after it's creation in init.
+            self._integrator = self._get_integrator()
+
+    def _argument(self, args):
+        """Update the args, for the `rhs` and other operators."""
+        if args:
+            self._integrator.arguments(args)
+            self.rhs.arguments(args)
 
     @classmethod
     def avail_integrators(cls):

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -33,6 +33,7 @@ class Solver:
     # Class of option used by the solver
     optionsclass = SolverOptions
     odeoptionsclass = SolverOdeOptions
+    resultclass = Result
 
     def __init__(self, rhs, *, options=None):
         if isinstance(rhs, (QobjEvo, Qobj)):
@@ -127,9 +128,9 @@ class Solver:
         self._argument(args)
         self.stats["preparation time"] += time() - _time_start
 
-        results = Result(e_ops, self.options.results,
-                         self.rhs.issuper, _data0.shape[1]!=1)
-        results.add(tlist[0], state0)
+        results = self.resultclass(e_ops, self.options.results,
+                                   self.rhs.issuper, _data0.shape[1]!=1)
+        results.add(tlist[0], self._restore_state(_data0, copy=False))
 
         progress_bar = progess_bars[self.options['progress_bar']]()
         progress_bar.start(len(tlist)-1, **self.options['progress_kwargs'])

--- a/qutip/tests/solver/test_sesolve.py
+++ b/qutip/tests/solver/test_sesolve.py
@@ -219,9 +219,9 @@ class TestSeSolve():
         np.testing.assert_allclose(qutip.expect(qutip.sigmaz(), state), sr2,
                                    atol=2e-6)
 
-        new_options = SolverOptions(method='adams', atol=1e-7, rtol=1e-8,
-                                    progress_bar=None)
-        state = solver_obj.step(3, args={"a":0}, options=new_options)
+        solver_obj.options = SolverOptions(method='adams', atol=1e-7,
+                                           rtol=1e-8, progress_bar=None)
+        state = solver_obj.step(3, args={"a":0})
         np.testing.assert_allclose(qutip.expect(qutip.sigmax(), state), 0.,
                                    atol=2e-6)
         np.testing.assert_allclose(qutip.expect(qutip.sigmay(), state), sr2,


### PR DESCRIPTION
**Description**
`Solver` create the integrator at `__init__` instead of in `run` and `start`.
`step` and `run` no longer take an `options` parameter.  `solver.options = new_options` will now reset the integrator to use the new options. However changing options will always reset the integrator.

**Related issues or PRs**
Similar improvement where first made in #1710, splitting it to made that PR simpler.

**Changelog**
Sovlers manage options as a property instead of method's parameter.