### PR TITLE
Setting qutip-qip as an optional plugin for qutip-5 [unitaryhack]

### DIFF
--- a/qutip/qip.py
+++ b/qutip/qip.py
@@ -8,6 +8,6 @@ try:
     del qutip_qip
 except ImportError:
     raise ImportError(
-        "'qutip.qip' imports require the `qutip_qip` package. Install it with "
+        "'qutip.qip' imports require the 'qutip_qip' package. Install it with "
         "`pip install qutip-qip` or with `pip install qutip[qip]`."
     )

--- a/qutip/qip.py
+++ b/qutip/qip.py
@@ -9,5 +9,5 @@ except ImportError:
     raise ImportError(
         "Importing 'qutip.qip' requires the 'qutip_qip' package. Install it "
         "with `pip install qutip-qip` (for more details, go to "
-        "https://qutip-qip.rtfd.io/en/stable/)."
+        "https://qutip-qip.readthedocs.io/)."
     )

--- a/qutip/qip.py
+++ b/qutip/qip.py
@@ -1,0 +1,13 @@
+"""Module replicating the qutip_qip package from within qutip."""
+import sys
+
+try:
+    import qutip_qip
+
+    sys.modules["qutip.qip"] = sys.modules["qutip_qip"]
+    del qutip_qip
+except ImportError:
+    raise ImportError(
+        "'qutip.qip' imports require the `qutip_qip` package. Install it with "
+        "`pip install qutip-qip` or with `pip install qutip[qip]`."
+    )

--- a/qutip/qip.py
+++ b/qutip/qip.py
@@ -3,11 +3,11 @@ import sys
 
 try:
     import qutip_qip
-
-    sys.modules["qutip.qip"] = sys.modules["qutip_qip"]
     del qutip_qip
+    sys.modules["qutip.qip"] = sys.modules["qutip_qip"]
 except ImportError:
     raise ImportError(
-        "'qutip.qip' imports require the 'qutip_qip' package. Install it with "
-        "`pip install qutip-qip` or with `pip install qutip[qip]`."
+        "Importing 'qutip.qip' requires the 'qutip_qip' package. Install it "
+        "with `pip install qutip-qip` (for more details, go to "
+        "https://qutip-qip.rtfd.io/en/stable/)."
     )

--- a/qutip/tests/test_qip.py
+++ b/qutip/tests/test_qip.py
@@ -1,0 +1,39 @@
+import sys
+import unittest
+
+import pytest
+
+
+class TestWithoutQip(unittest.TestCase):
+    def setUp(self):
+        self._temp_qip = None
+        if sys.modules.get("qutip_qip"):
+            self._temp_qip = sys.modules["qutip_qip"]
+        sys.modules["qutip_qip"] = None
+
+    def tearDown(self):
+        if self._temp_qip:
+            sys.modules["qutip_qip"] = self._temp_qip
+        else:
+            del sys.modules["qutip_qip"]
+
+    def test_failed_import(self):
+        # Ensure 'qutip.qip' is not imported yet
+        assert "qutip.qip" not in sys.modules
+        with pytest.raises(
+            ImportError,
+            match="'qutip.qip' imports require the 'qutip_qip' package.",
+        ):
+            import qutip.qip
+
+
+def test_with_qip():
+    # Skips test if 'qutip_qip' is not installed
+    qutip_qip = pytest.importorskip("qutip_qip")
+    import qutip.qip
+    import qutip.qip.circuit as circuit
+    from qutip.qip.circuit import QubitCircuit
+
+    assert qutip.qip is qutip_qip
+    assert circuit is qutip_qip.circuit
+    assert QubitCircuit is qutip_qip.circuit.QubitCircuit

--- a/qutip/tests/test_qip.py
+++ b/qutip/tests/test_qip.py
@@ -19,6 +19,8 @@ def with_qutip_qip_stub(tmp_path, monkeypatch):
     circuit_file.write_text("class QubitCircuit:\n    pass")
 
     monkeypatch.syspath_prepend(tmp_path)
+    # Make sure the stub modules is the one imported
+    monkeypatch.delitem(sys.modules, "qutip_qip", raising=False)
     monkeypatch.delitem(sys.modules, "qutip.qip", raising=False)
 
 
@@ -32,7 +34,7 @@ def test_failed_import(without_qutip_qip):
         import qutip.qip
 
 
-def test_with_qip(monkeypatch, with_qutip_qip_stub):
+def test_with_qip(with_qutip_qip_stub):
     import qutip.qip
     import qutip.qip.circuit as circuit
     from qutip.qip.circuit import QubitCircuit


### PR DESCRIPTION
**Description**

- Allow imports of `qutip.qip` seamlessly as imports of `qutip_qip`
- Test the import behaviour when `qutip_qip` is installed and when not.

**Related issues or PRs**
Incorporates the ideas in the discussion of #1500.
Fixes #1893.

**Todos and questions**
- [ ] ~~Have `qutip-qip` be an optional dependency~~ (will be left for a future PR)
- [ ] ~~Add installation of `qutip-qip` to the CI workflow~~

I have a draft of these changes locally, but they fail due to a dependency conflict: `qutip_qip` currently requires `qutip<5 and >=4.6 ` while these changes are being implemented in `v5.0.0.dev`, ie `>5`. This will cause the unit test where `qutip_qip` is installed to be skipped. Any ideas on how to get around this?

**Edit**: Uses a stub for the `qutip_qip` package in the units tests instead, which removes the need of having `qutip-qip` installed.

**Changelog**

Allow imports of `qutip.qip` seamlessly as imports of `qutip_qip`.
Have `qutip-qip` be an optional dependency.