### PR TITLE
`bloch_redfield_tensor` support different spectra types

### DIFF
--- a/doc/changes/1951.feature
+++ b/doc/changes/1951.feature
@@ -1,0 +1,1 @@
+Add support for different spectra types for bloch_redfield_tensor

--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -119,10 +119,10 @@ def brterm(H, a_op, spectra, sec_cutoff=0.1,
 
     spectra : :class:`Coefficient`, func, str
         The corresponding bath spectra.
-        Can be a `Coefficient` using an 'w' args, a function of the
-        frequency or a string. The `SpectraCoefficient` can be used for
+        Can be a :class:`~Coefficient` using an 'w' args, a function of the
+        frequency or a string. The :class:`SpectraCoefficient` can be used for
         array based coefficient.
-        The spectra function can depend on ``t`` if the corresponding
+        The spectra can depend on ``t`` if the corresponding
         ``a_op`` is a :class:`QobjEvo`.
 
         Example:

--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -35,10 +35,10 @@ def bloch_redfield_tensor(H, a_ops, c_ops=[], sec_cutoff=0.1,
 
         spectra : :class:`Coefficient`, func, str
             The corresponding bath spectra.
-            Can be a `Coefficient` using an 'w' args, a function of the
-            frequency or a string. The `SpectraCoefficient` can be used for
+            Can be a :class:`~Coefficient` using an 'w' args, a function of the
+            frequency or a string. The :class:`SpectraCoefficient` can be used for
             array based coefficient.
-            The spectra function can depend on ``t`` if the corresponding
+            The spectra can depend on ``t`` if the corresponding
             ``a_op`` is a :class:`QobjEvo`.
 
         Example:

--- a/qutip/tests/core/test_brtools.py
+++ b/qutip/tests/core/test_brtools.py
@@ -303,3 +303,34 @@ def test_bloch_redfield_tensor_time_dependence(cutoff, fock_basis):
         R_expected = R_expected[0] if not fock_basis else R_expected
         np.testing.assert_allclose(R(t).full(), R_expected.full(),
                                    rtol=1e-14, atol=1e-14)
+
+
+def test_bloch_redfield_tensor_spectral_string():
+    N = 5
+    H = qutip.num(N)
+    a = qutip.destroy(N)
+    A_op = a + a.dag()
+    spectra = "(w>0) * 0.5"
+    R_eigs, evecs = bloch_redfield_tensor(
+        H=H,
+        a_ops=[(A_op, spectra)],
+        c_ops=[a**2],
+        fock_basis=False
+    )
+    assert isinstance(R_eigs, qutip.QobjEvo)
+    assert isinstance(evecs, qutip.Qobj)
+
+def test_bloch_redfield_tensor_spectral_callable():
+    N = 5
+    H = qutip.num(N)
+    a = qutip.destroy(N)
+    A_op = a + a.dag()
+    spectra = lambda w: (w>0) * 0.5
+    R_eigs, evecs = bloch_redfield_tensor(
+        H=H,
+        a_ops=[(A_op, spectra)],
+        c_ops=[a**2],
+        fock_basis=False
+    )
+    assert isinstance(R_eigs, qutip.QobjEvo)
+    assert isinstance(evecs, qutip.Qobj)

--- a/qutip/tests/core/test_brtools.py
+++ b/qutip/tests/core/test_brtools.py
@@ -317,7 +317,7 @@ def test_bloch_redfield_tensor_spectral_string():
         c_ops=[a**2],
         fock_basis=False
     )
-    assert isinstance(R_eigs, qutip.QobjEvo)
+    assert isinstance(R_eigs, qutip.Qobj)
     assert isinstance(evecs, qutip.Qobj)
 
 def test_bloch_redfield_tensor_spectral_callable():
@@ -332,5 +332,5 @@ def test_bloch_redfield_tensor_spectral_callable():
         c_ops=[a**2],
         fock_basis=False
     )
-    assert isinstance(R_eigs, qutip.QobjEvo)
+    assert isinstance(R_eigs, qutip.Qobj)
     assert isinstance(evecs, qutip.Qobj)


### PR DESCRIPTION
**Description**
The function `bloch_redfield_tensor` required the spectra given in `a_ops` to be `qutip.Coefficient`. For compatability with `brmesolve` I added support for strings and callables in `bloch_redfield_tensor`. 