### PR TITLE
Fix some warnings in tests

### DIFF
--- a/qutip/core/data/src/intdtype.h
+++ b/qutip/core/data/src/intdtype.h
@@ -1,2 +1,2 @@
-typedef int64_t idxint;
-int _idxint_size=64;
+typedef int32_t idxint;
+int _idxint_size=32;

--- a/qutip/core/states.py
+++ b/qutip/core/states.py
@@ -903,7 +903,8 @@ shape = [8, 1], type = ket
     state : :class:`qutip.Qobj.qobj`
         The state as a :class:`qutip.Qobj.qobj` instance.
 
-
+    .. note:
+        Deprecated in v5, use :func:`basis` instead.
     """
     warnings.warn("basis() is a drop-in replacement for this",
                   DeprecationWarning)

--- a/qutip/core/states.py
+++ b/qutip/core/states.py
@@ -904,7 +904,7 @@ shape = [8, 1], type = ket
         The state as a :class:`qutip.Qobj.qobj` instance.
 
     .. note:
-        Deprecated in v5, use :func:`basis` instead.
+        Deprecated in QuTiP 5.0, use :func:`basis` instead.
     """
     warnings.warn("basis() is a drop-in replacement for this",
                   DeprecationWarning)

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -178,10 +178,15 @@ def _rand_herm_sparse(N, density, pos_def):
     M = sp.coo_matrix((data, (row_idx, col_idx)),
                       dtype=complex, shape=(N, N))
     M = 0.5 * (M + M.conj().transpose())
-    if pos_def:
-        M.setdiag(np.abs(M.diagonal()) + np.sqrt(2) * N)
     M.sort_indices()
-    return _data.create(M)
+    rand_mat = _data.create(M)
+    if pos_def:
+        rand_mat = _data.add(
+            rand_mat,
+            _data.diag(np.ones(N, dtype=complex)),
+            np.sqrt(2) * N + 1
+        )
+    return rand_mat
 
 
 def _rand_herm_dense(N, density, pos_def):

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -263,6 +263,9 @@ def test_CoeffOptions():
     pytest.param("t + (0 if not 'something' else 1)", {},
                  lambda t: t + 1, id="branch")
 ])
+@pytest.mark.filterwarnings(
+    "ignore::qutip.core.coefficient.StringParsingWarning"
+)
 def test_CoeffParsingStressTest(codestring, args, reference):
     opt = CompilationOptions(recompile=True)
     coeff = coefficient(codestring, args=args, compile_opt=opt)

--- a/qutip/tests/core/test_states.py
+++ b/qutip/tests/core/test_states.py
@@ -14,7 +14,7 @@ def test_basis_simple(size, n):
 
 
 @pytest.mark.parametrize("to_test", [
-    qutip.basis, qutip.fock, qutip.fock_dm, qutip.state_number_qobj
+    qutip.basis, qutip.fock, qutip.fock_dm,
 ])
 @pytest.mark.parametrize("size, n", [([2, 2], [0, 1]), ([2, 3, 4], [1, 2, 0])])
 def test_implicit_tensor_basis_like(to_test, size, n):
@@ -292,7 +292,6 @@ dtype_types = list(qutip.data.to._str2type.values()) + list(qutip.data.to.dtypes
     (qutip.ket, ("001",)),
     (qutip.bra, ('010',)),
     (qutip.qstate, ("uud",)),
-    (qutip.state_number_qobj, ([2, 2, 2], [1, 0, 1])),
     (qutip.w_state, (5,)),
     (qutip.ghz_state, (5,)),
     (qutip.qutrit_basis, ()),

--- a/qutip/tests/solve/test_mcsolve.py
+++ b/qutip/tests/solve/test_mcsolve.py
@@ -73,23 +73,9 @@ class TestNoCollapse(StatesAndExpectOutputCase):
                               'tol'],
                              cases)
 
-    # Previously the "states_only" and "expect_only" tests were mixed in to
-    # every other test case.  We move them out into the simplest set so that
-    # their behaviour remains tested, but isn't repeated as often to keep test
-    # runtimes shorter.  The known-good cases are still tested in the other
-    # test cases, this is just testing the single-output behaviour.
-
-    def test_states_only(self, hamiltonian, args, c_ops, expected, tol):
-        options = qutip.SolverOptions(average_states=True, store_states=True)
-        result = qutip.mcsolve(hamiltonian, self.state, self.times, args=args,
-                               c_ops=c_ops, e_ops=[], ntraj=self.ntraj,
-                               options=options)
-        self._assert_states(result, expected, tol)
-
-    def test_expect_only(self, hamiltonian, args, c_ops, expected, tol):
-        result = qutip.mcsolve(hamiltonian, self.state, self.times, args=args,
-                               c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj)
-        self._assert_expect(result, expected, tol)
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    def test_states_and_expect(self, hamiltonian, args, c_ops, expected, tol):
+        super().test_states_and_expect(hamiltonian, args, c_ops, expected, tol)
 
 
 class TestConstantCollapse(StatesAndExpectOutputCase):
