### PR TITLE
Single definition for map_kw default

### DIFF
--- a/qutip/solver/options.py
+++ b/qutip/solver/options.py
@@ -3,8 +3,6 @@ __all__ = ['SolverOptions',
            'McOptions']
 
 from ..optionsclass import optionsclass
-import multiprocessing
-import threading
 
 @optionsclass("solver")
 class SolverOptions:
@@ -233,8 +231,10 @@ class McOptions:
     map_options: dict
         keys:
             'num_cpus': number of cpus to use.
-            'timeout': maximum time for all trajectories. (sec)
-            'job_timeout': maximum time per trajectory. (sec)
+            'timeout': maximum time (sec) for all trajectories. ``None`` will
+                use the maximum timeout value.
+            'job_timeout': maximum time (sec) per trajectory. ``None`` will
+                use the maximum timeout value.
         Only finished trajectories will be returned when timeout is reached.
 
     mc_corr_eps : float {1e-10}
@@ -257,8 +257,8 @@ class McOptions:
         "mc_corr_eps": 1e-10,
 
         "map_options": {
-            'num_cpus': multiprocessing.cpu_count(),
-            'timeout': threading.TIMEOUT_MAX,
-            'job_timeout': threading.TIMEOUT_MAX,
+            'num_cpus': None,
+            'timeout': None,
+            'job_timeout': None,
         },
     }

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -55,19 +55,24 @@ def serial_map(task, values, task_args=None, task_kwargs=None,
         The optional additional argument to the ``task`` function.
     task_kwargs : list / dictionary
         The optional additional keyword argument to the ``task`` function.
+    reduce_func : func (optional)
+        If provided, it will be called with the output of each tasks instead of
+        storing a them in a list.
     progress_bar : string
         Progress bar options's string for showing progress.
     progress_bar_kwargs : dict
-        Options for the progress bar
-    map_kw:
-        Other options
+        Options for the progress bar.
+    map_kw: dict (optional)
+        Dictionary containing entry for 'timeout' the maximum time for the
+        whole map.
 
     Returns
     --------
     result : list
         The result list contains the value of
         ``task(value, *task_args, **task_kwargs)`` for each
-        value in ``values``.
+        value in ``values``. If a ``reduce_func`` is provided, and empty list
+        will be returned.
 
     """
     if task_args is None:
@@ -113,19 +118,26 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
         The optional additional argument to the ``task`` function.
     task_kwargs : list / dictionary
         The optional additional keyword argument to the ``task`` function.
+    reduce_func : func (optional)
+        If provided, it will be called with the output of each tasks instead of
+        storing a them in a list.
     progress_bar : string
         Progress bar options's string for showing progress.
     progress_bar_kwargs : dict
-        Options for the progress bar
-    map_kw:
-        Other options
+        Options for the progress bar.
+    map_kw: dict (optional)
+        Dictionary containing entry for:
+        'timeout': Maximum time for the whole map.
+        'job_timeout': Maximum time for each job in the map.
+        'num_cpus': Number of job to run at once.
 
     Returns
     --------
     result : list
         The result list contains the value of
         ``task(value, *task_args, **task_kwargs)`` for
-        each value in ``values``.
+        each value in ``values``. If a ``reduce_func`` is provided, and empty
+        list will be returned.
 
     """
     if task_args is None:
@@ -193,19 +205,26 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
         The optional additional argument to the ``task`` function.
     task_kwargs : list / dictionary
         The optional additional keyword argument to the ``task`` function.
+    reduce_func : func (optional)
+        If provided, it will be called with the output of each tasks instead of
+        storing a them in a list.
     progress_bar : string
         Progress bar options's string for showing progress.
     progress_bar_kwargs : dict
-        Options for the progress bar
-    **kwargs:
-        Other options to pass to loky
+        Options for the progress bar.
+    map_kw: dict (optional)
+        Dictionary containing entry for:
+        'timeout': Maximum time for the whole map.
+        'job_timeout': Maximum time for each job in the map.
+        'num_cpus': Number of job to run at once.
 
     Returns
     --------
     result : list
         The result list contains the value of
         ``task(value, *task_args, **task_kwargs)`` for
-        each value in ``values``.
+        each value in ``values``. If a ``reduce_func`` is provided, and empty
+        list will be returned.
 
     """
     if task_args is None:
@@ -216,14 +235,12 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
     os.environ['QUTIP_IN_PARALLEL'] = 'TRUE'
     from loky import get_reusable_executor, TimeoutError
 
-    kw = map_kw
-
     progress_bar = progess_bars[progress_bar]()
     progress_bar.start(len(values), **progress_bar_kwargs)
 
-    executor = get_reusable_executor(max_workers=kw['num_cpus'])
-    end_time = kw['timeout'] + time.time()
-    job_time = kw['job_timeout']
+    executor = get_reusable_executor(max_workers=map_kw['num_cpus'])
+    end_time = map_kw['timeout'] + time.time()
+    job_time = map_kw['job_timeout']
     results = []
 
     try:

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -28,9 +28,7 @@ default_map_kw = {
 def _read_map_kw(options):
     options = options or {}
     map_kw = default_map_kw.copy()
-    for key in map_kw:
-        if options.get(key) is not None:
-            map_kw[key] = options[key]
+    map_kw.update({k: v for k, v in options.items() if v is not None})
     return map_kw
 
 


### PR DESCRIPTION
**Description**
Parallel map options' defaults are set in both options.py and parallel.py. As remarked by Asier in #1710, they should be defined in only one place.
The default are now set in parallel.py. Everywhere else can set the value to `None` or not set the key to use the default.
Also the default number of cpus is obtain with `utilities.available_cpu_count` instead of `multiprocessing.cpu_count`.

**Related issues or PRs**
Originally in #1710

**Changelog**
Single definition for map_kw defaults.
