### PR TITLE
Build documentation with latest pip

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Install documentation dependencies
         run: |
+          pip install pip --upgrade
           python -mpip install -r doc/requirements.txt
           sudo apt-get update
           sudo apt-get install texlive-full

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,8 @@ jobs:
           # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
           - case-name: Windows Latest
             os: windows-latest
-            pytest-extra-options: "-k 'not (test_correlation or test_interpolate or test_mcsolve)'"
+            python-version: "3.10"
+            pytest-extra-options: "-W ignore::ImportWarning -k 'not (test_correlation or test_interpolate or test_mcsolve)'"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**Description**
pip 22.1 broke support for `oldest-supported-numpy` when using `--no-build-isolation` by complaining that oldest-supported-numpy was not installed. Later versions of pip fixed this check.

**Related issues or PRs**
- #1897 was the equivalent PR for dev.major

**Changelog**
Build documentation with latest pip version.