### PR TITLE
[unitaryhack] DOC: Hyperlinks to QuTiP functions and classes fixed #1526

### DIFF
--- a/doc/apidoc/classes.rst
+++ b/doc/apidoc/classes.rst
@@ -36,6 +36,8 @@ Bloch sphere
 .. autoclass:: qutip.bloch.Bloch
     :members:
 
+.. autoclass:: qutip.bloch3d.Bloch3d
+    :members:
 
 Distributions
 -------------

--- a/doc/apidoc/functions.rst
+++ b/doc/apidoc/functions.rst
@@ -120,7 +120,7 @@ Measurement of quantum states
 -----------------------------
 
 .. automodule:: qutip.measurement
-    :members: measure, measure_observable, measurement_statistics, measurement_statistics_observable
+    :members: measure, measure_povm, measure_observable, measurement_statistics, measurement_statistics_observable, measurement_statistics_povm
 
 
 Dynamics and Time-Evolution

--- a/doc/apidoc/functions.rst
+++ b/doc/apidoc/functions.rst
@@ -103,7 +103,7 @@ Density Matrix Metrics
 ----------------------
 
 .. automodule:: qutip.metrics
-    :members: fidelity, tracedist, bures_dist, bures_angle, hilbert_dist, average_gate_fidelity, process_fidelity
+    :members: fidelity, tracedist, bures_dist, bures_angle, hellinger_dist, hilbert_dist, average_gate_fidelity, process_fidelity, unitarity, dnorm
 
 
 Continuous Variables

--- a/doc/gallery/src/qip/plot_qip_intro_processor.py
+++ b/doc/gallery/src/qip/plot_qip_intro_processor.py
@@ -2,7 +2,7 @@
 Basic use of Processor
 =============================
 
