### PR TITLE
Fix warning at installation from broken link in manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,11 +2,10 @@ include README.md
 include LICENSE.txt
 include VERSION
 include requirements.txt
-include qutip.bib
+include CITATION.bib
 include pyproject.toml
 recursive-include qutip *.pyx
 recursive-include qutip *.pxd
 recursive-include qutip *.hpp
 recursive-include qutip *.cpp
 recursive-include qutip *.ini
-recursive-include qutip/tests/qasm_files *.qasm


### PR DESCRIPTION
**Description**
Installing `dev.major` is raising warnings because of errors in MANIFEST.in:
```
...
reading manifest file 'qutip.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'qutip.bib'   <=====
warning: no files found matching '*.qasm' under directory 'qutip/tests/qasm_files'   <=====
adding license file 'LICENSE.txt'
writing manifest file 'qutip.egg-info/SOURCES.txt'
running build_ext
...
```
qutip.bib was renamed to CITATION.bib in #1662 
qasm files were removed in #1890 and are now only included with qutip-qip

**Changelog**
Update MANIFEST.in to reflect changes in #1662 and #1890
