### PR TITLE
Bloch vector methods

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -434,7 +434,7 @@ class Bloch:
         else:
             colors = np.asarray(colors)
 
-        if colors.ndim != 1 and colors.size != n_vectors:
+        if colors.ndim != 1 or colors.size != n_vectors:
             raise ValueError("The included colors are not valid. colors must "
                              "be equivalent to a 1D array with the same "
                              "size as the number of vectors. ")

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -45,7 +45,6 @@ try:
             xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
             self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
             return np.min(zs)
-
 except ImportError:
     pass
 

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -768,11 +768,11 @@ class Bloch:
             ys3d = -vec[0] * np.array([0, 1])
             zs3d = vec[2] * np.array([0, 1])
 
+            alpha = self.vector_alpha[k]
             color = self.vector_color[k]
             if color is None:
                 idx = k % len(self.vector_default_color)
                 color = self.vector_default_color[idx]
-            alpha = self.vector_alpha[k]
 
             if self.vector_style == '':
                 # simple line style

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -422,10 +422,11 @@ class Bloch:
             vectors = vectors[np.newaxis, :]
 
         if vectors.ndim != 2 or vectors.shape[1] != 3:
-            raise ValueError("The included vectors are not valid. Vectors must "
-                             "be equivalent to a 2D array where the first "
-                             "index represents the x,y,z values and the "
-                             "second index iterates over the vectors.")
+            raise ValueError(
+                "The included vectors are not valid. Vectors must "
+                "be equivalent to a 2D array where the first "
+                "index represents the iteration over the vectors and the "
+                "second index represents the position in 3D of vector head.")
 
         n_vectors = vectors.shape[0]
         if colors is None:

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -776,18 +776,10 @@ class Bloch:
 
             if self.vector_style == '':
                 # simple line style
-                self.axes.plot(xs3d, ys3d, zs3d,
-                               zs=0, zdir='z', label='Z',
+                self.axes.plot(xs3d, ys3d, zs3d, zdir='z', label='Z',
                                lw=self.vector_width, color=color,
                                alpha=alpha)
             else:
-                print(
-                    xs3d, ys3d, zs3d,
-                            self.vector_mutation,
-                            self.vector_width,
-                            self.vector_style,
-                            color,
-                            alpha)
                 # decorated style, with arrow heads
                 a = Arrow3D(xs3d, ys3d, zs3d,
                             mutation_scale=self.vector_mutation,

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -429,7 +429,7 @@ class Bloch:
 
         n_vectors = vectors.shape[0]
         if colors is None:
-            colors = np.array([None]*n_vectors)
+            colors = np.array([None] * n_vectors)
         else:
             colors = np.asarray(colors)
 

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -453,3 +453,21 @@ class TestBloch:
                    "second index represents the position in 3D of vector "
                    "head.")
         assert str(err.value) == err_msg
+
+    @pytest.mark.parametrize("vectors, colors",
+                             [([0, 0, 1], ['g', 'y']),
+                             ([[0, 0, 1], [0, 1, 0]], ['y']),
+                             ([0, 0, 1], [['g', 'y']])],
+                             ids=["one-vec-two-colors", "two-vec-one-color",
+                                  "wrong-dimension-list"]
+                             )
+    def test_vector_errors_color_length(self, vectors, colors):
+        with pytest.raises(ValueError) as err:
+            b = Bloch()
+            b.add_vectors(vectors, colors=colors)
+            b.render()
+
+        err_msg = ("The included colors are not valid. colors must "
+                   "be equivalent to a 1D array with the same "
+                   "size as the number of vectors. ")
+        assert str(err.value) == err_msg

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -456,8 +456,8 @@ class TestBloch:
 
     @pytest.mark.parametrize("vectors, colors",
                              [([0, 0, 1], ['g', 'y']),
-                             ([[0, 0, 1], [0, 1, 0]], ['y']),
-                             ([0, 0, 1], [['g', 'y']])],
+                              ([[0, 0, 1], [0, 1, 0]], ['y']),
+                              ([0, 0, 1], [['g', 'y']])],
                              ids=["one-vec-two-colors", "two-vec-one-color",
                                   "wrong-dimension-list"]
                              )

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -354,6 +354,7 @@ class TestBloch:
         b = RefBloch(fig=fig)
         b.render_back()
         vector_colors = ['g', '#CC6600', 'b', 'r']
+        idx = 0
 
         for kw in vector_kws:
             vectors = kw.pop("vectors")
@@ -361,19 +362,21 @@ class TestBloch:
             if not isinstance(vectors[0], (list, tuple, np.ndarray)):
                 vectors = [vectors]
 
-            for idx, v in enumerate(vectors):
+            for v in vectors:
                 color = vector_colors[idx % len(vector_colors)]
                 alpha = kw.get("alpha", 1.0)
+                idx += 1
+
                 xs3d = v[1] * np.array([0, 1])
                 ys3d = -v[0] * np.array([0, 1])
                 zs3d = v[2] * np.array([0, 1])
