### PR TITLE
Backport fix for IPython helper _repr_svg_ from dev.major.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
         # rather than in the GitHub Actions file directly, because bash gives us
         # a proper programming language to use.
         run: |
-          QUTIP_TARGET="tests,graphics,semidefinite"
+          QUTIP_TARGET="tests,graphics,semidefinite,ipython"
           if [[ -z "${{ matrix.nocython }}" ]]; then
             QUTIP_TARGET="$QUTIP_TARGET,runtime_compilation"
           fi

--- a/doc/changes/1970.bugfix
+++ b/doc/changes/1970.bugfix
@@ -1,0 +1,4 @@
+Backport fix for IPython helper Bloch._repr_svg_ from dev.major. Previously the
+print_figure function returned byte code, but since ipython/ipython#5452
+(in 2014) it returns a Unicode string. This fix updates QuTiP's helper to
+match. 

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -293,7 +293,7 @@ class Bloch:
     def _repr_svg_(self):
         from IPython.core.pylabtools import print_figure
         self.render()
-        fig_data = print_figure(self.fig, 'svg').decode('utf-8')
+        fig_data = print_figure(self.fig, 'svg')
         plt.close(self.fig)
         return fig_data
 

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -361,3 +361,10 @@ class TestBloch:
             vector_kws = [vector_kws]
         self.plot_vector_test(fig_test, copy.deepcopy(vector_kws))
         self.plot_vector_ref(fig_ref, copy.deepcopy(vector_kws))
+
+
+def test_repr_svg():
+    svg = Bloch()._repr_svg_()
+    assert isinstance(svg, str)
+    assert svg.startswith("<?xml")
+    assert svg.endswith("</svg>\n")

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,8 @@ semidefinite =
 tests =
     pytest>=5.2
     pytest-rerunfailures
+ipython =
+    ipython
 ; This uses ConfigParser's string interpolation to include all the above
 ; dependencies into one single target, convenient for testing full builds.
 full =
@@ -59,3 +61,4 @@ full =
     %(runtime_compilation)s
     %(semidefinite)s
     %(tests)s
+    %(ipython)s


### PR DESCRIPTION
**Description**
Backport the fix for #1912 to master.

The issue was that previously the print_figure function returned byte code, but since https://github.com/ipython/ipython/pull/5452 (in 2014) it returns a Unicode string.

**Related issues or PRs**
- #1912 (original issue)
- #1918 (fix for dev.major)
- #1943 (previous attempt at a fix for 4.7.X)