### PR TITLE
parallel map raise subprocess error.

### DIFF
--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -27,6 +27,7 @@ default_map_kw = {
     'job_timeout': threading.TIMEOUT_MAX,
     'timeout': threading.TIMEOUT_MAX,
     'num_cpus': available_cpu_count(),
+    'fail_fast': True,
 }
 
 
@@ -35,6 +36,13 @@ def _read_map_kw(options):
     map_kw = default_map_kw.copy()
     map_kw.update({k: v for k, v in options.items() if v is not None})
     return map_kw
+
+
+class MapExceptions(Exception):
+    def __init__(self, msg, errors, results):
+        super().__init__(msg, errors, results)
+        self.errors = errors
+        self.results = results
 
 
 def serial_map(task, values, task_args=None, task_kwargs=None,
@@ -68,8 +76,9 @@ def serial_map(task, values, task_args=None, task_kwargs=None,
     progress_bar_kwargs : dict
         Options for the progress bar.
     map_kw: dict (optional)
-        Dictionary containing entry for 'timeout' the maximum time for the
-        whole map.
+        Dictionary containing:
+        - timeout: float, Maximum time (sec) for the whole map.
+        - fail_fast: bool, Raise an error at the first.
 
     Returns
     --------
@@ -88,18 +97,31 @@ def serial_map(task, values, task_args=None, task_kwargs=None,
     progress_bar = progess_bars[progress_bar]()
     progress_bar.start(len(values), **progress_bar_kwargs)
     end_time = map_kw['timeout'] + time.time()
-    results = []
+    results = None
+    if reduce_func is None:
+        results = [None] * len(values)
+    errors = {}
     for n, value in enumerate(values):
         if time.time() > end_time:
             break
         progress_bar.update(n)
-        result = task(value, *task_args, **task_kwargs)
-        if reduce_func is not None:
-            reduce_func(result)
+        try:
+            result = task(value, *task_args, **task_kwargs)
+        except Exception as err:
+            if map_kw["fail_fast"]:
+                raise err
+            else:
+                errors[n] = err
         else:
-            results.append(result)
+            if reduce_func is not None:
+                reduce_func(result)
+            else:
+                results[n] = result
     progress_bar.finished()
 
+    if errors:
+        raise MapExceptions(f"{len(errors)} iterations failed in serial_map",
+                            errors, results)
     return results
 
 
@@ -133,9 +155,10 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
         Options for the progress bar.
     map_kw: dict (optional)
         Dictionary containing entry for:
-        'timeout': Maximum time for the whole map.
-        'job_timeout': Maximum time for each job in the map.
-        'num_cpus': Number of job to run at once.
+        - timeout: float, Maximum time (sec) for the whole map.
+        - job_timeout: float, Maximum time (sec) for each job in the map.
+        - num_cpus: int, Number of job to run at once.
+        - fail_fast: bool, Raise an error at the first.
 
     Returns
     --------
@@ -157,7 +180,7 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
     progress_bar = progess_bars[progress_bar]()
     progress_bar.start(len(values), **progress_bar_kwargs)
 
-    errors = []
+    errors = {}
     if reduce_func is not None:
         results = None
         result_func = lambda i, value: reduce_func(value)
@@ -170,8 +193,7 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
             try:
                 result = future.result()
             except Exception as e:
-                errors.append(e)
-                raise e
+                errors[future._i] = e
         result_func(future._i, result)
         progress_bar.update()
 
@@ -202,7 +224,7 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
                         timeout=timeout,
                         return_when=concurrent.futures.FIRST_COMPLETED,
                     )
-                if time.time() >= end_time or errors:
+                if time.time() >= end_time or (errors and map_kw['fail_fast']):
                     # no time left, exit the loop
                     break
                 while len(waiting) < map_kw['num_cpus'] and i < len(values):
@@ -225,15 +247,13 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
         os.environ['QUTIP_IN_PARALLEL'] = 'FALSE'
 
     progress_bar.finished()
-    if errors:
-        parents = tuple(set(err.__class__ for err in errors))
-
-        class ParallelExceptions(*parents):
-            def __init__(self, msg, errors):
-                super().__init__(msg, errors)
-                self.errors = errors
-
-        raise ParallelExceptions("Errors in parallel_map subprocess.", errors)
+    if errors and map_kw["fail_fast"]:
+        raise list(errors.values())[0]
+    elif errors:
+        raise MapExceptions(
+            f"{len(errors)} iterations failed in parallel_map",
+            errors, results
+        )
 
     return results
 
@@ -269,9 +289,10 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
         Options for the progress bar.
     map_kw: dict (optional)
         Dictionary containing entry for:
-        'timeout': Maximum time for the whole map.
-        'job_timeout': Maximum time for each job in the map.
-        'num_cpus': Number of job to run at once.
+        - timeout: float, Maximum time (sec) for the whole map.
+        - job_timeout: float, Maximum time (sec) for each job in the map.
+        - num_cpus: int, Number of job to run at once.
+        - fail_fast: bool, Raise an error at the first.
 
     Returns
     --------
@@ -296,19 +317,29 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
     executor = get_reusable_executor(max_workers=map_kw['num_cpus'])
     end_time = map_kw['timeout'] + time.time()
     job_time = map_kw['job_timeout']
-    results = []
+    results = None
+    errors = {}
+    if reduce_func is None:
+        results = [None] * len(values)
 
     try:
         jobs = [executor.submit(task, value, *task_args, **task_kwargs)
                for value in values]
 
-        for job in jobs:
+        for n, job in enumerate(jobs):
             remaining_time = min(end_time - time.time(), job_time)
-            result = job.result(remaining_time)
-            if reduce_func is not None:
-                reduce_func(result)
+            try:
+                result = job.result(remaining_time)
+            except Exception as err:
+                if map_kw["fail_fast"]:
+                    raise err
+                else:
+                    errors[n] = err
             else:
-                results.append(result)
+                if reduce_func is not None:
+                    reduce_func(result)
+                else:
+                    results[n] = result
             progress_bar.update()
 
     except KeyboardInterrupt as e:
@@ -322,6 +353,11 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
         executor.shutdown()
     progress_bar.finished()
     os.environ['QUTIP_IN_PARALLEL'] = 'FALSE'
+    if errors:
+        raise MapExceptions(
+            f"{len(errors)} iterations failed in loky_pmap",
+            errors, results
+        )
     return results
 
 

--- a/qutip/tests/solver/test_parallel.py
+++ b/qutip/tests/solver/test_parallel.py
@@ -90,4 +90,4 @@ def test_map_pass_error(map):
 
     with pytest.raises(MyException) as err:
         map(func, [None]*3)
-    assert str(err.value) == "Error in subprocess"
+    assert "Error in subprocess" in str(err.value)

--- a/qutip/tests/solver/test_parallel.py
+++ b/qutip/tests/solver/test_parallel.py
@@ -69,3 +69,25 @@ def test_map_accumulator(map, num_cpus):
 
     map(_func2, x, args, kwargs, reduce_func=y2.append, map_kw=map_kw)
     assert ((np.array(sorted(y1)) == np.array(sorted(y2))).all())
+
+
+class MyException(Exception):
+    pass
+
+
+def func(i):
+    raise MyException("Error in subprocess")
+
+
+@pytest.mark.parametrize('map', [
+    pytest.param(parallel_map, id='parallel_map'),
+    pytest.param(loky_pmap, id='loky_pmap'),
+    pytest.param(serial_map, id='serial_map'),
+])
+def test_map_pass_error(map):
+    if map is loky_pmap:
+        loky = pytest.importorskip("loky")
+
+    with pytest.raises(MyException) as err:
+        map(func, [None]*3)
+    assert str(err.value) == "Error in subprocess"

--- a/qutip/tests/solver/test_parallel.py
+++ b/qutip/tests/solver/test_parallel.py
@@ -73,13 +73,13 @@ def test_map_accumulator(map, num_cpus):
     assert ((np.array(sorted(y1)) == np.array(sorted(y2))).all())
 
 
-class TestException(Exception):
+class CustomException(Exception):
     pass
 
 
 def func(i):
     if i % 2 == 1:
-        raise TestException(f"Error in subprocess {i}")
+        raise CustomException(f"Error in subprocess {i}")
     return i
 
 
@@ -92,7 +92,7 @@ def test_map_pass_error(map):
     if map is loky_pmap:
         loky = pytest.importorskip("loky")
 
-    with pytest.raises(TestException) as err:
+    with pytest.raises(CustomException) as err:
         map(func, range(10))
     assert "Error in subprocess" in str(err.value)
 
@@ -111,7 +111,7 @@ def test_map_store_error(map):
     map_error = err.value
     assert "iterations failed" in str(map_error)
     for iter, error in map_error.errors.items():
-        assert isinstance(error, TestException)
+        assert isinstance(error, CustomException)
         assert f"Error in subprocess {iter}" == str(error)
     for n, result in enumerate(map_error.results):
         if n % 2 == 0:

--- a/qutip/tests/solver/test_parallel.py
+++ b/qutip/tests/solver/test_parallel.py
@@ -3,7 +3,9 @@ import time
 import pytest
 import threading
 
-from qutip.solver.parallel import parallel_map, serial_map, loky_pmap
+from qutip.solver.parallel import (
+    parallel_map, serial_map, loky_pmap, MapExceptions
+)
 
 
 def _func1(x):
@@ -71,12 +73,14 @@ def test_map_accumulator(map, num_cpus):
     assert ((np.array(sorted(y1)) == np.array(sorted(y2))).all())
 
 
-class MyException(Exception):
+class TestException(Exception):
     pass
 
 
 def func(i):
-    raise MyException("Error in subprocess")
+    if i % 2 == 1:
+        raise TestException(f"Error in subprocess {i}")
+    return i
 
 
 @pytest.mark.parametrize('map', [
@@ -88,6 +92,30 @@ def test_map_pass_error(map):
     if map is loky_pmap:
         loky = pytest.importorskip("loky")
 
-    with pytest.raises(MyException) as err:
-        map(func, [None]*3)
+    with pytest.raises(TestException) as err:
+        map(func, range(10))
     assert "Error in subprocess" in str(err.value)
+
+
+@pytest.mark.parametrize('map', [
+    pytest.param(parallel_map, id='parallel_map'),
+    pytest.param(loky_pmap, id='loky_pmap'),
+    pytest.param(serial_map, id='serial_map'),
+])
+def test_map_store_error(map):
+    if map is loky_pmap:
+        loky = pytest.importorskip("loky")
+
+    with pytest.raises(MapExceptions) as err:
+        map(func, range(10), map_kw={"fail_fast": False})
+    map_error = err.value
+    assert "iterations failed" in str(map_error)
+    for iter, error in map_error.errors.items():
+        assert isinstance(error, TestException)
+        assert f"Error in subprocess {iter}" == str(error)
+    for n, result in enumerate(map_error.results):
+        if n % 2 == 0:
+            # Passed
+            assert result == n
+        else:
+            assert result is None


### PR DESCRIPTION
**Description**
`parallel_map` did not propagate error of sub-procceses:
```
def f(i):
    raise Exception
    return i

out = qutip.solver.parallel.parallel_map(f, range(5))
```
would print: 
```
ERROR:concurrent.futures:exception calling callback for <Future at 0x7fcdfb9b8e50 state=finished raised Exception>
concurrent.futures.process._RemoteTraceback: 
...
raise Exception
```
but it would return normally with `out = [None, None, None, None, None]`.

This mean we can't use a `try` block to catch error coming from sub-process and only when the output is used, an error is risen.

This change `parallel_map` so it raise the first error it encounter.


