### PR TITLE
Set proper default intdtype.h file

### DIFF
--- a/qutip/core/data/src/intdtype.h
+++ b/qutip/core/data/src/intdtype.h
@@ -1,2 +1,2 @@
-typedef int64_t idxint;
-int _idxint_size=64;
+typedef int32_t idxint;
+int _idxint_size=32;


### PR DESCRIPTION
**Description**
When merging  #1874, the 64 bits version of `intdtype.h` was added. 
But it should have been the 32 bits versions since it's the default version.

Adding it to the gitignore would make it impossible to install with build systems not using setup.py (#1815) instead of defaulting to int32. 

**Related issues or PRs**
Fix a mistake in #1874 

