### PR TITLE
Fix hinton plot scaling

### DIFF
--- a/doc/changes/2012.bugfix
+++ b/doc/changes/2012.bugfix
@@ -1,0 +1,1 @@
+Fix the hinton visualization method to take into account all the matrix coefficients to set the squares scale, instead of only the diagonal coefficients.

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -303,7 +303,7 @@ def hinton(rho, xlabels=None, ylabels=None, title=None, ax=None, cmap=None,
 
     height, width = W.shape
 
-    w_max = 1.25 * max(abs(np.diag(np.array(W))))
+    w_max = 1.25 * max(abs(np.array(W)).flatten())
     if w_max <= 0.0:
         w_max = 1.0
 


### PR DESCRIPTION
**Description**
Fix the hinton visualization method to take into account all the matrix coefficients to set the squares scale, instead of only the diagonal coefficients.

**Related issues or PRs**
Fix issu #2010. Cascading PR #2011.