### PR TITLE
Fix fidelity for pure states

### DIFF
--- a/doc/changes/1964.bugfix
+++ b/doc/changes/1964.bugfix
@@ -1,0 +1,1 @@
+Fix fidelity for pure states.

--- a/doc/changes/1964.bugfix
+++ b/doc/changes/1964.bugfix
@@ -1,1 +1,1 @@
-Fix fidelity for pure states.
+Change fidelity(A, B) to use the reduced fidelity formula for pure states which is more numerically efficient and accurate.

--- a/qutip/metrics.py
+++ b/qutip/metrics.py
@@ -53,12 +53,13 @@ def fidelity(A, B):
     >>> np.testing.assert_almost_equal(fidelity(x,y), 0.24104350624628332)
     """
     if A.isket or A.isbra:
+        if B.isket or B.isbra:
+            # The fidelity for pure states reduces to the modulus of their
+            # inner product.
+            return np.abs(A.overlap(B))
         # Take advantage of the fact that the density operator for A
         # is a projector to avoid a sqrtm call.
         sqrtmA = ket2dm(A)
-        # Check whether we have to turn B into a density operator, too.
-        if B.isket or B.isbra:
-            B = ket2dm(B)
     else:
         if B.isket or B.isbra:
             # Swap the order so that we can take a more numerically


### PR DESCRIPTION
**Description**
The previous code converted both states to density matrices, which is both inefficient and numerically inaccurate. We propose to use the reduced fidelity formula for pure states, given by the modulus of their inner product.

**Related issues or PRs**
Related to #361 and #925.

Reusing @lucainnocenti example (https://github.com/qutip/qutip/issues/925#issuecomment-542318121):
```python
import qutip as qt
import numpy as np

A = qt.Qobj(np.array([
    0.867314655330313 - 0.4576338188944636j,
    0.17267952805615244 - 0.09111291375544905j,
    0.013020232894921149 -0.006875138252288391j
]))
B = qt.Qobj(np.array([
    0.9806443568092577, 0.19524328915024022, 0.014720852555238875
]))

fid1 = np.abs(np.vdot(A.full(), B.full()))
fid2 = np.abs((A.dag() * B)[0, 0])
fid3 = np.abs(A.overlap(B))
fid_qt = qt.fidelity(A, B)
print(f'Correct:\n{fid1}\n{fid2}\n{fid3}')
print(f'Incorrect:\n{fid_qt}')
```
```
Correct:
0.9999999999849929
0.9999999999849929
0.9999999999849929
Incorrect:
1.0000000028441378
```

Note that this PR does not fix the proposition from @lucainnocenti https://github.com/qutip/qutip/issues/925#issuecomment-542318121 to perform the general computation using `scipy.linalg.svdvals` at the cost of computing the square root of both matrices.