### PR TITLE
edits for working latex renders in vscode

### DIFF
--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -809,7 +809,7 @@ class Qobj(object):
         """
         t = self.type
         shape = self.shape
-        s = r'$'
+        s = r''
         if self.type in ['oper', 'super']:
             s += ("Quantum object: " +
                   "dims = " + str(self.dims) +
@@ -829,7 +829,7 @@ class Qobj(object):
 
         M, N = self.data.shape
 
-        s += r'\\\left(\begin{matrix}'
+        s += r' $ \\ \left(\begin{matrix}'
 
         def _format_float(value):
             if value == 0.0:

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -809,7 +809,7 @@ class Qobj(object):
         """
         t = self.type
         shape = self.shape
-        s = r''
+        s = r'$'
         if self.type in ['oper', 'super']:
             s += ("Quantum object: " +
                   "dims = " + str(self.dims) +
@@ -829,7 +829,7 @@ class Qobj(object):
 
         M, N = self.data.shape
 
-        s += r'\begin{equation*}\left(\begin{array}{*{11}c}'
+        s += r'\\\left(\begin{matrix}'
 
         def _format_float(value):
             if value == 0.0:
@@ -916,7 +916,7 @@ class Qobj(object):
                     s += _format_element(m, n, self.data[m, n])
                 s += r'\\'
 
-        s += r'\end{array}\right)\end{equation*}'
+        s += r'\end{matrix}\right)$'
         return s
 
     def dag(self):


### PR DESCRIPTION
**Description**
Changes the string generated by `_repr_latex()` in `qobj.py` so that it plays nicely with VSCode jupyter notebooks. 
Specifically, changes the output to be encased in `$...$`, and changes from `\begin{equation} \begin{array}...` to `\begin{matrix} ...`

This lets matrices be output nicely in VSCode.

**Related issues or PRs**
fixes #1887