### PR TITLE
Explicitly define matplotlib backend for Windows tests (v5).

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
   cases:
     name: ${{ matrix.os }}, python${{ matrix.python-version }}, ${{ matrix.case-name }}
     runs-on: ${{ matrix.os }}
+    env:
+      MPLBACKEND: Agg  # Explicitly define matplotlib backend for Windows tests
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Description**
Explicitly define matplotlib backend for Windows tests.

**Related issues or PRs**
- #2013 (equivalent change for master)
- Cherry pick of 123163f4