### PR TITLE
Allow propagator to accept Solver input

### DIFF
--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -285,7 +285,6 @@ class BRSolver(Solver):
         self._integrator = self._get_integrator()
         self._state_metadata = {}
         self.stats = self._initialize_stats()
-        self.sys_dims = self.rhs.dims[0]
         self.evolve_dm = True
 
 

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -285,7 +285,6 @@ class BRSolver(Solver):
         self._integrator = self._get_integrator()
         self._state_metadata = {}
         self.stats = self._initialize_stats()
-        self.evolve_dm = True
 
 
     def _initialize_stats(self):

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -66,7 +66,7 @@ def brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[],
             ]
 
         .. note:
-            ``Cubic_Spline`` has been replaced by :class:`Coefficient`\:
+            ``Cubic_Spline`` has been replaced by :class:`Coefficient`:
                 ``spline = qutip.coefficient(array, tlist=times)``
 
             Whether the ``a_ops`` is time dependent is decided by the type of
@@ -285,6 +285,8 @@ class BRSolver(Solver):
         self._integrator = self._get_integrator()
         self._state_metadata = {}
         self.stats = self._initialize_stats()
+        self.sys_dims = self.rhs.dims[0]
+        self.evolve_dm = True
 
 
     def _initialize_stats(self):

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -1135,13 +1135,6 @@ class HEOMSolver(Solver):
         """
         super().start(state0, t0)
 
-    def step(self, t, *, args=None, copy=True):
-        ado = super().step(t, args=args, copy=copy)
-        if self.options["store_ados"]:
-            return ado
-        else:
-            return ado.rho
-
     @property
     def options(self):
         """

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -654,12 +654,11 @@ class HEOMSolver(Solver):
         self._init_rhs_time = time() - _time_start
 
         super().__init__(rhs, options=options)
-        self.evolve_dm = True
 
     @property
     def sys_dims(self):
         """
-        Dimensions of the space that the system use:
+        Dimensions of the space that the system use, excluding any environment:
 
         ``qutip.basis(sovler.dims)`` will create a state with proper dimensions
         for this solver.

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -16,7 +16,7 @@ import numpy as np
 import scipy.sparse as sp
 from scipy.sparse.linalg import spsolve
 
-from qutip import settings
+from qutip.settings import settings
 from qutip import state_number_enumerate
 from qutip.core import data as _data
 from qutip.core.data import csr as _csr

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -609,7 +609,6 @@ class HEOMSolver(Solver):
 
         self._sys_shape = int(np.sqrt(self.L_sys.shape[0]))
         self._sup_shape = self.L_sys.shape[0]
-        self._sys_dims = self.L_sys.dims[0]
 
         self.ados = HierarchyADOs(
             self._combine_bath_exponents(bath), max_depth,
@@ -654,6 +653,8 @@ class HEOMSolver(Solver):
         self._init_rhs_time = time() - _time_start
 
         super().__init__(rhs, options=options)
+        self.sys_dims = self.L_sys.dims[0]
+        self.evolve_dm = True
 
     def _initialize_stats(self):
         stats = super()._initialize_stats()
@@ -962,7 +963,7 @@ class HEOMSolver(Solver):
 
         data = _data.Dense(solution[:n ** 2].reshape((n, n)))
         data = _data.mul(_data.add(data, data.conj()), 0.5)
-        steady_state = Qobj(data, dims=self._sys_dims)
+        steady_state = Qobj(data, dims=self.sys_dims)
 
         solution = solution.reshape((self._n_ados, n, n))
         steady_ados = HierarchyADOsState(steady_state, self.ados, solution)
@@ -1040,7 +1041,7 @@ class HEOMSolver(Solver):
 
     def _prepare_state(self, state):
         n = self._sys_shape
-        rho_dims = self._sys_dims
+        rho_dims = self.sys_dims
         hierarchy_shape = (self._n_ados, n, n)
 
         rho0 = state
@@ -1082,7 +1083,7 @@ class HEOMSolver(Solver):
     def _restore_state(self, state, *, copy=True):
         n = self._sys_shape
         rho_shape = (n, n)
-        rho_dims = self._sys_dims
+        rho_dims = self.sys_dims
         hierarchy_shape = (self._n_ados, n, n)
 
         rho = Qobj(

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -8,6 +8,7 @@ from ..core import data as _data
 from .mesolve import mesolve, MeSolver
 from .sesolve import sesolve, SeSolver
 from .mcsolve import McSolver
+from .heom.bofin_solvers import HEOMSolver
 from .solver_base import Solver
 from .multitraj import MultiTrajSolver
 
@@ -151,6 +152,9 @@ class Propagator:
         if isinstance(system, MultiTrajSolver):
             raise TypeError("Non-deterministic solver cannot be used in "
                             "propagator")
+        elif isinstance(system, HEOMSolver):
+            raise TypeError("HEOM is not supported by Propagator. "
+                            "Please, tell us on GitHub issues if you need it!")
         elif isinstance(system, Solver):
             self.solver = system
         else:

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -121,7 +121,7 @@ class Propagator:
         ``list`` of [:class:`Qobj`, :class:`Coefficient`] or callable that can
         be made into :class:`QobjEvo` are also accepted.
 
-        Solver that run non-deterministacilly, such as :class:`McSolver`, are
+        Solvers that run non-deterministacilly, such as :class:`McSolver`, are
         not supported.
 
     c_ops : list, optional
@@ -150,8 +150,8 @@ class Propagator:
     def __init__(self, system, *, c_ops=(), args=None, options=None,
                  memoize=10, tol=1e-14):
         if isinstance(system, MultiTrajSolver):
-            raise TypeError("Non-deterministic solver cannot be used in "
-                            "propagator")
+            raise TypeError("Non-deterministic solvers cannot be used "
+                            "as a propagator system")
         elif isinstance(system, HEOMSolver):
             raise TypeError("HEOM is not supported by Propagator. "
                             "Please, tell us on GitHub issues if you need it!")

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -9,6 +9,7 @@ from .mesolve import mesolve, MeSolver
 from .sesolve import sesolve, SeSolver
 from .mcsolve import McSolver
 from .solver_base import Solver
+from .multitraj import MultiTrajSolver
 
 
 def propagator(H, t, c_ops=(), args=None, options=None, **kwargs):
@@ -147,8 +148,9 @@ class Propagator:
     """
     def __init__(self, system, *, c_ops=(), args=None, options=None,
                  memoize=10, tol=1e-14):
