### PR TITLE
Floquet rates integration

### DIFF
--- a/qutip/floquet.py
+++ b/qutip/floquet.py
@@ -612,7 +612,7 @@ def floquet_master_equation_rates(f_modes_0, f_energies, c_op, H, T,
     Gamma = np.zeros((N, N, M))
     A = np.zeros((N, N))
 
-    nT = 100
+    nT = 2 * kmax * np.ceil(omega)
     dT = T / nT
     tlist = np.arange(dT, T + dT / 2, dT)
 

--- a/qutip/floquet.py
+++ b/qutip/floquet.py
@@ -612,7 +612,8 @@ def floquet_master_equation_rates(f_modes_0, f_energies, c_op, H, T,
     Gamma = np.zeros((N, N, M))
     A = np.zeros((N, N))
 
-    nT = 2 * kmax * np.ceil(omega)
+    # time steps for integration of coupling operator
+    nT = np.max([2 * kmax * np.ceil(omega), 100])
     dT = T / nT
     tlist = np.arange(dT, T + dT / 2, dT)
 


### PR DESCRIPTION
**Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.
- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](http://qutip.org/docs/latest/development/contributing.html#Changelog%20Generation) for more information).

**Description**
The numerical integration for the `X` matrix uses the rectangular rule with a fixed number of time steps `nT = 100`. I changed `nT` to vary with the given `kmax` since the integrands frequency increases with `kmax`. 
