### PR TITLE
Allow `sum(kets)`

### DIFF
--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -94,6 +94,8 @@ def _require_equal_type(method):
     """
     @functools.wraps(method)
     def out(self, other):
+        if other == 0:
+            return method(self, other)
         if (
             self.type in ('oper', 'super')
             and self.dims[0] == self.dims[1]
@@ -399,6 +401,8 @@ class Qobj:
 
     @_require_equal_type
     def __add__(self, other):
+        if other == 0:
+            return self.copy()
         isherm = (self._isherm and other._isherm) or None
         return Qobj(_data.add(self._data, other._data),
                     dims=self.dims,
@@ -412,6 +416,8 @@ class Qobj:
 
     @_require_equal_type
     def __sub__(self, other):
+        if other == 0:
+            return self.copy()
         isherm = (self._isherm and other._isherm) or None
         return Qobj(_data.sub(self._data, other._data),
                     dims=self.dims,

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -1081,3 +1081,19 @@ def test_contract(expanded, contracted, inplace):
     assert out.dims == contracted
     assert out.shape == qobj.shape
     assert np.all(out.full() == qobj.full())
+
+
+@pytest.mark.parametrize(["shape"], [
+    pytest.param((5, 1), id='ket'),
+    pytest.param((5, 2), id='tall'),
+    pytest.param((1, 5), id='bra'),
+    pytest.param((2, 5), id='wide'),
+    pytest.param((3, 3), id='oper'),
+])
+def test_sum_zero(shape):
+    data = np.random.rand(*shape) + 1j*np.random.rand(*shape)
+    ket = qutip.Qobj(data)
+    assert ket + 0 == ket
+    assert ket - 0 == ket
+    assert 0 + ket == ket
+    assert 0 - ket == -ket

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -1092,8 +1092,21 @@ def test_contract(expanded, contracted, inplace):
 ])
 def test_sum_zero(shape):
     data = np.random.rand(*shape) + 1j*np.random.rand(*shape)
-    ket = qutip.Qobj(data)
-    assert ket + 0 == ket
-    assert ket - 0 == ket
-    assert 0 + ket == ket
-    assert 0 - ket == -ket
+    qobj = qutip.Qobj(data)
+    assert qobj + 0 == qobj
+    assert qobj - 0 == qobj
+    assert 0 + qobj == qobj
+    assert 0 - qobj == -qobj
+
+
+@pytest.mark.parametrize(["shape"], [
+    pytest.param((5, 1), id='ket'),
+    pytest.param((5, 2), id='tall'),
+    pytest.param((1, 5), id='bra'),
+    pytest.param((2, 5), id='wide'),
+    pytest.param((3, 3), id='oper'),
+])
+def test_sum_buildin(shape):
+    data = np.random.rand(*shape) + 1j*np.random.rand(*shape)
+    qobj = qutip.Qobj(data)
+    assert sum([qobj, 2 * qobj, -qobj]) == 2 * qobj


### PR DESCRIPTION
**Description**
Allow `qobj +/- 0` for `Qobj` of any shape and type to allow the use of `sum(kets)` as discussed in #1841.
Addition and subtraction of any other number will still raise an error if the object is not square as before.

**Related issues or PRs**
Issue raised in #1841

**Changelog**
Allow `ket + 0`.
