### PR TITLE
Keep isherm flag in constant QobjEvo

### DIFF
--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -316,7 +316,10 @@ cdef class QobjEvo:
         t = self._prepare(t, None)
 
         if self.isconstant:
-            # When the QobjEvo is constant, it is usually made of only one Qobj
+            # For constant QobjEvo's, we sum the contained Qobjs directly in
+            # order to retain the cached values of attributes like .isherm when
+            # possible, rather than calling _call(t) which may lose this cached
+            # information.
             return sum(element.qobj(t) for element in self.elements)
 
         cdef _BaseElement part = self.elements[0]

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -312,6 +312,9 @@ cdef class QobjEvo:
             if _args is not None:
                 kwargs.update(_args)
             return QobjEvo(self, args=kwargs)(t)
+        if self.isconstant:
+            # When the QobjEvo is constant, it is usually made of only one Qobj
+            return sum(element.qobj(t) for element in self.elements)
         return Qobj(
             self._call(t), dims=self.dims, copy=False,
             type=self.type, superrep=self.superrep

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -1,7 +1,8 @@
 import operator
 
 import pytest
-from qutip import *
+from qutip import (Qobj, QobjEvo, coefficient, qeye, sigmax, sigmaz,
+                   rand_stochastic, rand_herm, rand_ket, liouvillian)
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -59,18 +60,18 @@ def _cplx(t, args):
 
 
 real_qevo = Pseudo_qevo(
-    rand_stochastic(N).to(data.CSR),
-    rand_stochastic(N).to(data.CSR),
+    rand_stochastic(N).to(_data.CSR),
+    rand_stochastic(N).to(_data.CSR),
     _real, "sin(t*w1)", args)
 
 herm_qevo = Pseudo_qevo(
-    rand_herm(N).to(data.Dense),
-    rand_herm(N).to(data.Dense),
+    rand_herm(N).to(_data.Dense),
+    rand_herm(N).to(_data.Dense),
     _real, "sin(t*w1)", args)
 
 cplx_qevo = Pseudo_qevo(
-    rand_stochastic(N).to(data.Dense),
-    rand_stochastic(N).to(data.CSR) + rand_stochastic(N).to(data.CSR) * 1j,
+    rand_stochastic(N).to(_data.Dense),
+    rand_stochastic(N).to(_data.CSR) + rand_stochastic(N).to(_data.CSR) * 1j,
     _cplx, "exp(1j*t*w2)", args)
 
 
@@ -355,7 +356,7 @@ def test_expect_rho(all_qevo):
 
 @pytest.mark.parametrize('dtype',
 [pytest.param(dtype, id=dtype.__name__)
-     for dtype in core.data.to.dtypes])
+     for dtype in _data.to.dtypes])
 def test_convert(all_qevo, dtype):
     "QobjEvo expect rho"
     op = all_qevo.to(dtype)
@@ -380,14 +381,14 @@ def test_compress():
 
 @pytest.mark.parametrize(['qobjdtype'],
     [pytest.param(dtype, id=dtype.__name__)
-     for dtype in core.data.to.dtypes])
+     for dtype in _data.to.dtypes])
 @pytest.mark.parametrize(['statedtype'],
     [pytest.param(dtype, id=dtype.__name__)
-     for dtype in core.data.to.dtypes])
+     for dtype in _data.to.dtypes])
 def test_layer_support(qobjdtype, statedtype):
     N = 10
     qevo = QobjEvo(rand_herm(N).to(qobjdtype))
-    state_dense = rand_ket(N).to(core.data.Dense)
+    state_dense = rand_ket(N).to(_data.Dense)
     state = state_dense.to(statedtype).data
     state_dense = state_dense.data
     exp_any = qevo.expect_data(0, state)
@@ -431,3 +432,11 @@ def test_QobjEvo_step_coeff():
     assert qobjevo(6.7)[0,1] == coeff2[4]
     assert qobjevo(7.9999)[0,1] == coeff2[4]
     assert qobjevo(3.9999)[0,1] == coeff2[1]
+
+
+def test_QobjEvo_isherm_flag_knowcase():
+    assert QobjEvo(sigmax())(0)._isherm is True
+    non_hermitian = sigmax() + 1j
+    non_hermitian.isherm  # set flag
+    assert QobjEvo(non_hermitian)(0)._isherm is False
+    assert QobjEvo([sigmax(), sigmaz()])(0)._isherm is True

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -440,3 +440,7 @@ def test_QobjEvo_isherm_flag_knowcase():
     non_hermitian.isherm  # set flag
     assert QobjEvo(non_hermitian)(0)._isherm is False
     assert QobjEvo([sigmax(), sigmaz()])(0)._isherm is True
+    assert QobjEvo([sigmax(), "t"])(0)._isherm is True
+    assert QobjEvo([sigmax(), "1j"])(0)._isherm is None
+    assert QobjEvo([[sigmax(), "t"], [sigmaz(), "1"]])(0)._isherm is True
+    assert QobjEvo([[sigmax(), "t"], [sigmaz(), "1j"]])(0)._isherm is None


### PR DESCRIPTION
**Description**
In solvers, we often wrap `Qobj` into `QobjEvo` to remove code duplication while allowing support for time-dependant operators even when constant case are the norm (`e_ops`). Doing so we lose the `isherm` flag, which can sometime be nice to have. 
This PR allow the flag to be kept when calling the `QobjEvo` in such case:
```
>>> QobjEvo(qeye(N))(0)._isherm
True
```

This will be useful for the `diag` integration method which need compute the eigenstates of a constant `QobjEvo`.

