### PR TITLE
Have coefficient compilation use relative path

### DIFF
--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -482,10 +482,12 @@ cdef class StrCoefficient(Coefficient):
 
 def compile_code(code, file_name, parsed, c_opt):
     pwd = os.getcwd()
-    root = qset.coeffroot
+    os.chdir(qset.coeffroot)
+    # Files with the same name, but differents extension than the pyx file, are
+    # erased during cythonization process, breaking filelock.
+    # Adding a prefix make them safe to use.
+    lock = filelock.FileLock("compile_lock_" + file_name + ".lock")
     try:
-        os.chdir(root)
-        lock = filelock.FileLock(file_name + ".lock")
         lock.acquire(timeout=0)
         for file in glob.glob(file_name + "*"):
             os.remove(file)

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -483,14 +483,13 @@ cdef class StrCoefficient(Coefficient):
 def compile_code(code, file_name, parsed, c_opt):
     pwd = os.getcwd()
     root = qset.coeffroot
-    lock = filelock.FileLock(file_name + ".lock")
     try:
-        lock.acquire(timeout=0)
         os.chdir(root)
+        lock = filelock.FileLock(file_name + ".lock")
+        lock.acquire(timeout=0)
         for file in glob.glob(file_name + "*"):
             os.remove(file)
-        full_file_name = os.path.join(root, file_name)
-        file_ = open(full_file_name + ".pyx", "w")
+        file_ = open(file_name + ".pyx", "w")
         file_.writelines(code)
         file_.close()
         oldargs = sys.argv
@@ -498,7 +497,7 @@ def compile_code(code, file_name, parsed, c_opt):
             sys.argv = ["setup.py", "build_ext", "--inplace"]
             coeff_file = Extension(
                 file_name,
-                sources=[full_file_name + ".pyx"],
+                sources=[file_name + ".pyx"],
                 extra_compile_args=c_opt['compiler_flags'].split(),
                 extra_link_args=c_opt['link_flags'].split(),
                 include_dirs=[np.get_include()],


### PR DESCRIPTION
**Description**
A change in setuptools (pypa/setuptools#3521) raise a warning when compiling coefficient using absolute path, which breaks our tests for `dev.major`:
```
DeprecationWarning: Absolute path '/home/runner/.qutip/qutip_coeffs_1.1/qtcoeff_8208be2129365a87dda9c12028c457' is being replaced with a relative path 'home/runner/.qutip/qutip_coeffs_1.1/qtcoeff_8208be2129365a87dda9c12028c457' for outputs. This behavior is deprecated. If this behavior is desired, please comment in pypa/distutils#169.
```
This changes the path to be relative.

I change the path before creating the lock files, which otherwise were polluting the active directory.