-This example contains the basic functions of :class:`qutip.qip.device.Processor.` We define a simulator with control Hamiltonian, pulse amplitude and time slice for each pulse. The two figures illustrate the pulse shape for two different setup: step function or continuous pulse.
+This example contains the basic functions of :class:`qutip.qip.device.Processor`. We define a simulator with control Hamiltonian, pulse amplitude and time slice for each pulse. The two figures illustrate the pulse shape for two different setup: step function or continuous pulse.
 """
 import copy
 import numpy as np

--- a/doc/guide/dynamics/dynamics-floquet.rst
+++ b/doc/guide/dynamics/dynamics-floquet.rst
@@ -150,7 +150,7 @@ For some problems interesting observations can be draw from the quasienergy leve
    >>> plt.title(r'Floquet quasienergies') # doctest: +SKIP
    >>> plt.show() # doctest: +SKIP
 
-Given the Floquet modes at :math:`t=0`, we obtain the Floquet mode at some later time :math:`t` using the function :func:`qutip.floquet.floquet_mode_t`:
+Given the Floquet modes at :math:`t=0`, we obtain the Floquet mode at some later time :math:`t` using the function :func:`qutip.floquet.floquet_modes_t`:
 
 .. plot::
    :context: close-figs

--- a/doc/guide/dynamics/dynamics-photocurrent.rst
+++ b/doc/guide/dynamics/dynamics-photocurrent.rst
@@ -63,7 +63,7 @@ Here :math:`\delta N = 1` with a probability of :math:`\delta \omega` and
 Trajectories obtained with this algorithm are equivalent to those obtained with
 monte-carlo evolution (up to :math:`O(\delta t^2)`).
 In most cases, :func:`qutip.mcsolve` is more efficient than
-:func:`qutip.photocurrent_sesolve`.
+:func:`qutip.stochastic.photocurrent_sesolve`.
 
 Open system
 -----------

--- a/doc/guide/dynamics/dynamics-time.rst
+++ b/doc/guide/dynamics/dynamics-time.rst
@@ -13,8 +13,8 @@ we assumed that the systems under consideration were described by time-independe
 However, many systems have explicit time dependence in either the Hamiltonian,
 or the collapse operators describing coupling to the environment, and sometimes both components might depend on time.
 The time-evolutions  solvers
-:func:`qutip.mesolve`, :func:`qutip.mcsolve`, :func:`qutip.sesolve`, :func:`qutip.brmesolve`
-:func:`qutip.ssesolve`, :func:`qutip.photocurrent_sesolve`, :func:`qutip.smesolve`, and :func:`qutip.photocurrent_mesolve`
+:func:`qutip.mesolve`, :func:`qutip.mcsolve`, :func:`qutip.sesolve`, :func:`qutip.bloch_redfield.brmesolve`
+:func:`qutip.stochastic.ssesolve`, :func:`qutip.stochastic.photocurrent_sesolve`, :func:`qutip.stochastic.smesolve`, and :func:`qutip.stochastic.photocurrent_mesolve`
 are all capable of handling time-dependent Hamiltonians and collapse terms.
 There are, in general, three different ways to implement time-dependent problems in QuTiP:
 
@@ -33,7 +33,7 @@ In short, the function based method (option #1) is the most general,
 allowing for essentially arbitrary coefficients expressed via user defined functions.
 However, by automatically compiling your system into C++ code,
 the second option (string based) tends to be more efficient and will run faster
-[This is also the only format that is supported in the :func:`qutip.brmesolve` solver].
+[This is also the only format that is supported in the :func:`qutip.bloch_redfield.brmesolve` solver].
 Of course, for small system sizes and evolution times, the difference will be minor.
 Although this method does not support all time-dependent coefficients that one can think of,
 it does support essentially all problems that one would typically encounter.
@@ -351,14 +351,14 @@ expectation values and collapse can also be obtained.
 +-------------------+-------------------------+----------------------+------------------------------------------------------------------+
 
 Here ``psi0`` is the initial value used for tests before the evolution begins.
-:func:`qutip.brmesolve` does not support these arguments.
+:func:`qutip.bloch_redfield.brmesolve` does not support these arguments.
 
 Reusing Time-Dependent Hamiltonian Data
 =======================================
 
 .. note:: This section covers a specialized topic and may be skipped if you are new to QuTiP.
 
-When repeatedly simulating a system where only the time-dependent variables, or initial state change, it is possible to reuse the Hamiltonian data stored in QuTiP and there by avoid spending time needlessly preparing the Hamiltonian and collapse terms for simulation.  To turn on the the reuse features, we must pass a :class:`qutip.Options` object with the ``rhs_reuse`` flag turned on.  Instructions on setting flags are found in :ref:`Options`.  For example, we can do
+When repeatedly simulating a system where only the time-dependent variables, or initial state change, it is possible to reuse the Hamiltonian data stored in QuTiP and there by avoid spending time needlessly preparing the Hamiltonian and collapse terms for simulation.  To turn on the the reuse features, we must pass a :class:`qutip.solver.Options` object with the ``rhs_reuse`` flag turned on.  Instructions on setting flags are found in :ref:`Options`.  For example, we can do
 
 .. plot::
     :context: close-figs
@@ -380,7 +380,7 @@ Running String-Based Time-Dependent Problems using Parfor
 
 .. note:: This section covers a specialized topic and may be skipped if you are new to QuTiP.
 
-In this section we discuss running string-based time-dependent problems using the :func:`qutip.parfor` function.  As the :func:`qutip.mcsolve` function is already parallelized, running string-based time dependent problems inside of parfor loops should be restricted to the :func:`qutip.mesolve` function only. When using the string-based format, the system Hamiltonian and collapse operators are converted into C code with a specific file name that is automatically genrated, or supplied by the user via the ``rhs_filename`` property of the :class:`qutip.Options` class. Because the :func:`qutip.parfor` function uses the built-in Python multiprocessing functionality, in calling the solver inside a parfor loop, each thread will try to generate compiled code with the same file name, leading to a crash.  To get around this problem you can call the :func:`qutip.rhs_generate` function to compile simulation into C code before calling parfor.  You **must** then set the :class:`qutip.Odedata` object ``rhs_reuse=True`` for all solver calls inside the parfor loop that indicates that a valid C code file already exists and a new one should not be generated.  As an example, we will look at the Landau-Zener-Stuckelberg interferometry example that can be found in the notebook "Time-dependent master equation: Landau-Zener-Stuckelberg inteferometry" in the tutorials section of the QuTiP web site.
+In this section we discuss running string-based time-dependent problems using the :func:`qutip.parallel.parfor` function.  As the :func:`qutip.mcsolve` function is already parallelized, running string-based time dependent problems inside of parfor loops should be restricted to the :func:`qutip.mesolve` function only. When using the string-based format, the system Hamiltonian and collapse operators are converted into C code with a specific file name that is automatically genrated, or supplied by the user via the ``rhs_filename`` property of the :class:`qutip.solver.Options` class. Because the :func:`qutip.parallel.parfor` function uses the built-in Python multiprocessing functionality, in calling the solver inside a parfor loop, each thread will try to generate compiled code with the same file name, leading to a crash.  To get around this problem you can call the :func:`qutip.rhs_generate` function to compile simulation into C code before calling parfor.  You **must** then set the :class:`qutip.solver.Options` object ``rhs_reuse=True`` for all solver calls inside the parfor loop that indicates that a valid C code file already exists and a new one should not be generated.  As an example, we will look at the Landau-Zener-Stuckelberg interferometry example that can be found in the notebook "Time-dependent master equation: Landau-Zener-Stuckelberg inteferometry" in the tutorials section of the QuTiP web site.
 
 To set up the problem, we run the following code:
 

--- a/doc/guide/guide-bloch.rst
+++ b/doc/guide/guide-bloch.rst
@@ -9,7 +9,7 @@ Plotting on the Bloch Sphere
 Introduction
 ============
 
-When studying the dynamics of a two-level system, it is often convenient to visualize the state of the system by plotting the state-vector or density matrix on the Bloch sphere.  In QuTiP, we have created two different classes to allow for easy creation and manipulation of data sets, both vectors and data points, on the Bloch sphere.  The :class:`qutip.Bloch` class, uses Matplotlib to render the Bloch sphere, where as :class:`qutip.Bloch3d` uses the Mayavi rendering engine to generate a more faithful 3D reconstruction of the Bloch sphere.
+When studying the dynamics of a two-level system, it is often convenient to visualize the state of the system by plotting the state-vector or density matrix on the Bloch sphere.  In QuTiP, we have created two different classes to allow for easy creation and manipulation of data sets, both vectors and data points, on the Bloch sphere.  The :class:`qutip.bloch.Bloch` class, uses Matplotlib to render the Bloch sphere, where as :class:`qutip.bloch3d.Bloch3d` uses the Mayavi rendering engine to generate a more faithful 3D reconstruction of the Bloch sphere.
 
 .. _bloch-class:
 
@@ -23,11 +23,11 @@ In QuTiP, creating a Bloch sphere is accomplished by calling either:
 
     b = qutip.Bloch()
 
-which will load an instance of the :class:`qutip.Bloch` class, or using ::
+which will load an instance of the :class:`qutip.bloch.Bloch` class, or using ::
 
    >>> b3d = qutip.Bloch3d()
 
-that loads the :class:`qutip.Bloch3d` version.  Before getting into the details of these objects, we can simply plot the blank Bloch sphere associated with these instances via:
+that loads the :class:`qutip.bloch3d.Bloch3d` version.  Before getting into the details of these objects, we can simply plot the blank Bloch sphere associated with these instances via:
 
 .. plot::
     :context:
@@ -42,7 +42,7 @@ or
     :width: 3.5in
     :figclass: align-center
 
-In addition to the ``show`` command, see the API documentation for :class:`~Bloch` for a full list of other available functions.
+In addition to the ``show`` command, see the API documentation for :class:`~qutip.bloch.Bloch` for a full list of other available functions.
 As an example, we can add a single data point:
 
 .. plot::
@@ -156,7 +156,7 @@ Notice that, in contrast to states or vectors, each point remains the same color
 
 The color and shape of the data points is varied automatically by the Bloch class.  Notice how the color and point markers change for each set of data.  Again, we have had to call ``add_points`` twice because adding more than one set of multiple data points is *not* supported by the ``add_points`` function.
 
-What if we want to vary the color of our points.  We can tell the :class:`qutip.Bloch` class to vary the color of each point according to the colors listed in the ``b.point_color`` list (see :ref:`bloch-config` below).  Again after ``clear()``:
+What if we want to vary the color of our points.  We can tell the :class:`qutip.bloch.Bloch` class to vary the color of each point according to the colors listed in the ``b.point_color`` list (see :ref:`bloch-config` below).  Again after ``clear()``:
 
 .. plot::
     :context: close-figs
@@ -183,7 +183,7 @@ Now, the data points cycle through a variety of predefined colors.  Now lets add
     b.add_points([xz, yz, zz])  # no 'm'
     b.render()
 
-Again, the same plot can be generated using the :class:`qutip.Bloch3d` class by replacing ``Bloch`` with ``Bloch3d``:
+Again, the same plot can be generated using the :class:`qutip.bloch3d.Bloch3d` class by replacing ``Bloch`` with ``Bloch3d``:
 
 .. figure:: figures/bloch3d+points.png
     :width: 3.5in

--- a/doc/guide/guide-measurement.rst
+++ b/doc/guide/guide-measurement.rst
@@ -42,8 +42,8 @@ along the z-axis.
 
 We choose what to measure (in this case) by selecting a **measurement operator**.
 For example,
-we could select :func:`~qutip.sigmaz` which measures the z-component of the
-spin of a spin-1/2 particle, or :func:`~qutip.sigmax` which measures the
+we could select :func:`~qutip.operators.sigmaz` which measures the z-component of the
+spin of a spin-1/2 particle, or :func:`~qutip.operators.sigmax` which measures the
 x-component:
 
 .. testcode::
@@ -136,7 +136,7 @@ We can also choose what to measure by specifying a *list of projection operators
 example, we could select the projection operators :math:`\ket{0} \bra{0}` and
 :math:`\ket{1} \bra{1}` which measure the state in the :math:`\ket{0}, \ket{1}`
 basis. Note that these projection operators are simply the projectors determined by
-the eigenstates of the :func:`~qutip.sigmaz` operator.
+the eigenstates of the :func:`~qutip.operators.sigmaz` operator.
 
 .. testcode::
 

--- a/doc/guide/guide-states.rst
+++ b/doc/guide/guide-states.rst
@@ -1002,7 +1002,7 @@ convention,
     J(\Lambda) = (\mathbb{1} \otimes \Lambda) [|\mathbb{1}\rangle\!\rangle \langle\!\langle \mathbb{1}|].
 
 In QuTiP, :math:`J(\Lambda)` can be found by calling the :func:`~qutip.superop_reps.to_choi`
-function on a ``type="super"`` :obj:`~Qobj`.
+function on a ``type="super"`` :obj:`~qutip.Qobj`.
 
 .. testcode:: [states]
 
@@ -1042,7 +1042,7 @@ function on a ``type="super"`` :obj:`~Qobj`.
    [0. 0. 0. 0.]
    [1. 0. 0. 1.]]
 
-If a :obj:`~Qobj` instance is already in the Choi :attr:`~Qobj.superrep`, then calling :func:`~qutip.superop_reps.to_choi`
+If a :obj:`~qutip.Qobj` instance is already in the Choi :attr:`~qutip.Qobj.superrep`, then calling :func:`~qutip.superop_reps.to_choi`
 does nothing:
 
 .. testcode:: [states]
@@ -1220,7 +1220,7 @@ using the :func:`~qutip.superop_reps.to_kraus` function.
      [0.         0.70710678]]]
 
 As with the other representation conversion functions, :func:`~qutip.superop_reps.to_kraus`
-checks the :attr:`~Qobj.superrep` attribute of its input, and chooses an appropriate
+checks the :attr:`~qutip.Qobj.superrep` attribute of its input, and chooses an appropriate
 conversion method. Thus, in the above example, we can also call :func:`~qutip.superop_reps.to_kraus`
 on ``J``.
 
@@ -1414,7 +1414,7 @@ the :math:`\chi_{00}` element:
 Here, the factor of 4 comes from the dimension of the underlying
 Hilbert space :math:`\mathcal{H}`. As with the superoperator
 and Choi representations, the :math:`\chi` representation is
-denoted by the :attr:`~Qobj.superrep`, such that :func:`~qutip.superop_reps.to_super`,
+denoted by the :attr:`~qutip.Qobj.superrep`, such that :func:`~qutip.superop_reps.to_super`,
 :func:`~qutip.superop_reps.to_choi`, :func:`~qutip.superop_reps.to_kraus`,
 :func:`~qutip.superop_reps.to_stinespring` and :func:`~qutip.superop_reps.to_chi`
 all convert from the :math:`\chi` representation appropriately.
@@ -1425,7 +1425,7 @@ Properties of Quantum Maps
 In addition to converting between the different representations of quantum maps,
 QuTiP also provides attributes to make it easy to check if a map is completely
 positive, trace preserving and/or hermicity preserving. Each of these attributes
-uses :attr:`~Qobj.superrep` to automatically perform any needed conversions.
+uses :attr:`~qutip.Qobj.superrep` to automatically perform any needed conversions.
 
 In particular, a quantum map is said to be positive (but not necessarily completely
 positive) if it maps all positive operators to positive operators. For instance, the
@@ -1451,7 +1451,7 @@ with negative eigenvalues. Complete positivity addresses this by requiring that
 a map returns positive operators for all positive operators, and does so even
 under tensoring with another map. The Choi matrix is very useful here, as it
 can be shown that a map is completely positive if and only if its Choi matrix
-is positive [Wat13]_. QuTiP implements this check with the :attr:`~Qobj.iscp`
+is positive [Wat13]_. QuTiP implements this check with the :attr:`~qutip.Qobj.iscp`
 attribute. As an example, notice that the snippet above already calculates
 the Choi matrix of the transpose map by acting it on half of an entangled
 pair. We simply need to manually set the ``dims`` and ``superrep`` attributes to reflect the
@@ -1477,7 +1477,7 @@ That is, :math:`\Lambda(\rho) = (\Lambda(\rho))^\dagger` for all :math:`\rho` su
 :math:`\rho = \rho^\dagger`. To see this, we note that :math:`(\rho^{\mathrm{T}})^\dagger
 = \rho^*`, the complex conjugate of :math:`\rho`. By assumption, :math:`\rho = \rho^\dagger
 = (\rho^*)^{\mathrm{T}}`, though, such that :math:`\Lambda(\rho) = \Lambda(\rho^\dagger) = \rho^*`.
-We can confirm this by checking the :attr:`~Qobj.ishp` attribute:
+We can confirm this by checking the :attr:`~qutip.Qobj.ishp` attribute:
 
 .. testcode:: [states]
 
@@ -1492,7 +1492,7 @@ We can confirm this by checking the :attr:`~Qobj.ishp` attribute:
 
 Next, we note that the transpose map does preserve the trace of its inputs, such that
 :math:`\operatorname{Tr}(\Lambda[\rho]) = \operatorname{Tr}(\rho)` for all :math:`\rho`.
-This can be confirmed by the :attr:`~Qobj.istp` attribute:
+This can be confirmed by the :attr:`~qutip.Qobj.istp` attribute:
 
 .. testcode:: [states]
 

--- a/doc/guide/guide-tensor.rst
+++ b/doc/guide/guide-tensor.rst
@@ -375,7 +375,7 @@ To represent superoperators acting on :math:`\mathcal{L}(\mathcal{H}_1 \otimes \
 :math:`\mathcal{H}_1 \otimes \mathcal{H}_2 \otimes \mathcal{H}_1 \otimes \mathcal{H}_2`.
 
 In particular, this means that :func:`qutip.tensor` does not act as
-one might expect on the results of :func:`qutip.to_super`:
+one might expect on the results of :func:`qutip.superop_reps.to_super`:
 
 .. doctest:: [tensor]
 
@@ -394,7 +394,7 @@ of the compound index with dims ``[2, 3]``. In the latter
 case, however, each of the Hilbert space indices is listed
 independently and in the wrong order.
 
-The :func:`qutip.super_tensor` function performs the needed
+The :func:`qutip.tensor.super_tensor` function performs the needed
 rearrangement, providing the most direct analog to :func:`qutip.tensor` on
 the underlying Hilbert space. In particular, for any two ``type="oper"``
 Qobjs ``A`` and ``B``, ``to_super(tensor(A, B)) == super_tensor(to_super(A), to_super(B))`` and
@@ -405,8 +405,8 @@ Qobjs ``A`` and ``B``, ``to_super(tensor(A, B)) == super_tensor(to_super(A), to_
   >>> super_tensor(to_super(A), to_super(B)).dims
   [[[2, 3], [2, 3]], [[2, 3], [2, 3]]]
 
-The :func:`qutip.composite` function automatically switches between
-:func:`qutip.tensor` and :func:`qutip.super_tensor` based on the ``type``
+The :func:`qutip.tensor.composite` function automatically switches between
+:func:`qutip.tensor` and :func:`qutip.tensor.super_tensor` based on the ``type``
 of its arguments, such that ``composite(A, B)`` returns an appropriate Qobj to
 represent the composition of two systems.
 
@@ -420,7 +420,7 @@ represent the composition of two systems.
 
 QuTiP also allows more general tensor manipulations that are
 useful for converting between superoperator representations [WBC11]_.
-In particular, the :func:`tensor_contract` function allows for
+In particular, the :func:`~qutip.tensor.tensor_contract` function allows for
 contracting one or more pairs of indices. As detailed in
 the `channel contraction tutorial`_, this can be used to find
 superoperators that represent partial trace maps.

--- a/doc/guide/guide-visualization.rst
+++ b/doc/guide/guide-visualization.rst
@@ -280,7 +280,7 @@ QuTiP offers a few functions for quickly visualizing matrix data in the
 form of histograms, :func:`qutip.visualization.matrix_histogram` and
 :func:`qutip.visualization.matrix_histogram_complex`, and as Hinton diagram of weighted
 squares, :func:`qutip.visualization.hinton`. These functions takes a
-:class:`qutip.Qobj.Qobj` as first argument, and optional arguments to, for
+:class:`qutip.Qobj` as first argument, and optional arguments to, for
 example, set the axis labels and figure title (see the function's documentation
 for details).
 
@@ -388,7 +388,7 @@ Note that to obtain :math:`\chi` with this method we have to construct a matrix 
 Implementation in QuTiP
 -----------------------
 
-In QuTiP, the procedure described above is implemented in the function :func:`qutip.tomography.qpt`, which returns the :math:`\chi` matrix given a density matrix propagator. To illustrate how to use this function, let's consider the :math:`i`-SWAP gate for two qubits. In QuTiP the function :func:`qutip.qip.operations.iswap` generates the unitary transformation for the state kets:
+In QuTiP, the procedure described above is implemented in the function :func:`qutip.tomography.qpt`, which returns the :math:`\chi` matrix given a density matrix propagator. To illustrate how to use this function, let's consider the :math:`i`-SWAP gate for two qubits. In QuTiP the function :func:`qutip.qip.operations.iswap<qutip.qip.operations.gates.iswap>` generates the unitary transformation for the state kets:
 
 
 .. plot::

--- a/doc/guide/heom/intro.rst
+++ b/doc/guide/heom/intro.rst
@@ -40,4 +40,4 @@ In addition to support for bosonic environments, QuTiP also provides support for
 feriomic environments which is described in :doc:`fermionic`.
 
 Both bosonic and fermionic environments are supported via a single solver,
-:class:`HEOMSolver`, that supports solving for both dynamics and steady-states.
+:class:`~qutip.nonmarkov.heom.HEOMSolver`, that supports solving for both dynamics and steady-states.

--- a/doc/guide/qip/qip-basics.rst
+++ b/doc/guide/qip/qip-basics.rst
@@ -331,4 +331,4 @@ There are two different ways to simulate the action of quantum circuits using Qu
 
 - A different method of circuit simulation employs driving Hamiltonians with the ability to
   simulate circuits in the presence of noise. This can be achieved through the various classes
-  in :class:`qutip.qip.device`.A short guide to processors for QIP simulation can be found at :ref:`qip_processor`.
+  in :class:`qutip.qip.device`. A short guide to processors for QIP simulation can be found at :ref:`qip_processor`.

--- a/doc/guide/qip/qip-basics.rst
+++ b/doc/guide/qip/qip-basics.rst
@@ -7,7 +7,7 @@ Quantum Information Processing
 Introduction
 ============
 
-The Quantum Information Processing (QIP) module aims at providing basic tools for quantum computing simulation both for simple quantum algorithm design and for experimental realization. It offers two different approaches, one with :class:`~qutip.qip.QubitCircuit` calculating unitary evolution under quantum gates by matrix product, another called :class:`~qutip.qip.device.Processor` using open system solvers in QuTiP to simulate noisy quantum device.
+The Quantum Information Processing (QIP) module aims at providing basic tools for quantum computing simulation both for simple quantum algorithm design and for experimental realization. It offers two different approaches, one with :class:`~qutip.qip.circuit.QubitCircuit` calculating unitary evolution under quantum gates by matrix product, another called :class:`~qutip.qip.device.Processor` using open system solvers in QuTiP to simulate noisy quantum device.
 
 .. _quantum_circuits:
 
@@ -15,7 +15,7 @@ Quantum Circuit
 ===============
 
 The most common model for quantum computing is the quantum circuit model.
-In QuTiP, we use :class:`~qutip.qip.QubitCircuit` to represent a quantum circuit.
+In QuTiP, we use :class:`~qutip.qip.circuit.QubitCircuit` to represent a quantum circuit.
 The circuit is characterized by registers and gates:
 
 - **Registers**: The argument ``N`` specifies the number of qubit registers in the circuit
@@ -28,7 +28,7 @@ The circuit is characterized by registers and gates:
   with the argument ``classical_controls``.
 
 - **Measurements**: We can also carry out measurements on individual qubit (both in the middle and at the end of the circuit).
-  Each measurement is saved as a class object :class:`~qutip.qip.Measurement` with parameters such as `targets`,
+  Each measurement is saved as a class object :class:`~qutip.qip.circuit.Measurement` with parameters such as `targets`,
   the target qubit on which the measurement will be carried out, and `classical_store`,
   the index of the classical register which stores the result of the measurement.
 
@@ -177,7 +177,7 @@ Gate name                           Description
 "GLOBALPHASE"         Global phase
 ====================  ========================================
 
-For some of the gates listed above, :class:`~qutip.qip.QubitCircuit` also has a primitive :func:`~qutip.qip.QubitCircuit.resolve_gates()` method that decomposes them into elementary gate sets such as CNOT or SWAP with single-qubit gates (RX, RY and RZ). However, this method is not fully optimized. It is very likely that the depth of the circuit can be further reduced by merging quantum gates. It is required that the gate resolution be carried out before the measurements to the circuit are added.
+For some of the gates listed above, :class:`~qutip.qip.circuit.QubitCircuit` also has a primitive :func:`~qutip.qip.circuit.QubitCircuit.resolve_gates()` method that decomposes them into elementary gate sets such as CNOT or SWAP with single-qubit gates (RX, RY and RZ). However, this method is not fully optimized. It is very likely that the depth of the circuit can be further reduced by merging quantum gates. It is required that the gate resolution be carried out before the measurements to the circuit are added.
 
 **Custom Gates**
 
@@ -326,9 +326,9 @@ There are two different ways to simulate the action of quantum circuits using Qu
 
 - The first method utilizes unitary application through matrix products on the input states.
   This method simulates circuits exactly in a deterministic manner. This is achieved through
-  :class:`~qutip.qip.CircuitSimulator`. A short guide to exact simulation can be
+  :class:`~qutip.qip.circuit.CircuitSimulator`. A short guide to exact simulation can be
   found at :ref:`qip_simulator`. The teleportation notebook is also useful as an example.
 
 - A different method of circuit simulation employs driving Hamiltonians with the ability to
   simulate circuits in the presence of noise. This can be achieved through the various classes
-  in :class:`~qutip.qip.device`.A short guide to processors for QIP simulation can be found at :ref:`qip_processor`.
+  in :class:`qutip.qip.device`.A short guide to processors for QIP simulation can be found at :ref:`qip_processor`.

--- a/doc/guide/qip/qip-processor.rst
+++ b/doc/guide/qip/qip-processor.rst
@@ -217,7 +217,7 @@ It is called implicitly when calling the method
 Here we first use :meth:`~qutip.qip.circuit.QubitCircuit.resolve_gates`
 to decompose the X gate to its natural gate on Spin Chain model,
 the rotation over X-axis.
-We pass the hardware parameters of the :class:`~qutip.qip.device.SpinChain `` model, ``processor.params``, as well as a map between the pulse name and pulse index ``pulse_dict`` to the compiler.
+We pass the hardware parameters of the :class:`~qutip.qip.device.SpinChain` model, ``processor.params``, as well as a map between the pulse name and pulse index ``pulse_dict`` to the compiler.
 The later one allows one to address the pulse more conveniently in the compiler.
 
 The compiler returns a list of ``tlist`` and ``coeff``, corresponding to each pulse.
@@ -273,7 +273,7 @@ repeats the scheduling a few times to get a better result.
 The result shows the scheduling order of each gate in the original circuit.
 
 For pulse schedule, or scheduling gates with different duration,
-one will need to wrap the :class:`qutip.qip.circuit.Gate` object with :class:`qutip.qip.compiler.instruction` object,
+one will need to wrap the :class:`qutip.qip.Gate` object with :class:`qutip.qip.compiler.Instruction` object,
 with a parameter `duration`.
 The result will then be the start time of each instruction.
 

--- a/doc/guide/qip/qip-simulator.rst
+++ b/doc/guide/qip/qip-simulator.rst
@@ -134,9 +134,9 @@ outputs, we can use the :meth:`~qutip.qip.circuit.QubitCircuit.run_statistics` f
     [0.]]
     with probability 0.33333485891662384
 
-The function returns a :class:`~qutip.qip.Result` object which contains
+The function returns a :class:`~qutip.qip.circuit.CircuitResult` object which contains
 the output states.
-The method :meth:`~qutip.qip.Result.get_results` can be used to obtain the
+The method :meth:`~qutip.qip.circuit.QubitCircuit.run_statistics` can be used to obtain the
 possible states and probabilities.
 Since the state created by the circuit is the W-state, we observe the states
 :math:`\ket{001}`,  :math:`\ket{010}` and :math:`\ket{100}` with equal probability.

--- a/qutip/bloch_redfield.py
+++ b/qutip/bloch_redfield.py
@@ -239,15 +239,15 @@ def bloch_redfield_solve(R, ekets, rho0, tlist, e_ops=[], options=None, progress
     e_ops : list of :class:`qutip.qobj` / callback function
         List of operators for which to evaluate expectation values.
 
-    options : :class:`qutip.Qdeoptions`
+    options : :class:`qutip.solver.Options`
         Options for the ODE solver.
 
     Returns
     -------
 
-    output: :class:`qutip.solver`
+    output: :class:`qutip.solver.Result`
 
-        An instance of the class :class:`qutip.solver`, which contains either
+        An instance of the class :class:`qutip.solver.Result`, which contains either
         an *array* of expectation values for the times specified by `tlist`.
 
     """

