### PR TITLE
Added division by scalar to be more flexible.

### DIFF
--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -512,9 +512,7 @@ class Qobj:
                     copy=False)
 
     def __truediv__(self, other):
-        if not isinstance(other, numbers.Number):
-            return NotImplemented
-        return self.__mul__(1 / complex(other))
+        return self.__mul__(1 / other)
 
     def __neg__(self):
         return Qobj(_data.neg(self._data),

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -351,6 +351,41 @@ def test_QobjMulNotValidScalar(not_scalar):
         q1 * not_scalar
 
 
+# Allowed division operations (scalar)
+@pytest.mark.parametrize("scalar",
+                         [2+2j,  np.array(2+2j), np.array([2+2j])],
+                         ids=[
+                             "python_number",
+                             "scalar_like_array_shape_0",
+                             "scalar_like_array_shape_1",
+                         ])
+def test_QobjDivisionValidScalar(scalar):
+    "Tests multiplication of Qobj times scalar."
+    data = np.array([[1, 2], [3, 4]])
+    q = qutip.Qobj(data)
+    expect = data / (2+2j)
+
+    # Check __truediv__
+    result = q / scalar
+    assert np.all(result.full() == expect)
+
+
+# Similar as in test_QobjMulNotValidScalar, we do not allow multiplication by
+# non scalar numpy values. This should also be removed in case of implementing
+# broadcasting rules for Qobj.
+@pytest.mark.parametrize("not_scalar",
+                         [np.array([2j, 1]), np.array([[1, 2], [3, 4]])],
+                         ids=[
+                             "not_scalar_like_vector",
+                             "not_scalar_like_matrix",
+                         ])
+def test_QobjDivisionNotValidScalar(not_scalar):
+    q1 = qutip.Qobj(np.array([[1, 2], [3, 4]]))
+
+    with pytest.raises(TypeError):
+        not_scalar / q1
+
+
 def test_QobjDivision():
     "qutip.Qobj division"
     data = _random_not_singular(5)

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -383,7 +383,7 @@ def test_QobjDivisionNotValidScalar(not_scalar):
     q1 = qutip.Qobj(np.array([[1, 2], [3, 4]]))
 
     with pytest.raises(TypeError):
-        not_scalar / q1
+        q1 / not_scalar
 
 
 def test_QobjDivision():

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -386,6 +386,23 @@ def test_QobjDivisionNotValidScalar(not_scalar):
         q1 / not_scalar
 
 
+def test_QobjNotImplemented():
+    class MockerScalar():
+        def __mul__(self, other):
+            return "object not accepted by _data.mul, mul"
+
+        def __rmul__(self, other):
+            return "object not accepted by _data.mul, rmul"
+
+        def __rtruediv__(self, other):
+            return "object not accepted by _data.mul, rtruediv"
+
+    qobj = qutip.Qobj(np.array([[1, 2], [3, 4]]))
+    scalar = MockerScalar()
+    assert (qobj*scalar) == "object not accepted by _data.mul, rmul"
+    assert (scalar*qobj) == "object not accepted by _data.mul, mul"
+    assert (qobj/scalar) == "object not accepted by _data.mul, rtruediv"
+
 def test_QobjDivision():
     "qutip.Qobj division"
     data = _random_not_singular(5)


### PR DESCRIPTION
**Description**
Fix issue part of the issue with qutip/qutip-tensorflow#37.

We rely on `__mul__` to decide what to do with other instead of making it complex in `__truediv__`.

**Related issues or PRs**
This fix was already discussed in #1620. 