### PR TITLE
Fix _repr_svg_ for recent IPython

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -293,7 +293,7 @@ class Bloch:
     def _repr_svg_(self):
         from IPython.core.pylabtools import print_figure
         self.render()
-        fig_data = print_figure(self.fig, 'svg').decode('utf-8')
+        fig_data = print_figure(self.fig, 'svg')
         plt.close(self.fig)
         return fig_data
 

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -361,3 +361,7 @@ class TestBloch:
             vector_kws = [vector_kws]
         self.plot_vector_test(fig_test, copy.deepcopy(vector_kws))
         self.plot_vector_ref(fig_ref, copy.deepcopy(vector_kws))
+
+def test_repr_svg():
+    svg = Bloch()._repr_svg_()
+    assert isinstance(svg, str)

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -363,5 +363,9 @@ class TestBloch:
         self.plot_vector_ref(fig_ref, copy.deepcopy(vector_kws))
 
 def test_repr_svg():
-    svg = Bloch()._repr_svg_()
-    assert isinstance(svg, str)
+    try:
+        # test when ipython is available
+        svg = Bloch()._repr_svg_()
+        assert isinstance(svg, str)
+    except ImportError:
+        pass


### PR DESCRIPTION
The ipython `print_figure` method was modified to return `str` instead of `bytes` when the `svg` option is used. See https://github.com/ipython/ipython/commit/4a2e85faf8e30c70a5d2c1af6bb45e2cdee5a067

This PR fixes the conversion in `qutip`, but does it using a check so that older versions of ipython still work.


