### PR TITLE
Remove shift in coefficient and qobjevo after 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,6 @@ jobs:
           # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
           - case-name: Windows Latest
             os: windows-latest
-            pytest-extra-options: "-k 'not (test_correlation)'"
 
     steps:
       - uses: actions/checkout@v2

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -24,7 +24,7 @@ from .options import QutipOptions
 from .data import Data
 from .cy.coefficient import (
     Coefficient, InterCoefficient, FunctionCoefficient, StrFunctionCoefficient,
-    ConjCoefficient, NormCoefficient, ShiftCoefficient
+    ConjCoefficient, NormCoefficient
 )
 
 
@@ -151,12 +151,6 @@ def conj(coeff):
     """ return a Coefficient with is the conjugate.
     """
     return ConjCoefficient(coeff)
-
-
-def shift(coeff, _t0=0):
-    """ return a Coefficient in which t is shifted by _t0.
-    """
-    return ShiftCoefficient(coeff, _t0)
 
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -155,10 +155,6 @@ cdef class Coefficient:
         """ Return a :obj:`Coefficient` being the norm of this"""
         return NormCoefficient(self)
 
-    def _shift(self):
-        """ Return a :obj:`Coefficient` with a time shift"""
-        return ShiftCoefficient(self, 0)
-
 
 @cython.auto_pickle(True)
 cdef class FunctionCoefficient(Coefficient):
@@ -721,55 +717,3 @@ cdef class NormCoefficient(Coefficient):
     cpdef Coefficient copy(self):
         """Return a copy of the :obj:`Coefficient`."""
         return NormCoefficient(self.base.copy())
-
-
-@cython.auto_pickle(True)
-cdef class ShiftCoefficient(Coefficient):
-    """
-    Introduce a time shift into the :obj:`Coefficient`.
-
-    Used internally within qutip when calculating correlations.
-
-    :obj:ShiftCoefficient is returned by
-    ``qutip.coefficent.shift(Coefficient)``.
-    """
-    cdef Coefficient base
-    cdef double _t0
-
-    def __init__(self, Coefficient base, double _t0):
-        self.base = base
-        self._t0 = _t0
-
-    def replace_arguments(self, _args=None, **kwargs):
-        """
-        Replace the arguments (``args``) of a coefficient.
-
-        Returns a new :obj:`Coefficient` if the coefficient has arguments, or
-        the original coefficient if it does not. Arguments to replace may be
-        supplied either in a dictionary as the first position argument, or
-        passed as keywords, or as a combination of the two. Arguments not
-        replaced retain their previous values.
-
-        Parameters
-        ----------
-        _args : dict
-            Dictionary of arguments to replace.
-
-        **kwargs
-            Arguments to replace.
-        """
-        if _args:
-            kwargs.update(_args)
-        try:
-            _t0 = kwargs["_t0"]
-            del kwargs["_t0"]
-        except KeyError:
-            _t0 = self._t0
-        return ShiftCoefficient(self.base.replace_arguments(**kwargs), _t0)
-
-    cdef complex _call(self, double t) except *:
-        return self.base._call(t + self._t0)
-
-    cpdef Coefficient copy(self):
-        """Return a copy of the :obj:`Coefficient`."""
-        return ShiftCoefficient(self.base.copy(), self._t0)

--- a/qutip/core/cy/qobjevo.pxd
+++ b/qutip/core/cy/qobjevo.pxd
@@ -12,7 +12,6 @@ cdef class QobjEvo:
         readonly str superrep
         int _issuper
         int _isoper
-        double _shift_dt
 
     cpdef Data _call(QobjEvo self, double t)
 

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -187,7 +187,6 @@ cdef class QobjEvo:
             self.dims = Q_object.dims.copy()
             self.shape = Q_object.shape
             self.type = Q_object.type
-            self._shift_dt = (<QobjEvo> Q_object)._shift_dt
             self._issuper = (<QobjEvo> Q_object)._issuper
             self._isoper = (<QobjEvo> Q_object)._isoper
             self.elements = (<QobjEvo> Q_object).elements.copy()
@@ -202,7 +201,6 @@ cdef class QobjEvo:
         self.shape = (0, 0)
         self._issuper = -1
         self._isoper = -1
