### PR TITLE
Fix typos in docs for time-dependent Hamiltonians

### DIFF
--- a/doc/guide/dynamics/dynamics-time.rst
+++ b/doc/guide/dynamics/dynamics-time.rst
@@ -28,9 +28,9 @@ There are, in general, three different ways to implement time-dependent problems
 4. **Hamiltonian function (outdated)**: The Hamiltonian is itself a Python function with time-dependence.  Collapse operators must be time independent using this input format.
 
 
-Give the multiple choices of input style, the first question that arrises is which option to choose?
+Given the multiple choices of input style, the first question that arrises is which option to choose?
 In short, the function based method (option #1) is the most general,
-allowing for essentially arbitrary coefficients expressed via user defined functions.
+allowing for essentially arbitrary coefficients expressed via user-defined functions.
 However, by automatically compiling your system into C++ code,
 the second option (string based) tends to be more efficient and will run faster
 [This is also the only format that is supported in the :func:`qutip.bloch_redfield.brmesolve` solver].
@@ -48,12 +48,12 @@ In addition, QuTiP supports cubic spline based interpolation functions [:ref:`ti
 
 If you require mathematical functions other than those listed above,
 it is possible to call any of the functions in the NumPy library using the prefix ``np.``
-before the function name in the string, i.e ``'np.sin(t)'`` and  ``scipy.special`` imported as ``spe``.
+before the function name in the string, i.e. ``'np.sin(t)'`` and  ``scipy.special`` imported as ``spe``.
 This includes a wide range of functionality, but comes with a small overhead created by going from C++->Python->C++.
 
 Finally option #4, expressing the Hamiltonian as a Python function,
 is the original method for time dependence in QuTiP 1.x.
-However, this method is somewhat less efficient then the previously mentioned methods.
+This method is somewhat less efficient then the previously mentioned ones.
 However, in contrast to the other options
 this method can be used in implementing time-dependent Hamiltonians that cannot be
 expressed as a function of constant operators with time-dependent coefficients.
@@ -69,11 +69,11 @@ A very general way to write a time-dependent Hamiltonian or collapse operator is
 
 >>> H = [H0, [H1, py_coeff1], [H2, py_coeff2], ...] # doctest: +SKIP
 
-where ``H0`` is a time-independent Hamiltonian, while ``H1``and ``H2`` are time dependent. The same format can be used for collapse operators:
+where ``H0`` is a time-independent Hamiltonian, while ``H1`` and ``H2`` are time-dependent. The same format can be used for collapse operators:
 
 >>> c_ops = [[C0, py_coeff0], C1, [C2, py_coeff2], ...] # doctest: +SKIP
 
-Here we have demonstrated that the ordering of time-dependent and time-independent terms does not matter.  In addition, any or all of the collapse operators may be time dependent.
+Here we have demonstrated that the ordering of time-dependent and time-independent terms does not matter.  In addition, any or all of the collapse operators may be time-dependent.
 
 .. note:: While, in general, you can arrange time-dependent and time-independent terms in any order you like, it is best to place all time-independent terms first.
 
@@ -121,7 +121,7 @@ Given that we have a single time-dependent Hamiltonian term, and constant collap
     def H1_coeff(t, args):
         return 9 * np.exp(-(t / 5.) ** 2)
 
-In this case, the return value dependents only on time.  However, when specifying Python functions for coefficients, **the function must have (t,args) as the input variables, in that order**.  Having specified our coefficient function, we can now specify the Hamiltonian in list format and call the solver (in this case :func:`qutip.mesolve`)
+In this case, the return value depends only on time.  However, when specifying Python functions for coefficients, **the function must have (t,args) as the input variables, in that order**.  Having specified our coefficient function, we can now specify the Hamiltonian in list format and call the solver (in this case :func:`qutip.mesolve`)
 
 .. plot::
     :context:
@@ -163,7 +163,7 @@ The output from the master equation solver is identical to that shown in the exa
 
 Using the args variable
 ------------------------
-In the previous example we hardcoded all of the variables, driving amplitude :math:`A` and width :math:`\sigma`, with their numerical values.  This is fine for problems that are specialized, or that we only want to run once.  However, in many cases, we would like to change the parameters of the problem in only one location (usually at the top of the script), and not have to worry about manually changing the values on each run.  QuTiP allows you to accomplish this using the keyword ``args`` as an input to the solvers.  For instance, instead of explicitly writing 9 for the amplitude and 5 for the width of the gaussian driving term, we can make us of the args variable
+In the previous example we hardcoded all of the variables, driving amplitude :math:`A` and width :math:`\sigma`, with their numerical values.  This is fine for problems that are specialized, or that we only want to run once.  However, in many cases, we would like to change the parameters of the problem in only one location (usually at the top of the script), and not have to worry about manually changing the values on each run.  QuTiP allows you to accomplish this using the keyword ``args`` as an input to the solvers.  For instance, instead of explicitly writing 9 for the amplitude and 5 for the width of the gaussian driving term, we can make use of the ``args`` variable
 
 .. plot::
     :context:
@@ -183,7 +183,7 @@ or equivalently,
           sig = args['sigma']
           return A * np.exp(-(t / sig) ** 2)
 
-where args is a Python dictionary of ``key: value`` pairs ``args = {'A': a, 'sigma': b}`` where ``a`` and ``b`` are the two parameters for the amplitude and width, respectively.  Of course, we can always hardcode the values in the dictionary as well ``args = {'A': 9, 'sigma': 5}``, but there is much more flexibility by using variables in ``args``.  To let the solvers know that we have a set of args to pass we append the ``args`` to the end of the solver input:
+where ``args`` is a Python dictionary of ``key: value`` pairs ``args = {'A': a, 'sigma': b}`` where ``a`` and ``b`` are the two parameters for the amplitude and width, respectively.  Of course, we can always hardcode the values in the dictionary as well ``args = {'A': 9, 'sigma': 5}``, but there is much more flexibility by using variables in ``args``.  To let the solvers know that we have a set of args to pass we append the ``args`` to the end of the solver input:
 
 .. plot::
     :context:
@@ -209,7 +209,7 @@ String Format Method
 
 .. note:: You must have Cython installed on your computer to use this format.  See :ref:`install` for instructions on installing Cython.
 
-The string-based time-dependent format works in a similar manner as the previously discussed Python function method.  That being said, the underlying code does something completely different.  When using this format, the strings used to represent the time-dependent coefficients, as well as Hamiltonian and collapse operators, are rewritten as Cython code using a code generator class and then compiled into C code.  The details of this meta-programming will be published in due course.  however, in short, this can lead to a substantial reduction in time for complex time-dependent problems, or when simulating over long intervals.
+The string-based time-dependent format works in a similar manner as the previously discussed Python function method.  That being said, the underlying code does something completely different.  When using this format, the strings used to represent the time-dependent coefficients, as well as Hamiltonian and collapse operators, are rewritten as Cython code using a code generator class and then compiled into C code.  The details of this meta-programming will be published in due course.  However, in short, this can lead to a substantial reduction in time for complex time-dependent problems, or when simulating over long intervals.
 
 Like the previous method, the string-based format uses a list pair format ``[Op, str]`` where ``str`` is now a string representing the time-dependent coefficient.  For our first example, this string would be ``'9 * exp(-(t / 5.) ** 2)'``.  The Hamiltonian in this format would take the form:
 
@@ -282,7 +282,7 @@ Collapse operators are handled in the exact same way.
 Modeling Non-Analytic and/or Experimental Time-Dependent Parameters using Interpolating Functions
 =================================================================================================
 
-Sometimes it is necessary to model a system where the time-dependent parameters are non-analytic functions, or are derived from experimental data (i.e. a collection of data points).  In these situations, one can use interpolating functions as an approximate functional form for input into a time-dependent solver.  QuTiP includes it own custom cubic spline interpolation class :class:`qutip.interpolate.Cubic_Spline` to provide this functionality.  To see how this works, lets first generate some noisy data:
+Sometimes it is necessary to model a system where the time-dependent parameters are non-analytic functions, or are derived from experimental data (i.e. a collection of data points).  In these situations, one can use interpolating functions as an approximate functional form for input into a time-dependent solver.  QuTiP includes its own custom cubic spline interpolation class :class:`qutip.interpolate.Cubic_Spline` to provide this functionality.  To see how this works, lets first generate some noisy data:
 
 .. plot::
     :context: close-figs
@@ -392,7 +392,7 @@ Running String-Based Time-Dependent Problems using Parfor
 
 .. note:: This section covers a specialized topic and may be skipped if you are new to QuTiP.
 
-In this section we discuss running string-based time-dependent problems using the :func:`qutip.parallel.parfor` function.  As the :func:`qutip.mcsolve` function is already parallelized, running string-based time dependent problems inside of parfor loops should be restricted to the :func:`qutip.mesolve` function only. When using the string-based format, the system Hamiltonian and collapse operators are converted into C code with a specific file name that is automatically genrated, or supplied by the user via the ``rhs_filename`` property of the :class:`qutip.solver.Options` class. Because the :func:`qutip.parallel.parfor` function uses the built-in Python multiprocessing functionality, in calling the solver inside a parfor loop, each thread will try to generate compiled code with the same file name, leading to a crash.  To get around this problem you can call the :func:`qutip.rhs_generate` function to compile simulation into C code before calling parfor.  You **must** then set the :class:`qutip.solver.Options` object ``rhs_reuse=True`` for all solver calls inside the parfor loop that indicates that a valid C code file already exists and a new one should not be generated.  As an example, we will look at the Landau-Zener-Stuckelberg interferometry example that can be found in the notebook "Time-dependent master equation: Landau-Zener-Stuckelberg inteferometry" in the tutorials section of the QuTiP web site.
+In this section we discuss running string-based time-dependent problems using the :func:`qutip.parallel.parfor` function.  As the :func:`qutip.mcsolve` function is already parallelized, running string-based time-dependent problems inside of parfor loops should be restricted to the :func:`qutip.mesolve` function only. When using the string-based format, the system Hamiltonian and collapse operators are converted into C code with a specific file name that is automatically genrated, or supplied by the user via the ``rhs_filename`` property of the :class:`qutip.solver.Options` class. Because the :func:`qutip.parallel.parfor` function uses the built-in Python multiprocessing functionality, in calling the solver inside a parfor loop, each thread will try to generate compiled code with the same file name, leading to a crash.  To get around this problem you can call the :func:`qutip.rhs_generate` function to compile simulation into C code before calling parfor.  You **must** then set the :class:`qutip.solver.Options` object ``rhs_reuse=True`` for all solver calls inside the parfor loop that indicates that a valid C code file already exists and a new one should not be generated.  As an example, we will look at the Landau-Zener-Stuckelberg interferometry example that can be found in the notebook "Time-dependent master equation: Landau-Zener-Stuckelberg inteferometry" in the tutorials section of the QuTiP web site.
 
 To set up the problem, we run the following code:
 
@@ -447,7 +447,7 @@ Here, we have given the generated file a custom name ``lz_func``, however this i
           p_mat_m[n] = expect(sn, rho_ss)
       return [m, p_mat_m]
 
-Notice the Options ``opts`` in the call to the :func:`qutip.propagator` function.  This is tells the :func:`qutip.mesolve` function used in the propagator to call the pre-generated file ``lz_func``. If this were missing then the routine would fail.
+Notice the Options ``opts`` in the call to the :func:`qutip.propagator` function.  This tells the :func:`qutip.mesolve` function used in the propagator to call the pre-generated file ``lz_func``. If this was missing then the routine would fail.
 
 .. plot::
     :context: reset


### PR DESCRIPTION
**Description**
This fixes typos I was able to find in the documentation for "Solving Problems with Time-dependent Hamiltonians"

**Related issues or PRs**
None

**Changelog**
Some typos in the documentation for solving problems with time-dependent Hamiltonians have been corrected