### PR TITLE
QobjEvo's call take kwargs

### DIFF
--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -293,6 +293,26 @@ cdef class QobjEvo:
         return out
 
     def __call__(self, double t, dict _args=None, **kwargs):
+        """
+        Get the :cls:`Qobj` at ``t``.
+
+        parameter
+        ---------
+        t : float
+            Time at which the ``QobjEvo`` is to be evalued.
+
+        args : dict [positional / optional]
+            New arguments as a dict. Update args with ``arguments(new_args)``.
+
+        **kwargs :
+            New arguments as a keywors. Update args with
+            ``arguments(**new_args)``.
+
+        .. note:
+            If both the positional ``args`` and keywords are passed new values
+            from both will be used. If a key is present with both, the ``args``
+            dict value will take priority.
+        """
         if _args is not None or kwargs:
             if _args:
                 kwargs.update(_args)
@@ -326,7 +346,23 @@ cdef class QobjEvo:
         return QobjEvo(self, compress=False)
 
     def arguments(QobjEvo self, dict _args=None, **kwargs):
-        """Update the arguments"""
+        """
+        Update the arguments.
+
+        parameter
+        ---------
+        args : dict [positional / optional]
+            New arguments as a dict. Update args with ``arguments(new_args)``.
+
+        **kwargs :
+            New arguments as a keywors. Update args with
+            ``arguments(**new_args)``.
+
+        .. note:
+            If both the positional ``args`` and keywords are passed new values
+            from both will be used. If a key is present with both, the ``args``
+            dict value will take priority.
+        """
         if _args:
             kwargs.update(_args)
         cache = []

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -301,7 +301,7 @@ cdef class QobjEvo:
         t : float
             Time at which the ``QobjEvo`` is to be evalued.
 
-        args : dict [positional / optional]
+        _args : dict [optional]
             New arguments as a dict. Update args with ``arguments(new_args)``.
 
         **kwargs :
@@ -309,12 +309,12 @@ cdef class QobjEvo:
             ``arguments(**new_args)``.
 
         .. note:
-            If both the positional ``args`` and keywords are passed new values
-            from both will be used. If a key is present with both, the ``args``
+            If both the positional ``_args`` and keywords are passed new values
+            from both will be used. If a key is present with both, the ``_args``
             dict value will take priority.
         """
         if _args is not None or kwargs:
-            if _args:
+            if _args is not None:
                 kwargs.update(_args)
             return QobjEvo(self, args=kwargs)(t)
         return Qobj(
@@ -351,7 +351,7 @@ cdef class QobjEvo:
 
         parameter
         ---------
-        args : dict [positional / optional]
+        _args : dict [optional]
             New arguments as a dict. Update args with ``arguments(new_args)``.
 
         **kwargs :
@@ -359,11 +359,11 @@ cdef class QobjEvo:
             ``arguments(**new_args)``.
 
         .. note:
-            If both the positional ``args`` and keywords are passed new values
-            from both will be used. If a key is present with both, the ``args``
+            If both the positional ``_args`` and keywords are passed new values
+            from both will be used. If a key is present with both, the ``_args``
             dict value will take priority.
         """
-        if _args:
+        if _args is not None:
             kwargs.update(_args)
         cache = []
         self.elements = [

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -292,9 +292,11 @@ cdef class QobjEvo:
 
         return out
 
-    def __call__(self, double t, dict args=None):
-        if args:
-            return QobjEvo(self, args=args)(t)
+    def __call__(self, double t, dict _args=None, **kwargs):
+        if _args is not None or kwargs:
+            if _args:
+                kwargs.update(_args)
+            return QobjEvo(self, args=kwargs)(t)
         return Qobj(
             self._call(t), dims=self.dims, copy=False,
             type=self.type, superrep=self.superrep
@@ -323,11 +325,13 @@ cdef class QobjEvo:
         """Return a copy of this `QobjEvo`"""
         return QobjEvo(self, compress=False)
 
-    def arguments(QobjEvo self, dict new_args):
+    def arguments(QobjEvo self, dict _args=None, **kwargs):
         """Update the arguments"""
+        if _args:
+            kwargs.update(_args)
         cache = []
         self.elements = [
-            element.replace_arguments(new_args, cache=cache)
+            element.replace_arguments(kwargs, cache=cache)
             for element in self.elements
         ]
 

--- a/qutip/core/data/src/intdtype.h
+++ b/qutip/core/data/src/intdtype.h
@@ -1,2 +1,2 @@
-typedef int64_t idxint;
-int _idxint_size=64;
+typedef int32_t idxint;
+int _idxint_size=32;

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -230,11 +230,18 @@ def test_args(pseudo_qevo, args_coeff_type):
 
     for t in TESTTIMES:
         _assert_qobj_almost_eq(obj(t, args), pseudo_qevo(t, args))
+        _assert_qobj_almost_eq(obj(t, **args), pseudo_qevo(t, args))
 
     # Did it modify original args
     _assert_qobjevo_equivalent(obj, pseudo_qevo)
 
     obj.arguments(args)
+    _assert_qobjevo_different(obj, pseudo_qevo)
+    for t in TESTTIMES:
+        _assert_qobj_almost_eq(obj(t), pseudo_qevo(t, args))
+
+    args = {'w1': 4, "w2": 4}
+    obj.arguments(**args)
     _assert_qobjevo_different(obj, pseudo_qevo)
     for t in TESTTIMES:
         _assert_qobj_almost_eq(obj(t), pseudo_qevo(t, args))


### PR DESCRIPTION
**Description**
We updated the signature for arguments in coefficient from dict to keyword format, changing call from `coeff(t, args)` to `coeff(t, **args)`. However `QobjEvo`, which have a similar call taking time and argument still took the new args as dictionary instead of keyword. Added keywork support for `QobjEvo.__call__` and `QobjEvo.arguments` . The `__init__` still take argument as a dict since it already takes a lot of parameters.

**Related issues or PRs**
Follow up to #1633 

**Changelog**
QobjEvo call accept keywords for new args.