-        self._shift_dt = 0
         args = args or {}
 
         if (
@@ -357,7 +355,8 @@ cdef class QobjEvo:
 
     cdef double _prepare(QobjEvo self, double t, Data state=None):
         """ Precomputation before computing getting the element at `t`"""
-        return t + self._shift_dt
+        # We keep the function for feedback eventually
+        return t
 
     def copy(QobjEvo self):
         """Return a copy of this `QobjEvo`"""
@@ -652,16 +651,6 @@ cdef class QobjEvo:
         """
         return self.linear_map(partial(Qobj.to, data_type=data_type),
                                _skip_check=True)
-
-    def _insert_time_shift(QobjEvo self, dt):
-        """
-        Add a shift in the time ``t = t + _t0``.
-        To be used in correlation.py only. It does not propage safely with
-        binop between QobjEvo with different shift.
-        """
-        cdef QobjEvo out = self.copy()
-        out._shift_dt = dt
-        return out
 
     def tidyup(self, atol=1e-12):
         """Removes small elements from quantum object."""

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -4,7 +4,7 @@ import qutip
 import numpy as np
 import scipy.interpolate as interp
 from functools import partial
-from qutip.core.coefficient import (coefficient, norm, conj, shift,
+from qutip.core.coefficient import (coefficient, norm, conj,
                                     CompilationOptions, Coefficient,
                                     clean_compiled_coefficient
                                    )
@@ -175,21 +175,6 @@ def test_CoeffUnitaryTransform(style, transform, expected):
     _assert_eq_over_interval(transform(coeff), lambda t: expected(coeff(t)))
 
 
-@pytest.mark.parametrize(['style'], [
-    pytest.param("func", id="func"),
-    pytest.param("array", id="array"),
-    pytest.param("arraylog", id="logarray"),
-    pytest.param("string", id="string"),
-    pytest.param("steparray", id="steparray"),
-    pytest.param("steparraylog", id="steparraylog")
-])
-def test_CoeffShift(style):
-    coeff = coeff_generator(style, "f")
-    dt = np.e / 30
-    _assert_eq_over_interval(shift(coeff, dt),
-                             lambda t: coeff(t + dt))
-
-
 @pytest.mark.parametrize(['style_left'], [
     pytest.param("func", id="func"),
     pytest.param("array", id="array"),
@@ -310,10 +295,6 @@ def _mul(coeff):
     return coeff * coeff
 
 
-def _shift(coeff):
-    return shift(coeff, 0.05)
-
-
 @pytest.mark.parametrize(['style'], [
     pytest.param("func", id="func"),
     pytest.param("array", id="array"),
@@ -328,7 +309,6 @@ def _shift(coeff):
     pytest.param(_mul, id="prod"),
     pytest.param(norm, id="norm"),
     pytest.param(conj, id="conj"),
-    pytest.param(_shift, id="shift"),
 ])
 def test_Coeffpickle(style, transform):
     coeff = coeff_generator(style, "f")
@@ -351,7 +331,6 @@ def test_Coeffpickle(style, transform):
     pytest.param(_mul, id="prod"),
     pytest.param(norm, id="norm"),
     pytest.param(conj, id="conj"),
-    pytest.param(_shift, id="shift"),
 ])
 def test_Coeffcopy(style, transform):
     coeff = coeff_generator(style, "f")

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -301,12 +301,6 @@ def test_QobjEvo_pickle(all_qevo):
     recreated = pickle.loads(pickled)
     _assert_qobjevo_equivalent(recreated, obj)
 
-def test_shift(all_qevo):
-    dt = 0.2
-    obj = all_qevo
-    shited = obj._insert_time_shift(dt)
-    for t in TESTTIMES:
-        _assert_qobj_almost_eq(obj(t + dt), shited(t))
 
 def test_mul_vec(all_qevo):
     "QobjEvo matmul ket"
@@ -315,6 +309,7 @@ def test_mul_vec(all_qevo):
     for t in TESTTIMES:
         assert_allclose((op(t) @ vec).full(),
                         op.matmul(t, vec).full(), atol=1e-14)
+
 
 def test_matmul(all_qevo):
     "QobjEvo matmul oper"


### PR DESCRIPTION
**Description**
With the update of correlation to v5 in #1997, the need for  `shift` in `QobjEvo` and `Coefficient` disappeared.
`ShiftCoefficient`, `QobjEvo._insert_time_shift` and related tests are removed.

I also restored the correlation tests on windows hoping they are now fast enough to not timeout.

**Related issues or PRs**
#1997