### PR TITLE
McSolver class for dev.major

### DIFF
--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -1,0 +1,407 @@
+__all__ = ['mcsolve', "McSolver"]
+
+import warnings
+
+import numpy as np
+from copy import copy
+from ..core import QobjEvo, spre, spost, Qobj, unstack_columns, liouvillian
+from .multitraj import MultiTrajSolver
+from .result import McResult, Result
+from .mesolve import mesolve, MeSolver
+import qutip.core.data as _data
+from time import time
+
+
+def mcsolve(H, state, tlist, c_ops=(), e_ops=None, ntraj=500, *,
+            args=None, options=None, seeds=None, target_tol=None, timeout=1e8):
+    r"""
+    Monte Carlo evolution of a state vector :math:`|\psi \rangle` for a
+    given Hamiltonian and sets of collapse operators. Options for the
+    underlying ODE solver are given by the Options class.
+
+    Parameters
+    ----------
+    H : :class:`qutip.Qobj`, :class:`qutip.QobjEvo`, ``list``, callable.
+        System Hamiltonian as a Qobj, QobjEvo. It can also be any input type
+        that QobjEvo accepts (see :class:`qutip.QobjEvo`'s documentation).
+        ``H`` can also be a superoperator (liouvillian) if some collapse
+        operators are to be treated deterministically.
+
+    state : :class:`qutip.Qobj`
+        Initial state vector.
+
+    tlist : array_like
+        Times at which results are recorded.
+
+    c_ops : list
+        A ``list`` of collapse operators in any input type that QobjEvo accepts
+        (see :class:`qutip.QobjEvo`'s documentation). They must be operators
+        even if ``H`` is a superoperator. If none are given, the solver will
+        defer to ``sesolve`` or ``mesolve``.
+
+    e_ops : list, [optional]
+        A ``list`` of operator as Qobj, QobjEvo or callable with signature of
+        (t, state: Qobj) for calculating expectation values. When no ``e_ops``
+        are given, the solver will default to save the states.
+
+    ntraj : int
+        Maximum number of trajectories to run. Can be cut short if a time limit
+        is passed with the ``timeout`` keyword or if the target tolerance is
+        reached, see ``target_tol``.
+
+    args : dict, [optional]
+        Arguments for time-dependent Hamiltonian and collapse operator terms.
+
+    options : SolverOptions, [optional]
+        Options for the evolution.
+
+    seeds : int, SeedSequence, list, [optional]
+        Seed for the random number generator. It can be a single seed used to
+        spawn seeds for each trajectory or a list of seeds, one for each
+        trajectory. Seeds are saved in the result and they can be reused with::
+            seeds=prev_result.seeds
+
+    target_tol : {float, tuple, list}, optional [None]
+        Target tolerance of the evolution. The evolution will compute
+        trajectories until the error on the expectation values is lower than
+        this tolerance. The maximum number of trajectories employed is
+        given by ``ntraj``. The error is computed using jackknife resampling.
+        ``target_tol`` can be an absolute tolerance or a pair of absolute and
+        relative tolerance, in that order. Lastly, it can be a list of pairs of
+        (atol, rtol) for each e_ops.
+
+    timeout : float [optional] {1e8}
+        Maximum time for the evolution in second. When reached, no more
+        trajectories will be computed. Overwrite the option of the same name.
+
+    Returns
+    -------
+    results : :class:`qutip.solver.Result`
+        Object storing all results from the simulation. Which results is saved
+        depends on the presence of ``e_ops`` and the options used. ``collapse``
+        and ``photocurrent`` is available to Monte Carlo simulation results.
+
+    .. note:
+        The simulation will end when the first end condition is reached between
+        ``ntraj``, ``timeout`` and ``target_tol``.
+    """
+    H = QobjEvo(H, args=args, tlist=tlist)
+    if not isinstance(c_ops, (list, tuple)):
+        c_ops = [c_ops]
+    c_ops = [QobjEvo(c_op, args=args, tlist=tlist) for c_op in c_ops]
+
+    if len(c_ops) == 0:
+        options = {
+            key: options[key]
+            for key in options
+            if key in MeSolver.solver_options
+        }
+        return mesolve(H, state, tlist, e_ops=e_ops, args=args,
+                       options=options)
+
+    if isinstance(ntraj, list):
+        raise TypeError("No longer supported, use `result.expect_traj_avg`"
+                        "with the options `keep_runs_results=True`.")
+
+    mc = McSolver(H, c_ops, options=options)
+    result = mc.run(state, tlist=tlist, ntraj=ntraj, e_ops=e_ops,
+                    seed=seeds, target_tol=target_tol, timeout=timeout)
+    return result
+
+
+class MCIntegrator:
+    """
+    Solver for one mcsolve trajectory. Created by a :class:`McSolver`.
+    """
+    name = "mcsolve"
+
+    def __init__(self, integrator, c_ops, n_ops, options=None):
+        self._integrator = integrator
+        self._c_ops = c_ops
+        self._n_ops = n_ops
+        self.options = options
+        self._generator = None
+        self.method = f"{self.name} {self._integrator.method}"
+        self._is_set = False
+        self.issuper = c_ops[0].issuper
+
+    def set_state(self, t, state0, generator):
+        """
+        Set the state of the ODE solver.
+
+        Parameters
+        ----------
+        t : float
+            Initial time
+
+        state0 : qutip.Data
+            Initial state.
+
+        generator : numpy.random.generator
+            Random number generator.
+        """
+        self.collapses = []
+        self._generator = generator
+        self.target_norm = self._generator.random()
+        self._integrator.set_state(t, state0)
+        self._is_set = True
+
+    def get_state(self, copy=True):
+        return *self._integrator.get_state(copy), self._generator
+
+    def integrate(self, t, copy=False):
+        t_old, y_old = self._integrator.get_state(copy=False)
+        norm_old = self._prob_func(y_old)
+        while t_old < t:
+            t_step, state = self._integrator.mcstep(t, copy=False)
+            norm = self._prob_func(state)
+            if norm <= self.target_norm:
+                t_col, state = self._find_collapse_time(norm_old, norm,
+                                                        t_old, t_step)
+                self._do_collapse(t_col, state)
+                t_old, y_old = self._integrator.get_state(copy=False)
+                norm_old = 1.
+            else:
+                t_old, y_old = t_step, state
+                norm_old = norm
+
+        return t_old, _data.mul(y_old, 1 / self._norm_func(y_old))
+
+    def run(self, tlist):
+        for t in tlist[1:]:
+            yield self.integrate(t, False)
+
+    def reset(self, hard=False):
+        self._integrator(hard)
+
+    def _prob_func(self, state):
+        if self.issuper:
+            return _data.norm.trace(unstack_columns(state))
+        return _data.norm.l2(state)**2
+
+    def _norm_func(self, state):
+        if self.issuper:
+            return _data.norm.trace(unstack_columns(state))
+        return _data.norm.l2(state)
+
+    def _find_collapse_time(self, norm_old, norm, t_prev, t_final):
+        """Find the time of the collapse and state just before it."""
+        tries = 0
+        while tries < self.options['norm_steps']:
+            tries += 1
+            if (t_final - t_prev) < self.options['norm_t_tol']:
+                t_guess = t_final
+                _, state = self._integrator.get_state()
+                break
+            t_guess = (
+                t_prev
+                + ((t_final - t_prev)
+                   * np.log(norm_old / self.target_norm)
+                   / np.log(norm_old / norm))
+            )
+            if (t_guess - t_prev) < self.options['norm_t_tol']:
+                t_guess = t_prev + self.options['norm_t_tol']
+            _, state = self._integrator.mcstep(t_guess, copy=False)
+            norm2_guess = self._prob_func(state)
+            if (
+                np.abs(self.target_norm - norm2_guess) <
+                self.options['norm_tol'] * self.target_norm
+            ):
+                break
+            elif (norm2_guess < self.target_norm):
+                # t_guess is still > t_jump
+                t_final = t_guess
+                norm = norm2_guess
+            else:
+                # t_guess < t_jump
+                t_prev = t_guess
+                norm_old = norm2_guess
+
+        if tries >= self.options['norm_steps']:
+            raise RuntimeError(
+                "Could not find the collapse time within desired tolerance. "
+                "Increase accuracy of the ODE solver or lower the tolerance "
+                "with the options 'norm_steps', 'norm_tol', 'norm_t_tol'.")
+
+        return t_guess, state
+
+    def _do_collapse(self, collapse_time, state):
+        """
+        Do the collapse:
+        - Find which operator did the collapse.
+        - Update the state and Integrator.
+        - Next collapse norm location
+        - Store collapse info.
+        """
+        # collapse_time, state is at the collapse
+        if len(self._n_ops) == 1:
+            which = 0
+        else:
+            probs = np.zeros(len(self._n_ops))
+            for i, n_op in enumerate(self._n_ops):
+                probs[i] = n_op.expect_data(collapse_time, state).real
+            probs = np.cumsum(probs)
+            which = np.searchsorted(probs,
+                                    probs[-1] * self._generator.random())
+
+        state_new = self._c_ops[which].matmul_data(collapse_time, state)
+        new_norm = self._norm_func(state_new)
+        if new_norm < self.options['mc_corr_eps']:
+            # This happen when the collapse is caused by numerical error
+            state_new = _data.mul(state, 1 / self._norm_func(state))
+        else:
+            state_new = _data.mul(state_new, 1 / new_norm)
+            self.collapses.append((collapse_time, which))
+            self.target_norm = self._generator.random()
+        self._integrator.set_state(collapse_time, state_new)
+
+    def arguments(self, args):
+        if args:
+            self._integrator.arguments(args)
+            for c_op in self._c_ops:
+                c_op.arguments(args)
+            for n_op in self._n_ops:
+                n_op.arguments(args)
+
+    @property
+    def integrator_options(self):
+        return self._integrator.integrator_options
+
+
+# -----------------------------------------------------------------------------
+# MONTE CARLO CLASS
+# -----------------------------------------------------------------------------
+class McSolver(MultiTrajSolver):
+    r"""
+    Monte Carlo Solver of a state vector :math:`|\psi \rangle` for a
+    given Hamiltonian and sets of collapse operators. Options for the
+    underlying ODE solver are given by the Options class.
+
+    Parameters
+    ----------
+    H : :class:`qutip.Qobj`, :class:`qutip.QobjEvo`, ``list``, callable.
+        System Hamiltonian as a Qobj, QobjEvo. It can also be any input type
+        that QobjEvo accepts (see :class:`qutip.QobjEvo`'s documentation).
+        ``H`` can also be a superoperator (liouvillian) if some collapse
+        operators are to be treated deterministically.
+
+    c_ops : list
+        A ``list`` of collapse operators in any input type that QobjEvo accepts
+        (see :class:`qutip.QobjEvo`'s documentation). They must be operators
+        even if ``H`` is a superoperator.
+
+    options : SolverOptions, [optional]
+        Options for the evolution.
+
+    seed : int, SeedSequence, list, [optional]
+        Seed for the random number generator. It can be a single seed used to
+        spawn seeds for each trajectory or a list of seed, one for each
+        trajectory. Seeds are saved in the result and can be reused with::
+            seeds=prev_result.seeds
+    """
+    name = "mcsolve"
+    resultclass = McResult
+    solver_options = {
+        "progress_bar": "text",
+        "progress_kwargs": {"chunk_size": 10},
+        "store_final_state": False,
+        "store_states": None,
+        "keep_runs_results": False,
+        "method": "adams",
+        "map": "serial",
+        "timeout": None,
+        "job_timeout": None,
+        "num_cpus": None,
+        "bitgenerator": None,
+        "mc_corr_eps": 1e-10,
+        "norm_steps": 5,
+        "norm_t_tol": 1e-6,
+        "norm_tol": 1e-4,
+    }
+
+    def __init__(self, H, c_ops, *, options=None):
+        _time_start = time()
+
+        if isinstance(c_ops, (Qobj, QobjEvo)):
+            c_ops = [c_ops]
+        c_ops = [QobjEvo(c_op) for c_op in c_ops]
+
+        if H.issuper:
+            self._c_ops = [
+                spre(c_op) * spost(c_op.dag()) if c_op.isoper else c_op
+                for c_op in c_ops
+            ]
+            self._n_ops = self._c_ops
+            rhs = QobjEvo(H)
+            for c_op in c_ops:
+                cdc = c_op.dag() @ c_op
+                rhs -= 0.5 * (spre(cdc) + spost(cdc))
+        else:
+            self._c_ops = c_ops
+            self._n_ops = [c_op.dag() * c_op for c_op in c_ops]
+            rhs = -1j * QobjEvo(H)
+            for n_op in self._n_ops:
+                rhs -= 0.5 * n_op
+
+        self._num_collapse = len(self._c_ops)
+
+        super().__init__(rhs, options=options)
+
+    def _restore_state(self, data, *, copy=True):
+        """
+        Retore the Qobj state from its data.
+        """
+        if self._state_metadata['dims'] == self.rhs.dims[1]:
+            state = Qobj(unstack_columns(data),
+                         **self._state_metadata, copy=False)
+        else:
+            state = Qobj(data, **self._state_metadata, copy=copy)
+
+        return state
+
+    def _initialize_stats(self):
+        stats = super()._initialize_stats()
+        stats.update({
+            "method": self.options["method"],
+            "solver": "Master Equation Evolution",
+            "num_collapse": self._num_collapse,
+        })
+        return stats
+
+    def _argument(self, args):
+        self._integrator.arguments(args)
+        self.rhs.arguments(args)
+        for c_op in self._c_ops:
+            c_op.arguments(args)
+        for n_op in self._n_ops:
+            n_op.arguments(args)
+
+    def _run_one_traj(self, seed, state, tlist, e_ops):
+        """
+        Run one trajectory and return the result.
+        """
+        result = Result(e_ops, {**self.options, "normalize_output": False})
+        generator = self._get_generator(seed)
+        self._integrator.set_state(tlist[0], state, generator)
+        result.add(tlist[0], self._restore_state(state, copy=False))
+        for t in tlist[1:]:
+            t, state = self._integrator.integrate(t, copy=False)
+            result.add(t, self._restore_state(state, copy=False))
+        result.collapse = self._integrator.collapses
+        return seed, result
+
+    def _get_integrator(self):
+        _time_start = time()
+        method = self._options["method"]
+        if method in self.avail_integrators():
+            integrator = self.avail_integrators()[method]
+        elif issubclass(method, Integrator):
+            integrator = method
+        else:
+            raise ValueError("Integrator method not supported.")
+        integrator_instance = integrator(self.rhs, self.options)
+        mc_integrator = MCIntegrator(
+            integrator_instance, self._c_ops, self._n_ops, self.options
+        )
+        self._init_integrator_time = time() - _time_start
+        return mc_integrator

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -6,6 +6,7 @@ import numpy as np
 from copy import copy
 from ..core import QobjEvo, spre, spost, Qobj, unstack_columns, liouvillian
 from .multitraj import MultiTrajSolver