-        if isinstance(system, McSolver):
-            raise TypeError("McSolver cannot be used in propagator")
+        if isinstance(system, MultiTrajSolver):
+            raise TypeError("Non-deterministic solver cannot be used in "
+                            "propagator")
         elif isinstance(system, Solver):
             self.solver = system
         else:
@@ -163,7 +165,7 @@ class Propagator:
         self.invs = [None]
         self.props = [qeye(self.solver.sys_dims)]
         self.cte = self.solver.rhs.isconstant
-        self.unitary = isinstance(system, SeSolver)
+        self.unitary = not self.solver.evolve_dm and self.solver.rhs(0).isherm
         self.args = args
         self.memoize = max(3, int(memoize))
         self.tol = tol

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -7,6 +7,7 @@ from .. import Qobj, qeye, unstack_columns, QobjEvo
 from ..core import data as _data
 from .mesolve import mesolve, MeSolver
 from .sesolve import sesolve, SeSolver
+from .mcsolve import McSolver
 from .solver_base import Solver
 
 
@@ -146,7 +147,9 @@ class Propagator:
     """
     def __init__(self, system, *, c_ops=(), args=None, options=None,
                  memoize=10, tol=1e-14):
-        if isinstance(system, Solver):
+        if isinstance(system, McSolver):
+            raise TypeError("McSolver cannot be used in propagator")
+        elif isinstance(system, Solver):
             self.solver = system
         else:
             Hevo = QobjEvo(system, args=args)

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -153,8 +153,10 @@ class Propagator:
             raise TypeError("Non-deterministic solvers cannot be used "
                             "as a propagator system")
         elif isinstance(system, HEOMSolver):
-            raise TypeError("HEOM is not supported by Propagator. "
-                            "Please, tell us on GitHub issues if you need it!")
+            raise NotImplementedError(
+                "HEOM is not supported by Propagator. "
+                "Please, tell us on GitHub issues if you need it!"
+            )
         elif isinstance(system, Solver):
             self.solver = system
         else:
@@ -169,7 +171,8 @@ class Propagator:
         self.invs = [None]
         self.props = [qeye(self.solver.sys_dims)]
         self.cte = self.solver.rhs.isconstant
-        self.unitary = not self.solver.evolve_dm and self.solver.rhs(0).isherm
+        H_0 = self.solver.rhs(0)
+        self.unitary = not H_0.issuper and H_0.isherm
         self.args = args
         self.memoize = max(3, int(memoize))
         self.tol = tol

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -23,13 +23,6 @@ class Solver:
 
     options : dict
         Options for the solver
-
-    Attributes
-    ----------
-    evolve_dm : bool
-        Whether the solver is able to evolve density matrix. When ``False``,
-        operator initial input may not raise error but return ``U @ operator``
-        where ``U`` is the propagator.
     """
     name = ""
 
@@ -53,7 +46,6 @@ class Solver:
             self.rhs = QobjEvo(rhs)
         else:
             TypeError("The rhs must be a QobjEvo")
