### PR TITLE
Fix dispatch signatures errors

### DIFF
--- a/qutip/core/data/linalg.py
+++ b/qutip/core/data/linalg.py
@@ -32,10 +32,10 @@ def inv_csr(data):
 
 from .dispatch import Dispatcher as _Dispatcher
 
-inv = _Dispatcher(inv_dense, name='inv', inputs=('data',), out=False)
+inv = _Dispatcher(inv_dense, name='inv', inputs=('data',), out=True)
 inv.__doc__ =\
     """
-    Return matric inverse for a data-layer object.
+    Return matrix inverse for a data-layer object.
 
     Parameters
     ----------
@@ -48,8 +48,8 @@ inv.__doc__ =\
         Inverse of data
     """
 inv.add_specialisations([
-    (CSR, inv_csr),
-    (Dense, inv_dense),
+    (CSR, CSR, inv_csr),
+    (Dense, Dense, inv_dense),
 ], _defer=True)
 
 del _Dispatcher

--- a/qutip/core/data/reshape.pyx
+++ b/qutip/core/data/reshape.pyx
@@ -139,7 +139,7 @@ reshape = _Dispatcher(
         _inspect.Parameter('n_rows_out', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
         _inspect.Parameter('n_cols_out', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
     ]),
-    name='inspect',
+    name='reshape',
     module=__name__,
     inputs=('matrix',),
     out=True,


### PR DESCRIPTION
**Description**
Fix some mistakes in dispatch signatures:
- Typo in `inv`.
- `inv` dispatch on output.
- Wrong `rehape` name