### PR TITLE
Correlation support time dependent c_ops

### DIFF
--- a/doc/changes/1979.bugfix
+++ b/doc/changes/1979.bugfix
@@ -1,0 +1,1 @@
+Fix correlation for case where only the collapse operators are time dependent.


### PR DESCRIPTION
**Description**
Fix the bug in correlation where it would not properly detect that the system were time-dependent when only the c_ops were.

**Related issues or PRs**
fix #1808
replace #1929