### PR TITLE
Draft: Reduce qutip import time by setting logger names

### DIFF
--- a/doc/changes/1981.feature
+++ b/doc/changes/1981.feature
@@ -1,0 +1,1 @@
+Improve qutip import times by setting logger names explicitly.

--- a/qutip/control/dump.py
+++ b/qutip/control/dump.py
@@ -16,7 +16,7 @@ from numpy.compat import asbytes
 import qutip.control.io as qtrlio
 # QuTiP logging
 import qutip.logging_utils
-logger = qutip.logging_utils.get_logger()
+logger = qutip.logging_utils.get_logger('qutip.control.dump')
 
 DUMP_DIR = "~/.qtrl_dump"
 

--- a/qutip/control/grape.py
+++ b/qutip/control/grape.py
@@ -17,7 +17,7 @@ from qutip.ui.progressbar import BaseProgressBar
 from qutip.control.cy_grape import cy_overlap, cy_grape_inner
 
 import qutip.logging_utils
-logger = qutip.logging_utils.get_logger()
+logger = qutip.logging_utils.get_logger('qutip.control.grape')
 
 
 class GRAPEResult:

--- a/qutip/control/optimconfig.py
+++ b/qutip/control/optimconfig.py
@@ -13,7 +13,7 @@ import numpy as np
 import qutip.control.io as qtrlio
 # QuTiP logging
 import qutip.logging_utils
-logger = qutip.logging_utils.get_logger()
+logger = qutip.logging_utils.get_logger('qutip.optimcontrol.grape')
 
 
 class OptimConfig(object):

--- a/qutip/core/semidefinite.py
+++ b/qutip/core/semidefinite.py
@@ -18,7 +18,7 @@ except ImportError:
 from .tensor import tensor_swap
 from .operators import qeye
 from ..logging_utils import get_logger
-logger = get_logger()
+logger = get_logger('qutip.core.semidefinite')
 
 Complex = collections.namedtuple('Complex', ['re', 'im'])
 

--- a/qutip/solve/steadystate.py
+++ b/qutip/solve/steadystate.py
@@ -9,6 +9,7 @@ __all__ = ['steadystate', 'steadystate_floquet',
 
 import warnings
 import time
+import functools
 from packaging.version import parse as _parse_version
 
 import numpy as np
@@ -29,7 +30,7 @@ from ..settings import settings
 from . import _steadystate
 
 import qutip.logging_utils
-logger = qutip.logging_utils.get_logger()
+logger = qutip.logging_utils.get_logger('qutip.solve.steadystate')
 logger.setLevel('DEBUG')
 
 # Load MKL spsolve if avaiable


### PR DESCRIPTION
<!-- **Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.

- [ ] Please read [Contributing to QuTiP Development](http://qutip.org/docs/latest/development/contributing.html)
- [ ] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
- [ ] Please add tests to cover your changes if applicable.
- [ ] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-notebooks). Feel free to ask if you are not sure.
- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](http://qutip.org/docs/latest/development/contributing.html#Changelog%20Generation) for more information).

Delete this checklist after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.
-->
**Description**

This PR reduced the qutip import time by setting the logger names explicitly. 

**Related issues or PRs**

See #1980 for more details.