-        self.evolve_dm = rhs.issuper
         self._options = {}
         self.options = {} if options is None else options
         self._integrator = self._get_integrator()

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -23,6 +23,13 @@ class Solver:
 
     options : dict
         Options for the solver
+
+    Attributes
+    ----------
+    evolve_dm : bool
+        Whether the solver is able to evolve density matrix. When ``False``,
+        operator initial input may not raise error but return ``U @ operator``
+        where ``U`` is the propagator.
     """
     name = ""
 
@@ -46,7 +53,6 @@ class Solver:
             self.rhs = QobjEvo(rhs)
         else:
             TypeError("The rhs must be a QobjEvo")
-        self.sys_dims = rhs.dims[0]
         self.evolve_dm = rhs.issuper
         self._options = {}
         self.options = {} if options is None else options
@@ -225,6 +231,16 @@ class Solver:
         integrator_instance = integrator(self.rhs, self.options)
         self._init_integrator_time = time() - _time_start
         return integrator_instance
+
+    @property
+    def sys_dims(self):
+        """
+        Dimensions of the space that the system use:
+
+        ``qutip.basis(sovler.dims)`` will create a state with proper dimensions
+        for this solver.
+        """
+        return self.rhs.dims[0]
 
     @property
     def options(self):

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -46,6 +46,8 @@ class Solver:
             self.rhs = QobjEvo(rhs)
         else:
             TypeError("The rhs must be a QobjEvo")
+        self.sys_dims = rhs.dims[0]
+        self.evolve_dm = rhs.issuper
         self._options = {}
         self.options = {} if options is None else options
         self._integrator = self._get_integrator()

--- a/qutip/tests/solver/heom/test_bofin_solvers.py
+++ b/qutip/tests/solver/heom/test_bofin_solvers.py
@@ -880,7 +880,7 @@ class TestHEOMSolver:
         ck_real, vk_real, ck_imag, vk_imag = dlm.bath_coefficients()
 
         bath = BosonicBath(dlm.Q, ck_real, vk_real, ck_imag, vk_imag)
-        options = {"nsteps": 15_000}
+        options = {"nsteps": 15_000, "store_ados": True}
         hsolver = HEOMSolver(dlm.H, bath, 14, options=options)
 
         tlist = np.linspace(0, 10, 21)

--- a/qutip/tests/solver/test_propagator.py
+++ b/qutip/tests/solver/test_propagator.py
@@ -144,7 +144,10 @@ def testPropHEOM():
 
     rho = qutip.rand_dm(2)
     hsolver.start(rho, 0)
-    np.testing.assert_allclose(U(1)(rho).full(), hsolver.step(1).full())
+    np.testing.assert_allclose(
+        U(1)(rho).full(), hsolver.step(1).full(),
+        atol=1e-6
+    )
 
 
 def testPropMcSolver():

--- a/qutip/tests/solver/test_propagator.py
+++ b/qutip/tests/solver/test_propagator.py
@@ -142,6 +142,10 @@ def testPropHEOM():
     assert U(1).dims == [[[2], [2]], [[2], [2]]]
     assert U(2).istp
 
+    rho = qutip.rand_dm(2)
+    hsolver.start(rho, 0)
+    np.testing.assert_allclose(U(1)(rho).full(), hsolver.step(1).full())
+
 
 def testPropMcSolver():
     a = destroy(5)

--- a/qutip/tests/solver/test_propagator.py
+++ b/qutip/tests/solver/test_propagator.py
@@ -131,25 +131,6 @@ def testPropSolver(solver):
     assert (U(1.5, 0.5) - propagator(H, 1, c_ops)).norm('max') < 1e-4
 
 
-def testPropHEOM():
-    from qutip.solver.heom.bofin_baths import Bath, BathExponent
-    from qutip.solver.heom.bofin_solvers import HEOMSolver
-    a = destroy(2)
-    H = a.dag()*a
-    bath = Bath([BathExponent("R", None, Q=a, ck=1, vk=0)])
-    hsolver = HEOMSolver(H, bath, 1)
-    U = Propagator(hsolver)
-    assert U(1).dims == [[[2], [2]], [[2], [2]]]
-    assert U(2).istp
-
-    rho = qutip.rand_dm(2)
-    hsolver.start(rho, 0)
-    np.testing.assert_allclose(
-        U(1)(rho).full(), hsolver.step(1).full(),
-        atol=1e-6
-    )
-
-
 def testPropMcSolver():
     a = destroy(5)
     H = a.dag()*a


### PR DESCRIPTION
**Description**
Allow `Propagator` to take a `Solver` instead of an Hamiltonian, this allow to make propagator work with brmesolve or HEOM.

To help with that, I made the system's solver dimensions accessible through `sys_dims` and whether they represent super dims in `evolve_dm`. 

