### PR TITLE
Explicitly define matplotlib backend for Windows tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
   cases:
     name: ${{ matrix.os }}, python${{ matrix.python-version }}, ${{ matrix.case-name }}
     runs-on: ${{ matrix.os }}
+    env:
+      MPLBACKEND: Agg  # Explicitly define matplotlib backend for Windows tests
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Description**
For awhile the matplotlib tests have failed intermittently on Windows. Setting the matplotlib backend explicitly before running the tests is said to help, so let's try it.

**Related issues or PRs**
- ???