--- a/qutip/continuous_variables.py
+++ b/qutip/continuous_variables.py
@@ -222,7 +222,7 @@ def wigner_covariance_matrix(a1=None, a2=None, R=None, rho=None, g=np.sqrt(2)):
 def logarithmic_negativity(V, g=np.sqrt(2)):
     """
     Calculates the logarithmic negativity given a symmetrized covariance
-    matrix, see :func:`qutip.continous_variables.covariance_matrix`. Note that
+    matrix, see :func:`qutip.continuous_variables.covariance_matrix`. Note that
     the two-mode field state that is described by `V` must be Gaussian for this
     function to applicable.
 

--- a/qutip/control/dump.py
+++ b/qutip/control/dump.py
@@ -229,7 +229,7 @@ class OptimDump(Dump):
     dump_summary : bool
         When True summary items are appended to the iter_summary
 
-    iter_summary : list of :class:`optimizer.OptimIterSummary`
+    iter_summary : list of :class:`qutip.control.optimizer.OptimIterSummary`
         Summary at each iteration
 
     dump_fid_err : bool

--- a/qutip/control/dynamics.py
+++ b/qutip/control/dynamics.py
@@ -326,7 +326,7 @@ class Dynamics(object):
         Tolerance used in checking if operator is unitary
         Default is 1e-10
 
-    dump : :class:`dump.DynamicsDump`
+    dump : :class:`qutip.control.dump.DynamicsDump`
         Store of historical calculation data.
         Set to None (Default) for no storing of historical data
         Use dumping property to set level of data dumping

--- a/qutip/control/optimizer.py
+++ b/qutip/control/optimizer.py
@@ -204,7 +204,7 @@ class Optimizer(object):
         set to None to reduce overhead of calculating stats.
         Note it is (usually) shared with the Dynamics instance
 
-    dump : :class:`dump.OptimDump`
+    dump : :class:`qutip.control.dump.OptimDump`
         Container for data dumped during the optimisation.
         Can be set by specifying the dumping level or set directly.
         Note this is mainly intended for user and a development debugging

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -202,7 +202,7 @@ def optimize_pulse(
 
     method_params : dict
         Parameters for the ``optim_method``.  Note that where there is an
-        attribute of the :obj:`~Optimizer` object or the termination_conditions
+        attribute of the :obj:`~qutip.control.optimizer.Optimizer` object or the termination_conditions
         matching the key that attribute. Otherwise, and in some case also, they
         are assumed to be method_options for the ``scipy.optimize.minimize``
         method.
@@ -218,11 +218,11 @@ def optimize_pulse(
 
     dyn_type : string
         Dynamics type, i.e. the type of matrix used to describe the dynamics.
-        Options are ``UNIT``, ``GEN_MAT``, ``SYMPL`` (see :obj:`~Dynamics`
+        Options are ``UNIT``, ``GEN_MAT``, ``SYMPL`` (see :obj:`~qutip.control.dynamics.Dynamics`
         classes for details).
 
     dyn_params : dict
-        Parameters for the :obj:`~Dynamics` object.  The key value pairs are
+        Parameters for the :obj:`~qutip.control.dynamics.Dynamics` object.  The key value pairs are
         assumed to be attribute name value pairs.  They applied after the
         object is created.
 
@@ -271,7 +271,7 @@ def optimize_pulse(
     init_pulse_type : string
         Type / shape of pulse(s) used to initialise the control amplitudes.
         Options (GRAPE) include: RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW.
-        Default is RND.  (see :obj:`~PulseGen` classes for details.) For the
+        Default is RND.  (see :obj:`~qutip.control.pulsegen.PulseGen` classes for details.) For the
         CRAB the this the ``guess_pulse_type``.
 
     init_pulse_params : dict
@@ -320,7 +320,7 @@ def optimize_pulse(
     Returns
     -------
     opt : OptimResult
-        Returns instance of :obj:`~OptimResult`, which has attributes giving
+        Returns instance of :obj:`~qutip.control.optimresult.OptimResult`, which has attributes giving
         the reason for termination, final fidelity error, final evolution final
         amplitudes, statistics etc.
     """