+from .solver_base import Solver
 from .result import McResult, Result
 from .mesolve import mesolve, MeSolver
 import qutip.core.data as _data
@@ -508,3 +509,12 @@ class McSolver(MultiTrajSolver):
     @options.setter
     def options(self, new_options):
         MultiTrajSolver.options.fset(self, new_options)
+
+    @classmethod
+    def avail_integrators(cls):
+        if cls is Solver:
+            return cls._avail_integrators.copy()
+        return {
+            **Solver.avail_integrators(),
+            **cls._avail_integrators,
+        }

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -42,7 +42,6 @@ class MultiTrajSolver(Solver):
         "normalize_output": False,
         "method": "",
         "map": "serial",
-        "timeout": None,
         "job_timeout": None,
         "num_cpus": None,
         "bitgenerator": None,
@@ -178,7 +177,7 @@ class MultiTrajSolver(Solver):
 
         map_func = get_map[self._options['map']]
         map_kw = {
-            'timeout': timeout or self.options['timeout'],
+            'timeout': timeout,
             'job_timeout': self.options['job_timeout'],
             'num_cpus': self.options['num_cpus'],
         }
@@ -246,8 +245,6 @@ class MultiTrajSolver(Solver):
             # We check for the method, not the type to accept pseudo non-random
             # generator for debug/testing purpose.
             return seed
