### PR TITLE
update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ recursive-include qutip *.pxd
 recursive-include qutip *.hpp
 recursive-include qutip *.cpp
 recursive-include qutip *.ini
+recursive-include qutip *.h


### PR DESCRIPTION
**Description**
Adding `recursive-include qutip *.h` to `MANIFEST.in` in order to fix QobjEvo instanciation with string.

**Related issues or PRs**
Fix #1960