### PR TITLE
Add `solve` and `svn` to dispatched function

### DIFF
--- a/qutip/core/data/__init__.py
+++ b/qutip/core/data/__init__.py
@@ -24,6 +24,7 @@ from .ptrace import *
 from .reshape import *
 from .tidyup import *
 from .trace import *
+from .solve import *
 # For operations with mulitple related versions, we just import the module.
 from . import norm, permute
 

--- a/qutip/core/data/eigen.py
+++ b/qutip/core/data/eigen.py
@@ -443,7 +443,7 @@ svd.__doc__ =\
         Right singular vectors as rows. Only returned if ``vecs == True``.
     """
 # Dense implementation return all states, but sparse implementation compute
-# only a few states. So only the dense version is registed.
+# only a few states. So only the dense version is registered.
 svd.add_specialisations([
     (Dense, svd_dense),
 ], _defer=True)

--- a/qutip/core/data/solve.py
+++ b/qutip/core/data/solve.py
@@ -6,7 +6,7 @@ from qutip.settings import settings
 if settings.has_mkl:
     from qutip._mkl.spsolve import mkl_spsolve
 else:
-    mkl = None
+    mkl_spsolve = None
 
 
 def _splu(A, B, **kwargs):
@@ -61,10 +61,10 @@ def solve_csr_dense(matrix: CSR, target: Dense, method=None,
         solver = _splu
     elif hasattr(splinalg, method):
         solver = getattr(splinalg, method)
-    elif method.startswith("mkl") and mkl is None:
+    elif method == "mkl_spsolve" and mkl_spsolve is None:
         raise ValueError("mkl is not available")
     elif method == "mkl_spsolve":
-        solver = getattr(mkl, method)
+        solver = mkl_spsolve
     else:
         raise ValueError(f"Unknown sparse solver {method}.")
 

--- a/qutip/core/data/solve.py
+++ b/qutip/core/data/solve.py
@@ -61,10 +61,10 @@ def solve_csr_dense(matrix: CSR, target: Dense, method=None,
         solver = _splu
     elif hasattr(splinalg, method):
         solver = getattr(splinalg, method)
-    elif method in ["mkl_spsolve", "mkl"]:
-        solver = getattr(mkl, method)
     elif method.startswith("mkl") and mkl is None:
         raise ValueError("mkl is not available")
+    elif method == "mkl_spsolve":
+        solver = getattr(mkl, method)
     else:
         raise ValueError(f"Unknown sparse solver {method}.")
 
@@ -73,7 +73,6 @@ def solve_csr_dense(matrix: CSR, target: Dense, method=None,
     if options.pop("csc", False):
         M = M.tocsc()
 
-    print(type(M))
     out = solver(M, b, **options)
 
     if isinstance(out, tuple) and len(out) == 2:
@@ -96,8 +95,7 @@ def solve_csr_dense(matrix: CSR, target: Dense, method=None,
     elif isinstance(out, tuple) and len(out) > 2:
         # least sqare method return residual, flag, etc.
         out, *_ = out
-    # spsolve can return both scipy sparse matrix or ndarray
-    return _data.create(out, copy=False)
+    return Dense(out, copy=False)
 
 
 def solve_dense(matrix: Dense, target: Data, method=None,
@@ -136,7 +134,6 @@ def solve_dense(matrix: Dense, target: Data, method=None,
     else:
         b = target.to_array()
 
-
     if method in ["solve", None]:
         out = np.linalg.solve(matrix.as_ndarray(), b)
     elif method == "lstsq":
@@ -148,8 +145,7 @@ def solve_dense(matrix: Dense, target: Data, method=None,
     else:
         raise ValueError(f"Unknown solver {method},"
                          " 'solve' and 'lstsq' are supported.")
-    print(out)
-    return _data.create(out, copy=False)
+    return Dense(out, copy=False)
 
 
 from .dispatch import Dispatcher as _Dispatcher

--- a/qutip/core/data/solve.py
+++ b/qutip/core/data/solve.py
@@ -1,0 +1,206 @@
+from qutip.core.data import CSR, Data, csr, Dense
+import qutip.core.data as _data
+import scipy.sparse.linalg as splinalg
+import numpy as np
+from qutip.settings import settings
+if settings.has_mkl:
+    from qutip._mkl.spsolve import mkl_spsolve
+else:
+    mkl = None
+
+
+def _splu(A, B, **kwargs):
+    lu = splinalg.splu(A, **kwargs)
+    return lu.solve(B)
+
+
+def solve_csr(matrix: CSR, target: Data, method: str ="spsolve",
+              options: dict={}) -> Data:
+    """
+    Solve ``Ax=b`` for ``x``.
+
+    Parameters:
+    -----------
+
+    matrix : CSR
+        The matrix ``A``.
+
+    target : Data
+        The matrix or vector ``b``.
+
+    method : str {"spsolve", "splu", "mkl_spsolve", etc.}, default="spsolve"
+        The function to use to solve the system. Any function from
+        scipy.sparse.linalg which solve the equation Ax=b can be used.
+        `splu` from the same and `mkl_spsolve` are also valid choice.
+
+    options : dict
+        Keywork options to pass to the solver. Refer to the documenentation in
+        scipy.sparse.linalg of the used method for a list of supported keyword.
+        The keyword "csc" can be set to ``True`` to convert the sparse matrix
+        before passing it to the solver.
+
+    .. note::
+        Options for ``mkl_spsolve`` are presently only found in the source
+        code.
+
+    Returns:
+    --------
+    x : Dense
+        Solution to the system Ax = b.
+    """
+    if matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("can only solve using square matrix")
+    if matrix.shape[1] != target.shape[0]:
+        raise ValueError("target does not match the system")
+
+    if isinstance(target, CSR) and csr.nnz(target) < np.prod(target.shape)*0.1:
+        b = target.as_scipy()
+    elif isinstance(target, Dense):
+        b = target.as_ndarray()
+    else:
+        b = target.to_array()
+
+
+    if method == "splu":
+        solver = _splu
+    elif hasattr(splinalg, method):
+        solver = getattr(splinalg, method)
+    elif method in ["mkl_spsolve", "mkl"]:
+        solver = getattr(mkl, method)
+    elif method.startswith("mkl") and mkl is None:
+        raise ValueError("mkl is not available")
+    else:
+        raise ValueError(f"Unknown sparse solver {method}.")
+
+    M = matrix.as_scipy()
+    if options.pop("csc", False):
+        M = M.tocsc()
+
+    out = solver(matrix.as_scipy(), b, **options)
+
+    if isinstance(out, tuple):
+        out, check = out
+        if check == 0:
+            # Successful
+            pass
+        elif check > 0:
+            raise RunTimeError(
+                f"scipy.sparse.linalg.{method} error: Tolerance was not"
+                " reached. Error code: {check}"
+            )
+
+        elif check < 0:
+            raise RunTimeError(
+                f"scipy.sparse.linalg.{method} error: Bad input. "
+                "Error code: {check}"
+            )
+    # spsolve can return both scipy sparse matrix or ndarray
+    return _data.create(out, copy=False)
+
+
+def solve_dense(matrix: Dense, target: Data, method: str="solve",
+                options: dict={}) -> Dense:
+    """
+    Solve ``Ax=b`` for ``x``.
+
+    Parameters:
+    -----------
+
+    matrix : Dense
+        The matrix ``A``.
+
+    target : Data
+        The matrix or vector ``b``.
+
+    method : str {"solve", "lstsq"}, default="solve"
+        The function from numpy.linalg to use to solve the system.
+
+    options : dict
+        Options to pass to the solver. "lstsq" use "rcond" while, "solve" do
+        not use any.
+
+    Returns:
+    --------
+    x : Dense
+        Solution to the system Ax = b.
+    """
+    if matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("can only solve using square matrix")
+    if matrix.shape[1] != target.shape[0]:
+        raise ValueError("target does not match the system")
+
+    if isinstance(target, Dense):
+        b = target.as_ndarray()
+    else:
+        b = target.to_array()
+
+
+    if method == "solve":
+        out = np.linalg.solve(matrix.as_ndarray(), b)
+    elif method == "lstsq":
+        out, *_ = np.linalg.lstsq(
+            matrix.as_ndarray(),
+            b,
+            rcond=options.get("rcond", None)
+        )
+    else:
+        raise ValueError(f"Unknown solver {method},"
+                         " 'solve' and 'lstsq' are supported.")
+    print(out)
+    return _data.create(out, copy=False)
+
+
+from .dispatch import Dispatcher as _Dispatcher
+import inspect as _inspect
+
+
+solve = _Dispatcher(
+    _inspect.Signature([
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('target', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('method', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('options', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    ]),
+    name='solve',
+    module=__name__,
+    inputs=('matrix', 'target'),
+    out=True,
+)
+solve.__doc__ = """
+    Solve ``Ax=b`` for ``x``.
+
+    Parameters:
+    -----------
+    matrix : Data
+    The matrix ``A``.
+
+    target : Data
+    The matrix or vector ``b``.
+
+    method : str
+        The function to use to solve the system. Function which solve the
+        equation Ax=b from scipy.sparse.linalg (CSR ``matrix``) or
+        numpy.linalg (Dense ``matrix``) can be used.
+        Sparse cases also accept `splu` and `mkl_spsolve`.
+
+    options : dict
+        Keywork options to pass to the solver. Refer to the documenentation
+        for the chosen method in scipy.sparse.linalg or numpy.linalg.
+        The keyword "csc" can be set to ``True`` to convert the sparse matrix
+        in sparse cases.
+
+    .. note::
+        Options for ``mkl_spsolve`` are presently only found in the source
+        code.
+
+    Returns:
+    --------
+    x : Data
+        Solution to the system Ax = b.
+"""
+solve.add_specialisations([
+    (CSR, CSR, Dense, solve_csr),
+    (CSR, Dense, Dense, solve_csr),
+    (Dense, CSR, Dense, solve_dense),
+    (Dense, Dense, Dense, solve_dense),
+], _defer=True)

--- a/qutip/tests/core/data/test_linalg.py
+++ b/qutip/tests/core/data/test_linalg.py
@@ -1,0 +1,115 @@
+import qutip.settings as settings
+import numpy as np
+import scipy
+import pytest
+import qutip
+
+from qutip.core import data as _data
+from qutip.core.data import Data, Dense, CSR
+
+
+class TestSolve():
+    def op_numpy(self, A, b):
+        return np.linalg.solve(A, b)
+
+    def _gen_op(self, N, dtype):
+        return qutip.rand_unitary(N, dtype=dtype).data
+
+    def _gen_ket(self, N, dtype):
+        return qutip.rand_ket(N, dtype=dtype).data
+
+    @pytest.mark.parametrize(['method', "opt"], [
+        ("spsolve", {}),
+        ("splu", {"csc": True}),
+        ("gmres", {"atol": 1e-8}),
+        ("lsqr", {}),
+        pytest.param(
+            "mkl_spsolve", {},
+            marks=pytest.mark.skipif(not settings.has_mkl, reason="mkl not available")
+        ),
+    ],
+        ids=["spsolve", "splu", "gmres", "lsqr", "mkl_spsolve"]
+    )
+    def test_mathematically_correct_CSR(self, method, opt):
+        """
+        Test that the binary operation is mathematically correct for all the
+        known type specialisations.
+        """
+        A = self._gen_op(10, CSR)
+        b = self._gen_ket(10, Dense)
+        expected = self.op_numpy(A.to_array(), b.to_array())
+        test = _data.solve_csr_dense(A, b, method, opt)
+        test1 = _data.solve(A, b, method, opt)
+
+        assert test.shape == expected.shape
+        np.testing.assert_allclose(test.to_array(), expected,
+                                   atol=1e-7, rtol=1e-7)
+        np.testing.assert_allclose(test1.to_array(), expected,
+                                   atol=1e-7, rtol=1e-7)
+
+    @pytest.mark.parametrize(['method', "opt"], [
+        ("solve", {}),
+        ("lstsq", {}),
+    ])
+    def test_mathematically_correct_Dense(self, method, opt):
+        A = self._gen_op(10, Dense)
+        b = self._gen_ket(10, Dense)
+        expected = self.op_numpy(A.to_array(), b.to_array())
+        test = _data.solve_dense(A, b, method, opt)
+        test1 = _data.solve(A, b, method, opt)
+
+        assert test.shape == expected.shape
+        np.testing.assert_allclose(test.to_array(), expected,
+                                   atol=1e-7, rtol=1e-7)
+        np.testing.assert_allclose(test1.to_array(), expected,
+                                   atol=1e-7, rtol=1e-7)
+
+
+    def test_incorrect_shape_non_square(self):
+        A = qutip.Qobj(np.random.rand(5, 10)).data
+        b = qutip.Qobj(np.random.rand(10, 1)).data
+        with pytest.raises(ValueError):
+            test1 = _data.solve(A, b)
+
+
+    def test_incorrect_shape_mismatch(self):
+        A = qutip.Qobj(np.random.rand(10, 10)).data
+        b = qutip.Qobj(np.random.rand(9, 1)).data
+        with pytest.raises(ValueError):
+            test1 = _data.solve(A, b)
+
+
+class TestSVD():
+    def op_numpy(self, A):
+        return np.linalg.svd(A)
+
+    def _gen_dm(self, N, rank, dtype):
+        return qutip.rand_dm(N, rank=rank, dtype=dtype).data
+
+    @pytest.mark.parametrize("dtype", [CSR, Dense], ids=["CSR", "Dense"])
+    def test_mathematically_correct_svd(self, dtype):
+        matrix = self._gen_dm(10, 6, dtype)
+        u, s, v = self.op_numpy(matrix.to_array())
+        test_U, test_S1, test_V = _data.svd(matrix, True)
+        test_S2 = _data.svd(matrix, False)
+
+        assert sum(test_S1 > 1e-10) == 6
+        np.testing.assert_allclose(test_U.to_array(), u, atol=1e-7, rtol=1e-7)
+        np.testing.assert_allclose(test_V.to_array(), v, atol=1e-7, rtol=1e-7)
+        np.testing.assert_allclose(test_S1, s, atol=1e-7, rtol=1e-7)
+        np.testing.assert_allclose(test_S2, s, atol=1e-7, rtol=1e-7)
+
+        np.testing.assert_allclose(
+            matrix.to_array(),
+            (test_U @ _data.diag(test_S1, [0]) @ test_V).to_array(),
+            atol=1e-7, rtol=1e-7
+        )
+
+
+    def test_mathematically_correct_svd_csr(self):
+        matrix = self._gen_dm(5, 4, CSR)
+        test_U, test_S1, test_V = _data.svd_csr(matrix, True, k=2)
+        test_S2 = _data.svd_csr(matrix, False, k=2)
+
+        assert sum(test_S1 > 1e-10) == 2
+        assert sum(test_S2 > 1e-10) == 2


### PR DESCRIPTION
**Description**
Add data layer functions needed to update `steadystate` to use qutip's data layer.

Most of `steadystate`'s methods solve the system `L(rho_ss) = 0` using different solver from numpy, scipy, mkl.
This add the `solve` dispatched function to wraps this operation at the data layer level.
For the `CSR` version, it gives access to all methods available in `scipy.sparse.linalg` and our mkl version.
For the `Dense` version, `solve` and `lstsq` from `numpy.linalg` are made available.
Options supported by numpy / scipy for each function are pass through:
`qutip.data.solve(A, B, method, options)` call `scipy.sparse.linalg.method(A, B, **options)`.

Other methods of `steadystate` decompose the Liouvillian with either `eigen` or `svd`.
`svd` was added as a dispatched function, but only with specialization for `Dense`. 
I made a sparse version, but  `svds` can't readily compute all singular values and does not respond well to splitting the problem into 2 like it was done for sparse eigensolver. 

This PR only include the new dispatched functions, not updated `steadystate` using them or `Qobj` interface.