-                print(
-                    xs3d, ys3d, zs3d,
-                    20,
-                    3,
-                    "-|>",
-                    color,
-                    alpha)
+                # print(
+                    # xs3d, ys3d, zs3d,
+                    # 20,
+                    # 3,
+                    # "-|>",
+                    # color,
+                    # alpha)
                 a = Arrow3D(
                     xs3d, ys3d, zs3d,
                     mutation_scale=20, lw=3, arrowstyle="-|>",

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -354,7 +354,6 @@ class TestBloch:
         b = RefBloch(fig=fig)
         b.render_back()
         vector_colors = ['g', '#CC6600', 'b', 'r']
-        idx = 0
 
         for kw in vector_kws:
             vectors = kw.pop("vectors")
@@ -362,13 +361,19 @@ class TestBloch:
             if not isinstance(vectors[0], (list, tuple, np.ndarray)):
                 vectors = [vectors]
 
-            for v in vectors:
+            for idx, v in enumerate(vectors):
                 color = vector_colors[idx % len(vector_colors)]
                 alpha = kw.get("alpha", 1.0)
-                idx += 1
                 xs3d = v[1] * np.array([0, 1])
                 ys3d = -v[0] * np.array([0, 1])
                 zs3d = v[2] * np.array([0, 1])
+                print(
+                    xs3d, ys3d, zs3d,
+                    20,
+                    3,
+                    "-|>",
+                    color,
+                    alpha)
                 a = Arrow3D(
                     xs3d, ys3d, zs3d,
                     mutation_scale=20, lw=3, arrowstyle="-|>",

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -434,3 +434,22 @@ class TestBloch:
             vector_kws = [vector_kws]
         self.plot_vector_test(fig_test, copy.deepcopy(vector_kws))
         self.plot_vector_ref(fig_ref, copy.deepcopy(vector_kws))
+
+    @pytest.mark.parametrize("vectors",
+                             [(0, 1, 0, 1), (0, 1), [0, 1], np.array((0, 1)),
+                              np.arange(12).reshape((3, 2, 2))],
+                             ids=["long_tuple", "short_tuple", "short_list",
+                                  "short_numpy", "wrong_shape_numpy"]
+                             )
+    def test_vector_errors_wrong_vectors(self, vectors):
+        with pytest.raises(ValueError) as err:
+            b = Bloch()
+            b.add_vectors(vectors)
+            b.render()
+
+        err_msg = ("The included vectors are not valid. Vectors must "
+                   "be equivalent to a 2D array where the first "
+                   "index represents the iteration over the vectors and the "
+                   "second index represents the position in 3D of vector "
+                   "head.")
+        assert str(err.value) == err_msg

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -362,21 +362,19 @@ class TestBloch:
             if not isinstance(vectors[0], (list, tuple, np.ndarray)):
                 vectors = [vectors]
 
-            for v in vectors:
-                color = vector_colors[idx % len(vector_colors)]
+            colors = kw.pop("colors", None)
+            for k, v in enumerate(vectors):
+                if colors is None:
+                    color = vector_colors[idx % len(vector_colors)]
+                else:
+                    color = colors[k]
+
                 alpha = kw.get("alpha", 1.0)
                 idx += 1
 
                 xs3d = v[1] * np.array([0, 1])
                 ys3d = -v[0] * np.array([0, 1])
                 zs3d = v[2] * np.array([0, 1])
-                # print(
-                    # xs3d, ys3d, zs3d,
-                    # 20,
-                    # 3,
-                    # "-|>",
-                    # color,
-                    # alpha)
                 a = Arrow3D(
                     xs3d, ys3d, zs3d,
                     mutation_scale=20, lw=3, arrowstyle="-|>",
@@ -420,6 +418,15 @@ class TestBloch:
             dict(vectors=[(0, 0, 1), (0, 1, 0)], alpha=1.0),
             dict(vectors=[(1, 0, 1), (1, 1, 0)], alpha=0.5),
         ], id="alpha-multiple-vector-sets"),
+        pytest.param(
+            dict(vectors=(0, 0, 1), colors=['y']), id="color-y"),
+        pytest.param(
+            dict(vectors=[(0, 0, 1), (0, 1, 0)], colors=['y', 'y']),
+            id="color-two-y"),
+        pytest.param([
+            dict(vectors=[(0, 0, 1)], colors=['y']),
+            dict(vectors=[(1, 0, 1)], colors=['g']),
+        ], id="color-yg"),
     ])
     @check_pngs_equal
     def test_vector(self, vector_kws, fig_test, fig_ref):


### PR DESCRIPTION
**Description**
Clean-up of the methods `add_vectors` and `plot_vectors`.
- raise ValueError when wrong values on inputs for vectors and colors.
- fixes issue #1916 
- colors argument was bugged as it was not being taken into account when plotting. I kept the colors argument behaving as it was first intended, although we may want to change it later to match the behavior of points.
- Added tests for new ValueErrors and for the colors argument.

**Related issues or PRs**
#1913.

**Changelog**
Clean-up of the methods `add_vectors` and `plot_vectors`.
Now add_vectors raises ValueErrors for wrong vectors and colors argument
Fix issue #1916 
Fix colors argument
Improve test coverage
