### PR TITLE
`Brmesolve` properly raise error when ode fails.

### DIFF
--- a/doc/changes/1965.bugfix
+++ b/doc/changes/1965.bugfix
@@ -1,0 +1,1 @@
+`brmesolve` raise an error when ode is not successful

--- a/qutip/bloch_redfield.py
+++ b/qutip/bloch_redfield.py
@@ -33,48 +33,48 @@ def brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[],
               progress_bar=None, _safe_mode=True, verbose=False):
     """
     Solves for the dynamics of a system using the Bloch-Redfield master equation,
-    given an input Hamiltonian, Hermitian bath-coupling terms and their associated 
+    given an input Hamiltonian, Hermitian bath-coupling terms and their associated
     spectrum functions, as well as possible Lindblad collapse operators.
-              
+
     For time-independent systems, the Hamiltonian must be given as a Qobj,
     whereas the bath-coupling terms (a_ops), must be written as a nested list
     of operator - spectrum function pairs, where the frequency is specified by
     the `w` variable.
-              
+
     *Example*
 
-        a_ops = [[a+a.dag(),lambda w: 0.2*(w>=0)]] 
-              
+        a_ops = [[a+a.dag(),lambda w: 0.2*(w>=0)]]
+
     For time-dependent systems, the Hamiltonian, a_ops, and Lindblad collapse
     operators (c_ops), can be specified in the QuTiP string-based time-dependent
-    format.  For the a_op spectra, the frequency variable must be `w`, and the 
+    format.  For the a_op spectra, the frequency variable must be `w`, and the
     string cannot contain any other variables other than the possibility of having
     a time-dependence through the time variable `t`:
-                            
+
     *Example*
 
         a_ops = [[a+a.dag(), '0.2*exp(-t)*(w>=0)']]
-              
+
     It is also possible to use Cubic_Spline objects for time-dependence.  In
     the case of a_ops, Cubic_Splines must be passed as a tuple:
-              
+
     *Example*
-              
+
         a_ops = [ [a+a.dag(), ( f(w), g(t)] ]
-              
+
     where f(w) and g(t) are strings or Cubic_spline objects for the bath
     spectrum and time-dependence, respectively.
-              
+
     Finally, if one has bath-couplimg terms of the form
     H = f(t)*a + conj[f(t)]*a.dag(), then the correct input format is
-              
+
     *Example*
-    
+
               a_ops = [ [(a,a.dag()), (f(w), g1(t), g2(t))],... ]
 
     where f(w) is the spectrum of the operators while g1(t) and g2(t)
-    are the time-dependence of the operators `a` and `a.dag()`, respectively 
-    
+    are the time-dependence of the operators `a` and `a.dag()`, respectively
+
     Parameters
     ----------
     H : Qobj / list
@@ -88,7 +88,7 @@ def brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[],
         List of times for evaluating evolution
 
     a_ops : list
-        Nested list of Hermitian system operators that couple to 
+        Nested list of Hermitian system operators that couple to
         the bath degrees of freedom, along with their associated
         spectra.
 
@@ -99,25 +99,25 @@ def brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[],
         List of system collapse operators, or nested list in
         string-based format.
 
-    args : dict 
+    args : dict
         Placeholder for future implementation, kept for API consistency.
 
     use_secular : bool {True}
         Use secular approximation when evaluating bath-coupling terms.
-    
+
     sec_cutoff : float {0.1}
         Cutoff for secular approximation.
-    
+
     tol : float {qutip.setttings.atol}
-        Tolerance used for removing small values after 
+        Tolerance used for removing small values after
         basis transformation.
-              
+
     spectra_cb : list
         DEPRECIATED. Do not use.
-    
+
     options : :class:`qutip.solver.Options`
         Options for the solver.
-              
+
     progress_bar : BaseProgressBar
         Optional instance of BaseProgressBar, or a subclass thereof, for
         showing the progress of the simulation.
@@ -136,7 +136,7 @@ def brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[],
     if isinstance(H, list):
         if np.all([isinstance(h,Qobj) for h in H]):
             H = sum(H)
-    
+
     if isinstance(c_ops, Qobj):
         c_ops = [c_ops]
 
@@ -148,7 +148,7 @@ def brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[],
         e_ops = [e for e in e_ops.values()]
     else:
         e_ops_dict = None
-    
+
     if not (spectra_cb is None):
         warnings.warn("The use of spectra_cb is depreciated.", DeprecationWarning)
         _a_ops = []
@@ -158,27 +158,27 @@ def brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[],
 
     if _safe_mode:
         _solver_safety_check(H, psi0, a_ops+c_ops, e_ops, args)
-    
+
     # check for type (if any) of time-dependent inputs
     _, n_func, n_str = _td_format_check(H, a_ops+c_ops)
-    
+
     if progress_bar is None:
         progress_bar = BaseProgressBar()
     elif progress_bar is True:
         progress_bar = TextProgressBar()
-        
+
     if options is None:
         options = Options()
 
     if (not options.rhs_reuse) or (not config.tdfunc):
         # reset config collapse and time-dependence flags to default values
         config.reset()
-    
+
     #check if should use OPENMP
     check_use_openmp(options)
-    
+
     if n_str == 0:
-    
+
         R, ekets = bloch_redfield_tensor(H, a_ops, spectra_cb=None, c_ops=c_ops,
                     use_secular=use_secular, sec_cutoff=sec_cutoff)
 
@@ -195,18 +195,18 @@ def brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[],
             output.states = results
 
         return output
-        
+
     elif n_str != 0 and n_func == 0:
-        output = _td_brmesolve(H, psi0, tlist, a_ops=a_ops, e_ops=e_ops, 
-                        c_ops=c_ops, args=args, use_secular=use_secular, 
+        output = _td_brmesolve(H, psi0, tlist, a_ops=a_ops, e_ops=e_ops,
+                        c_ops=c_ops, args=args, use_secular=use_secular,
                         sec_cutoff=sec_cutoff,
-                        tol=tol, options=options, 
+                        tol=tol, options=options,
                          progress_bar=progress_bar,
-                         _safe_mode=_safe_mode, verbose=verbose, 
+                         _safe_mode=_safe_mode, verbose=verbose,
                          _prep_time=_prep_time)
-                         
+
         return output
-        
+
     else:
         raise Exception('Cannot mix func and str formats.')
 
@@ -262,7 +262,7 @@ def bloch_redfield_solve(R, ekets, rho0, tlist, e_ops=[], options=None, progress
         progress_bar = BaseProgressBar()
     elif progress_bar is True:
         progress_bar = TextProgressBar()
-    
+
     #
     # check initial state
     #
@@ -310,7 +310,10 @@ def bloch_redfield_solve(R, ekets, rho0, tlist, e_ops=[], options=None, progress
     for t_idx, _ in enumerate(tlist):
         progress_bar.update(t_idx)
         if not r.successful():
-            break
+            raise Exception("ODE integration error: Try to increase "
+                            "the allowed number of substeps by increasing "
+                            "the nsteps parameter in the Options class.")
+
 
         rho_eb.data = dense2D_to_fastcsr_fmode(vec2mat(r.y), rho0.shape[0], rho0.shape[1])
 
@@ -332,17 +335,17 @@ def bloch_redfield_solve(R, ekets, rho0, tlist, e_ops=[], options=None, progress
 
 def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
                  use_secular=True, sec_cutoff=0.1,
-                 tol=qset.atol, options=None, 
+                 tol=qset.atol, options=None,
                  progress_bar=None,_safe_mode=True,
                  verbose=False,
                  _prep_time=0):
-    
+
     if isket(psi0):
         rho0 = ket2dm(psi0)
     else:
         rho0 = psi0
     nrows = rho0.shape[0]
-    
+
     H_terms = []
     H_td_terms = []
     H_obj = []
@@ -355,11 +358,11 @@ def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
     coupled_ops = []
     coupled_lengths = []
     coupled_spectra = []
-    
+
     if isinstance(H, Qobj):
         H_terms.append(H.full('f'))
         H_td_terms.append('1')
-    else: 
+    else:
         for kk, h in enumerate(H):
             if isinstance(h, Qobj):
                 H_terms.append(h.full('f'))
@@ -372,8 +375,8 @@ def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
                 H_td_terms.append(h[1])
             else:
                 raise Exception('Invalid Hamiltonian specification.')
-    
-            
+
+
     for kk, c in enumerate(c_ops):
         if isinstance(c, Qobj):
             C_terms.append(c.full('f'))
@@ -386,7 +389,7 @@ def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
             C_td_terms.append(c[1])
         else:
             raise Exception('Invalid collapse operator specification.')
-            
+
     coupled_offset = 0
     for kk, a in enumerate(a_ops):
         if isinstance(a, list):
@@ -405,25 +408,25 @@ def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
                     raise Exception('Invalid bath-coupling specification.')
                 if (len(a[0])+1) != len(a[1]):
                     raise Exception('BR a_ops tuple lengths not compatible.')
-                
+
                 coupled_ops.append(kk+coupled_offset)
                 coupled_lengths.append(len(a[0]))
                 coupled_spectra.append(a[1][0])
                 coupled_offset += len(a[0])-1
                 if isinstance(a[1][0],Cubic_Spline):
                     spline_count[1] += 1
-                
+
                 for nn, _a in enumerate(a[0]):
                     A_terms.append(_a.full('f'))
                     A_td_terms.append(a[1][nn+1])
                     if isinstance(a[1][nn+1],Cubic_Spline):
                         CA_obj.append(a[1][nn+1].coeffs)
                         spline_count[1] += 1
-                                
+
         else:
             raise Exception('Invalid bath-coupling specification.')
-            
-    
+
+
     string_list = []
     for kk,_ in enumerate(H_td_terms):
         string_list.append("H_terms[{0}]".format(kk))
@@ -443,7 +446,7 @@ def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
         else:
             string_list.append(str(value))
     parameter_string = ",".join(string_list)
-    
+
     if verbose:
         print('BR prep time:', time.time()-_prep_time)
     #
@@ -456,9 +459,9 @@ def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
             config.tdname = opt.rhs_filename
         if verbose:
             _st = time.time()
-        cgen = BR_Codegen(h_terms=len(H_terms), 
+        cgen = BR_Codegen(h_terms=len(H_terms),
                     h_td_terms=H_td_terms, h_obj=H_obj,
-                    c_terms=len(C_terms), 
+                    c_terms=len(C_terms),
                     c_td_terms=C_td_terms, c_obj=CA_obj,
                     a_terms=len(A_terms), a_td_terms=A_td_terms,
                     spline_count=spline_count,
@@ -469,11 +472,11 @@ def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
                     use_secular = use_secular,
                     sec_cutoff = sec_cutoff,
                     args=args,
-                    use_openmp=options.use_openmp, 
+                    use_openmp=options.use_openmp,
                     omp_thresh=qset.openmp_thresh if qset.has_openmp else None,
-                    omp_threads=options.num_cpus, 
+                    omp_threads=options.num_cpus,
                     atol=tol)
-        
+
         cgen.generate(config.tdname + ".pyx")
         code = compile('from ' + config.tdname + ' import cy_td_ode_rhs',
                        '<string>', 'exec')
@@ -482,19 +485,19 @@ def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
         if verbose:
             print('BR compile time:', time.time()-_st)
     initial_vector = mat2vec(rho0.full()).ravel()
-    
+
     _ode = scipy.integrate.ode(config.tdfunc)
     code = compile('_ode.set_f_params(' + parameter_string + ')',
                     '<string>', 'exec')
-    _ode.set_integrator('zvode', method=options.method, 
-                    order=options.order, atol=options.atol, 
+    _ode.set_integrator('zvode', method=options.method,
+                    order=options.order, atol=options.atol,
                     rtol=options.rtol, nsteps=options.nsteps,
-                    first_step=options.first_step, 
+                    first_step=options.first_step,
                     min_step=options.min_step,
                     max_step=options.max_step)
     _ode.set_initial_value(initial_vector, tlist[0])
     exec(code, locals())
-    
+
     #
     # prepare output array
     #
@@ -538,7 +541,7 @@ def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
     #
     if type(progress_bar)==BaseProgressBar and verbose:
         _run_time = time.time()
-    
+
     progress_bar.start(n_tsteps)
 
     rho = Qobj(rho0)
@@ -574,13 +577,13 @@ def _td_brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[], args={},
             _ode.integrate(_ode.t + dt[t_idx])
 
     progress_bar.finished()
-    
+
     if type(progress_bar)==BaseProgressBar and verbose:
         print('BR runtime:', time.time()-_run_time)
 
     if (not options.rhs_reuse) and (config.tdname is not None):
         _cython_build_cleanup(config.tdname)
-    
+
     if options.store_final_state:
         rho.data = dense2D_to_fastcsr_fmode(vec2mat(_ode.y), rho.shape[0], rho.shape[1])
         output.final_state = Qobj(rho, dims=rho0.dims, isherm=True)

--- a/qutip/bloch_redfield.py
+++ b/qutip/bloch_redfield.py
@@ -314,7 +314,6 @@ def bloch_redfield_solve(R, ekets, rho0, tlist, e_ops=[], options=None, progress
                             "the allowed number of substeps by increasing "
                             "the nsteps parameter in the Options class.")
 
-
         rho_eb.data = dense2D_to_fastcsr_fmode(vec2mat(r.y), rho0.shape[0], rho0.shape[1])
 
         # calculate all the expectation values, or output rho_eb if no

--- a/qutip/tests/test_brmesolve.py
+++ b/qutip/tests/test_brmesolve.py
@@ -166,3 +166,19 @@ def test_solver_accepts_list_hamiltonian():
     brme = qutip.brmesolve(H, psi0, times, [], e_ops, c_ops).expect
     for me_expectation, brme_expectation in zip(me, brme):
         np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-8)
+
+
+def test_solver_overwork_error():
+    """
+    brmesolve: input list of Qobj
+    """
+    c_ops = qutip.sigmax()
+    H = 100 * qutip.sigmax() +  200 * qutip.sigmaz()
+    psi0 = (2*qutip.basis(2, 0) + qutip.basis(2, 1)).unit()
+    times = np.linspace(0, 10, 100)
+    options = qutip.Options(nsteps=2)
+    with pytest.raises(Exception) as err:
+        brme = qutip.brmesolve(
+            H, psi0, times, a_ops=[[c_ops, lambda w: w>0]], options=options
+        )
+    assert "ODE integration error" in str(err.value)

--- a/qutip/tests/test_brmesolve.py
+++ b/qutip/tests/test_brmesolve.py
@@ -168,6 +168,7 @@ def test_solver_accepts_list_hamiltonian():
         np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-8)
 
 
+@pytest.mark.filterwarnings("ignore:zvode.*Excess work done:UserWarning")
 def test_solver_overwork_error():
     """
     brmesolve: input list of Qobj


### PR DESCRIPTION
**Description**
For constant systems, when the ODE solver is not successful, `brmesolve` returned an incomplete result without telling the user something failed.
With this PR. an exception is raised in these situations.

**Related issues or PRs**
#1965 