-        if not isinstance(seed, np.random.SeedSequence):
-            seed = np.random.SeedSequence(seed)
 
         if self.options['bitgenerator']:
             bit_gen = getattr(np.random, self.options['bitgenerator'])

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -1,6 +1,6 @@
 from .. import Qobj, QobjEvo
 from .result import Result, MultiTrajResult
-from .parallel import get_map
+from .parallel import _get_map
 from time import time
 from .solver_base import Solver
 import numpy as np
@@ -175,7 +175,7 @@ class MultiTrajSolver(Solver):
         )
         result.add_end_condition(ntraj, target_tol)
 
-        map_func = get_map[self._options['map']]
+        map_func = _get_map[self._options['map']]
         map_kw = {
             'timeout': timeout,
             'job_timeout': self.options['job_timeout'],

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -1,0 +1,257 @@
+from .. import Qobj, QobjEvo
+from .result import Result, MultiTrajResult
+from .parallel import get_map
+from time import time
+from .solver_base import Solver
+import numpy as np
+from copy import copy
+
+__all__ = ["MultiTrajSolver", "TrajectorySolver"]
+
+
+class MultiTrajSolver(Solver):
+    """
+    Basic class for multi-trajectory evolutions.
+
+    As :class:`Solver` it can ``run`` or ``step`` evolution.
+    It manages the random seed for each trajectory.
+
+    The actual evolution is done by a single trajectory solver::
+        ``_traj_solver_class``
+
+    Parameters
+    ----------
+    rhs : Qobj, QobjEvo
+        Right hand side of the evolution::
+            d state / dt = rhs @ state
+
+    options : dict
+        Options for the solver.
+    """
+    name = "generic multi trajectory"
+    resultclass = MultiTrajResult
+    _avail_integrators = {}
+
+    # Class of option used by the solver
+    solver_options = {
+        "progress_bar": "text",
+        "progress_kwargs": {"chunk_size": 10},
+        "store_final_state": False,
+        "store_states": None,
+        "keep_runs_results": False,
+        "normalize_output": False,
+        "method": "",
+        "map": "serial",
+        "timeout": None,
+        "job_timeout": None,
+        "num_cpus": None,
+        "bitgenerator": None,
+    }
+
+    def __init__(self, rhs, *, options=None):
+        self.rhs = rhs
+        self._options = {}
+        self.options = {} if options is None else options
+        self.seed_sequence = np.random.SeedSequence()
+        self._integrator = self._get_integrator()
+        self._state_metadata = {}
+        self.stats = self._initialize_stats()
+
+    def start(self, state, t0, seed=None):
+        """
+        Set the initial state and time for a step evolution.
+
+        Parameters
+        ----------
+        state : :class:`Qobj`
+            Initial state of the evolution.
+
+        t0 : double
+            Initial time of the evolution.
+
+        seed : int, SeedSequence, list, {None}
+            Seed for the random number generator. It can be a single seed used
+            to spawn seeds for each trajectory or a list of seed, one for each
+            trajectory.
+
+        ..note ::
+            When using step evolution, only one trajectory can be computed at
+            once.
+        """
+        seeds = self._read_seed(seed, 1)
+        generator = self._get_generator(seeds[0])
+        self._integrator.set_state(t0, self._prepare_state(state), generator)
+
+    def step(self, t, *, args=None, copy=True):
+        """
+        Evolve the state to ``t`` and return the state as a :class:`Qobj`.
+
+        Parameters
+        ----------
+        t : double
+            Time to evolve to, must be higher than the last call.
+
+        args : dict, optional {None}
+            Update the ``args`` of the system.
+            The change is effective from the beginning of the interval.
+            Changing ``args`` can slow the evolution.
+
+        copy : bool, optional {True}
+            Whether to return a copy of the data or the data in the ODE solver.
+        """
+        if not self._integrator._is_set:
+            raise RuntimeError("The `start` method must called first.")
+        self._argument(args)
+        _, state = self._integrator.integrate(t, copy=False)
+        return self._restore_state(state, copy=copy)
+
+    def run(self, state, tlist, ntraj=1, *,
+            args=None, e_ops=(), timeout=None, target_tol=None, seed=None):
+        """
+        Do the evolution of the Quantum system.
+
+        For a ``state`` at time ``tlist[0]`` do the evolution as directed by
+        ``rhs`` and for each time in ``tlist`` store the state and/or
+        expectation values in a :cls:`Result`. The evolution method and stored
+        results are determined by ``options``.
+
+        Parameters
+        ----------
+        state : :class:`Qobj`
+            Initial state of the evolution.
+
+        tlist : list of double
+            Time for which to save the results (state and/or expect) of the
+            evolution. The first element of the list is the initial time of the
+            evolution. Time in the list must be in increasing order, but does
+            not need to be uniformly distributed.
+
+        ntraj : int
+            Number of trajectories to add.
+
+        args : dict, optional {None}
+            Change the ``args`` of the rhs for the evolution.
+
+        e_ops : list
+            list of Qobj or QobjEvo to compute the expectation values.
+            Alternatively, function[s] with the signature f(t, state) -> expect
+            can be used.
+
+        timeout : float, optional [1e8]
+            Maximum time in seconds for the trajectories to run. Once this time
+            is reached, the simulation will end even if the number
+            of trajectories is less than ``ntraj``. The map function, set in
+            options, can interupt the running trajectory or wait for it to
+            finish. Set to an arbitrary high number to disable.
+
+        target_tol : {float, tuple, list}, optional [None]
+            Target tolerance of the evolution. The evolution will compute
+            trajectories until the error on the expectation values is lower
+            than this tolerance. The maximum number of trajectories employed is
+            given by ``ntraj``. The error is computed using jackknife
+            resampling. ``target_tol`` can be an absolute tolerance or a pair
+            of absolute and relative tolerance, in that order. Lastly, it can
+            be a list of pairs of (atol, rtol) for each e_ops.
+
+        seed : {int, SeedSequence, list} optional
+            Seed or list of seeds for each trajectories.
+
+        Return
+        ------
+        results : :class:`qutip.solver.MultiTrajResult`
+            Results of the evolution. States and/or expect will be saved. You
+            can control the saved data in the options.
+
+        .. note:
+            The simulation will end when the first end condition is reached
+            between ``ntraj``, ``timeout`` and ``target_tol``.
+        """
+        start_time = time()
+        self._argument(args)
+        stats = self._initialize_stats()
+        seeds = self._read_seed(seed, ntraj)
+
+        result = self.resultclass(
+            e_ops, self.options, solver=self.name, stats=stats
+        )
+        result.add_end_condition(ntraj, target_tol)
+
+        map_func = get_map[self._options['map']]
+        map_kw = {
+            'timeout': timeout or self.options['timeout'],
+            'job_timeout': self.options['job_timeout'],
+            'num_cpus': self.options['num_cpus'],
+        }
+        state0 = self._prepare_state(state)
+        stats['preparation time'] += time() - start_time
+
+        start_time = time()
+        map_func(
+            self._run_one_traj, seeds,
+            (state0, tlist, e_ops),
+            reduce_func=result.add, map_kw=map_kw,
+            progress_bar=self.options["progress_bar"],
+            progress_bar_kwargs=self.options["progress_kwargs"]
+        )
+        result.stats['run time'] = time() - start_time
+        return result
+
+    def _run_one_traj(self, seed, state, tlist, e_ops):
+        """
+        Run one trajectory and return the result.
+        """
+        result = Result(e_ops, self.options)
+        generator = self._get_generator(seed)
+        self._integrator.set_state(tlist[0], state, generator)
+        result.add(tlist[0], self._restore_state(state, copy=False))
+        for t in tlist[1:]:
+            t, state = self._integrator.step(t, copy=False)
+            result.add(t, self._restore_state(state, copy=False))
+        return seed, result
+
+    def _read_seed(self, seed, ntraj):
+        """
+        Read user provided seed(s) and produce one for each trajectory.
+        Let numpy raise error for inputs that cannot be seeds.
+        """
+        if seed is None:
+            seeds = self.seed_sequence.spawn(ntraj)
+        elif isinstance(seed, np.random.SeedSequence):
+            seeds = seed.spawn(ntraj)
+        elif not isinstance(seed, list):
+            seeds = np.random.SeedSequence(seed).spawn(ntraj)
+        elif len(seed) >= ntraj:
+            seeds = [
+                seed_ if (isinstance(seed_, np.random.SeedSequence)
+                          or hasattr(seed_, 'random'))
+                else np.random.SeedSequence(seed_)
+                for seed_ in seed[:ntraj]
+            ]
+        else:
+            raise ValueError("A seed list must be longer than ntraj")
+        return seeds
+
+    def _argument(self, args):
+        """Update the args, for the `rhs` and `c_ops` and other operators."""
+        if args:
+            self.rhs.arguments(args)
+
+    def _get_generator(self, seed):
+        """
+        Read the seed and create the random number generator.
+        If the ``seed`` has a ``random`` method, it will be used as the
+        generator.
+        """
+        if hasattr(seed, 'random'):
+            # We check for the method, not the type to accept pseudo non-random
+            # generator for debug/testing purpose.
+            return seed
+        if not isinstance(seed, np.random.SeedSequence):
+            seed = np.random.SeedSequence(seed)
+
+        if self.options['bitgenerator']:
+            bit_gen = getattr(np.random, self.options['bitgenerator'])
+            generator = np.random.Generator(bit_gen(seed))
+        else:
+            generator = np.random.default_rng(seed)
+        return generator

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -252,3 +252,7 @@ class MultiTrajSolver(Solver):
         else:
             generator = np.random.default_rng(seed)
         return generator
+
+    @classmethod
+    def avail_integrators(cls):
+        return cls._avail_integrators

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -2,7 +2,7 @@
 This module provides functions for parallel execution of loops and function
 mappings, using the builtin Python module multiprocessing or the loky parallel execution library.
 """
-__all__ = ['parallel_map', 'serial_map', 'loky_pmap', 'get_map']
+__all__ = ['parallel_map', 'serial_map', 'loky_pmap']
 
 import multiprocessing
 import os
@@ -309,7 +309,7 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
     return results
 
 
-get_map = {
+_get_map = {
     "parallel_map": parallel_map,
     "parallel": parallel_map,
     "serial_map": serial_map,

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -309,13 +309,10 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
     return results
 
 
-def get_map(options):
-    if "parallel" in options['map']:
-        return parallel_map
-    elif "serial" in options['map']:
-        return serial_map
-    elif "loky" in options['map']:
-        return loky_pmap
-    else:
-        raise ValueError("map not found, available options are 'parallel',"
-                         " 'serial' and 'loky'")
+get_map = {
+    "parallel_map": parallel_map,
+    "parallel": parallel_map,
+    "serial_map": serial_map,
+    "serial": serial_map,
+    "loky": loky_pmap
+}

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -498,7 +498,7 @@ class MultiTrajResult(_BaseResult):
         self.e_ops = trajectory.e_ops
 
         self.average_e_data = {
-            k: avg_expect.astype(np.array(expect).dtype)
+            k: avg_expect if np.iscomplexobj(expect) else avg_expect.real
             for k, avg_expect, expect
             in zip(self._raw_ops, self._sum_expect, trajectory.expect)
         }
@@ -529,7 +529,7 @@ class MultiTrajResult(_BaseResult):
         avg2 = self._sum2_expect / self.num_trajectories
 
         self.average_e_data = {
-            k: avg_expect.astype(expect.dtype)
+            k: avg_expect if np.iscomplexobj(expect) else avg_expect.real
             for k, avg_expect, expect
             in zip(self._raw_ops, avg, self.average_expect)
         }

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -497,6 +497,13 @@ class MultiTrajResult(_BaseResult):
 
         self.e_ops = trajectory.e_ops
 
+        self.average_e_data = {
+            k: avg_expect.astype(np.array(expect).dtype)
+            for k, avg_expect, expect
+            in zip(self._raw_ops, self._sum_expect, trajectory.expect)
+        }
+        self.average_expect = list(self.average_e_data.values())
+
     def _store_trajectory(self, trajectory):
         self.trajectories.append(trajectory)
 
@@ -522,21 +529,19 @@ class MultiTrajResult(_BaseResult):
         avg2 = self._sum2_expect / self.num_trajectories
 
         self.average_e_data = {
-            k: avg_expect
-            for k, avg_expect in zip(self._raw_ops, avg)
+            k: avg_expect.astype(expect.dtype)
+            for k, avg_expect, expect
+            in zip(self._raw_ops, avg, self.average_expect)
         }
         self.average_expect = list(self.average_e_data.values())
 
         self.expect = self.average_expect
         self.e_data = self.average_e_data
 
-        [
-            print(avg_expect2 - abs(avg_expect**2))
-            for k, avg_expect, avg_expect2 in zip(self._raw_ops, avg, avg2)
-        ]
-
+        # mean(expect**2) - mean(expect)**2 can something be very small
+        # negative (-1e-15) which raise an error for float sqrt.
         self.std_e_data = {
-            k: np.sqrt(np.maximum(avg_expect2 - abs(avg_expect**2), 0))
+            k: np.sqrt(np.abs(avg_expect2 - np.abs(avg_expect**2)))
             for k, avg_expect, avg_expect2 in zip(self._raw_ops, avg, avg2)
         }
         self.std_expect = list(self.std_e_data.values())
@@ -616,7 +621,7 @@ class MultiTrajResult(_BaseResult):
         self._early_finish_check = self._no_end
         self.stats['end_condition'] = 'unknown'
 
-    def add(self, trajectory):
+    def add(self, trajectory_info):
         """
         Add a trajectory to the evolution.
 
@@ -625,11 +630,11 @@ class MultiTrajResult(_BaseResult):
 
         Parameters
         ----------
-        seed : int, SeedSequence
-            Seed used to generate the trajectory.
-
-        trajectory : :class:`Result`
-            Run result for one evolution over the times.
+        trajectory_info : tuple of seed and trajectory
+            - seed: int, SeedSequence
+              Seed used to generate the trajectory.
+            - trajectory : :class:`Result`
+              Run result for one evolution over the times.
 
         Return
         ------
@@ -637,7 +642,7 @@ class MultiTrajResult(_BaseResult):
             Return the number of trajectories still needed to reach the target
             tolerance. If no tolerance is provided, return infinity.
         """
-        seed, trajectory = trajectory
+        seed, trajectory = trajectory_info
         self.seeds.append(seed)
 
         for op in self._state_processors:
@@ -862,8 +867,14 @@ class MultiTrajResult(_BaseResult):
 
         if self._sum_states is not None and other._sum_states is not None:
             new._sum_states = self._sum_states + other._sum_states
-        if self._sum_final_states is not None and other._sum_final_states is not None:
-            new._sum_final_states = self._sum_final_states + other._sum_final_states
+
+        if (
+            self._sum_final_states is not None
+            and other._sum_final_states is not None
+        ):
+            new._sum_final_states = (
+                self._sum_final_states + other._sum_final_states
+            )
         new._target_tols = None
 
         if self._raw_ops:
@@ -896,6 +907,9 @@ class MultiTrajResult(_BaseResult):
                 new.runs_expect = list(new.runs_e_data.values())
                 new.expect = new.runs_expect
                 new.e_data = new.runs_e_data
+
+        new.stats["run time"] += other.stats["run time"]
+        new.stats['end_condition'] = "Merged results"
 
         return new
 

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -611,7 +611,7 @@ class MultiTrajResult(_BaseResult):
         self._early_finish_check = self._no_end
         self.stats['end_condition'] = 'unknown'
 
-    def add(self, seed, trajectory):
+    def add(self, trajectory):
         """
         Add a trajectory to the evolution.
 
@@ -632,6 +632,7 @@ class MultiTrajResult(_BaseResult):
             Return the number of trajectories still needed to reach the target
             tolerance. If no tolerance is provided, return infinity.
         """
+        seed, trajectory = trajectory
         self.seeds.append(seed)
 
         for op in self._state_processors:
@@ -846,15 +847,18 @@ class MultiTrajResult(_BaseResult):
             raise ValueError("Shared `e_ops` is required to merge results")
         if self.times != other.times:
             raise ValueError("Shared `times` are is required to merge results")
-        new = self.__class__(self._raw_ops, self.options, solver=self.solver)
+        new = self.__class__(self._raw_ops, self.options,
+                             solver=self.solver, stats=self.stats)
         if self.trajectories and other.trajectories:
             new.trajectories = self.trajectories + other.trajectories
         new.num_trajectories = self.num_trajectories + other.num_trajectories
         new.times = self.times
         new.seeds = self.seeds + other.seeds
 
-        new._sum_states = self._sum_states + other._sum_states
-        new._sum_final_states = self._sum_final_states + other._sum_final_states
+        if self._sum_states is not None and other._sum_states is not None:
+            new._sum_states = self._sum_states + other._sum_states
+        if self._sum_final_states is not None and other._sum_final_states is not None:
+            new._sum_final_states = self._sum_final_states + other._sum_final_states
         new._target_tols = None
 
         if self._raw_ops:

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -530,8 +530,13 @@ class MultiTrajResult(_BaseResult):
         self.expect = self.average_expect
         self.e_data = self.average_e_data
 
+        [
+            print(avg_expect2 - abs(avg_expect**2))
+            for k, avg_expect, avg_expect2 in zip(self._raw_ops, avg, avg2)
+        ]
+
         self.std_e_data = {
-            k: np.sqrt(avg_expect2 - abs(avg_expect**2))
+            k: np.sqrt(np.maximum(avg_expect2 - abs(avg_expect**2), 0))
             for k, avg_expect, avg_expect2 in zip(self._raw_ops, avg, avg2)
         }
         self.std_expect = list(self.std_e_data.values())

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -239,22 +239,22 @@ def test_expectation_outputs(keep_runs_results):
     data = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj,
                    options={"keep_runs_results": keep_runs_results,
                             'map': 'serial'})
-    # assert isinstance(data.average_expect[0][1], float)
-    # assert isinstance(data.average_expect[1][1], float)
-    # assert isinstance(data.average_expect[2][1], complex)
-    # assert isinstance(data.std_expect[0][1], float)
-    # assert isinstance(data.std_expect[1][1], float)
-    # assert isinstance(data.std_expect[2][1], float)
+    assert isinstance(data.average_expect[0][1], float)
+    assert isinstance(data.average_expect[1][1], float)
+    assert isinstance(data.average_expect[2][1], complex)
+    assert isinstance(data.std_expect[0][1], float)
+    assert isinstance(data.std_expect[1][1], float)
+    assert isinstance(data.std_expect[2][1], float)
     if keep_runs_results:
         assert len(data.runs_expect) == len(e_ops)
         assert len(data.runs_expect[0]) == ntraj
-        # assert isinstance(data.runs_expect[0][0][1], float)
-        # assert isinstance(data.runs_expect[1][0][1], float)
-        # assert isinstance(data.runs_expect[2][0][1], complex)
+        assert isinstance(data.runs_expect[0][0][1], float)
+        assert isinstance(data.runs_expect[1][0][1], float)
+        assert isinstance(data.runs_expect[2][0][1], complex)
         assert not np.allclose(data.std_expect[0][1],
                                data.expect_traj_std(3)[0][1])
-    # assert isinstance(data.photocurrent[0][0], float)
-    # assert isinstance(data.photocurrent[1][0], float)
+    assert isinstance(data.photocurrent[0][0], float)
+    assert isinstance(data.photocurrent[1][0], float)
     assert (np.array(data.runs_photocurrent).shape
             == (ntraj, len(c_ops), len(times)-1))
     np.testing.assert_allclose(times, data.times)

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -1,0 +1,440 @@
+import pytest
+import numpy as np
+import qutip
+from copy import copy
+from qutip.solver.mcsolve import mcsolve, McSolver
+from qutip.solver.solver_base import Solver
+from qutip.solver.options import SolverOptions
+
+def _return_constant(t, args):
+    return args['constant']
+
+
+def _return_decay(t, args):
+    return args['constant'] * np.exp(-args['rate'] * t)
+
+
+class callable_qobj:
+    def __init__(self, oper, coeff=None):
+        self.oper = oper
+        self.coeff = coeff
+
+    def __call__(self, t, args):
+        if self.coeff is not None:
+            return self.oper * self.coeff(t, args)
+        return self.oper
+
+
+@pytest.mark.usefixtures("in_temporary_directory")
+class StatesAndExpectOutputCase:
+    """
+    Mixin class to test the states and expectation values from ``mcsolve``.
+    """
+    size = 10
+    h = qutip.num(size)
+    state = qutip.basis(size, size-1)
+    times = np.linspace(0, 1, 101)
+    e_ops = [qutip.num(size)]
+    ntraj = 2000
+
+    def _assert_states(self, result, expected, tol):
+        assert hasattr(result, 'states')
+        assert len(result.states) == len(self.times)
+        for test_operator, expected_part in zip(self.e_ops, expected):
+            test = qutip.expect(test_operator, result.states)
+            np.testing.assert_allclose(test, expected_part, rtol=tol)
+
+    def _assert_expect(self, result, expected, tol):
+        assert hasattr(result, 'expect')
+        assert len(result.expect) == len(self.e_ops)
+        for test, expected_part in zip(result.expect, expected):
+            np.testing.assert_allclose(test, expected_part, rtol=tol)
+
+    def test_states_and_expect(self, hamiltonian, args, c_ops, expected, tol):
+        options = SolverOptions(store_states=True, map='serial')
+        result = mcsolve(hamiltonian, self.state, self.times, args=args,
+                         c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj,
+                         options=options, target_tol=0.05)
+        self._assert_expect(result, expected, tol)
+        self._assert_states(result, expected, tol)
+
+
+class TestNoCollapse(StatesAndExpectOutputCase):
+    """
+    Test that `mcsolve` correctly solves the system when there is a constant
+    Hamiltonian and no collapses.
+    """
+    def pytest_generate_tests(self, metafunc):
+        tol = 1e-8
+        expect = (qutip.expect(self.e_ops[0], self.state)
+                  * np.ones_like(self.times))
+        hamiltonian_types = [
+            (self.h, "Qobj"),
+            ([self.h], "list"),
+            (qutip.QobjEvo([self.h, [self.h, _return_constant]],
+                           args= {'constant': 0}), "QobjEvo"),
+            (callable_qobj(self.h), "callable"),
+        ]
+        cases = [pytest.param(hamiltonian, {}, [], [expect], tol, id=id)
+                 for hamiltonian, id in hamiltonian_types]
+        metafunc.parametrize(
+            ['hamiltonian', 'args', 'c_ops', 'expected', 'tol'],
+            cases)
+
+    # Previously the "states_only" and "expect_only" tests were mixed in to
+    # every other test case.  We move them out into the simplest set so that
+    # their behaviour remains tested, but isn't repeated as often to keep test
+    # runtimes shorter.  The known-good cases are still tested in the other
+    # test cases, this is just testing the single-output behaviour.
+
+    def test_states_only(self, hamiltonian, args, c_ops, expected, tol):
+        options = SolverOptions(store_states=None, map='serial')
+        result = mcsolve(hamiltonian, self.state, self.times, args=args,
+                         c_ops=c_ops, e_ops=[], ntraj=self.ntraj,
+                         options=options)
+        self._assert_states(result, expected, tol)
+
+    def test_expect_only(self, hamiltonian, args, c_ops, expected, tol):
+        result = mcsolve(hamiltonian, self.state, self.times, args=args,
+                         c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj,
+                         options={'map': 'serial'})
+        self._assert_expect(result, expected, tol)
+
+
+class TestConstantCollapse(StatesAndExpectOutputCase):
+    """
+    Test that `mcsolve` correctly solves the system when there is a constant
+    collapse operator.
+    """
+    def pytest_generate_tests(self, metafunc):
+        tol = 0.25
+        coupling = 0.2
+        expect = (qutip.expect(self.e_ops[0], self.state)
+                  * np.exp(-coupling * self.times))
+        collapse_op = qutip.destroy(self.size)
+        c_op_types = [
+            (np.sqrt(coupling)*collapse_op, {}, "constant"),
+            ([collapse_op, 'sqrt({})'.format(coupling)], {}, "string"),
+            (callable_qobj(collapse_op, _return_constant),
+             {'constant': np.sqrt(coupling)}, "function"),
+        ]
+        cases = [pytest.param(self.h, args, [c_op], [expect], tol, id=id)
+                 for c_op, args, id in c_op_types]
+        metafunc.parametrize(
+            ['hamiltonian', 'args', 'c_ops', 'expected', 'tol'],
+            cases)
+
+
+class TestTimeDependentCollapse(StatesAndExpectOutputCase):
+    """
+    Test that `mcsolve` correctly solves the system when the collapse operators
+    are time-dependent.
+    """
+    def pytest_generate_tests(self, metafunc):
+        tol = 0.25
+        coupling = 0.2
+        expect = (qutip.expect(self.e_ops[0], self.state)
+                  * np.exp(-coupling * (1 - np.exp(-self.times))))
+        collapse_op = qutip.destroy(self.size)
+        collapse_args = {'constant': np.sqrt(coupling), 'rate': 0.5}
+        collapse_string = 'sqrt({} * exp(-t))'.format(coupling)
+        c_op_types = [
+            ([collapse_op, _return_decay], collapse_args, "function"),
+            ([collapse_op, collapse_string], {}, "string"),
+        ]
+        cases = [pytest.param(self.h, args, [c_op], [expect], tol, id=id)
+                 for c_op, args, id in c_op_types]
+        metafunc.parametrize(
+            ['hamiltonian', 'args', 'c_ops', 'expected', 'tol'],
+            cases)
+
+
+def test_stored_collapse_operators_and_times():
+    """
+    Test that the output contains information on which collapses happened and
+    at what times, and make sure that this information makes sense.
+    """
+    size = 10
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    state = qutip.basis(size, size-1)
+    times = np.linspace(0, 10, 100)
+    c_ops = [a, a]
+    result = mcsolve(H, state, times, c_ops, ntraj=3,
+                     options={'map': 'serial'})
+    assert len(result.col_times[0]) > 0
+    assert len(result.col_which) == len(result.col_times)
+    assert all(col in [0, 1] for col in result.col_which[0])
+
+
+@pytest.mark.parametrize('keep_runs_results', [True, False])
+def test_states_outputs(keep_runs_results):
+    # We're just testing the output value, so it's important whether certain
+    # things are complex or real, but not what the magnitudes of constants are.
+    focks = 5
+    ntraj = 5
+    a = qutip.tensor(qutip.destroy(focks), qutip.qeye(2))
+    sm = qutip.tensor(qutip.qeye(focks), qutip.sigmam())
+    H = 1j*a.dag()*sm + a
+    H = H + H.dag()
+    state = qutip.basis([focks, 2], [0, 1])
+    times = np.linspace(0, 10, 21)
+    c_ops = [a, sm]
+    data = mcsolve(H, state, times, c_ops, ntraj=ntraj,
+                   options={"keep_runs_results": keep_runs_results,
+                            'map': 'serial'})
+
+    assert len(data.average_states) == len(times)
+    assert isinstance(data.average_states[0], qutip.Qobj)
+    assert data.average_states[0].norm() == pytest.approx(1.)
+    assert data.average_states[0].isoper
+
+    assert isinstance(data.average_final_state, qutip.Qobj)
+    assert data.average_final_state.norm() == pytest.approx(1.)
+    assert data.average_final_state.isoper
+
+    assert isinstance(data.photocurrent[0][1], float)
+    assert isinstance(data.photocurrent[1][1], float)
+    assert (np.array(data.runs_photocurrent).shape
+        == (ntraj, len(c_ops), len(times)-1))
+
+    if keep_runs_results:
+        assert len(data.runs_states) == ntraj
+        assert len(data.runs_states[0]) == len(times)
+        assert isinstance(data.runs_states[0][0], qutip.Qobj)
+        assert data.runs_states[0][0].norm() == pytest.approx(1.)
+        assert data.runs_states[0][0].isket
+
+        assert len(data.runs_final_states) == ntraj
+        assert isinstance(data.runs_final_states[0], qutip.Qobj)
+        assert data.runs_final_states[0].norm() == pytest.approx(1.)
+        assert data.runs_final_states[0].isket
+
+    assert isinstance(data.steady_state(), qutip.Qobj)
+    assert data.steady_state().norm() == pytest.approx(1.)
+    assert data.steady_state().isoper
+
+    np.testing.assert_allclose(times, data.times)
+    assert data.num_trajectories == ntraj
+    assert len(data.e_ops) == 0
+    assert data.stats["num_collapse"] == len(c_ops)
+    assert len(data.col_times) == ntraj
+    assert np.max(np.hstack(data.col_which)) <= len(c_ops)
+    assert data.stats['end_condition'] == "ntraj reached"
+
+
+@pytest.mark.parametrize('keep_runs_results', [True, False])
+def test_expectation_outputs(keep_runs_results):
+    # We're just testing the output value, so it's important whether certain
+    # things are complex or real, but not what the magnitudes of constants are.
+    focks = 5
+    ntraj = 5
+    a = qutip.tensor(qutip.destroy(focks), qutip.qeye(2))
+    sm = qutip.tensor(qutip.qeye(focks), qutip.sigmam())
+    H = 1j*a.dag()*sm + a
+    H = H + H.dag()
+    state = qutip.basis([focks, 2], [0, 1])
+    times = np.linspace(0, 10, 5)
+    c_ops = [a, sm]
+    e_ops = [a.dag()*a, sm.dag()*sm, a]
+    data = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj,
+                   options={"keep_runs_results": keep_runs_results,
+                            'map': 'serial'})
+    # assert isinstance(data.average_expect[0][1], float)
+    # assert isinstance(data.average_expect[1][1], float)
+    # assert isinstance(data.average_expect[2][1], complex)
+    # assert isinstance(data.std_expect[0][1], float)
+    # assert isinstance(data.std_expect[1][1], float)
+    # assert isinstance(data.std_expect[2][1], float)
+    if keep_runs_results:
+        assert len(data.runs_expect) == len(e_ops)
+        assert len(data.runs_expect[0]) == ntraj
+        # assert isinstance(data.runs_expect[0][0][1], float)
+        # assert isinstance(data.runs_expect[1][0][1], float)
+        # assert isinstance(data.runs_expect[2][0][1], complex)
+        assert not np.allclose(data.std_expect[0][1],
+                               data.expect_traj_std(3)[0][1])
+    # assert isinstance(data.photocurrent[0][0], float)
+    # assert isinstance(data.photocurrent[1][0], float)
+    assert (np.array(data.runs_photocurrent).shape
+            == (ntraj, len(c_ops), len(times)-1))
+    np.testing.assert_allclose(times, data.times)
+    assert data.num_trajectories == ntraj
+    assert len(data.e_ops) == len(e_ops)
+    assert data.stats["num_collapse"] == len(c_ops)
+    assert len(data.col_times) == ntraj
+    assert np.max(np.hstack(data.col_which)) <= len(c_ops)
+    assert data.stats['end_condition'] == "ntraj reached"
+
+
+class TestSeeds:
+    sizes = [6, 6, 6]
+    dampings = [0.1, 0.4, 0.1]
+    ntraj = 25  # Big enough to ensure there are differences without being slow
+    a = [qutip.destroy(size) for size in sizes]
+    H = 1j * (qutip.tensor(a[0], a[1].dag(), a[2].dag())
+              - qutip.tensor(a[0].dag(), a[1], a[2]))
+    state = qutip.tensor(qutip.coherent(sizes[0], np.sqrt(2)),
+                         qutip.basis(sizes[1:], [0, 0]))
+    times = np.linspace(0, 10, 2)
+    c_ops = [
+        np.sqrt(2*dampings[0]) * qutip.tensor(a[0], qutip.qeye(sizes[1:])),
+        (np.sqrt(2*dampings[1])
+         * qutip.tensor(qutip.qeye(sizes[0]), a[1], qutip.qeye(sizes[2]))),
+        np.sqrt(2*dampings[2]) * qutip.tensor(qutip.qeye(sizes[:2]), a[2]),
+    ]
+
+    def test_seeds_can_be_reused(self):
+        args = (self.H, self.state, self.times)
+        kwargs = {'c_ops': self.c_ops, 'ntraj': self.ntraj}
+        first = mcsolve(*args, **kwargs)
+        second = mcsolve(*args, seeds=first.seeds, **kwargs)
+        for first_t, second_t in zip(first.col_times, second.col_times):
+            np.testing.assert_equal(first_t, second_t)
+        for first_w, second_w in zip(first.col_which, second.col_which):
+            np.testing.assert_equal(first_w, second_w)
+
+    def test_seeds_are_not_reused_by_default(self):
+        args = (self.H, self.state, self.times)
+        kwargs = {'c_ops': self.c_ops, 'ntraj': self.ntraj}
+        first = mcsolve(*args, **kwargs)
+        second = mcsolve(*args, **kwargs)
+        assert not all(np.array_equal(first_t, second_t)
+                       for first_t, second_t in zip(first.col_times,
+                                                    second.col_times))
+        assert not all(np.array_equal(first_w, second_w)
+                       for first_w, second_w in zip(first.col_which,
+                                                    second.col_which))
+
+    @pytest.mark.parametrize('seed', [1, np.random.SeedSequence(2)])
+    def test_seed_type(self, seed):
+        args = (self.H, self.state, self.times)
+        kwargs = {'c_ops': self.c_ops, 'ntraj': self.ntraj}
+        first = mcsolve(*args, seeds=copy(seed), **kwargs)
+        second = mcsolve(*args, seeds=copy(seed), **kwargs)
+        for f_seed, s_seed in zip(first.seeds, second.seeds):
+            assert f_seed.state == s_seed.state
+
+    def test_bad_seed(self):
+        args = (self.H, self.state, self.times)
+        kwargs = {'c_ops': self.c_ops, 'ntraj': self.ntraj}
+        with pytest.raises(ValueError):
+            first = mcsolve(*args, seeds=[1], **kwargs)
+
+    def test_generator(self):
+        args = (self.H, self.state, self.times)
+        kwargs = {'c_ops': self.c_ops, 'ntraj': self.ntraj}
+        first = mcsolve(*args, seeds=1, options={'bitgenerator': 'MT19937'},
+                        **kwargs)
+        second = mcsolve(*args, seeds=1, **kwargs)
+        for f_seed, s_seed in zip(first.seeds, second.seeds):
+            assert f_seed.state == s_seed.state
+        assert not all(np.array_equal(first_t, second_t)
+                       for first_t, second_t in zip(first.col_times,
+                                                    second.col_times))
+        assert not all(np.array_equal(first_w, second_w)
+                       for first_w, second_w in zip(first.col_which,
+                                                    second.col_which))
+
+    def test_stepping(self):
+        size = 10
+        a = qutip.QobjEvo([qutip.destroy(size), 'alpha'], args={'alpha': 0})
+        H = qutip.num(size)
+        mcsolver = McSolver(H, a, options={'map': 'serial'})
+        mcsolver.start(qutip.basis(size, size-1), 0, seed=5)
+        state_1 = mcsolver.step(1, args={'alpha':1})
+
+        mcsolver.start(qutip.basis(size, size-1), 0, seed=5)
+        state_2 = mcsolver.step(1, args={'alpha':1})
+        assert state_1 == state_2
+
+
+def test_timeout():
+    size = 10
+    ntraj = 1000
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    state = qutip.basis(size, size-1)
+    times = np.linspace(0, 1.0, 100)
+    coupling = 0.5
+    n_th = 0.05
+    c_ops = np.sqrt(coupling * (n_th + 1)) * a
+    e_ops = [qutip.num(size)]
+    res = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj,
+                  options={'map': 'serial'}, timeout=1e-6)
+    assert res.stats['end_condition'] == 'timeout'
+
+
+def test_super_H():
+    size = 10
+    ntraj = 1000
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    state = qutip.basis(size, size-1)
+    times = np.linspace(0, 1.0, 100)
+    # Arbitrary coupling and bath temperature.
+    coupling = 0.5
+    n_th = 0.05
+    c_ops = np.sqrt(coupling * (n_th + 1)) * a
+    e_ops = [qutip.num(size)]
+    mc_expected = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj,
+                          target_tol=0.1, options={'map': 'serial'})
+    mc = mcsolve(qutip.liouvillian(H), state, times, c_ops, e_ops, ntraj=ntraj,
+                 target_tol=0.1, options={'map': 'serial'})
+    np.testing.assert_allclose(mc_expected.expect[0], mc.expect[0], atol=0.5)
+
+
+def test_McSolver_run():
+    size = 10
+    a = qutip.QobjEvo([qutip.destroy(size), 'coupling'], args={'coupling':0})
+    H = qutip.num(size)
+    solver = McSolver(H, a)
+    solver.options = {'store_final_state': True}
+    res = solver.run(qutip.basis(size, size-1), np.linspace(0, 5.0, 11),
+                     e_ops=[qutip.qeye(size)], args={'coupling': 1})
+    assert res.final_state is not None
+    assert len(res.collapse[0]) != 0
+    assert res.num_trajectories == 1
+    np.testing.assert_allclose(res.expect[0], np.ones(11))
+    res += solver.run(
+        qutip.basis(size, size-1), np.linspace(0, 5.0, 11),
+        e_ops=[qutip.qeye(size)], args={'coupling': 1},
+        ntraj=1000, target_tol=0.1
+    )
+    assert res.num_trajectories == 1001
+
+
+def test_McSolver_stepping():
+    size = 10
+    a = qutip.QobjEvo([qutip.destroy(size), 'coupling'], args={'coupling':0})
+    H = qutip.num(size)
+    solver = McSolver(H, a)
+    solver.start(qutip.basis(size, size-1), 0, seed=0)
+    solver.options = {'method': 'lsoda'}
+    state = solver.step(1)
+    assert qutip.expect(qutip.qeye(size), state) == pytest.approx(1)
+    assert qutip.expect(qutip.num(size), state) == pytest.approx(size - 1)
+    assert state.isket
+    state = solver.step(5, args={'coupling': 5})
+    assert qutip.expect(qutip.qeye(size), state) == pytest.approx(1)
+    assert qutip.expect(qutip.num(size), state) <= size - 1
+    assert state.isket
+
+
+# Defined in module-scope so it's pickleable.
+def _dynamic(t, args):
+    return 0 if args["collapse"] else 1
+
+
+@pytest.mark.xfail(reason="current limitation of SolverOptions")
+def test_dynamic_arguments():
+    """Test dynamically updated arguments are usable."""
+    size = 5
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    times = np.linspace(0, 1, 11)
+    state = qutip.basis(size, 2)
+
+    c_ops = [[a, _dynamic], [a.dag(), _dynamic]]
+    mc = mcsolve(H, state, times, c_ops, ntraj=25, args={"collapse": []})
+    assert all(len(collapses) <= 1 for collapses in mc.col_which)

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -4,7 +4,6 @@ import qutip
 from copy import copy
 from qutip.solver.mcsolve import mcsolve, McSolver
 from qutip.solver.solver_base import Solver
-from qutip.solver.options import SolverOptions
 
 def _return_constant(t, args):
     return args['constant']
@@ -51,7 +50,7 @@ class StatesAndExpectOutputCase:
             np.testing.assert_allclose(test, expected_part, rtol=tol)
 
     def test_states_and_expect(self, hamiltonian, args, c_ops, expected, tol):
-        options = SolverOptions(store_states=True, map='serial')
+        options = {"store_states": True, "map": "serial"}
         result = mcsolve(hamiltonian, self.state, self.times, args=args,
                          c_ops=c_ops, e_ops=self.e_ops, ntraj=self.ntraj,
                          options=options, target_tol=0.05)
@@ -88,7 +87,7 @@ class TestNoCollapse(StatesAndExpectOutputCase):
     # test cases, this is just testing the single-output behaviour.
 
     def test_states_only(self, hamiltonian, args, c_ops, expected, tol):
-        options = SolverOptions(store_states=None, map='serial')
+        options = {"store_states": True, "map": "serial"}
         result = mcsolve(hamiltonian, self.state, self.times, args=args,
                          c_ops=c_ops, e_ops=[], ntraj=self.ntraj,
                          options=options)
@@ -426,7 +425,7 @@ def _dynamic(t, args):
     return 0 if args["collapse"] else 1
 
 
-@pytest.mark.xfail(reason="current limitation of SolverOptions")
+@pytest.mark.xfail(reason="current limitation of McSolve")
 def test_dynamic_arguments():
     """Test dynamically updated arguments are usable."""
     size = 5

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -39,6 +39,7 @@ class StatesAndExpectOutputCase:
     def _assert_states(self, result, expected, tol):
         assert hasattr(result, 'states')
         assert len(result.states) == len(self.times)
+        assert len(self.e_ops) == len(expected)
         for test_operator, expected_part in zip(self.e_ops, expected):
             test = qutip.expect(test_operator, result.states)
             np.testing.assert_allclose(test, expected_part, rtol=tol)
@@ -46,6 +47,7 @@ class StatesAndExpectOutputCase:
     def _assert_expect(self, result, expected, tol):
         assert hasattr(result, 'expect')
         assert len(result.expect) == len(self.e_ops)
+        assert len(self.e_ops) == len(expected)
         for test, expected_part in zip(result.expect, expected):
             np.testing.assert_allclose(test, expected_part, rtol=tol)
 

--- a/qutip/tests/solver/test_results.py
+++ b/qutip/tests/solver/test_results.py
@@ -345,18 +345,20 @@ class TestMultiTrajResult:
         opt = fill_options(
             keep_runs_results=keep_runs_results, store_states=True
         )
-        m_res1 = MultiTrajResult([qutip.num(10)], opt)
+        m_res1 = MultiTrajResult([qutip.num(10)], opt, stats={"run time": 1})
         self._fill_trajectories(m_res1, N, 10, noise=0.1)
 
-        m_res2 = MultiTrajResult([qutip.num(10)], opt)
+        m_res2 = MultiTrajResult([qutip.num(10)], opt, stats={"run time": 2})
         self._fill_trajectories(m_res2, N, 30, noise=0.1)
 
         merged_res = m_res1 + m_res2
         assert merged_res.num_trajectories == 40
-        np.testing.assert_allclose(merged_res.average_expect[0], np.arange(10), rtol=0.1)
+        np.testing.assert_allclose(merged_res.average_expect[0],
+                                   np.arange(10), rtol=0.1)
         np.testing.assert_allclose(
             np.diag(sum(merged_res.average_states).full()),
             np.ones(N),
             rtol=0.1
         )
         assert bool(merged_res.trajectories) == keep_runs_results
+        assert merged_res.stats["run time"] == 3

--- a/qutip/tests/solver/test_results.py
+++ b/qutip/tests/solver/test_results.py
@@ -183,7 +183,7 @@ class TestMultiTrajResult:
                     result.collapse.append((t+0.1, 0))
                     result.collapse.append((t+0.2, 1))
                     result.collapse.append((t+0.3, 1))
-            if multiresult.add(0, result) <= 0:
+            if multiresult.add((0, result)) <= 0:
                 break
 
     def _expect_check_types(self, multiresult):


### PR DESCRIPTION
**Description**
Rewrite `mcsolve` as a class for dev.major.

Main addition:
- `MultitrajSolver` class as a base class for solver computing trajectory from a seed: it uses custom 
  - It uses custom integrator using a generator which `MultitrajSolver` provide. 
  - Stepping run one trajectory at a time.
  - Use numpy.random new interface with `SeedSequence` and `Generator`.
  - `run` can end on number of trajectories reached, timeout reached, or error bars on expectation values under a certain tolerance.
- `McSolver` class for mcsolve class interface.
  - Support closed and open system. For open systems. `H` must be a Liouvillian. The `c_ops` are computed stochasticly and are used for collapse. Dissipation terms to be used in a deterministic way can be added as Lindblad dissipators to the liouvillian.
  - McSolver's results include the photocurrent.
  - McSolver need a layer between the solver interface and the integrator. In #1710, this was a trajectory solver, but here I use a pseudo integrator. This makes `MultitrajSolver` easier to use with stochastic which need custom integrator and thus a trajectory solver did very little.

Other fixes:
- `MultiTrajResult` keep the `dtype` of expect.
- `MultiTrajResult` can merge instance with no states stored.

**Related issues or PRs**
Replace #1710 