### PR TITLE
Build documentation with latest pip version

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Install documentation dependencies
         run: |
+          pip install pip --upgrade
           python -mpip install -r doc/requirements.txt
 
       - name: Install QuTiP from GitHub


### PR DESCRIPTION
**Description**
A bug in [pip 22.1](https://github.com/pypa/pip/issues/11116) break the documentation build.  It's fixed in 22.1.1 but 22.1 is still the version packaged with the python we use for the build.

**Changelog**
Build documentation with latest pip version
