### PR TITLE
Add missing Dense specialisations

### DIFF
--- a/qutip/core/data/constant.py
+++ b/qutip/core/data/constant.py
@@ -30,8 +30,8 @@ zeros.__doc__ =\
     (which is their representation of 0), and dense matrices will still be
     filled.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     rows, cols : int
         The number of rows and columns in the output matrix.
     """
@@ -58,8 +58,8 @@ identity.__doc__ =\
     `scale` can be given, where all the diagonal elements will be that instead
     of 1.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     dimension : int
         The dimension of the square output identity matrix.
     scale : complex, optional

--- a/qutip/core/data/dispatch.pyx
+++ b/qutip/core/data/dispatch.pyx
@@ -347,8 +347,8 @@ cdef class Dispatcher:
         """
         Create a new data layer dispatching operator.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         signature_source : callable or inspect.Signature
             An object from which the call signature of operation can be
             determined.  You can pass any callable defined in Python space, and
@@ -430,8 +430,8 @@ cdef class Dispatcher:
         recent version; you can use this to override currently known
         specialisations if desired.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         specialisations : iterable of tuples
             An iterable where each element specifies a new specialisation for
             this operation.  Each element of the iterable should be a tuple,

--- a/qutip/core/data/inner.pyx
+++ b/qutip/core/data/inner.pyx
@@ -185,7 +185,7 @@ cpdef double complex inner_op_dense(Dense left, Dense op, Dense right,
     all other times.
     """
     _check_shape_inner_op(left, op, right)
-    return inner_dense(left, matmul_dense(op, right))
+    return inner_dense(left, matmul_dense(op, right), scalar_is_ket)
 
 
 from .dispatch import Dispatcher as _Dispatcher

--- a/qutip/core/data/inner.pyx
+++ b/qutip/core/data/inner.pyx
@@ -5,12 +5,14 @@ cdef extern from "<complex>" namespace "std" nogil:
     double complex conj(double complex x)
 
 from qutip.core.data.base cimport idxint, Data
-from qutip.core.data cimport csr
+from qutip.core.data cimport csr, dense
 from qutip.core.data.csr cimport CSR
+from qutip.core.data.dense cimport Dense
+from qutip.core.data.matmul cimport matmul_dense
 
 __all__ = [
-    'inner', 'inner_csr',
-    'inner_op', 'inner_op_csr',
+    'inner', 'inner_csr', 'inner_dense',
+    'inner_op', 'inner_op_csr', 'inner_op_dense',
 ]
 
 
@@ -88,6 +90,33 @@ cpdef double complex inner_csr(CSR left, CSR right, bint scalar_is_ket=False) no
         return _inner_csr_bra_ket(left, right)
     return _inner_csr_ket_ket(left, right)
 
+cpdef double complex inner_dense(Dense left, Dense right, bint scalar_is_ket=False) nogil except *:
+    """
+    Compute the complex inner product <left|right>.  The shape of `left` is
+    used to determine if it has been supplied as a ket or a bra.  The result of
+    this function will be identical if passed `left` or `adjoint(left)`.
+
+    The parameter `scalar_is_ket` is only intended for the case where `left`
+    and `right` are both of shape (1, 1).  In this case, `left` will be assumed
+    to be a ket unless `scalar_is_ket` is False.  This parameter is ignored at
+    all other times.
+    """
+    _check_shape_inner(left, right)
+    if left.shape[0] == left.shape[1] == right.shape[1] == 1:
+        return (
+                conj(left.data[0]) * right.data[0] if scalar_is_ket
+                else left.data[0] * right.data[0]
+        )
+    cdef double complex out = 0
+    cdef size_t i
+    if left.shape[0] == 1:
+        for i in range(right.shape[0]):
+            out += left.data[i] * right.data[i]
+    else:
+        for i in range(right.shape[0]):
+            out += conj(left.data[i]) * right.data[i]
+    return out
+
 
 cdef double complex _inner_op_csr_bra_ket(CSR left, CSR op, CSR right) nogil:
     cdef size_t ptr_l, ptr_op, ptr_r, row, col
@@ -143,6 +172,21 @@ cpdef double complex inner_op_csr(CSR left, CSR op, CSR right,
         return _inner_op_csr_bra_ket(left, op, right)
     return _inner_op_csr_ket_ket(left, op, right)
 
+cpdef double complex inner_op_dense(Dense left, Dense op, Dense right,
+                                  bint scalar_is_ket=False) except *:
+    """
+    Compute the complex inner product <left|op|right>.  The shape of `left` is
+    used to determine if it has been supplied as a ket or a bra.  The result of
+    this function will be identical if passed `left` or `adjoint(left)`.
+
+    The parameter `scalar_is_ket` is only intended for the case where `left`
+    and `right` are both of shape (1, 1).  In this case, `left` will be assumed
+    to be a ket unless `scalar_is_ket` is False.  This parameter is ignored at
+    all other times.
+    """
+    _check_shape_inner_op(left, op, right)
+    return inner_dense(left, matmul_dense(op, right))
+
 
 from .dispatch import Dispatcher as _Dispatcher
 import inspect as _inspect
@@ -172,8 +216,8 @@ inner.__doc__ =\
     to be a ket unless `scalar_is_ket` is False.  This parameter is ignored at
     all other times.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     left : Data
         The left operand as either a bra or a ket matrix.
 
@@ -187,6 +231,7 @@ inner.__doc__ =\
     """
 inner.add_specialisations([
     (CSR, CSR, inner_csr),
+    (Dense, Dense, inner_dense),
 ], _defer=True)
 
 inner_op = _Dispatcher(
@@ -216,8 +261,8 @@ inner_op.__doc__ =\
     to be a ket unless `scalar_is_ket` is False.  This parameter is ignored at
     all other times.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     left : Data
         The left operand as either a bra or a ket matrix.
 
@@ -235,6 +280,7 @@ inner_op.__doc__ =\
     """
 inner_op.add_specialisations([
     (CSR, CSR, CSR, inner_op_csr),
+    (Dense, Dense, Dense, inner_op_dense),
 ], _defer=True)
 
 del _inspect, _Dispatcher

--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -255,6 +255,23 @@ cpdef Dense matmul_dense(Dense left, Dense right, double complex scale=1, Dense 
     cdef double complex *b
     cdef char transa, transb
     cdef int m, n, k=left.shape[1], lda, ldb
+    if right.shape[1] == 1:
+        # Matrix Vector product
+        a, b = left.data, right.data
+        if left.fortran:
+            lda = left.shape[0]
+            transa = b'n'
+            m = left.shape[0]
+            n = left.shape[1]
+        else:
+            lda = left.shape[1]
+            transa = b't'
+            m = left.shape[1]
+            n = left.shape[0]
+        ldb = 1
+        blas.zgemv(&transa, &m , &n, &scale, a, &lda, b, &ldb,
+                   &out_scale, out.data, &ldb)
+        return out
     # We use the BLAS routine zgemm for every single call and pretend that
     # we're always supplying it with Fortran-ordered matrices, but to achieve
     # what we want, we use the property of matrix multiplication that

--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -397,8 +397,8 @@ matmul.__doc__ =\
     where `scale` is (optionally) a scalar, and `left` and `right` are
     matrices.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     left : Data
         The left operand as either a bra or a ket matrix.
 

--- a/qutip/core/data/pow.pyx
+++ b/qutip/core/data/pow.pyx
@@ -3,12 +3,14 @@
 
 cimport cython
 
-from qutip.core.data cimport csr
+from qutip.core.data cimport csr, dense
 from qutip.core.data.csr cimport CSR
+from qutip.core.data.dense cimport Dense
 from qutip.core.data.matmul cimport matmul_csr
+import numpy as np
 
 __all__ = [
-    'pow', 'pow_csr',
+    'pow', 'pow_csr', 'pow_dense',
 ]
 
 
@@ -39,6 +41,16 @@ cpdef CSR pow_csr(CSR matrix, unsigned long long n):
     return out
 
 
+cpdef Dense pow_dense(Dense matrix, unsigned long long n):
+    if matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("matrix power only works with square matrices")
+    if n == 0:
+        return dense.identity(matrix.shape[0])
+    if n == 1:
+        return matrix.copy()
+    return Dense(np.linalg.matrix_power(matrix.as_ndarray(), n))
+
+
 from .dispatch import Dispatcher as _Dispatcher
 import inspect as _inspect
 
@@ -58,8 +70,8 @@ pow.__doc__ =\
     must be an integer >= 0.  `A ** 0` is defined to be the identity matrix of
     the same shape.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     matrix : Data
         Input matrix to take the power of.
 
@@ -68,6 +80,7 @@ pow.__doc__ =\
     """
 pow.add_specialisations([
     (CSR, CSR, pow_csr),
+    (Dense, Dense, pow_dense),
 ], _defer=True)
 
 del _inspect, _Dispatcher

--- a/qutip/core/data/project.pyx
+++ b/qutip/core/data/project.pyx
@@ -131,8 +131,8 @@ project.__doc__ =\
     Get the projector of a state with itself.  Mathematically, if passed an
     object `|a>` or `<a|`, then return the matrix `|a><a|`.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     state : Data
         The input state bra- or ket-like vector.
     """

--- a/qutip/core/data/properties.pyx
+++ b/qutip/core/data/properties.pyx
@@ -161,14 +161,6 @@ cpdef bint isherm_dense(Dense matrix, double tol=-1):
     -------
     bint
         Boolean True if it is Hermitian, False if not.
-
-    Notes
-    -----
-    The implementation is effectively just taking the adjoint, but rather than
-    actually allocating and creating a new matrix, we just check whether the
-    output would match the input matrix.  If we cannot be certain of Hermicity
-    because the sizes of some elements are within tolerance of 0, we have to
-    resort to a complete adjoint calculation.
     """
     if matrix.shape[0] != matrix.shape[1]:
         return False

--- a/qutip/core/data/properties.pyx
+++ b/qutip/core/data/properties.pyx
@@ -167,7 +167,7 @@ cpdef bint isherm_dense(Dense matrix, double tol=-1):
     tol = tol if tol >= 0 else settings.core["atol"]
     cdef size_t row, col, size=matrix.shape[0]
     for row in range(size):
-        for col in range(size):
+        for col in range(row + 1):
             if not _conj_feq(
                 matrix.data[col*size+row],
                 matrix.data[row*size+col],

--- a/qutip/core/data/ptrace.pyx
+++ b/qutip/core/data/ptrace.pyx
@@ -193,8 +193,8 @@ ptrace.__doc__ =\
         ptrace(data, [2, 3, 4], [0, 2])
     will be a matrix with effective dimensions `[[2, 4], [2, 4]]`.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     matrix : Data
         The density matrix to be partially traced.
 

--- a/qutip/core/data/reshape.pyx
+++ b/qutip/core/data/reshape.pyx
@@ -149,8 +149,8 @@ reshape.__doc__ =\
     Reshape the input matrix.  The values of `n_rows_out` and `n_cols_out` must
     match the current total number of elements of the matrix.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     matrix : Data
         The input matrix to reshape.
 
@@ -196,8 +196,8 @@ column_stack.__doc__ =\
 
     The inverse of this operation is `column_unstack`.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     matrix : Data
         The matrix to stack the columns of.
     """
@@ -232,8 +232,8 @@ column_unstack.__doc__ =\
 
     The inverse of this operation is `column_stack`.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     matrix : Data
         The matrix to unstack the columns of.
 
@@ -263,8 +263,8 @@ split_columns.__doc__ =\
     Make a ket-shaped data out of each columns of the matrix.
     This is used for to split the eigenvectors from :obj:`eigs`.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     matrix : Data
         The matrix to unstack the columns of.
 

--- a/qutip/core/data/tidyup.pyx
+++ b/qutip/core/data/tidyup.pyx
@@ -84,8 +84,8 @@ tidyup.__doc__ =\
     By default, this operation is in-place.  The output type will always match
     the input type; no dispatching takes place on the output.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     matrix : Data
         The matrix to tidy up.
 

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -614,6 +614,7 @@ class TestInner(BinaryOpMixin):
 
     specialisations = [
         pytest.param(data.inner_csr, CSR, CSR, complex),
+        pytest.param(data.inner_dense, Dense, Dense, complex),
     ]
 
     def generate_scalar_is_ket(self, metafunc):
@@ -683,6 +684,7 @@ class TestInnerOp(TernaryOpMixin):
 
     specialisations = [
         pytest.param(data.inner_op_csr, CSR, CSR, CSR, complex),
+        pytest.param(data.inner_op_dense, Dense, Dense, Dense, complex),
     ]
 
     def generate_scalar_is_ket(self, metafunc):
@@ -810,6 +812,7 @@ class TestPow(UnaryOpMixin):
     bad_shapes = shapes_not_square()
     specialisations = [
         pytest.param(data.pow_csr, CSR, CSR),
+        pytest.param(data.pow_dense, Dense, Dense),
     ]
 
     @pytest.mark.parametrize("n", [0, 1, 10], ids=["n_0", "n_1", "n_10"])

--- a/qutip/tests/core/data/test_properties.py
+++ b/qutip/tests/core/data/test_properties.py
@@ -154,3 +154,22 @@ class Test_isherm:
                          [1,0,1]])
         base = _data.to(datatype, _data.create(base))
         assert not _data.isherm(base, tol=self.tol)
+
+
+class Test_isdiag:
+    @pytest.mark.parametrize("shape",
+        [(10, 1), (2, 5), (5, 2), (5, 5)]
+    )
+    def test_isdiag(self, shape, datatype):
+        mat = np.zeros(shape)
+        data = _data.to(datatype, _data.Dense(mat))
+        # empty matrices are diagonal
+        assert _data.isdiag(data)
+
+        mat[0, 0] = 1
+        data = _data.to(datatype, _data.Dense(mat))
+        assert _data.isdiag(data)
+
+        mat[1, 0] = 1
+        data = _data.to(datatype, _data.Dense(mat))
+        assert not _data.isdiag(data)

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -10,6 +10,11 @@ import qutip
 from qutip.core import data as _data
 
 
+@pytest.fixture(params=[_data.CSR, _data.Dense], ids=["CSR", "Dense"])
+def datatype(request):
+    return request.param
+
+
 def _random_not_singular(N):
     """
     return a N*N complex array with determinant not 0.
@@ -693,11 +698,11 @@ def test_QobjPurity():
     np.testing.assert_allclose(rho_mixed.purity(), 0.5)
 
 
-def test_QobjPermute():
+def test_QobjPermute(datatype):
     "qutip.Qobj permute"
-    A = qutip.basis(3, 0)
-    B = qutip.basis(5, 4)
-    C = qutip.basis(4, 2)
+    A = qutip.basis(3, 0, dtype=datatype)
+    B = qutip.basis(5, 4, dtype=datatype)
+    C = qutip.basis(4, 2, dtype=datatype)
     psi = qutip.tensor(A, B, C)
     psi2 = psi.permute([2, 0, 1])
     assert psi2 == qutip.tensor(C, A, B)
@@ -706,17 +711,17 @@ def test_QobjPermute():
     psi2_bra = psi_bra.permute([2, 0, 1])
     assert psi2_bra == qutip.tensor(C, A, B).dag()
 
-    A = qutip.fock_dm(3, 0)
-    B = qutip.fock_dm(5, 4)
-    C = qutip.fock_dm(4, 2)
+    A = qutip.fock_dm(3, 0, dtype=datatype)
+    B = qutip.fock_dm(5, 4, dtype=datatype)
+    C = qutip.fock_dm(4, 2, dtype=datatype)
     rho = qutip.tensor(A, B, C)
     rho2 = rho.permute([2, 0, 1])
     assert rho2 == qutip.tensor(C, A, B)
 
     for _ in range(3):
-        A = qutip.rand_ket(3)
-        B = qutip.rand_ket(4)
-        C = qutip.rand_ket(5)
+        A = qutip.rand_ket(3, dtype=datatype)
+        B = qutip.rand_ket(4, dtype=datatype)
+        C = qutip.rand_ket(5, dtype=datatype)
         psi = qutip.tensor(A, B, C)
         psi2 = psi.permute([1, 0, 2])
         assert psi2 == qutip.tensor(B, A, C)
@@ -726,9 +731,9 @@ def test_QobjPermute():
         assert psi2_bra == qutip.tensor(B, A, C).dag()
 
     for _ in range(3):
-        A = qutip.rand_dm(3)
-        B = qutip.rand_dm(4)
-        C = qutip.rand_dm(5)
+        A = qutip.rand_dm(3, dtype=datatype)
+        B = qutip.rand_dm(4, dtype=datatype)
+        C = qutip.rand_dm(5, dtype=datatype)
         rho = qutip.tensor(A, B, C)
         rho2 = rho.permute([1, 0, 2])
         assert rho2 == qutip.tensor(B, A, C)
@@ -744,7 +749,7 @@ def test_QobjPermute():
 
     for _ in range(3):
         super_dims = [3, 5, 4]
-        U = qutip.rand_unitary(super_dims)
+        U = qutip.rand_unitary(super_dims, dtype=datatype)
         Unew = U.permute([2, 1, 0])
         S_tens = qutip.to_super(U)
         S_tens_new = qutip.to_super(Unew)


### PR DESCRIPTION
**Description**
`Dense` was missing some dispatch specialisations:
`isherm`, `isdiag`, `inner`, `inner_op`, `pow`, `indices` and `dimensions`.
Some of them are quite commonly used:
- `isherm` is called in a few method of `Qobj` like `eigenstates`.
- `inner` is used in `Qobj.__matmul__` between `bra` and `ket`.

Tests for new functions are added.
For `isherm`, it was already tested for Dense, but relied on the automatic conversion of the dispatcher.

Also fix some docstings which used `Arguments` instead of `Parameters`.