@@ -581,7 +581,7 @@ def optimize_pulse_unitary(
 
     method_params : dict
         Parameters for the ``optim_method``.  Note that where there is an
-        attribute of the :obj:`~Optimizer` object or the
+        attribute of the :obj:`~qutip.control.optimizer.Optimizer` object or the
         ``termination_conditions`` matching the key that attribute. Otherwise,
         and in some case also, they are assumed to be method_options for the
         ``scipy.optimize.minimize`` method.
@@ -603,7 +603,7 @@ def optimize_pulse_unitary(
         - SU - global phase included
 
     dyn_params : dict
-        Parameters for the :obj:`~Dynamics` object.  The key value pairs are
+        Parameters for the :obj:`~qutip.control.dynamics.Dynamics` object.  The key value pairs are
         assumed to be attribute name value pairs.  They applied after the
         object is created.
 
@@ -634,7 +634,7 @@ def optimize_pulse_unitary(
     init_pulse_type : string
         Type / shape of pulse(s) used to initialise the control amplitudes.
         Options (GRAPE) include: RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW.
-        DEF is RND.  (see :obj:`~PulseGen` classes for details.) For the CRAB
+        DEF is RND.  (see :obj:`~qutip.control.pulsegen.PulseGen` classes for details.) For the CRAB
         the this the guess_pulse_type.
 
     init_pulse_params : dict
@@ -683,7 +683,7 @@ def optimize_pulse_unitary(
     Returns
     -------
     opt : OptimResult
-        Returns instance of :obj:`~OptimResult`, which has attributes giving
+        Returns instance of :obj:`~qutip.control.optimresult.OptimResult`, which has attributes giving
         the reason for termination, final fidelity error, final evolution final
         amplitudes, statistics etc.
     """
@@ -864,7 +864,7 @@ def opt_pulse_crab(
 
     method_params : dict
         Parameters for the optim_method.  Note that where there is an attribute
-        of the :obj:`~Optimizer` object or the termination_conditions matching
+        of the :class:`~qutip.control.optimizer.Optimizer` object or the termination_conditions matching
         the key that attribute. Otherwise, and in some case also, they are
         assumed to be method_options for the ``scipy.optimize.minimize``
         method.  The commonly used parameter are:
@@ -877,7 +877,7 @@ def opt_pulse_crab(
         Options are UNIT, GEN_MAT, SYMPL (see Dynamics classes for details).
 
     dyn_params : dict
-        Parameters for the Dynamics object.  The key value pairs are assumed to
+        Parameters for the :class:`qutip.control.dynamics.Dynamics` object.  The key value pairs are assumed to
         be attribute name value pairs.  They applied after the object is
         created.
 
@@ -1138,7 +1138,7 @@ def opt_pulse_crab_unitary(
 
     method_params : dict
         Parameters for the ``optim_method``.  Note that where there is an
-        attribute of the :obj:`~Optimizer` object or the termination_conditions
+        attribute of the :obj:`~qutip.control.optimizer.Optimizer` object or the termination_conditions
         matching the key that attribute. Otherwise, and in some case also, they
         are assumed to be method_options for the ``scipy.optimize.minimize``
         method.  The commonly used parameter are:
@@ -1154,7 +1154,7 @@ def opt_pulse_crab_unitary(
         - SU - global phase included
 
     dyn_params : dict
-        Parameters for the :obj:`~Dynamics` object.  The key value pairs are
+        Parameters for the :obj:`~qutip.control.dynamics.Dynamics` object.  The key value pairs are
         assumed to be attribute name value pairs.  They applied after the
         object is created.
 
@@ -1233,7 +1233,7 @@ def opt_pulse_crab_unitary(
     Returns
     -------
     opt : OptimResult
-        Returns instance of :obj:`~OptimResult`, which has attributes giving
+        Returns instance of :obj:`~qutip.control.optimresult.OptimResult`, which has attributes giving
         the reason for termination, final fidelity error, final evolution final
         amplitudes, statistics etc.
     """
@@ -1403,7 +1403,7 @@ def create_pulse_optimizer(
     method_params : dict
         Parameters for the optim_method.
         Note that where there is an attribute of the
-        :class:`qutip.control.optimizer.Optimizer` object or the termination_conditions matching the key
+        :class:`~qutip.control.optimizer.Optimizer` object or the termination_conditions matching the key
         that attribute. Otherwise, and in some case also,
         they are assumed to be method_options
         for the scipy.optimize.minimize method.
@@ -1464,9 +1464,9 @@ def create_pulse_optimizer(
         (See TimeslotComputer classes for details)
 
     tslot_params : dict
-        Parameters for the TimeslotComputer object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the TimeslotComputer object.
+        The key value pairs are assumed to be attribute name value pairs.
+        They applied after the object is created.
 
     amp_update_mode : string
         Deprecated. Use tslot_type instead.
@@ -1483,9 +1483,9 @@ def create_pulse_optimizer(
         For the CRAB the this the guess_pulse_type.
 
     init_pulse_params : dict
-        Parameters for the initial / guess pulse generator object
-        The key value pairs are assumed to be attribute name value pairs
-        They applied after the object is created
+        Parameters for the initial / guess pulse generator object.
+        The key value pairs are assumed to be attribute name value pairs.
+        They applied after the object is created.
 
     pulse_scaling : float
         Linear scale factor for generated initial / guess pulses
@@ -1504,8 +1504,8 @@ def create_pulse_optimizer(
         GAUSSIAN_EDGE was added for this purpose.
 
     ramping_pulse_params : dict
-        Parameters for the ramping pulse generator object
-        The key value pairs are assumed to be attribute name value pairs
+        Parameters for the ramping pulse generator object.
+        The key value pairs are assumed to be attribute name value pairs.
         They applied after the object is created
 
     log_level : integer

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -230,21 +230,21 @@ def optimize_pulse(
         Propagator type i.e. the method used to calculate the propagators and
         propagator gradient for each timeslot options are DEF, APPROX, DIAG,
         FRECHET, AUG_MAT.  DEF will use the default for the specific
-        ``dyn_type`` (see :obj:`~PropagatorComputer` classes for details).
+        ``dyn_type`` (see :obj:`~qutip.control.propcomp.PropagatorComputer` classes for details).
 
     prop_params : dict
-        Parameters for the :obj:`~PropagatorComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
     fid_type : string
         Fidelity error (and fidelity error gradient) computation method.
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX.  DEF will use the default
-        for the specific ``dyn_type`` (See :obj:`~FidelityComputer` classes for
+        for the specific ``dyn_type`` (See :obj:`~qutip.control.fidcomp.FidelityComputer` classes for
         details).
 
     fid_params : dict
-        Parameters for the :obj:`~FidelityComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
@@ -257,11 +257,11 @@ def optimize_pulse(
     tslot_type : string
         Method for computing the dynamics generators, propagators and evolution
         in the timeslots.  Options: DEF, UPDATE_ALL, DYNAMIC.  UPDATE_ALL is
-        the only one that currently works.  (See :obj:`~TimeslotComputer`
+        the only one that currently works.  (See :obj:`~qutip.control.tslotcomp.TimeslotComputer`
         classes for details.)
 
     tslot_params : dict
-        Parameters for the :obj:`~TimeslotComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
@@ -608,12 +608,12 @@ def optimize_pulse_unitary(
         object is created.
 
     prop_params : dict
-        Parameters for the :obj:`~PropagatorComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
     fid_params : dict
-        Parameters for the :obj:`~FidelityComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
@@ -621,10 +621,10 @@ def optimize_pulse_unitary(
         Method for computing the dynamics generators, propagators and evolution
         in the timeslots.  Options: ``DEF``, ``UPDATE_ALL``, ``DYNAMIC``.
         ``UPDATE_ALL`` is the only one that currently works.  (See
-        :obj:`~TimeslotComputer` classes for details.)
+        :obj:`~qutip.control.tslotcomp.TimeslotComputer` classes for details.)
 
     tslot_params : dict
-        Parameters for the :obj:`~TimeslotComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
@@ -885,32 +885,32 @@ def opt_pulse_crab(
         Propagator type i.e. the method used to calculate the propagtors and
         propagtor gradient for each timeslot options are DEF, APPROX, DIAG,
         FRECHET, AUG_MAT DEF will use the default for the specific dyn_type
-        (see :obj:`~PropagatorComputer` classes for details).
+        (see :obj:`~qutip.control.propcomp.PropagatorComputer` classes for details).
 
     prop_params : dict
-        Parameters for the :obj:`~PropagatorComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
     fid_type : string
         Fidelity error (and fidelity error gradient) computation method.
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX.  DEF will use the default
-        for the specific dyn_type.  (See :obj:`~FidelityComputer` classes for
+        for the specific dyn_type.  (See :obj:`~qutip.control.fidcomp.FidelityComputer` classes for
         details).
 
     fid_params : dict
-        Parameters for the :obj:`~FidelityComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
     tslot_type : string
         Method for computing the dynamics generators, propagators and evolution
         in the timeslots.  Options: DEF, UPDATE_ALL, DYNAMIC UPDATE_ALL is the
-        only one that currently works.  (See :obj:`~TimeslotComputer` classes
+        only one that currently works.  (See :obj:`~qutip.control.tslotcomp.TimeslotComputer` classes
         for details).
 
     tslot_params : dict
-        Parameters for the :obj:`~TimeslotComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
@@ -1159,23 +1159,23 @@ def opt_pulse_crab_unitary(
         object is created.
 
     prop_params : dict
-        Parameters for the :obj:`~PropagatorComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
     fid_params : dict
-        Parameters for the :obj:`~FidelityComputer` object.  The key value
+        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer` object.  The key value
         pairs are assumed to be attribute name value pairs.  They applied after
         the object is created.
 
     tslot_type : string
         Method for computing the dynamics generators, propagators and evolution
         in the timeslots.  Options: DEF, UPDATE_ALL, DYNAMIC.  UPDATE_ALL is
-        the only one that currently works.  (See :obj:`~TimeslotComputer`
+        the only one that currently works.  (See :obj:`~qutip.control.tslotcomp.TimeslotComputer`
         classes for details).
 
     tslot_params : dict
-        Parameters for the :obj:`~TimeslotComputer` object The key value pairs
+        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer` object The key value pairs
         are assumed to be attribute name value pairs. They applied after the
         object is created.
 
@@ -1403,7 +1403,7 @@ def create_pulse_optimizer(
     method_params : dict
         Parameters for the optim_method.
         Note that where there is an attribute of the
-        Optimizer object or the termination_conditions matching the key
+        :class:`qutip.control.optimizer.Optimizer` object or the termination_conditions matching the key
         that attribute. Otherwise, and in some case also,
         they are assumed to be method_options
         for the scipy.optimize.minimize method.

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -889,7 +889,7 @@ def opt_pulse_crab(
         Propagator type i.e. the method used to calculate the propagtors and
         propagtor gradient for each timeslot options are DEF, APPROX, DIAG,
         FRECHET, AUG_MAT DEF will use the default for the specific dyn_type
-        (see :obj:`~qutip.control.propcomp.PropagatorComputer` classes for 
+        (see :obj:`~qutip.control.propcomp.PropagatorComputer` classes for
         details).
 
     prop_params : dict

--- a/qutip/control/pulseoptim.py
+++ b/qutip/control/pulseoptim.py
@@ -202,10 +202,10 @@ def optimize_pulse(
 
     method_params : dict
         Parameters for the ``optim_method``.  Note that where there is an
-        attribute of the :obj:`~qutip.control.optimizer.Optimizer` object or the termination_conditions
-        matching the key that attribute. Otherwise, and in some case also, they
-        are assumed to be method_options for the ``scipy.optimize.minimize``
-        method.
+        attribute of the :obj:`~qutip.control.optimizer.Optimizer` object or
+        the termination_conditions matching the key that attribute.
+        Otherwise, and in some case also, they are assumed to be method_options
+        for the ``scipy.optimize.minimize`` method.
 
     optim_alg : string
         Deprecated. Use ``optim_method``.
@@ -218,35 +218,37 @@ def optimize_pulse(
 
     dyn_type : string
         Dynamics type, i.e. the type of matrix used to describe the dynamics.
-        Options are ``UNIT``, ``GEN_MAT``, ``SYMPL`` (see :obj:`~qutip.control.dynamics.Dynamics`
-        classes for details).
+        Options are ``UNIT``, ``GEN_MAT``, ``SYMPL``
+        (see :obj:`~qutip.control.dynamics.Dynamics` classes for details).
 
     dyn_params : dict
-        Parameters for the :obj:`~qutip.control.dynamics.Dynamics` object.  The key value pairs are
-        assumed to be attribute name value pairs.  They applied after the
-        object is created.
+        Parameters for the :obj:`~qutip.control.dynamics.Dynamics` object.
+        The key value pairs are assumed to be attribute name value pairs.
+        They applied after the object is created.
 
     prop_type : string
         Propagator type i.e. the method used to calculate the propagators and
         propagator gradient for each timeslot options are DEF, APPROX, DIAG,
         FRECHET, AUG_MAT.  DEF will use the default for the specific
-        ``dyn_type`` (see :obj:`~qutip.control.propcomp.PropagatorComputer` classes for details).
+        ``dyn_type`` (see :obj:`~qutip.control.propcomp.PropagatorComputer`
+        classes for details).
 
     prop_params : dict
-        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs.  They applied after the object is created.
 
     fid_type : string
         Fidelity error (and fidelity error gradient) computation method.
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX.  DEF will use the default
-        for the specific ``dyn_type`` (See :obj:`~qutip.control.fidcomp.FidelityComputer` classes for
+        for the specific ``dyn_type``
+        (See :obj:`~qutip.control.fidcomp.FidelityComputer` classes for
         details).
 
     fid_params : dict
-        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs.  They applied after the object is created.
 
     phase_option : string
         Deprecated. Pass in ``fid_params`` instead.
@@ -257,13 +259,14 @@ def optimize_pulse(
     tslot_type : string
         Method for computing the dynamics generators, propagators and evolution
         in the timeslots.  Options: DEF, UPDATE_ALL, DYNAMIC.  UPDATE_ALL is
-        the only one that currently works.  (See :obj:`~qutip.control.tslotcomp.TimeslotComputer`
-        classes for details.)
+        the only one that currently works.
+        (See :obj:`~qutip.control.tslotcomp.TimeslotComputer` classes for
+        details.)
 
     tslot_params : dict
-        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs. They applied after the object is created.
 
     amp_update_mode : string
         Deprecated. Use ``tslot_type`` instead.
@@ -271,8 +274,8 @@ def optimize_pulse(
     init_pulse_type : string
         Type / shape of pulse(s) used to initialise the control amplitudes.
         Options (GRAPE) include: RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW.
-        Default is RND.  (see :obj:`~qutip.control.pulsegen.PulseGen` classes for details.) For the
-        CRAB the this the ``guess_pulse_type``.
+        Default is RND. (see :obj:`~qutip.control.pulsegen.PulseGen` classes
+        for details). For the CRAB the this the ``guess_pulse_type``.
 
     init_pulse_params : dict
         Parameters for the initial / guess pulse generator object.
@@ -320,9 +323,9 @@ def optimize_pulse(
     Returns
     -------
     opt : OptimResult
-        Returns instance of :obj:`~qutip.control.optimresult.OptimResult`, which has attributes giving
-        the reason for termination, final fidelity error, final evolution final
-        amplitudes, statistics etc.
+        Returns instance of :obj:`~qutip.control.optimresult.OptimResult`,
+        which has attributes giving the reason for termination, final fidelity
+        error, final evolution final amplitudes, statistics etc.
     """
     if log_level == logging.NOTSET:
         log_level = logger.getEffectiveLevel()
@@ -581,10 +584,10 @@ def optimize_pulse_unitary(
 
     method_params : dict
         Parameters for the ``optim_method``.  Note that where there is an
-        attribute of the :obj:`~qutip.control.optimizer.Optimizer` object or the
-        ``termination_conditions`` matching the key that attribute. Otherwise,
-        and in some case also, they are assumed to be method_options for the
-        ``scipy.optimize.minimize`` method.
+        attribute of the :obj:`~qutip.control.optimizer.Optimizer` object or
+        the ``termination_conditions`` matching the key that attribute.
+        Otherwise, and in some case also, they are assumed to be
+        method_options for the ``scipy.optimize.minimize`` method.
 
     optim_alg : string
         Deprecated. Use ``optim_method``.
@@ -603,19 +606,19 @@ def optimize_pulse_unitary(
         - SU - global phase included
 
     dyn_params : dict
-        Parameters for the :obj:`~qutip.control.dynamics.Dynamics` object.  The key value pairs are
-        assumed to be attribute name value pairs.  They applied after the
-        object is created.
+        Parameters for the :obj:`~qutip.control.dynamics.Dynamics` object.
+        The key value pairs are assumed to be attribute name value pairs.
+        They applied after the object is created.
 
     prop_params : dict
-        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs.  They applied after the object is created.
 
     fid_params : dict
-        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs.  They applied after the object is created.
 
     tslot_type : string
         Method for computing the dynamics generators, propagators and evolution
@@ -624,9 +627,9 @@ def optimize_pulse_unitary(
         :obj:`~qutip.control.tslotcomp.TimeslotComputer` classes for details.)
 
     tslot_params : dict
-        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs.  They applied after the object is created.
 
     amp_update_mode : string
         Deprecated. Use ``tslot_type`` instead.
@@ -634,8 +637,8 @@ def optimize_pulse_unitary(
     init_pulse_type : string
         Type / shape of pulse(s) used to initialise the control amplitudes.
         Options (GRAPE) include: RND, LIN, ZERO, SINE, SQUARE, TRIANGLE, SAW.
-        DEF is RND.  (see :obj:`~qutip.control.pulsegen.PulseGen` classes for details.) For the CRAB
-        the this the guess_pulse_type.
+        DEF is RND.  (see :obj:`~qutip.control.pulsegen.PulseGen` classes for
+        details.) For the CRAB the this the guess_pulse_type.
 
     init_pulse_params : dict
         Parameters for the initial / guess pulse generator object.  The key
@@ -683,9 +686,9 @@ def optimize_pulse_unitary(
     Returns
     -------
     opt : OptimResult
-        Returns instance of :obj:`~qutip.control.optimresult.OptimResult`, which has attributes giving
-        the reason for termination, final fidelity error, final evolution final
-        amplitudes, statistics etc.
+        Returns instance of :obj:`~qutip.control.optimresult.OptimResult`,
+        which has attributes giving the reason for termination, final fidelity
+        error, final evolution final amplitudes, statistics etc.
     """
 
     # parameters are checked in create pulse optimiser
@@ -749,7 +752,8 @@ def optimize_pulse_unitary(
             optim_method=optim_method, method_params=method_params,
             dyn_type='UNIT', dyn_params=dyn_params,
             prop_params=prop_params, fid_params=fid_params,
-            init_pulse_type=init_pulse_type, init_pulse_params=init_pulse_params,
+            init_pulse_type=init_pulse_type,
+            init_pulse_params=init_pulse_params,
             pulse_scaling=pulse_scaling, pulse_offset=pulse_offset,
             ramping_pulse_type=ramping_pulse_type,
             ramping_pulse_params=ramping_pulse_params,
@@ -864,10 +868,10 @@ def opt_pulse_crab(
 
     method_params : dict
         Parameters for the optim_method.  Note that where there is an attribute
-        of the :class:`~qutip.control.optimizer.Optimizer` object or the termination_conditions matching
-        the key that attribute. Otherwise, and in some case also, they are
-        assumed to be method_options for the ``scipy.optimize.minimize``
-        method.  The commonly used parameter are:
+        of the :class:`~qutip.control.optimizer.Optimizer` object or the
+        termination_conditions matching the key that attribute. Otherwise,
+        and in some case also, they are assumed to be method_options for the
+        ``scipy.optimize.minimize`` method.  The commonly used parameter are:
 
         - xtol - limit on variable change for convergence
         - ftol - limit on fidelity error change for convergence
@@ -877,42 +881,45 @@ def opt_pulse_crab(
         Options are UNIT, GEN_MAT, SYMPL (see Dynamics classes for details).
 
     dyn_params : dict
-        Parameters for the :class:`qutip.control.dynamics.Dynamics` object.  The key value pairs are assumed to
-        be attribute name value pairs.  They applied after the object is
-        created.
+        Parameters for the :class:`qutip.control.dynamics.Dynamics` object.
+        The key value pairs are assumed to be attribute name value pairs.
+        They applied after the object is created.
 
     prop_type : string
         Propagator type i.e. the method used to calculate the propagtors and
         propagtor gradient for each timeslot options are DEF, APPROX, DIAG,
         FRECHET, AUG_MAT DEF will use the default for the specific dyn_type
-        (see :obj:`~qutip.control.propcomp.PropagatorComputer` classes for details).
+        (see :obj:`~qutip.control.propcomp.PropagatorComputer` classes for 
+        details).
 
     prop_params : dict
-        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs. They applied after the object is created.
 
     fid_type : string
         Fidelity error (and fidelity error gradient) computation method.
         Options are DEF, UNIT, TRACEDIFF, TD_APPROX.  DEF will use the default
-        for the specific dyn_type.  (See :obj:`~qutip.control.fidcomp.FidelityComputer` classes for
+        for the specific dyn_type.
+        (See :obj:`~qutip.control.fidcomp.FidelityComputer` classes for
         details).
 
     fid_params : dict
-        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs. They applied after the object is created.
 
     tslot_type : string
         Method for computing the dynamics generators, propagators and evolution
         in the timeslots.  Options: DEF, UPDATE_ALL, DYNAMIC UPDATE_ALL is the
-        only one that currently works.  (See :obj:`~qutip.control.tslotcomp.TimeslotComputer` classes
+        only one that currently works.
+        (See :obj:`~qutip.control.tslotcomp.TimeslotComputer` classes
         for details).
 
     tslot_params : dict
-        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs. They applied after the object is created.
 
     guess_pulse_type : string, default None
         Type / shape of pulse(s) used modulate the control amplitudes.
@@ -1138,10 +1145,10 @@ def opt_pulse_crab_unitary(
 
     method_params : dict
         Parameters for the ``optim_method``.  Note that where there is an
-        attribute of the :obj:`~qutip.control.optimizer.Optimizer` object or the termination_conditions
-        matching the key that attribute. Otherwise, and in some case also, they
-        are assumed to be method_options for the ``scipy.optimize.minimize``
-        method.  The commonly used parameter are:
+        attribute of the :obj:`~qutip.control.optimizer.Optimizer` object or
+        the termination_conditions matching the key that attribute. Otherwise,
+        and in some case also, they are assumed to be method_options for the
+        ``scipy.optimize.minimize`` method.  The commonly used parameter are:
 
         - xtol - limit on variable change for convergence
         - ftol - limit on fidelity error change for convergence
@@ -1154,30 +1161,31 @@ def opt_pulse_crab_unitary(
         - SU - global phase included
 
     dyn_params : dict
-        Parameters for the :obj:`~qutip.control.dynamics.Dynamics` object.  The key value pairs are
-        assumed to be attribute name value pairs.  They applied after the
-        object is created.
+        Parameters for the :obj:`~qutip.control.dynamics.Dynamics` object.
+        The key value pairs are assumed to be attribute name value pairs.
+        They applied after the object is created.
 
     prop_params : dict
-        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.propcomp.PropagatorComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs.  They applied after the object is created.
 
     fid_params : dict
-        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer` object.  The key value
-        pairs are assumed to be attribute name value pairs.  They applied after
-        the object is created.
+        Parameters for the :obj:`~qutip.control.fidcomp.FidelityComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs. They applied after the object is created.
 
     tslot_type : string
         Method for computing the dynamics generators, propagators and evolution
         in the timeslots.  Options: DEF, UPDATE_ALL, DYNAMIC.  UPDATE_ALL is
-        the only one that currently works.  (See :obj:`~qutip.control.tslotcomp.TimeslotComputer`
-        classes for details).
+        the only one that currently works.
+        (See :obj:`~qutip.control.tslotcomp.TimeslotComputer` classes for
+        details).
 
     tslot_params : dict
-        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer` object The key value pairs
-        are assumed to be attribute name value pairs. They applied after the
-        object is created.
+        Parameters for the :obj:`~qutip.control.tslotcomp.TimeslotComputer`
+        object. The key value pairs are assumed to be attribute name value
+        pairs. They applied after the object is created.
 
     guess_pulse_type : string, optional
         Type / shape of pulse(s) used modulate the control amplitudes.
@@ -1233,9 +1241,9 @@ def opt_pulse_crab_unitary(
     Returns
     -------
     opt : OptimResult
-        Returns instance of :obj:`~qutip.control.optimresult.OptimResult`, which has attributes giving
-        the reason for termination, final fidelity error, final evolution final
-        amplitudes, statistics etc.
+        Returns instance of :obj:`~qutip.control.optimresult.OptimResult`,
+        which has attributes giving the reason for termination, final fidelity
+        error, final evolution final amplitudes, statistics etc.
     """
 
     # The parameters are checked in create_pulse_optimizer
@@ -1403,9 +1411,9 @@ def create_pulse_optimizer(
     method_params : dict
         Parameters for the optim_method.
         Note that where there is an attribute of the
-        :class:`~qutip.control.optimizer.Optimizer` object or the termination_conditions matching the key
-        that attribute. Otherwise, and in some case also,
-        they are assumed to be method_options
+        :class:`~qutip.control.optimizer.Optimizer` object or the
+        termination_conditions matching the key that attribute. Otherwise,
+        and in some case also, they are assumed to be method_options
         for the scipy.optimize.minimize method.
 
     optim_alg : string
@@ -1530,8 +1538,9 @@ def create_pulse_optimizer(
         Config, Dynamics, PulseGen, and TerminationConditions objects
         can be accessed as attributes.
         The PropagatorComputer, FidelityComputer and TimeslotComputer objects
-        can be accessed as attributes of the Dynamics object, e.g. optimizer.dynamics.fid_computer
-        The optimisation can be run through the optimizer.run_optimization
+        can be accessed as attributes of the Dynamics object,
+        e.g. optimizer.dynamics.fid_computer The optimisation can be run
+        through the optimizer.run_optimization
 
     """
 

--- a/qutip/eseries.py
+++ b/qutip/eseries.py
@@ -13,8 +13,8 @@ class eseries():
     time-dependent quantum objects.
 
     .. deprecated:: 4.6.0
-        :obj:`~eseries` will be removed in QuTiP 5.  Please use :obj:`~qutip.QobjEvo`
-        for general time-dependence.
+        :obj:`~eseries` will be removed in QuTiP 5.
+        Please use :obj:`~qutip.QobjEvo` for general time-dependence.
 
     Attributes
     ----------

--- a/qutip/eseries.py
+++ b/qutip/eseries.py
@@ -13,7 +13,7 @@ class eseries():
     time-dependent quantum objects.
 
     .. deprecated:: 4.6.0
-        :obj:`~eseries` will be removed in QuTiP 5.  Please use :obj:`~QobjEvo`
+        :obj:`~eseries` will be removed in QuTiP 5.  Please use :obj:`~qutip.QobjEvo`
         for general time-dependence.
 
     Attributes

--- a/qutip/essolve.py
+++ b/qutip/essolve.py
@@ -45,10 +45,10 @@ def essolve(H, rho0, tlist, c_op_list, e_ops):
     expectation values of the supplied operators (`e_ops`).
 
     .. deprecated:: 4.6.0
-        :obj:`~essolve` will be removed in QuTiP 5.  Please use :obj:`~qutip.sesolve`
-        or :obj:`~qutip.mesolve` for general-purpose integration of the
-        Schroedinger/Lindblad master equation.  This will likely be faster than
-        :obj:`~essolve` for you.
+        :obj:`~essolve` will be removed in QuTiP 5.  Please use
+        :obj:`~qutip.sesolve` or :obj:`~qutip.mesolve` for general-purpose
+        integration of the Schroedinger/Lindblad master equation.
+        This will likely be faster than :obj:`~essolve` for you.
 
     Parameters
     ----------
@@ -119,8 +119,8 @@ def ode2es(L, rho0):
 
     .. deprecated:: 4.6.0
         :obj:`~ode2es` will be removed in QuTiP 5.  Please use
-        :obj:`qutip.Qobj.eigenstates` to get the eigenstates and -values, and use
-        :obj:`~qutip.QobjEvo` for general time-dependence.
+        :obj:`qutip.Qobj.eigenstates` to get the eigenstates and -values,
+        and use :obj:`~qutip.QobjEvo` for general time-dependence.
 
     Parameters
     ----------

--- a/qutip/essolve.py
+++ b/qutip/essolve.py
@@ -45,8 +45,8 @@ def essolve(H, rho0, tlist, c_op_list, e_ops):
     expectation values of the supplied operators (`e_ops`).
 
     .. deprecated:: 4.6.0
-        :obj:`~essolev` will be removed in QuTiP 5.  Please use :obj:`~sesolve`
-        or :obj:`~mesolve` for general-purpose integration of the
+        :obj:`~essolve` will be removed in QuTiP 5.  Please use :obj:`~qutip.sesolve`
+        or :obj:`~qutip.mesolve` for general-purpose integration of the
         Schroedinger/Lindblad master equation.  This will likely be faster than
         :obj:`~essolve` for you.
 
@@ -119,8 +119,8 @@ def ode2es(L, rho0):
 
     .. deprecated:: 4.6.0
         :obj:`~ode2es` will be removed in QuTiP 5.  Please use
-        :obj:`Qobj.eigenstates` to get the eigenstates and -values, and use
-        :obj:`~QobjEvo` for general time-dependence.
+        :obj:`qutip.Qobj.eigenstates` to get the eigenstates and -values, and use
+        :obj:`~qutip.QobjEvo` for general time-dependence.
 
     Parameters
     ----------

--- a/qutip/floquet.py
+++ b/qutip/floquet.py
@@ -58,7 +58,7 @@ def floquet_modes(H, T, args=None, sort=False, U=None, options=None):
         If U is `None` (default), it will be calculated from the Hamiltonian
         `H` using :func:`qutip.propagator.propagator`.
 
-    options : :class:`qutip.solver`
+    options : :class:`qutip.solver.Options`
         options for the ODE solver. For the propagator U.
 
     Returns
@@ -128,7 +128,7 @@ def floquet_modes_t(f_modes_0, f_energies, t, H, T, args=None,
     T : float
         The period of the time-dependence of the hamiltonian.
 
-    options : :class:`qutip.solver`
+    options : :class:`qutip.solver.Options`
         options for the ODE solver. For the propagator.
 
     Returns
@@ -183,7 +183,7 @@ def floquet_modes_table(f_modes_0, f_energies, tlist, H, T, args=None,
     args : dictionary
         dictionary with variables required to evaluate H
 
-    options : :class:`qutip.solver`
+    options : :class:`qutip.solver.Options`
         options for the ODE solver.
 
     Returns
@@ -310,7 +310,7 @@ def floquet_states_t(f_modes_0, f_energies, t, H, T, args=None,
     args : dictionary
         Dictionary with variables required to evaluate H.
 
-    options : :class:`qutip.solver`
+    options : :class:`qutip.solver.Options`
         options for the ODE solver.
 
     Returns
@@ -443,7 +443,7 @@ def fsesolve(H, psi0, tlist, e_ops=[], T=None, args={}, Tsteps=100,
     Parameters
     ----------
 
-    H : :class:`qutip.qobj.Qobj`
+    H : :class:`qutip.Qobj`
         System Hamiltonian, time-dependent with period `T`.
 
     psi0 : :class:`qutip.qobj`
@@ -467,7 +467,7 @@ def fsesolve(H, psi0, tlist, e_ops=[], T=None, args={}, Tsteps=100,
         The number of time steps in one driving period for which to
         precalculate the Floquet modes. `Tsteps` should be an even number.
 
-    options_modes : :class:`qutip.solver`
+    options_modes : :class:`qutip.solver.Options`
         options for the ODE solver.
 
     Returns
@@ -589,7 +589,7 @@ def floquet_master_equation_rates(f_modes_0, f_energies, c_op, H, T,
         A lookup-table of Floquet modes at times precalculated by
         :func:`qutip.floquet.floquet_modes_table` (optional).
 
-    options : :class:`qutip.solver`
+    options : :class:`qutip.solver.Options`
         options for the ODE solver.
 
     Returns
@@ -784,7 +784,7 @@ def floquet_markov_mesolve(
     e_ops : list of :class:`qutip.qobj` / callback function
         list of operators for which to evaluate expectation values.
 
-    options : :class:`qutip.solver`
+    options : :class:`qutip.solver.Options`
         options for the ODE solver.
 
     floquet_basis: bool, True
@@ -974,7 +974,7 @@ def fmmesolve(H, rho0, tlist, c_ops=[], e_ops=[], spectra_cb=[], T=None,
         >>> args['w_th'] = temperature * (kB / h) * 2 * pi * 1e-9 \
             #doctest: +SKIP
 
-    options : :class:`qutip.solver`
+    options : :class:`qutip.solver.Options`
         options for the ODE solver. For solving the master equation.
 
     floquet_basis : bool
@@ -984,15 +984,15 @@ def fmmesolve(H, rho0, tlist, c_ops=[], e_ops=[], spectra_cb=[], T=None,
     k_max : int
         The truncation of the number of sidebands (default 5).
 
-    options_modes : :class:`qutip.solver`
+    options_modes : :class:`qutip.solver.Options`
         options for the ODE solver. For computing Floquet modes.
 
     Returns
     -------
 
-    output : :class:`qutip.solver`
+    output : :class:`qutip.solver.Result`
 
-        An instance of the class :class:`qutip.solver`, which contains either
+        An instance of the class :class:`qutip.solver.Result`, which contains either
         an *array* of expectation values for the times specified by `tlist`.
     """
 

--- a/qutip/floquet.py
+++ b/qutip/floquet.py
@@ -992,8 +992,9 @@ def fmmesolve(H, rho0, tlist, c_ops=[], e_ops=[], spectra_cb=[], T=None,
 
     output : :class:`qutip.solver.Result`
 
-        An instance of the class :class:`qutip.solver.Result`, which contains either
-        an *array* of expectation values for the times specified by `tlist`.
+        An instance of the class :class:`qutip.solver.Result`, which contains
+        either an *array* of expectation values for the times specified
+        by `tlist`.
     """
 
     if _safe_mode:

--- a/qutip/krylovsolve.py
+++ b/qutip/krylovsolve.py
@@ -76,8 +76,8 @@ def krylovsolve(
 
     Returns
     -------
-    result: :class:`qutip.Result`
-        An instance of the class :class:`qutip.Result`, which contains
+    result: :class:`qutip.solver.Result`
+        An instance of the class :class:`qutip.solver.Result`, which contains
         either an *array* `result.expect` of expectation values for the times
         `tlist`, or an *array* `result.states` of state vectors corresponding
         to the times `tlist` [if `e_ops` is an empty list].

--- a/qutip/measurement.py
+++ b/qutip/measurement.py
@@ -131,8 +131,8 @@ def measurement_statistics_povm(state, ops, targets=None):
 
     targets : list of ints, optional
               Specifies a list of target "qubit" indices on which to apply
-              the measurement using qutip.qip.operations.gates.expand_operator to expand
-              ops into full dimension.
+              the measurement using qutip.qip.operations.gates.expand_operator
+              to expand ops into full dimension.
 
 
     Returns
@@ -182,8 +182,8 @@ def measurement_statistics_observable(state, op, targets=None):
 
     targets : list of ints, optional
         Specifies a list of targets "qubit" indices on which to apply the
-        measurement using :func:`qutip.qip.operations.gates.expand_operator` to expand op
-        into full dimension.
+        measurement using :func:`qutip.qip.operations.gates.expand_operator`
+        to expand op into full dimension.
 
     Returns
     -------
@@ -234,8 +234,8 @@ def measure_observable(state, op, targets=None):
 
     targets : list of ints, optional
         Specifies a list of target "qubit" indices on which to apply the
-        measurement using :func:`qutip.qip.operations.gates.expand_operator` to expand op
-        into full dimension.
+        measurement using :func:`qutip.qip.operations.gates.expand_operator`
+        to expand op into full dimension.
 
     Returns
     -------
@@ -321,7 +321,8 @@ def measure_povm(state, ops, targets=None):
 
     targets : list of ints, optional
         Specifies a list of target "qubit" indices on which to apply
-        the measurement using :func:`qutip.qip.operations.gates.expand_operator`
+        the measurement using
+        :func:`qutip.qip.operations.gates.expand_operator`
         to expand ``ops`` into full dimension.
 
     Returns
@@ -367,8 +368,8 @@ def measurement_statistics(state, ops, targets=None):
 
     targets : list of ints, optional
         Specifies a list of target "qubit" indices on which to apply the
-        measurement using :func:`qutip.qip.operations.gates.expand_operator` to expand ops
-        into full dimension.
+        measurement using :func:`qutip.qip.operations.gates.expand_operator`
+        to expand ops into full dimension.
     """
     if isinstance(ops, list):
         return measurement_statistics_povm(state, ops, targets)
@@ -404,8 +405,8 @@ def measure(state, ops, targets=None):
 
     targets : list of ints, optional
         Specifies a list of target "qubit" indices on which to apply the
-        measurement using :func:`qutip.qip.operations.gates.expand_operator` to expand ops
-        into full dimension.
+        measurement using :func:`qutip.qip.operations.gates.expand_operator`
+        to expand ops into full dimension.
     """
     if isinstance(ops, list):
         return measure_povm(state, ops, targets)

--- a/qutip/measurement.py
+++ b/qutip/measurement.py
@@ -131,7 +131,7 @@ def measurement_statistics_povm(state, ops, targets=None):
 
     targets : list of ints, optional
               Specifies a list of target "qubit" indices on which to apply
-              the measurement using qutip.qip.gates.expand_operator to expand
+              the measurement using qutip.qip.operations.gates.expand_operator to expand
               ops into full dimension.
 
 
@@ -182,7 +182,7 @@ def measurement_statistics_observable(state, op, targets=None):
 
     targets : list of ints, optional
         Specifies a list of targets "qubit" indices on which to apply the
-        measurement using :func:`qutip.qip.gates.expand_operator` to expand op
+        measurement using :func:`qutip.qip.operations.gates.expand_operator` to expand op
         into full dimension.
 
     Returns
@@ -234,7 +234,7 @@ def measure_observable(state, op, targets=None):
 
     targets : list of ints, optional
         Specifies a list of target "qubit" indices on which to apply the
-        measurement using :func:`qutip.qip.gates.expand_operator` to expand op
+        measurement using :func:`qutip.qip.operations.gates.expand_operator` to expand op
         into full dimension.
 
     Returns
@@ -321,7 +321,7 @@ def measure_povm(state, ops, targets=None):
 
     targets : list of ints, optional
         Specifies a list of target "qubit" indices on which to apply
-        the measurement using :func:`qutip.qip.gates.expand_operator`
+        the measurement using :func:`qutip.qip.operations.gates.expand_operator`
         to expand ``ops`` into full dimension.
 
     Returns
@@ -367,7 +367,7 @@ def measurement_statistics(state, ops, targets=None):
 
     targets : list of ints, optional
         Specifies a list of target "qubit" indices on which to apply the
-        measurement using :func:`qutip.qip.gates.expand_operator` to expand ops
+        measurement using :func:`qutip.qip.operations.gates.expand_operator` to expand ops
         into full dimension.
     """
     if isinstance(ops, list):
@@ -404,7 +404,7 @@ def measure(state, ops, targets=None):
 
     targets : list of ints, optional
         Specifies a list of target "qubit" indices on which to apply the
-        measurement using :func:`qutip.qip.gates.expand_operator` to expand ops
+        measurement using :func:`qutip.qip.operations.gates.expand_operator` to expand ops
         into full dimension.
     """
     if isinstance(ops, list):

--- a/qutip/mesolve.py
+++ b/qutip/mesolve.py
@@ -139,7 +139,7 @@ def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None,
         dictionary of parameters for time-dependent Hamiltonians and
         collapse operators.
 
-    options : None / :class:`qutip.Options`
+    options : None / :class:`qutip.solver.Options`
         with options for the solver.
 
     progress_bar : None / BaseProgressBar
@@ -148,9 +148,9 @@ def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None,
 
     Returns
     -------
-    result: :class:`qutip.Result`
+    result: :class:`qutip.solver.Result`
 
-        An instance of the class :class:`qutip.Result`, which contains
+        An instance of the class :class:`qutip.solver.Result`, which contains
         either an *array* `result.expect` of expectation values for the times
         specified by `tlist`, or an *array* `result.states` of state vectors or
         density matrices corresponding to the times in `tlist` [if `e_ops` is

--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -283,6 +283,12 @@ def hellinger_dist(A, B, sparse=False, tol=0):
     -------
     hellinger_dist : float
         Quantum Hellinger distance between A and B. Ranges from 0 to sqrt(2).
+
+    Examples
+    --------
+    >>> x=fock_dm(5,3)
+    >>> y=coherent_dm(5,1)
+    >>> np.testing.assert_almost_equal(hellinger_dist(x,y), 1.3725145002591095)
     """
     if A.isket or A.isbra:
         sqrtmA = ket2dm(A)

--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -283,12 +283,6 @@ def hellinger_dist(A, B, sparse=False, tol=0):
     -------
     hellinger_dist : float
         Quantum Hellinger distance between A and B. Ranges from 0 to sqrt(2).
-
-    Examples
-    --------
-    >>> x=fock_dm(5,3)
-    >>> y=coherent_dm(5,1)
-    >>> np.testing.assert_almost_equal(hellinger_dist(x,y), 1.3725145002591095)
     """
     if A.isket or A.isbra:
         sqrtmA = ket2dm(A)

--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -315,7 +315,7 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
           sparse=True):
     """
     Calculates the diamond norm of the quantum map q_oper, using
-    the simplified semidefinite program of [Wat12]_.
+    the simplified semidefinite program of [Wat13]_.
 
     The diamond norm SDP is solved by using CVXPY_.
 

--- a/qutip/nonmarkov/bofin_solvers.py
+++ b/qutip/nonmarkov/bofin_solvers.py
@@ -375,8 +375,8 @@ class HEOMSolver:
     ----------
     H_sys : QObj, QobjEvo or a list
         The system Hamiltonian or Liouvillian specified as either a
-        :obj:`~qutip.Qobj`, a :obj:`~qutip.QobjEvo`, or a list of elements that may
-        be converted to a :obj:`~qutip.QobjEvo`.
+        :obj:`~qutip.Qobj`, a :obj:`~qutip.QobjEvo`, or a list of elements
+        that may be converted to a :obj:`~qutip.QobjEvo`.
 
     bath : Bath or list of Bath
         A :obj:`Bath` containing the exponents of the expansion of the

--- a/qutip/nonmarkov/bofin_solvers.py
+++ b/qutip/nonmarkov/bofin_solvers.py
@@ -312,7 +312,7 @@ class HierarchyADOsState:
 
     Parameters
     ----------
-    rho : :class:`Qobj`
+    rho : :class:`~qutip.Qobj`
         The current state of the system (i.e. the 0th component of the
         hierarchy).
     ados : :class:`HierarchyADOs`
@@ -356,7 +356,7 @@ class HierarchyADOsState:
         Returns
         -------
         Qobj
-            A :obj:`Qobj` representing the state of the specified ADO.
+            A :obj:`~qutip.Qobj` representing the state of the specified ADO.
         """
         if isinstance(idx_or_label, int):
             idx = idx_or_label
@@ -375,8 +375,8 @@ class HEOMSolver:
     ----------
     H_sys : QObj, QobjEvo or a list
         The system Hamiltonian or Liouvillian specified as either a
-        :obj:`Qobj`, a :obj:`QobjEvo`, or a list of elements that may
-        be converted to a :obj:`ObjEvo`.
+        :obj:`~qutip.Qobj`, a :obj:`~qutip.QobjEvo`, or a list of elements that may
+        be converted to a :obj:`~qutip.QobjEvo`.
 
     bath : Bath or list of Bath
         A :obj:`Bath` containing the exponents of the expansion of the
@@ -832,7 +832,7 @@ class HEOMSolver:
         Parameters
         ----------
         rho0 : Qobj or HierarchyADOsState or numpy.array
-            Initial state (:obj:`~Qobj` density matrix) of the system
+            Initial state (:obj:`~qutip.Qobj` density matrix) of the system
             if ``ado_init`` is ``False``.
 
             If ``ado_init`` is ``True``, then ``rho0`` should be an

--- a/qutip/nonmarkov/transfertensor.py
+++ b/qutip/nonmarkov/transfertensor.py
@@ -88,7 +88,7 @@ def ttmsolve(dynmaps, rho0, times, e_ops=[], learningtimes=None, tensors=None,
 
     kwargs : dictionary
         Optional keyword arguments. See
-        :class:`qutip.nonmarkov.ttm.TTMSolverOptions`.
+        :class:`qutip.nonmarkov.transfertensor.TTMSolverOptions`.
 
     Returns
     -------
@@ -199,7 +199,7 @@ def _generatetensors(dynmaps, learningtimes=None, **kwargs):
 
     kwargs : dictionary
         Optional keyword arguments. See
-        :class:`qutip.nonmarkov.ttm.TTMSolverOptions`.
+        :class:`qutip.nonmarkov.transfertensor.TTMSolverOptions`.
 
     Returns
     -------

--- a/qutip/operators.py
+++ b/qutip/operators.py
@@ -613,7 +613,7 @@ def squeeze(N, z, offset=0):
 
     Returns
     -------
-    oper : :class:`qutip.qobj.Qobj`
+    oper : :class:`qutip.Qobj`
         Squeezing operator.
 
 
@@ -644,10 +644,10 @@ def squeezing(a1, a2, z):
 
     Parameters
     ----------
-    a1 : :class:`qutip.qobj.Qobj`
+    a1 : :class:`qutip.Qobj`
         Operator 1.
 
-    a2 : :class:`qutip.qobj.Qobj`
+    a2 : :class:`qutip.Qobj`
         Operator 2.
 
     z : float/complex
@@ -655,7 +655,7 @@ def squeezing(a1, a2, z):
 
     Returns
     -------
-    oper : :class:`qutip.qobj.Qobj`
+    oper : :class:`qutip.Qobj`
         Squeezing operator.
 
     """

--- a/qutip/parallel.py
+++ b/qutip/parallel.py
@@ -44,7 +44,7 @@ def parfor(func, *args, **kwargs):
 
     .. note::
 
-        From QuTiP 3.1, we recommend to use :func:`qutip.parallel_map`
+        From QuTiP 3.1, we recommend to use :func:`qutip.parallel.parallel_map`
         instead of this function.
 
     Parameters
@@ -119,7 +119,7 @@ def serial_map(task, values, task_args=tuple(), task_kwargs={}, **kwargs):
 
         result = [task(value, *task_args, **task_kwargs) for value in values]
 
-    This function work as a drop-in replacement of :func:`qutip.parallel_map`.
+    This function work as a drop-in replacement of :func:`qutip.parallel.parallel_map`.
 
     Parameters
     ----------

--- a/qutip/parallel.py
+++ b/qutip/parallel.py
@@ -119,7 +119,8 @@ def serial_map(task, values, task_args=tuple(), task_kwargs={}, **kwargs):
 
         result = [task(value, *task_args, **task_kwargs) for value in values]
 
-    This function work as a drop-in replacement of :func:`qutip.parallel.parallel_map`.
+    This function work as a drop-in replacement of
+    :func:`qutip.parallel.parallel_map`.
 
     Parameters
     ----------

--- a/qutip/propagator.py
+++ b/qutip/propagator.py
@@ -49,7 +49,7 @@ def propagator(H, t, c_op_list=[], args={}, options=None,
         Parameters to callback functions for time-dependent Hamiltonians and
         collapse operators.
 
-    options : :class:`qutip.Options`
+    options : :class:`qutip.solver.Options`
         with options for the ODE solver.
 
     unitary_mode = str ('batch', 'single')

--- a/qutip/qip/device/modelprocessor.py
+++ b/qutip/qip/device/modelprocessor.py
@@ -118,9 +118,9 @@ class ModelProcessor(Processor):
 
         Returns
         -------
-        evo_result: :class:`qutip.Result`
+        evo_result: :class:`qutip.solver.Result`
             If ``analytical`` is False,  an instance of the class
-            :class:`qutip.Result` will be returned.
+            :class:`qutip.solver.Result` will be returned.
 
             If ``analytical`` is True, a list of matrices representation
             is returned.

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -691,9 +691,9 @@ class Processor(object):
 
         Returns
         -------
-        evo_result: :class:`qutip.Result`
+        evo_result: :class:`qutip.solver.Result`
             If ``analytical`` is False,  an instance of the class
-            :class:`qutip.Result` will be returned.
+            :class:`qutip.solver.Result` will be returned.
 
             If ``analytical`` is True, a list of matrices representation
             is returned.

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -166,7 +166,7 @@ class StateArgs:
 class EvoElement:
     """
     Internal type used to represent the time-dependent parts of a
-    :class:`~QobjEvo`.
+    :class:`~qutip.QobjEvo`.
 
     Availables "types" are
 
@@ -204,21 +204,21 @@ class QobjEvo:
 
     Basic math operations are defined:
 
-    - ``+``, ``-`` : :class:`~QobjEvo`, :class:`~Qobj`, scalars.
-    - ``*``: :class:`~Qobj`, C number
+    - ``+``, ``-`` : :class:`~qutip.QobjEvo`, :class:`~qutip.Qobj`, scalars.
+    - ``*``: :class:`~qutip.Qobj`, C number
     - ``/`` : C number
 
-    This object is constructed by passing a list of :obj:`~Qobj` instances,
+    This object is constructed by passing a list of :obj:`~qutip.Qobj` instances,
     each of which *may* have an associated scalar time dependence.  The list is
     summed to produce the final result.  In other words, if an instance of this
     class is :math:`Q(t)`, then it is constructed from a set of constant
-    :obj:`~Qobj` :math:`\\{Q_k\\}` and time-dependent scalars :math:`f_k(t)` by
+    :obj:`~qutip.Qobj` :math:`\\{Q_k\\}` and time-dependent scalars :math:`f_k(t)` by
 
     .. math::
 
         Q(t) = \\sum_k f_k(t) Q_k
 
-    If a scalar :math:`f_k(t)` is not passed with a given :obj:`~Qobj`, then
+    If a scalar :math:`f_k(t)` is not passed with a given :obj:`~qutip.Qobj`, then
     that term is assumed to be constant.  The next section contains more detail
     on the allowed forms of the constants, and gives several examples for how
     to build instances of this class.
@@ -295,7 +295,7 @@ class QobjEvo:
     they are updated at every call.  The initial values of these dictionary
     elements is unimportant.  The magic names available are:
 
-    - ``"state"``: the current state as a :class:`~Qobj`
+    - ``"state"``: the current state as a :class:`~qutip.Qobj`
     - ``"state_vec"``: the current state as a column-stacked 1D ``np.ndarray``
     - ``"state_mat"``: the current state as a 2D ``np.ndarray``
     - ``"expect_op_<n>"``: the current expectation value of the element
@@ -311,7 +311,7 @@ class QobjEvo:
 
     Parameters
     ----------
-    Q_object : list, :class:`~Qobj` or :class:`~QobjEvo`
+    Q_object : list, :class:`~qutip.Qobj` or :class:`~qutip.QobjEvo`
         The time-dependent description of the quantum object.  This is of the
         same format as the first parameter to the general ODE solvers; in
         general, it is a list of ``[Qobj, time_dependence]`` pairs that are
@@ -335,7 +335,7 @@ class QobjEvo:
 
     Attributes
     ----------
-    cte : :class:`~Qobj`
+    cte : :class:`~qutip.Qobj`
         Constant part of the QobjEvo.
 
     ops : list of :class:`.EvoElement`
@@ -378,7 +378,7 @@ class QobjEvo:
         Information about the type of coefficients used in the entire object.
 
     num_obj : int
-        Number of :obj:`~Qobj` in the QobjEvo.
+        Number of :obj:`~qutip.Qobj` in the QobjEvo.
 
     use_cython : bool
         Flag to compile string to Cython or Python
@@ -597,7 +597,7 @@ class QobjEvo:
 
     def __call__(self, t, data=False, state=None, args={}):
         """
-        Return a single :obj:`~Qobj` at the given time ``t``.
+        Return a single :obj:`~qutip.Qobj` at the given time ``t``.
         """
         try:
             t = float(t)

--- a/qutip/qobjevo.py
+++ b/qutip/qobjevo.py
@@ -15,7 +15,7 @@ from qutip.qobjevo_codegen import (_compile_str_single, _compiled_coeffs,
 from qutip.cy.spmatfuncs import (cy_expect_rho_vec, cy_expect_psi,
                                  spmv)
 from qutip.cy.cqobjevo import (CQobjCte, CQobjCteDense, CQobjEvoTd,
-                                 CQobjEvoTdMatched, CQobjEvoTdDense)
+                               CQobjEvoTdMatched, CQobjEvoTdDense)
 from qutip.cy.cqobjevo_factor import (InterCoeffT, InterCoeffCte,
                                       InterpolateCoeff, StrCoeff,
                                       StepCoeffCte, StepCoeffT)
@@ -81,6 +81,7 @@ class _file_list:
     """
     Contain temp a list .pyx to clean
     """
+
     def __init__(self):
         self.files = []
 
@@ -103,6 +104,7 @@ class _file_list:
     def __del__(self):
         self.clean()
 
+
 coeff_files = _file_list()
 
 
@@ -115,6 +117,7 @@ class _StrWrapper:
         env.update(args)
         exec(self.code, str_env, env)
         return env["_out"]
+
 
 class _CubicSplineWrapper:
     # Using scipy's CubicSpline since Qutip's one
@@ -136,6 +139,7 @@ class _CubicSplineWrapper:
     def __call__(self, t, args={}):
         return self.func([t])[0]
 
+
 class _StateAsArgs:
     # old with state (f(t, psi, args)) to new (args["state"] = psi)
     def __init__(self, coeff_func):
@@ -150,6 +154,7 @@ class StateArgs:
     """Object to indicate to use the state in args outside solver.
     args[key] = StateArgs(type, op)
     """
+
     def __init__(self, type="Qobj", op=None):
         self.dyn_args = (type, op)
 
@@ -208,20 +213,21 @@ class QobjEvo:
     - ``*``: :class:`~qutip.Qobj`, C number
     - ``/`` : C number
 
-    This object is constructed by passing a list of :obj:`~qutip.Qobj` instances,
-    each of which *may* have an associated scalar time dependence.  The list is
-    summed to produce the final result.  In other words, if an instance of this
-    class is :math:`Q(t)`, then it is constructed from a set of constant
-    :obj:`~qutip.Qobj` :math:`\\{Q_k\\}` and time-dependent scalars :math:`f_k(t)` by
+    This object is constructed by passing a list of :obj:`~qutip.Qobj`
+    instances, each of which *may* have an associated scalar time dependence.
+    The list is summed to produce the final result.  In other words, if an
+    instance of this class is :math:`Q(t)`, then it is constructed from a set
+    of constant:obj:`~qutip.Qobj` :math:`\\{Q_k\\}` and time-dependent scalars
+    :math:`f_k(t)` by
 
     .. math::
 
         Q(t) = \\sum_k f_k(t) Q_k
 
-    If a scalar :math:`f_k(t)` is not passed with a given :obj:`~qutip.Qobj`, then
-    that term is assumed to be constant.  The next section contains more detail
-    on the allowed forms of the constants, and gives several examples for how
-    to build instances of this class.
+    If a scalar :math:`f_k(t)` is not passed with a given :obj:`~qutip.Qobj`,
+    then that term is assumed to be constant.  The next section contains more
+    detail on the allowed forms of the constants, and gives several examples
+    for how to build instances of this class.
 
     **Time-dependence formats**
 
@@ -546,7 +552,7 @@ class QobjEvo:
         return out
 
     def _args_checks(self):
-        statedims = [self.cte.dims[1],[1]]
+        statedims = [self.cte.dims[1], [1]]
         for key in self.args:
             if key == "state" or key == "state_qobj":
                 self.dynamics_args += [(key, "Qobj", None)]
@@ -662,11 +668,12 @@ class QobjEvo:
                     elif what == "Qobj":
                         self.args[name] = Qobj(mat, dims=self.cte.dims[1])
                 elif state.shape[0] == s1:
-                    mat = state.reshape((-1,1))
+                    mat = state.reshape((-1, 1))
                     if what == "mat":
                         self.args[name] = mat
                     elif what == "Qobj":
-                        self.args[name] = Qobj(mat, dims=[self.cte.dims[1],[1]])
+                        self.args[name] = Qobj(
+                            mat, dims=[self.cte.dims[1], [1]])
                 elif state.shape[0] == s1*s1:
                     new_l = int(np.sqrt(s1))
                     mat = state.reshape((new_l, new_l), order="F")
@@ -687,7 +694,7 @@ class QobjEvo:
                 elif what == "expect":
                     self.args[name] = op.expect(t, state)
                 elif state.shape[1] == 1:
-                    self.args[name] = Qobj(state, dims=[self.cte.dims[1],[1]])
+                    self.args[name] = Qobj(state, dims=[self.cte.dims[1], [1]])
                 elif state.shape[1] == s1:
                     self.args[name] = Qobj(state, dims=self.cte.dims)
                 else:
@@ -917,7 +924,7 @@ class QobjEvo:
                 self.dynamics_args += other.dynamics_args
                 self.dummy_cte = self.dummy_cte and other.dummy_cte
                 self.num_obj = (len(self.ops) if
-                              self.dummy_cte else len(self.ops) + 1)
+                                self.dummy_cte else len(self.ops) + 1)
             self._reset_type()
             return self
         return NotImplemented
@@ -1600,8 +1607,8 @@ class QobjEvo:
                 for part in self.ops:
                     if isinstance(part.get_coeff, _StrWrapper):
                         get_coeff, file_ = _compile_str_single(
-                                                                part.coeff,
-                                                                self.args)
+                            part.coeff,
+                            self.args)
                         coeff_files.add(file_)
                         self.coeff_files.append(file_)
                         funclist.append(get_coeff)
@@ -1616,10 +1623,10 @@ class QobjEvo:
             elif self.type in ["mixed_callable"]:
                 funclist = [part.get_coeff for part in self.ops]
                 _UnitedStrCaller, Code, file_ = _compiled_coeffs_python(
-                                                        self.ops,
-                                                        self.args,
-                                                        self.dynamics_args,
-                                                        self.tlist)
+                    self.ops,
+                    self.args,
+                    self.dynamics_args,
+                    self.tlist)
                 coeff_files.add(file_)
                 self.coeff_files.append(file_)
                 self.coeff_get = _UnitedStrCaller(funclist, self.args,
@@ -1631,10 +1638,10 @@ class QobjEvo:
                 if self.use_cython:
                     # All factor can be compiled
                     self.coeff_get, Code, file_ = _compiled_coeffs(
-                                                        self.ops,
-                                                        self.args,
-                                                        self.dynamics_args,
-                                                        self.tlist)
+                        self.ops,
+                        self.args,
+                        self.dynamics_args,
+                        self.tlist)
                     coeff_files.add(file_)
                     self.coeff_files.append(file_)
                     self.compiled_qobjevo.set_factor(obj=self.coeff_get)
@@ -1642,10 +1649,10 @@ class QobjEvo:
                 else:
                     # All factor can be compiled
                     _UnitedStrCaller, Code, file_ = _compiled_coeffs_python(
-                                                        self.ops,
-                                                        self.args,
-                                                        self.dynamics_args,
-                                                        self.tlist)
+                        self.ops,
+                        self.args,
+                        self.dynamics_args,
+                        self.tlist)
                     coeff_files.add(file_)
                     self.coeff_files.append(file_)
                     funclist = [part.get_coeff for part in self.ops]
@@ -1661,7 +1668,7 @@ class QobjEvo:
                 except KeyError:
                     use_step_func = 0
                 if np.allclose(np.diff(self.tlist),
-                            self.tlist[1] - self.tlist[0]):
+                               self.tlist[1] - self.tlist[0]):
                     if use_step_func:
                         self.coeff_get = StepCoeffCte(
                             self.ops, None, self.tlist)
@@ -1708,7 +1715,7 @@ class QobjEvo:
         self.__dict__ = state[0]
         self.compiled_qobjevo = None
         if self.compiled:
-            mat_type, threading, td =  self.compiled.split()
+            mat_type, threading, td = self.compiled.split()
             if mat_type == "csr":
                 if self.safePickle:
                     # __getstate__ and __setstate__ of compiled_qobjevo pass pointers
@@ -1732,22 +1739,27 @@ class QobjEvo:
                             self.compiled_qobjevo.set_threads(self.omp)
 
                         if td == "pyfunc":
-                            self.compiled_qobjevo.set_factor(func=self.coeff_get)
+                            self.compiled_qobjevo.set_factor(
+                                func=self.coeff_get)
                         elif td == "cyfactor":
-                            self.compiled_qobjevo.set_factor(obj=self.coeff_get)
+                            self.compiled_qobjevo.set_factor(
+                                obj=self.coeff_get)
                 else:
                     if td == "cte":
                         if threading == "single":
                             self.compiled_qobjevo = CQobjCte.__new__(CQobjCte)
                         elif threading == "omp":
-                            self.compiled_qobjevo = CQobjCteOmp.__new__(CQobjCteOmp)
+                            self.compiled_qobjevo = CQobjCteOmp.__new__(
+                                CQobjCteOmp)
                             self.compiled_qobjevo.set_threads(self.omp)
                     else:
                         # time dependence is pyfunc or cyfactor
                         if threading == "single":
-                            self.compiled_qobjevo = CQobjEvoTd.__new__(CQobjEvoTd)
+                            self.compiled_qobjevo = CQobjEvoTd.__new__(
+                                CQobjEvoTd)
                         elif threading == "omp":
-                            self.compiled_qobjevo = CQobjEvoTdOmp.__new__(CQobjEvoTdOmp)
+                            self.compiled_qobjevo = CQobjEvoTdOmp.__new__(
+                                CQobjEvoTdOmp)
                             self.compiled_qobjevo.set_threads(self.omp)
                     self.compiled_qobjevo.__setstate__(state[1])
 
@@ -1795,12 +1807,12 @@ class _UnitedFuncCaller:
             elif what == "Qobj":
                 if self.shape[1] == shape[1]:  # oper
                     self.args[name] = Qobj(mat, dims=self.dims)
-                elif shape[1] == 1: # ket
-                    self.args[name] = Qobj(mat, dims=[self.dims[1],[1]])
+                elif shape[1] == 1:  # ket
+                    self.args[name] = Qobj(mat, dims=[self.dims[1], [1]])
                 else:  # rho
                     self.args[name] = Qobj(mat, dims=self.dims[1])
             elif what == "expect":
-                if shape[1] == op.cte.shape[1]: # same shape as object
+                if shape[1] == op.cte.shape[1]:  # same shape as object
                     self.args[name] = op.mul_mat(t, mat).trace()
                 else:
                     self.args[name] = op.expect(t, state)

--- a/qutip/rcsolve.py
+++ b/qutip/rcsolve.py
@@ -46,7 +46,7 @@ def rcsolve(Hsys, psi0, tlist, e_ops, Q, wc, alpha, N, w_th, sparse=False,
         Temperature.
     sparse: Boolean
         Optional argument to call the sparse eigenstates solver if needed.
-    options : :class:`qutip.Options`
+    options : :class:`qutip.solver.Options`
         With options for the solver.
 
     Returns

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -43,10 +43,10 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
     ----------
 
     H : :class:`~qutip.Qobj`, :class:`~qutip.QobjEvo`, list, or callable
-        System Hamiltonian as a :obj:`~qutip.Qobj` , list of :obj:`~qutip.Qobj` and
-        coefficient, :obj:`~qutip.QobjEvo`, or a callback function for time-dependent
-        Hamiltonians.  List format and options can be found in QobjEvo's
-        description.
+        System Hamiltonian as a :obj:`~qutip.Qobj` , list of
+        :obj:`~qutip.Qobj` and coefficient, :obj:`~qutip.QobjEvo`,
+        or a callback function for time-dependent Hamiltonians. List format
+        and options can be found in QobjEvo's description.
 
     psi0 : :class:`~qutip.Qobj`
         Initial state vector (ket) or initial unitary operator ``psi0 = U``.
@@ -79,12 +79,12 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
     -------
 
     output: :class:`~qutip.solver.Result`
-        An instance of the class :class:`~qutip.solver.Options`, which contains either
-        an array of expectation values for the times specified by ``tlist``, or
-        an array or state vectors corresponding to the times in ``tlist`` (if
-        ``e_ops`` is an empty list), or nothing if a callback function was
-        given inplace of operators for which to calculate the expectation
-        values.
+        An instance of the class :class:`~qutip.solver.Options`, which
+        contains either an array of expectation values for the times
+        specified by ``tlist``, or an array or state vectors
+        corresponding to the times in ``tlist`` (if ``e_ops`` is an empty
+        list), or nothing if a callback function was given inplace of
+        operators for which to calculate the expectation values.
     """
     if e_ops is None:
         e_ops = []

--- a/qutip/sesolve.py
+++ b/qutip/sesolve.py
@@ -42,13 +42,13 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
     Parameters
     ----------
 
-    H : :class:`~Qobj`, :class:`~QobjEvo`, list, or callable
-        System Hamiltonian as a :obj:`~Qobj , list of :obj:`Qobj` and
-        coefficient, :obj:`~QObjEvo`, or a callback function for time-dependent
+    H : :class:`~qutip.Qobj`, :class:`~qutip.QobjEvo`, list, or callable
+        System Hamiltonian as a :obj:`~qutip.Qobj` , list of :obj:`~qutip.Qobj` and
+        coefficient, :obj:`~qutip.QobjEvo`, or a callback function for time-dependent
         Hamiltonians.  List format and options can be found in QobjEvo's
         description.
 
-    psi0 : :class:`~Qobj`
+    psi0 : :class:`~qutip.Qobj`
         Initial state vector (ket) or initial unitary operator ``psi0 = U``.
 
     tlist : array_like of float
@@ -68,7 +68,7 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
     args : dict, optional
         Dictionary of scope parameters for time-dependent Hamiltonians.
 
-    options : :obj:`~solver.Options`, optional
+    options : :obj:`~qutip.solver.Options`, optional
         Options for the ODE solver.
 
     progress_bar : :obj:`~BaseProgressBar`, optional
@@ -78,8 +78,8 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None,
     Returns
     -------
 
-    output: :class:`~solver.Result`
-        An instance of the class :class:`~solver.Result`, which contains either
+    output: :class:`~qutip.solver.Result`
+        An instance of the class :class:`~qutip.solver.Options`, which contains either
         an array of expectation values for the times specified by ``tlist``, or
         an array or state vectors corresponding to the times in ``tlist`` (if
         ``e_ops`` is an empty list), or nothing if a callback function was

--- a/qutip/states.py
+++ b/qutip/states.py
@@ -870,8 +870,8 @@ shape = [8, 1], type = ket
 
     Returns
     -------
-    state : :class:`qutip.Qobj.qobj`
-        The state as a :class:`qutip.Qobj.qobj` instance.
+    state : :class:`qutip.Qobj`
+        The state as a :class:`qutip.Qobj` instance.
 
 
     """

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -104,7 +104,7 @@ def steadystate(A, c_op_list=[], method='direct', solver=None, **kwargs):
 
     Parameters
     ----------
-    A : :obj:`~Qobj`
+    A : :obj:`~qutip.Qobj`
         A Hamiltonian or Liouvillian operator.
 
     c_op_list : list
@@ -935,13 +935,13 @@ def steadystate_floquet(H_0, c_ops, Op_t, w_d=1.0, n_it=3, sparse=False):
 
     Parameters
     ----------
-    H_0 : :obj:`~Qobj`
+    H_0 : :obj:`~qutip.Qobj`
         A Hamiltonian or Liouvillian operator.
 
     c_ops : list
         A list of collapse operators.
 
-    Op_t : :obj:`~Qobj`
+    Op_t : :obj:`~qutip.Qobj`
         The the interaction operator which is multiplied by the cosine
 
     w_d : float, default 1.0

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -188,8 +188,8 @@ class StochasticSolverOptions:
     ----------
     H : time_dependent_object or list of time_dependent_object
         System Hamiltonian in standard time-dependent list format.  This is the
-        same as the argument that (e.g.) :func:`~qutip.mesolve` takes.  If this is a
-        list of elements, they are summed.
+        same as the argument that (e.g.) :func:`~qutip.mesolve` takes.
+        If this is a list of elements, they are summed.
 
     state0 : :class:`qutip.Qobj`
         Initial state vector (ket) or density matrix.

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -177,18 +177,18 @@ class StochasticSolverOptions:
 
     Within the attribute list, a ``time_dependent_object`` is either
 
-    - :class:`~Qobj`: a constant term
+    - :class:`~qutip.Qobj`: a constant term
     - 2-element list of ``[Qobj, time_dependence]``: a time-dependent term
       where the ``Qobj`` will be multiplied by the time-dependent scalar.
 
     For more details on all allowed time-dependent objects, see the
-    documentation for :class:`~QobjEvo`.
+    documentation for :class:`~qutip.QobjEvo`.
 
     Attributes
     ----------
     H : time_dependent_object or list of time_dependent_object
         System Hamiltonian in standard time-dependent list format.  This is the
-        same as the argument that (e.g.) :func:`~mesolve` takes.  If this is a
+        same as the argument that (e.g.) :func:`~qutip.mesolve` takes.  If this is a
         list of elements, they are summed.
 
     state0 : :class:`qutip.Qobj`

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -971,7 +971,7 @@ def plot_fock_distribution(rho, offset=0, fig=None, ax=None,
 
     Parameters
     ----------
-    rho : :class:`qutip.qobj.Qobj`
+    rho : :class:`qutip.Qobj`
         The density matrix (or ket) of the state to visualize.
 
     fig : a matplotlib Figure instance
@@ -1034,7 +1034,7 @@ def plot_wigner(rho, fig=None, ax=None, figsize=(6, 6),
 
     Parameters
     ----------
-    rho : :class:`qutip.qobj.Qobj`
+    rho : :class:`qutip.Qobj`
         The density matrix (or ket) of the state to visualize.
 
     fig : a matplotlib Figure instance
@@ -1127,7 +1127,7 @@ def plot_wigner_fock_distribution(rho, fig=None, axes=None, figsize=(8, 4),
 
     Parameters
     ----------
-    rho : :class:`qutip.qobj.Qobj`
+    rho : :class:`qutip.Qobj`
         The density matrix (or ket) of the state to visualize.
 
     fig : a matplotlib Figure instance


### PR DESCRIPTION
**Description**
Hyperlinks to functions and classes in the documentation were fixed/added.

Following classes and functions were added to the documentation, as there were broken-hyperlinks pointing to them:

Functions:
- Density Matrix Metrics:
  - Added: hellinger_dist, unitarity, dnorm
-  Measurement of quantum states:
   - Added: measure_povm, measurement_statistics_povm

Classes:
- Added: Bloch3d

**Related issues or PRs**
fixes #1526

**Changelog**
 DOC: Hyperlinks to QuTiP functions and classes fixed
