### PR TITLE
Fix hinton plot displaying rho.T instead of rho

### DIFF
--- a/doc/changes/2011.bugfix
+++ b/doc/changes/2011.bugfix
@@ -1,0 +1,1 @@
+Fix the hinton visualization method to plot the matrix instead of its transpose.

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -166,8 +166,8 @@ def _cb_labels(left_dims):
     return [
         map(fmt.format, basis_labels) for fmt in
         (
+            r"$\langle{}|$",
             r"$|{}\rangle$",
-            r"$\langle{}|$"
         )
     ]
 

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -331,8 +331,8 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
             _x = x + 1
             _y = y + 1
             _blob(
-                _x - 0.5, height - _y + 0.5, W[x, y], w_max,
-                min(1, abs(W[x, y]) / w_max), color_fn=color_fn, ax=ax)
+                _x - 0.5, height - _y + 0.5, W[y, x], w_max,
+                min(1, abs(W[y, x]) / w_max), color_fn=color_fn, ax=ax)
 
     # color axis
     vmax = np.pi if color_style == "phase" else abs(W).max()


### PR DESCRIPTION
**Description**
Fix the hinton visualization method to plot the matrix instead of its transpose.

**Related issues or PRs**
Fix #2009.