### PR TITLE
Run mac test without MKL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,9 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           # For the sdist we should be as conservative as possible with our
@@ -87,7 +87,7 @@ jobs:
           zip "$zipfile" -r "$stem"
           rm -r "$stem"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: sdist
           path: |
@@ -112,9 +112,9 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           # This is about the build environment, not the released wheel version.
@@ -134,7 +134,7 @@ jobs:
           if [[ ! -z "$OVERRIDE_VERSION" ]]; then echo "$OVERRIDE_VERSION" > VERSION; fi
           python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -157,9 +157,9 @@ jobs:
 
     steps:
       - name: Download build artifacts to local runner
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.7'

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
@@ -43,7 +43,7 @@ jobs:
           #   -T : display a full traceback if a Python exception occurs
 
       - name: Upload built PDF files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: qutip_pdf_docs
           path: doc/_build/latex/*
@@ -59,7 +59,7 @@ jobs:
           #   -T : display a full traceback if a Python exception occurs
 
       - name: Upload built HTML files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: qutip_html_docs
           path: doc/_build/html/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         # Test other versions of Python in special cases to avoid exploding the
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.9"]
@@ -33,6 +33,13 @@ jobs:
         # the lack of a variable is _always_ false-y, and the defaults lack all
         # the special cases.
         include:
+          # Needs an older version of Python because conda doesn't build old
+          # SciPy versions for Python 3.9.
+          - case-name: MacOS
+            os: macos-latest
+            python-version: "3.10"
+            nomkl: 1
+
           # Needs an older version of Python because conda doesn't build old
           # SciPy versions for Python 3.9.
           - case-name: old SciPy
@@ -89,7 +96,7 @@ jobs:
             pytest-extra-options: "-W ignore::ImportWarning -k 'not (test_correlation or test_interpolate or test_mcsolve)'"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
           # SciPy versions for Python 3.9.
           - case-name: MacOS
             os: macos-latest
-            python-version: "3.10"
+            python-version: "3.9"
             nomkl: 1
 
           # Needs an older version of Python because conda doesn't build old

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -1148,7 +1148,7 @@ def _pseudo_inverse_dense(L, rhoss, w=None, **pseudo_args):
         try:
             LIQ = np.linalg.solve(L.full(), Q)
         except Exception:
-            LIQ = np.linalg.lstsq(L.full(), Q)[0]
+            LIQ = np.linalg.lstsq(L.full(), Q, rcond=None)[0]
 
         R = np.dot(Q, LIQ)
 


### PR DESCRIPTION
**Description**
Run mac test with openblas instead of MKL to skip the tests failing with pardiso.

Update github action version since they are raising deprecation warning.

**Related issues or PRs**
#2019