### PR TITLE
Fix bug in correlation_2op_2t

### DIFF
--- a/qutip/correlation.py
+++ b/qutip/correlation.py
@@ -1079,7 +1079,7 @@ def _correlation_me_2t(H, state0, tlist, taulist, c_ops, a_op, b_op, c_op,
             _args["_t0"] = tlist[t_idx]
 
         corr_mat[t_idx, :] = mesolve(
-            H_shifted, c_op * rho * a_op, taulist, c_ops_shifted,
+            H_shifted, c_op * rho * a_op, taulist + tlist[t_idx], c_ops_shifted,
             [b_op], args=_args, options=options
         ).expect[0]
 

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -213,11 +213,14 @@ class TestTimeDependence:
         cops = [[qutip.destroy(2), lambda t, args: np.sqrt(8*t)]]
         a = qutip.destroy(2)
         ad = a.dag()
-        corre_result = qutip.correlation_2op_2t(H, psi0, tlist, tlist, cops, ad, a)
+        corre_result = qutip.correlation_2op_2t(H, psi0, tlist,
+                                                tlist, cops, ad, a)
         test_corre = corre_result[i1, i2-i1].real
-        rhom = qutip.mesolve(H, psi0, np.linspace(0, tlist[i1], 101), cops).states[-1]
-        msolve_result = (qutip.mesolve(H, a * rhom, np.linspace(tlist[i1], tlist[i2]
-                                                                , 101), cops).states[-1] * ad).tr()
+        rhom = qutip.mesolve(H, psi0,
+                             np.linspace(0,tlist[i1], 101), cops).states[-1]
+        msolve_result = (qutip.mesolve(H, a * rhom,
+                                       np.linspace(tlist[i1], tlist[i2]
+                                       ,101), cops).states[-1] * ad).tr()
         theory_result = np.exp(-(4.0 * t1 ** 2 + 4.0 * t2 ** 2) / 2)
 
         np.testing.assert_allclose(test_corre, msolve_result, atol=1e-6)

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -216,7 +216,8 @@ class TestTimeDependence:
         corre_result = qutip.correlation_2op_2t(H, psi0, tlist, tlist, cops, ad, a)
         test_corre = corre_result[i1, i2-i1].real
         rhom = qutip.mesolve(H, psi0, np.linspace(0, tlist[i1], 101), cops).states[-1]
-        msolve_result = (qutip.mesolve(H, a * rhom, np.linspace(tlist[i1], tlist[i2], 101), cops).states[-1] * ad).tr()
+        msolve_result = (qutip.mesolve(H, a * rhom, np.linspace(tlist[i1], tlist[i2]
+                                                                , 101), cops).states[-1] * ad).tr()
         theory_result = np.exp(-(4.0 * t1 ** 2 + 4.0 * t2 ** 2) / 2)
 
         np.testing.assert_allclose(test_corre, msolve_result, atol=1e-6)

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -217,16 +217,15 @@ class TestTimeDependence:
                                                 tlist, cops, ad, a)
         test_corre = corre_result[i1, i2-i1].real
         rhom = qutip.mesolve(H, psi0,
-                             np.linspace(0,tlist[i1], 101), cops).states[-1]
+                             np.linspace(0, tlist[i1], 101), cops).states[-1]
         msolve_result = (qutip.mesolve(H, a * rhom,
-                                       np.linspace(tlist[i1], tlist[i2]
-                                       ,101), cops).states[-1] * ad).tr()
+                                       np.linspace(tlist[i1],
+                                                   tlist[i2], 101),
+                                       cops).states[-1] * ad).tr()
         theory_result = np.exp(-(4.0 * t1 ** 2 + 4.0 * t2 ** 2) / 2)
 
         np.testing.assert_allclose(test_corre, msolve_result, atol=1e-6)
         np.testing.assert_allclose(test_corre, theory_result, atol=1e-6)
-
-
 
 
 def _step(t):

--- a/qutip/tests/test_correlation.py
+++ b/qutip/tests/test_correlation.py
@@ -203,6 +203,27 @@ class TestTimeDependence:
         g2_ab_0 = _trapz_2d(np.real(correlation_ab), times)
         assert abs(g2_ab_0 - 0.185) < 1e-2
 
+    def test_correlation_2op_2t(self):
+        i1, i2 = 20, 50
+        tlist = np.linspace(0, 1, 101)
+        t1 = tlist[i1]
+        t2 = tlist[i2]
+        H = 0.0 * qutip.identity(2)
+        psi0 = qutip.basis(2, 1)
+        cops = [[qutip.destroy(2), lambda t, args: np.sqrt(8*t)]]
+        a = qutip.destroy(2)
+        ad = a.dag()
+        corre_result = qutip.correlation_2op_2t(H, psi0, tlist, tlist, cops, ad, a)
+        test_corre = corre_result[i1, i2-i1].real
+        rhom = qutip.mesolve(H, psi0, np.linspace(0, tlist[i1], 101), cops).states[-1]
+        msolve_result = (qutip.mesolve(H, a * rhom, np.linspace(tlist[i1], tlist[i2], 101), cops).states[-1] * ad).tr()
+        theory_result = np.exp(-(4.0 * t1 ** 2 + 4.0 * t2 ** 2) / 2)
+
+        np.testing.assert_allclose(test_corre, msolve_result, atol=1e-6)
+        np.testing.assert_allclose(test_corre, theory_result, atol=1e-6)
+
+
+
 
 def _step(t):
     return np.arctan(t)/np.pi + 0.5


### PR DESCRIPTION
**Description**
Fix bug in `correlation 2op_2t `  when using time-dependent hamiltonians and collapse operators. Also, a test was added in `test_correlation`

**Related issues or PRs**
This PR addresses [#1808](uhttps://github.com/qutip/qutip/issues/1808). It solves the issue.

**Changelog**
Fixed error for time-dependent hamiltonians and collapse operators in correlation 2op_2t 