### PR TITLE
Swap the parameters `dims` and `targets` for expand_operator

### DIFF
--- a/doc/changes/1991.feature
+++ b/doc/changes/1991.feature
@@ -1,0 +1,1 @@
+Change the order of parameters in expand_operator

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -3,7 +3,6 @@ Internal use module for manipulating dims specifications.
 """
 
 # Everything should be explicitly imported, not made available by default.
-__all__ = ['expand_operator']
 
 import numpy as np
 from operator import getitem

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -412,14 +412,14 @@ def _targets_to_list(targets, oper=None, N=None):
     return targets
 
 
-def expand_operator(oper, targets, dims):
+def expand_operator(oper, dims, targets):
     """
     Expand an operator to one that acts on a system with desired dimensions.
     e.g.
     ```
-    expand_operator(oper, 2, [2, 3, 4, 5]) ==
+    expand_operator(oper, [2, 3, 4, 5], 2) ==
         tensor(qeye(2), qeye(3), oper, qeye(5))
-    expand_operator(tensor(oper1, oper2), [2, 0], [2, 3, 4, 5]) ==
+    expand_operator(tensor(oper1, oper2), [2, 3, 4, 5], [2, 0]) ==
         tensor(oper2, qeye(3), oper1, qeye(5))
     ```
 
@@ -429,11 +429,11 @@ def expand_operator(oper, targets, dims):
         An operator that act on the subsystem, has to be an operator and the
         dimension matches the tensored dims Hilbert space
         e.g. oper.dims = ``[[2, 3], [2, 3]]``
-    targets : int or list of int
-        The indices of subspace that are acted on.
     dims : list
         A list of integer for the dimension of each composite system.
         E.g ``[2, 3, 2, 3, 4]``.
+    targets : int or list of int
+        The indices of subspace that are acted on.
 
     Returns
     -------

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -368,7 +368,7 @@ def entangling_power(U):
         raise Exception("U must be a two-qubit gate.")
 
     from qutip.core.gates import swap
-    swap13 =  expand_operator(swap(), [1, 3], [2, 2, 2, 2])
+    swap13 =  expand_operator(swap(), [2, 2, 2, 2], [1, 3])
     a = tensor(U, U).dag() * swap13 * tensor(U, U) * swap13
     Uswap = swap() * U
     b = tensor(Uswap, Uswap).dag() * swap13 * tensor(Uswap, Uswap) * swap13

--- a/qutip/tests/core/test_tensor.py
+++ b/qutip/tests/core/test_tensor.py
@@ -211,7 +211,7 @@ class Test_expand_operator:
         ids=_permutation_id)
     def test_permutation_without_expansion(self, permutation):
         base = qutip.tensor([qutip.rand_unitary(2) for _ in permutation])
-        test = expand_operator(base, permutation, [2] * len(permutation))
+        test = expand_operator(base, [2] * len(permutation), permutation)
         expected = base.permute(_apply_permutation(permutation))
         np.testing.assert_allclose(test.full(), expected.full(), atol=1e-15)
 
@@ -223,12 +223,12 @@ class Test_expand_operator:
         for targets in itertools.permutations(range(n_qubits), n_targets):
             expected = _tensor_with_entanglement([qutip.qeye(2)] * n_qubits,
                                                  operation, targets)
-            test = expand_operator(operation, targets, [2] * 5)
+            test = expand_operator(operation, [2] * 5, targets)
             np.testing.assert_allclose(test.full(), expected.full(),
                                        atol=1e-15)
 
     def test_cnot_explicit(self):
-        test = expand_operator(qutip.gates.cnot(), [2, 0], [2]*3).full()
+        test = expand_operator(qutip.gates.cnot(), [2]*3, [2, 0]).full()
         expected = np.array([[1, 0, 0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 1, 0, 0],
                              [0, 0, 1, 0, 0, 0, 0, 0],
@@ -252,6 +252,6 @@ class Test_expand_operator:
                          for n, dimension in enumerate(dimensions)]
             expected = qutip.tensor(*operators)
             base_test = qutip.tensor(*[operators[x] for x in targets])
-            test = expand_operator(base_test, targets=targets, dims=dimensions)
+            test = expand_operator(base_test, dims=dimensions, targets=targets)
             assert test.dims == expected.dims
             np.testing.assert_allclose(test.full(), expected.full())


### PR DESCRIPTION
**Description**
Swap `dims` and `targets`. The new parameters (oper, dims, targets) better match with the ones in v4 (oper, N, targets, dims=None), which makes it easier to add deprecation warnings.

Remove `__all__ = ['expand_operator']` from `dimensions.py` which was probably a mistake from a previous PR.