### PR TITLE
Ignore DeprecationWarnings raised by pyximport on Python 3.10.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,13 +71,11 @@ jobs:
           # a warning on Python 3.10
           # Ignore DeprecationWarnings raised by cvxpy importing scipy.sparse.X
           # under SciPy 1.8.0+.
-          # Ignore DeprecationWarnings raised by pyximport when building .pyx
-          # extensions under setuptools >= 63.1.0.
           - case-name: Python 3.10
             os: ubuntu-latest
             python-version: "3.10"
             condaforge: 1
-            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper -W ignore::DeprecationWarning:setuptools._distutils.ccompiler"
+            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper"
 
           # Windows. Once all tests pass without special options needed, this
           # can be moved to the main os list in the test matrix. All the tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,11 +71,15 @@ jobs:
           # a warning on Python 3.10
           # Ignore DeprecationWarnings raised by cvxpy importing scipy.sparse.X
           # under SciPy 1.8.0+.
+          # Ignore DeprecationWarnings raised by versions of
+          # setuptools >= 65.0.0 during pyximport imports This can be removed
+          # once https://github.com/cython/cython/issues/4985
+          # is fixed and released.
           - case-name: Python 3.10
             os: ubuntu-latest
             python-version: "3.10"
             condaforge: 1
-            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper"
+            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper -W ignore:Absolute:DeprecationWarning"
 
           # Windows. Once all tests pass without special options needed, this
           # can be moved to the main os list in the test matrix. All the tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,11 +71,13 @@ jobs:
           # a warning on Python 3.10
           # Ignore DeprecationWarnings raised by cvxpy importing scipy.sparse.X
           # under SciPy 1.8.0+.
+          # Ignore DeprecationWarnings raised by pyximport when building .pyx
+          # extensions under setuptools >= 63.1.0.
           - case-name: Python 3.10
             os: ubuntu-latest
             python-version: "3.10"
             condaforge: 1
-            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper"
+            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper -W ignore::DeprecationWarning:setuptools._distutils.ccompiler"
 
           # Windows. Once all tests pass without special options needed, this
           # can be moved to the main os list in the test matrix. All the tests

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,13 @@ def _determine_user_arguments(options):
     """
     Add the 'openmp' option to the collection, based on the passed command-line
     arguments or environment variables.
+
+    If using PEP517 builds, one can pass these options on the command-line
+    using, for example:
+
+        python -m build \
+            --wheel \
+            --config-setting="--global-option=--with-openmp"
     """
     options['openmp'] = (
         '--with-openmp' in sys.argv


### PR DESCRIPTION
**Description**
- Ignore DeprecationWarnings raised by pyximport on Python 3.10.
- Explain (after much digging) how to pass `--with-openmp` to `python -m build`.

**Related issues or PRs**
- https://github.com/cython/cython/issues/4985
- https://github.com/pypa/distutils/issues/169