@@ -116,6 +102,24 @@ class TestConstantCollapse(StatesAndExpectOutputCase):
         metafunc.parametrize(['hamiltonian', 'args', 'c_ops', 'expected',
                               'tol'],
                              cases)
+
+    # Previously the "states_only" and "expect_only" tests were mixed in to
+    # every other test case.  We move them out into the simplest set so that
+    # their behaviour remains tested, but isn't repeated as often to keep test
+    # runtimes shorter.  The known-good cases are still tested in the other
+    # test cases, this is just testing the single-output behaviour.
+
+    def test_states_only(self, hamiltonian, args, c_ops, expected, tol):
+        options = qutip.SolverOptions(average_states=True, store_states=True)
+        result = qutip.mcsolve(hamiltonian, self.state, self.times, args=args,
+                               c_ops=c_ops, e_ops=[], ntraj=self.ntraj,
+                               options=options)
+        self._assert_states(result, expected, tol)
+
+    def test_expect_only(self, hamiltonian, args, c_ops, expected, tol):
+        result = qutip.mcsolve(hamiltonian, self.state, self.times, args=args,
+                               c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj)
+        self._assert_expect(result, expected, tol)
 
 
 class TestTimeDependentCollapse(StatesAndExpectOutputCase):
@@ -272,6 +276,7 @@ def _regression_490_f2(t, args):
     return -t
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_regression_490():
     """Test for regression of gh-490."""
     h = [qutip.sigmax(),

--- a/qutip/tests/solve/test_mcsolve.py
+++ b/qutip/tests/solve/test_mcsolve.py
@@ -276,7 +276,7 @@ def _regression_490_f2(t, args):
     return -t
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.filterwarnings("ignore:No c_ops, using sesolve:UserWarning")
 def test_regression_490():
     """Test for regression of gh-490."""
     h = [qutip.sigmax(),

--- a/qutip/tests/solve/test_qubit_evolution.py
+++ b/qutip/tests/solve/test_qubit_evolution.py
@@ -100,7 +100,7 @@ def test_MCSolverCase1():
     assert max(abs(sz - sz_analytic)) < 0.25
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.filterwarnings("ignore:No c_ops, using sesolve:UserWarning")
 def test_MCSolverCase2():
     """
     Test mcsolve qubit, no dissipation

--- a/qutip/tests/solve/test_qubit_evolution.py
+++ b/qutip/tests/solve/test_qubit_evolution.py
@@ -100,6 +100,7 @@ def test_MCSolverCase1():
     assert max(abs(sz - sz_analytic)) < 0.25
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_MCSolverCase2():
     """
     Test mcsolve qubit, no dissipation

--- a/qutip/tests/test_entropy.py
+++ b/qutip/tests/test_entropy.py
@@ -66,8 +66,8 @@ class TestRelativeEntropy:
         # S(rho || sigma) = sum_i(p_i log p_i) - sum_ij(p_i P_ij log q_i)
         rvals, rvecs = rho.eigenstates()
         svals, svecs = sigma.eigenstates()
-        rvecs = np.hstack(vec.full() for vec in rvecs).T
-        svecs = np.hstack(vec.full() for vec in svecs).T
+        rvecs = np.hstack([vec.full() for vec in rvecs]).T
+        svecs = np.hstack([vec.full() for vec in svecs]).T
         # Calculate S
         S = 0
         for i in range(len(rvals)):


### PR DESCRIPTION
**Description**
Fix some of the warnings in the tests in order to restore the `-Werror` flag later.
- Remove test for `state_number_qobj`: (function replaced by `basis`.)
- scipy.sparse matrix operation replaced by `data.CSR` operation.
- Fix passing generator to `hstack`.
- Add some `filterwarnings` for `mcsolve` fallback to `sesolve` and coefficient parsing warning.

**Related issues or PRs**
TODO in #1850

**Changelog**
Fix some warnings in tests.
