### PR TITLE
Protect compilation of coefficient using filelock

### DIFF
--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -157,7 +157,6 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
     progress_bar = progess_bars[progress_bar]()
     progress_bar.start(len(values), **progress_bar_kwargs)
 
-    errors = []
     if reduce_func is not None:
         results = None
         result_func = lambda i, value: reduce_func(value)
@@ -167,12 +166,7 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
 
     def _done_callback(future):
         if not future.cancelled():
-            try:
-                result = future.result()
-            except Exception as e:
-                errors.append(e)
-                raise e
-        result_func(future._i, result)
+            result_func(future._i, future.result())
         progress_bar.update()
 
     if sys.version_info >= (3, 7):
@@ -225,8 +219,6 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
         os.environ['QUTIP_IN_PARALLEL'] = 'FALSE'
 
     progress_bar.finished()
-    if errors:
-        raise errors[0]
     return results
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,9 @@ include = qutip*
 
 [options.extras_require]
 graphics = matplotlib>=1.2.1
-runtime_compilation = cython>=0.29.20
+runtime_compilation =
+    cython>=0.29.20
+    filelock
 semidefinite =
     cvxpy>=1.0
     cvxopt


### PR DESCRIPTION
**Description**
Add a lock for creating string coefficient. This allow to use the coefficient inside a parallel loop without issues.
The lock use `filelock` which works across processes, so it's safe to use with parallel coming from outside python.
The lock is per file, so different coefficient can compile in parallel. If there is a conflict, the first process will create and compile the coefficient and the other will use it (raising a hash collision error if not actually the same string.)

`filelock` is a new requirement for runtime compilation.

**Related issues or PRs**
#1963