### PR TITLE
HEOMSolver return states and progress bar

### DIFF
--- a/qutip/nonmarkov/bofin_solvers.py
+++ b/qutip/nonmarkov/bofin_solvers.py
@@ -938,7 +938,7 @@ class HEOMSolver:
                 solver.y[:n ** 2].reshape(rho_shape, order='F'),
                 dims=rho_dims,
             )
-            if self.options.store_states:
+            if self.options.store_states or not e_ops:
                 output.states.append(rho)
             if ado_return or e_ops_callables:
                 ado_state = HierarchyADOsState(

--- a/qutip/nonmarkov/bofin_solvers.py
+++ b/qutip/nonmarkov/bofin_solvers.py
@@ -455,12 +455,13 @@ class HEOMSolver:
             for k in range(self._n_exponents)
         ]
 
-        self.progress_bar = progress_bar
         if progress_bar is None:
             self.progress_bar = BaseProgressBar()
-        if progress_bar is True:
+        elif progress_bar is True:
             self.progress_bar = TextProgressBar()
-        if not isinstance(self.progress_bar, BaseProgressBar):
+        elif isinstance(progress_bar, BaseProgressBar):
+            self.progress_bar = progress_bar
+        else:
             raise TypeError(
                 "ProgressBar (progress_bar) is not and instance of"
                 "qutip.ui.BaseProgressBar"

--- a/qutip/nonmarkov/bofin_solvers.py
+++ b/qutip/nonmarkov/bofin_solvers.py
@@ -455,10 +455,16 @@ class HEOMSolver:
             for k in range(self._n_exponents)
         ]
 
+        self.progress_bar = progress_bar
         if progress_bar is None:
             self.progress_bar = BaseProgressBar()
         if progress_bar is True:
             self.progress_bar = TextProgressBar()
+        if not isinstance(self.progress_bar, BaseProgressBar):
+            raise TypeError(
+                "ProgressBar (progress_bar) is not and instance of"
+                "qutip.ui.BaseProgressBar"
+            )
 
         self._configure_solver()
 

--- a/qutip/nonmarkov/bofin_solvers.py
+++ b/qutip/nonmarkov/bofin_solvers.py
@@ -1031,11 +1031,6 @@ class HSolverDL(HEOMSolver):
         terminator is added to the system Liouvillian (and H_sys is
         promoted to a Liouvillian if it was a Hamiltonian).
 
-    progress_bar : None, True or :class:`BaseProgressBar`
-        Optional instance of BaseProgressBar, or a subclass thereof, for
-        showing the progress of the solver. If True, an instance of
-        :class:`TextProgressBar` is used instead.
-
     options : :class:`qutip.solver.Options`
         Generic solver options.
         If set to None the default options will be used.

--- a/qutip/nonmarkov/bofin_solvers.py
+++ b/qutip/nonmarkov/bofin_solvers.py
@@ -463,7 +463,7 @@ class HEOMSolver:
             self.progress_bar = progress_bar
         else:
             raise TypeError(
-                "ProgressBar (progress_bar) is not and instance of"
+                "ProgressBar (progress_bar) is not and instance of "
                 "qutip.ui.BaseProgressBar"
             )
 

--- a/qutip/nonmarkov/bofin_solvers.py
+++ b/qutip/nonmarkov/bofin_solvers.py
@@ -463,7 +463,7 @@ class HEOMSolver:
             self.progress_bar = progress_bar
         else:
             raise TypeError(
-                "ProgressBar (progress_bar) is not and instance of "
+                "progress_bar is not an instance of "
                 "qutip.ui.BaseProgressBar"
             )
 

--- a/qutip/tests/test_bofin_solvers.py
+++ b/qutip/tests/test_bofin_solvers.py
@@ -531,6 +531,9 @@ class TestHEOMSolver:
         hsolver = HEOMSolver(H, bath, 2, progress_bar=TextProgressBar())
         assert isinstance(hsolver.progress_bar, BaseProgressBar)
 
+        with pytest.raises(TypeError):
+            HEOMSolver(H, bath, 2, progress_bar=False)
+
     def test_create_bath_errors(self):
         Q = sigmaz()
         H = sigmax()

--- a/qutip/tests/test_bofin_solvers.py
+++ b/qutip/tests/test_bofin_solvers.py
@@ -528,6 +528,9 @@ class TestHEOMSolver:
         hsolver = HEOMSolver(H, bath, 2, progress_bar=True)
         assert isinstance(hsolver.progress_bar, TextProgressBar)
 
+        hsolver = HEOMSolver(H, bath, 2, progress_bar=TextProgressBar())
+        assert isinstance(hsolver.progress_bar, BaseProgressBar)
+
     def test_create_bath_errors(self):
         Q = sigmaz()
         H = sigmax()


### PR DESCRIPTION
**Description**
While working on the [heom-tls notebook] I discovered two wrong behaviors of the `HEOMSolver`. 
1. Running `hsolver.run()` does not return the states if `e_ops=None`, but the documentation says that it should do so. I added the missing if condition to `HEOMSolver`. 
2. If passing a progress bar like `qutip.ui.progressbar.TextProgressBar()` to `HEOMSolver` it results in an error, because internally it only checks for `None` or `True`. The documentation says it should also work if I pass an instance of `BaseProgressBar` (or a subclass). I added the checks and a test in the testfile for this.

**Related issues or PRs**
None

**Changelog**
Fix HEOMSolver state return and progress bar
