### PR TITLE
Fix add_gate behavior when inserting a gate at multiple indices

### DIFF
--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -527,7 +527,7 @@ class QubitCircuit:
         else:
             # NOTE: Every insertion shifts the indices in the original list of
             #       gates by an additional position to the right.
-            shifted_inds = np.asarray(index) + np.arange(len(index))
+            shifted_inds = np.sort(index) + np.arange(len(index))
             for position in shifted_inds:
                 gate = Gate(name, targets=targets, controls=controls,
                             arg_value=arg_value, arg_label=arg_label,

--- a/qutip/qip/circuit.py
+++ b/qutip/qip/circuit.py
@@ -493,7 +493,8 @@ class QubitCircuit:
         arg_label: string
             Label for gate representation.
         index : list
-            Positions to add the gate.
+            Positions to add the gate. Each index in the supplied list refers
+            to a position in the original list of gates.
         classical_controls : int or list of int, optional
             indices of classical bits to control gate on.
         control_value : int, optional
@@ -524,9 +525,10 @@ class QubitCircuit:
             self.gates.append(gate)
 
         else:
-            for position in index:
-                num_mes = (sum(isinstance(op, Measurement) for op
-                               in self.gates[:position]))
+            # NOTE: Every insertion shifts the indices in the original list of
+            #       gates by an additional position to the right.
+            shifted_inds = np.asarray(index) + np.arange(len(index))
+            for position in shifted_inds:
                 gate = Gate(name, targets=targets, controls=controls,
                             arg_value=arg_value, arg_label=arg_label,
                             classical_controls=classical_controls,

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -225,25 +225,48 @@ class TestQubitCircuit:
             # Single control
             pytest.raises(ValueError, qc.add_gate, gate, [0], [1])
 
-        dummy_gate = Gate("DUMMY")
+        dummy_gate1 = Gate("DUMMY1")
         inds = [1, 3, 4, 6]
-        qc.add_gate(dummy_gate, index=inds)
+        qc.add_gate(dummy_gate1, index=inds)
 
-        # Test adding gates at multiple indices at once.
+        # Test adding gates at multiple (sorted) indices at once.
         # NOTE: Every insertion shifts the indices in the original list of
         #       gates by an additional position to the right.
         expected_gate_names = [
             'CNOT',     # 0
-            'DUMMY',    # 1
+            'DUMMY1',   # 1
             'SWAP',     # 2
             'TOFFOLI',  # 3
-            'DUMMY',    # 4
+            'DUMMY1',   # 4
             'SWAP',     # 5
-            'DUMMY',    # 6
+            'DUMMY1',   # 6
             'SNOT',     # 7
             'RY',       # 8
-            'DUMMY',    # 9
+            'DUMMY1',   # 9
             'RY',       # 10
+        ]
+        actual_gate_names = list(map(attrgetter('name'), qc.gates))
+        assert actual_gate_names == expected_gate_names
+
+        dummy_gate2 = Gate("DUMMY2")
+        inds = [11, 0]
+        qc.add_gate(dummy_gate2, index=inds)
+
+        # Test adding gates at multiple (unsorted) indices at once.
+        expected_gate_names = [
+            'DUMMY2',   # 0
+            'CNOT',     # 1
+            'DUMMY1',   # 2
+            'SWAP',     # 3
+            'TOFFOLI',  # 4
+            'DUMMY1',   # 5
+            'SWAP',     # 6
+            'DUMMY1',   # 7
+            'SNOT',     # 8
+            'RY',       # 9
+            'DUMMY1',   # 10
+            'RY',       # 11
+            'DUMMY2',   # 12
         ]
         actual_gate_names = list(map(attrgetter('name'), qc.gates))
         assert actual_gate_names == expected_gate_names

--- a/qutip/tests/test_qubitcircuit.py
+++ b/qutip/tests/test_qubitcircuit.py
@@ -1,6 +1,5 @@
 import pytest
 import numpy as np
-from operator import attrgetter
 from pathlib import Path
 
 from qutip.qip.operations import gates
@@ -245,7 +244,7 @@ class TestQubitCircuit:
             'DUMMY1',   # 9
             'RY',       # 10
         ]
-        actual_gate_names = list(map(attrgetter('name'), qc.gates))
+        actual_gate_names = [gate.name for gate in qc.gates]
         assert actual_gate_names == expected_gate_names
 
         dummy_gate2 = Gate("DUMMY2")
@@ -268,7 +267,7 @@ class TestQubitCircuit:
             'RY',       # 11
             'DUMMY2',   # 12
         ]
-        actual_gate_names = list(map(attrgetter('name'), qc.gates))
+        actual_gate_names = [gate.name for gate in qc.gates]
         assert actual_gate_names == expected_gate_names
 
     def test_add_circuit(self):


### PR DESCRIPTION
**Description**
The fix pertains to `add_gate` behaviour when multiple insertion indices are supplied. Prior to the proposed fix, the insertion loop doesn't take into account the fact that inserting an element in the gates list, modifies the indices in the original list, whereas the caller of `add_gate` supplies a list of indices, with positions with respect to the indices in the original list.

Additionally, the PR removes unused variables and unused function (that has also not been imported).

**Related issues or PRs**
Fixes #1497.

**Changelog**
Fixed add_gate behavior when inserting a gate at multiple indices.
