### PR TITLE
Run mac tests without mkl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,9 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           # For the sdist we should be as conservative as possible with our
@@ -87,7 +87,7 @@ jobs:
           zip "$zipfile" -r "$stem"
           rm -r "$stem"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: sdist
           path: |
@@ -112,9 +112,9 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           # This is about the build environment, not the released wheel version.
@@ -134,7 +134,7 @@ jobs:
           if [[ ! -z "$OVERRIDE_VERSION" ]]; then echo "$OVERRIDE_VERSION" > VERSION; fi
           python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -157,9 +157,9 @@ jobs:
 
     steps:
       - name: Download build artifacts to local runner
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.7'

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
@@ -41,7 +41,7 @@ jobs:
           #   -T : display a full traceback if a Python exception occurs
 
       - name: Upload built files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: qutip_html_docs
           path: doc/_build/html/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
             os: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         # Test other versions of Python in special cases to avoid exploding the
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.9"]
@@ -33,6 +33,14 @@ jobs:
         # the lack of a variable is _always_ false-y, and the defaults lack all
         # the special cases.
         include:
+          # Mac
+          # Mac has issues with MKL since september 2022.
+          - case-name: macos
+            os: macos-latest
+            python-version: "3.10"
+            condaforge: 1
+            nomkl: 1
+
           # Scipy 1.5
           - case-name: old SciPy
             os: ubuntu-latest

--- a/qutip/solve/steadystate.py
+++ b/qutip/solve/steadystate.py
@@ -1199,7 +1199,7 @@ def _pseudo_inverse_dense(L, rhoss, w=None, **pseudo_args):
         try:
             LIQ = np.linalg.solve(L.full(), Q)
         except Exception:
-            LIQ = np.linalg.lstsq(L.full(), Q)[0]
+            LIQ = np.linalg.lstsq(L.full(), Q, rcond=None)[0]
 
         R = np.dot(Q, LIQ)
 


### PR DESCRIPTION
**Description**
Mac tests have been failing for a while because of MKL. 
Set the mac test to run with openblas, skipping failing tests.
Added `rcond=None` to `linalg.lstsq` to remove a warning.

I also updated versions of github action as some where raising warnings.
