### PR TITLE
Activate mcsolve tests on Windows in QuTiP 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
           # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
           - case-name: Windows Latest
             os: windows-latest
-            pytest-extra-options: "-k 'not (test_correlation or test_interpolate)'"
+            pytest-extra-options: "-k 'not (test_correlation)'"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,6 @@ jobs:
           # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
           - case-name: Windows Latest
             os: windows-latest
-            pytest-extra-options: "-k 'not (test_correlation)'"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,7 @@ jobs:
           # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
           - case-name: Windows Latest
             os: windows-latest
+            pytest-extra-options: "-k 'not (test_correlation)'"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
           # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
           - case-name: Windows Latest
             os: windows-latest
-            pytest-extra-options: "-k 'not (test_correlation or test_interpolate or test_mcsolve)'"
+            pytest-extra-options: "-k 'not (test_correlation or test_interpolate)'"
 
     steps:
       - uses: actions/checkout@v2

--- a/qutip/solve/mcsolve.py
+++ b/qutip/solve/mcsolve.py
@@ -9,7 +9,7 @@ from scipy.integrate._ode import zvode
 
 from ..core import Qobj, QobjEvo
 from ..core import data as _data
-from ..parallel import parallel_map, serial_map
+from ..solver.parallel import parallel_map, serial_map
 from ._mcsolve import CyMcOde, CyMcOdeDiag
 from .sesolve import sesolve
 from .solver import SolverOptions, Result, ExpectOps, solver_safe, SolverSystem
@@ -350,9 +350,9 @@ class _MC():
             self.seed(num_traj, self.seeds)
 
         if progress_bar is None:
-            progress_bar = BaseProgressBar()
+            progress_bar = ""
         elif progress_bar is True:
-            progress_bar = TextProgressBar()
+            progress_bar = "text"
 
         # set arguments for input to monte carlo
         map_kwargs_ = {'progress_bar': progress_bar}

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -155,6 +155,8 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
     if sys.version_info >= (3, 7):
         # ProcessPoolExecutor only supports mp_context from 3.7 onwards
         ctx_kw = {"mp_context": mp_context}
+    else:
+        ctx_kw = {}
 
     os.environ['QUTIP_IN_PARALLEL'] = 'TRUE'
     try:

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -123,7 +123,8 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
         The optional additional keyword argument to the ``task`` function.
     reduce_func : func (optional)
         If provided, it will be called with the output of each tasks instead of
-        storing a them in a list.
+        storing a them in a list. Note that the order in which results are
+        passed to ``reduce_func`` is not defined.
     progress_bar : string
         Progress bar options's string for showing progress.
     progress_bar_kwargs : dict

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -16,7 +16,9 @@ from qutip.settings import available_cpu_count
 if sys.platform == 'darwin':
     mp_context = multiprocessing.get_context('fork')
 elif sys.platform == 'linux':
-    mp_context = multiprocessing.get_context('forkserver')
+    # forkserver would handle threads better, but is much slower at starting
+    # the executor and spawning tasks
+    mp_context = multiprocessing.get_context('fork')
 else:
     mp_context = multiprocessing.get_context()
 

--- a/qutip/tests/solver/test_parallel.py
+++ b/qutip/tests/solver/test_parallel.py
@@ -68,4 +68,4 @@ def test_map_accumulator(map, num_cpus):
     y1 = [_func1(xx) for xx in x]
 
     map(_func2, x, args, kwargs, reduce_func=y2.append, map_kw=map_kw)
-    assert ((np.array(y1) == np.array(y2)).all())
+    assert ((np.array(sorted(y1)) == np.array(sorted(y2))).all())


### PR DESCRIPTION
**Description**
Activate the mcsolve tests in QuTiP 5.

Changes:
- [x] Swap parallel_map over to ProcessPoolExecutor.
- [x] Switch ``mcsolve`` to the new parallel_map. 
- [x] Reactivated mcsolve tests on Windows. 

**Related issues or PRs**
- Continues work from #1853 and #1854 in v4
- #1202 (maybe already resolved in QuTiP 5)
- #1190 (hopefully already resolved in QuTiP 5)