### PR TITLE
clarify docs of sesolve and mesolve

### DIFF
--- a/doc/guide/dynamics/dynamics-master.rst
+++ b/doc/guide/dynamics/dynamics-master.rst
@@ -23,7 +23,7 @@ where :math:`\Psi` is the wave function, :math:`\hat H` the Hamiltonian, and :ma
 
 where :math:`\left|\psi\right>` is the state vector and :math:`H` is the matrix representation of the Hamiltonian. This matrix equation can, in principle, be solved by diagonalizing the Hamiltonian matrix :math:`H`. In practice, however, it is difficult to perform this diagonalization unless the size of the Hilbert space (dimension of the matrix :math:`H`) is small. Analytically, it is a formidable task to calculate the dynamics for systems with more than two states. If, in addition, we consider dissipation due to the inevitable interaction with a surrounding environment, the computational complexity grows even larger, and we have to resort to numerical calculations in all realistic situations. This illustrates the importance of numerical calculations in describing the dynamics of open quantum systems, and the need for efficient and accessible tools for this task.
 
-The Schrödinger equation, which governs the time-evolution of closed quantum systems, is defined by its Hamiltonian and state vector. In the previous section, :ref:`tensor`, we showed how Hamiltonians and state vectors are constructed in QuTiP. Given a Hamiltonian, we can calculate the unitary (non-dissipative) time-evolution of an arbitrary state vector :math:`\left|\psi_0\right>` (``psi0``) using the QuTiP function :func:`qutip.mesolve`. It evolves the state vector and evaluates the expectation values for a set of operators ``expt_ops`` at the points in time in the list ``times``, using an ordinary differential equation solver.
+The Schrödinger equation, which governs the time-evolution of closed quantum systems, is defined by its Hamiltonian and state vector. In the previous section, :ref:`tensor`, we showed how Hamiltonians and state vectors are constructed in QuTiP. Given a Hamiltonian, we can calculate the unitary (non-dissipative) time-evolution of an arbitrary state vector :math:`\left|\psi_0\right>` (``psi0``) using the QuTiP function :func:`qutip.sesolve`. It evolves the state vector and evaluates the expectation values for a set of operators ``expt_ops`` at the points in time in the list ``times``, using an ordinary differential equation solver.
 
 For example, the time evolution of a quantum spin-1/2 system with tunneling rate 0.1 that initially is in the up state is calculated, and the  expectation values of the :math:`\sigma_z` operator evaluated, with the following code
 
@@ -36,9 +36,9 @@ For example, the time evolution of a quantum spin-1/2 system with tunneling rate
     >>> result = sesolve(H, psi0, times, [sigmaz()])
 
 
-The brackets in the fourth argument is an empty list of collapse operators, since we consider unitary evolution in this example. See the next section for examples on how dissipation is included by defining a list of collapse operators.
+See the next section for examples on how dissipation is included by defining a list of collapse operators and using :func:`qutip.mesolve` instead.
 
-The function returns an instance of :class:`qutip.solver.Result`, as described in the previous section :ref:`solver_result`. The attribute ``expect`` in ``result`` is a list of expectation values for the operators that are included in the list in the fifth argument. Adding operators to this list results in a larger output list returned by the function (one array of numbers, corresponding to the times in times, for each operator)
+The function :func:`qutip.sesolve` returns an instance of :class:`qutip.solver.Result`, as described in the previous section :ref:`solver_result`. The attribute ``expect`` in ``result`` is a list of expectation values for the operators that are included in the list in the fourth argument. Adding operators to this list results in a larger output list returned by the function (one array of numbers, corresponding to the times in times, for each operator)
 
 .. plot::
     :context:
@@ -72,13 +72,13 @@ The resulting list of expectation values can easily be visualized using matplotl
     >>> ax.legend(("Sigma-Z", "Sigma-Y")) # doctest: +SKIP
     >>> plt.show() # doctest: +SKIP
 
-If an empty list of operators is passed as fifth parameter, the :func:`qutip.mesolve` function returns a :class:`qutip.solver.Result` instance that contains a list of state vectors for the times specified in ``times``
+If an empty list of operators is passed as fourth parameter, the :func:`qutip.sesolve` function returns a :class:`qutip.solver.Result` instance that contains a list of state vectors for the times specified in ``times``
 
 .. plot::
     :context: close-figs
 
     >>> times = [0.0, 1.0]
-    >>> result = mesolve(H, psi0, times, [], [])
+    >>> result = sesolve(H, psi0, times, [])
     >>> result.states # doctest: +NORMALIZE_WHITESPACE
     [Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket
      Qobj data =
@@ -136,8 +136,8 @@ For systems with environments satisfying the conditions outlined above, the Lind
 
 For non-unitary evolution of a quantum systems, i.e., evolution that includes
 incoherent processes such as relaxation and dephasing, it is common to use
-master equations. In QuTiP, the same function (:func:`qutip.mesolve`) is used for
-evolution both according to the Schrödinger equation and to the master equation,
+master equations. In QuTiP, the function :func:`qutip.mesolve` is used for both:
+the evolution according to the Schrödinger equation and to the master equation,
 even though these two equations of motion are very different. The :func:`qutip.mesolve`
 function automatically determines if it is sufficient to use the Schrödinger
 equation (if no collapse operators were given) or if it has to use the
@@ -161,8 +161,9 @@ the master equation instead of the unitary Schrödinger equation.
 
 Using the example with the spin dynamics from the previous section, we can
 easily add a relaxation process (describing the dissipation of energy from the
-spin to its environment), by adding ``np.sqrt(0.05) * sigmax()`` to
-the previously empty list in the fourth parameter to the :func:`qutip.mesolve` function:
+spin to its environment), by adding ``np.sqrt(0.05) * sigmax()`` in the fourth
+parameter to the :func:`qutip.mesolve` function and moving the expectation
+operators ``[sigmaz(), sigmay()]`` to the fifth argument.
 
 
 .. plot::

--- a/doc/guide/dynamics/dynamics-master.rst
+++ b/doc/guide/dynamics/dynamics-master.rst
@@ -38,7 +38,7 @@ For example, the time evolution of a quantum spin-1/2 system with tunneling rate
 
 See the next section for examples on how dissipation is included by defining a list of collapse operators and using :func:`qutip.mesolve` instead.
 
-The function :func:`qutip.sesolve` returns an instance of :class:`qutip.solver.Result`, as described in the previous section :ref:`solver_result`. The attribute ``expect`` in ``result`` is a list of expectation values for the operators that are included in the list in the fourth argument. Adding operators to this list results in a larger output list returned by the function (one array of numbers, corresponding to the times in times, for each operator)
+The function :func:`qutip.sesolve` returns an instance of :class:`qutip.solver.Result`, as described in the previous section :ref:`solver_result`. The attribute ``expect`` in ``result`` is a list of expectation values for the operators that are included in the list in the fourth argument. Adding operators to this list results in a larger output list returned by the function (one array of numbers, corresponding to the times in times, for each operator).
 
 .. plot::
     :context:


### PR DESCRIPTION
**Description**
I found the description for unitary, non-dissipative time evolution a bit confusing as the text always referred to `mesolve` while the examples used `sesolve`. I adapted the text to `sesolve` for that section and introduced `mesolve` only in the next section.

**Related issues or PRs**
understanding the docs

**Changelog**
Improve documentation on solving for unitary dynamics by making the use of sesolve and mesolve in the code examples more consistent with the text, and by making the text clearer.
