### PR TITLE
Update `guide-settings` with v5's options

### DIFF
--- a/doc/guide/guide-settings.rst
+++ b/doc/guide/guide-settings.rst
@@ -9,60 +9,38 @@ Modifying Internal QuTiP Settings
 User Accessible Parameters
 ==========================
 
-In this section we show how to modify a few of the internal parameters used by QuTiP. The settings that can be modified are given in the following table:
+In this section we show how to modify a few of the internal parameters used by QuTiP.
+The settings that can be modified are given in the following table:
 
 .. tabularcolumns:: | p{3cm} | p{5cm} | p{5cm} |
 
 .. cssclass:: table-striped
 
-+-------------------------------+-------------------------------------------+-----------------------------+
-| Setting                       | Description                               | Options                     |
-+===============================+===========================================+=============================+
-| `auto_herm`                   | Automatically calculate the hermicity of  | True / False                |
-|                               | quantum objects.                          |                             |
-+-------------------------------+-------------------------------------------+-----------------------------+
-| `auto_tidyup`                 | Automatically tidyup quantum objects.     | True / False                |
-+-------------------------------+-------------------------------------------+-----------------------------+
-| `auto_tidyup_atol`            | Tolerance used by tidyup                  | any `float` value > 0       |
-+-------------------------------+-------------------------------------------+-----------------------------+
-| `atol`                        | General tolerance                         | any `float` value > 0       |
-+-------------------------------+-------------------------------------------+-----------------------------+
-| `num_cpus`                    | Number of CPU's used for multiprocessing. | `int` between 1 and # cpu's |
-+-------------------------------+-------------------------------------------+-----------------------------+
-| `debug`                       | Show debug printouts.                     | True / False                |
-+-------------------------------+-------------------------------------------+-----------------------------+
-| `openmp_thresh`               | NNZ matrix must have for OPENMP.          | Int                         |
-+-------------------------------+-------------------------------------------+-----------------------------+
++------------------------------+----------------------------------------------+------------------------------+
+| Setting                      | Description                                  | Options                      |
++==============================+==============================================+==============================+
+| `auto_tidyup`                | Automatically tidyup sparse quantum objects. | True / False                 |
++------------------------------+----------------------------------------------+------------------------------+
+| `auto_tidyup_atol`           | Tolerance used by tidyup. (sparse only)      | float {1e-14}                |
++------------------------------+----------------------------------------------+------------------------------+
+| `atol`                       | General absolute tolerance.                  | float {1e-12}                |
++------------------------------+----------------------------------------------+------------------------------+
+| `rtol`                       | General relative tolerance.                  | float {1e-12}                |
++------------------------------+----------------------------------------------+------------------------------+
+| `function_coefficient_style` | Signature expected by function coefficients. | {"auto", "pythonic", "dict"} |
++------------------------------+----------------------------------------------+------------------------------+
 
 .. _settings-usage:
 
 Example: Changing Settings
 ==========================
 
-The two most important settings are ``auto_tidyup`` and ``auto_tidyup_atol`` as they control whether the small elements of a quantum object should be removed, and what number should be considered as the cut-off tolerance. Modifying these, or any other parameters, is quite simple::
+The two most important settings are ``auto_tidyup`` and ``auto_tidyup_atol`` as they control whether the small elements of a quantum object should be removed, and what number should be considered as the cut-off tolerance.
+Modifying these, or any other parameters, is quite simple::
 
->>> qutip.settings.auto_tidyup = False
+>>> qutip.settings.core["auto_tidyup"] = False
 
-These settings will be used for the current QuTiP session only and will need to be modified again when restarting QuTiP.  If running QuTiP from a script file, then place the `qutip.settings.xxxx` commands immediately after `from qutip import *` at the top of the script file.  If you want to reset the parameters back to their default values then call the reset command::
+The settings can also be changed for a code block::
 
->>> qutip.settings.reset()
-
-Persistent Settings
-===================
-
-When QuTiP is imported, it looks for a file named ``qutiprc`` in a folder called ``.qutip`` user's home directory. If this file is found, it will be loaded and overwrite the QuTiP default settings, which allows for persistent changes in the QuTiP settings to be made. A sample ``qutiprc`` file is show below. The syntax is a simple key-value format, where the keys and possible values are described in the table above::
-
-    [qutip]
-    auto_tidyup=True
-    auto_herm=True
-    auto_tidyup_atol=1e-12
-    num_cpus=4
-    debug=False
-
-Note that the ``openmp_thresh`` value is automatically generatd by QuTiP.  It is also possible to set a specific compiler for QuTiP to use when generating runtime Cython code for time-dependent problems.  For example, the following section in the ``qutiprc`` file will set the compiler to be ``clang-3.9``::
-
-    [compiler]
-    cc = clang-3.9
-    cxx = clang-3.9
-
-
+>>> with qutip.CoreOptions(atol=1e-5):
+>>>     assert qutip.qeye(2) * 1e-9 == qutip.qzero(2)

--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -60,16 +60,13 @@ class CoreOptions(QutipOptions):
         Whether to tidyup during sparse operations.
 
     auto_tidyup_dims : bool [True]
-        use auto tidyup dims on multiplication
-
-    auto_herm : boolTrue
-        detect hermiticity
+        Use auto tidyup dims on multiplication. (Not used yet)
 
     atol : float {1e-12}
-        general absolute tolerance
+        General absolute tolerance
 
     rtol : float {1e-12}
-        general relative tolerance
+        General relative tolerance
         Used to choose QobjEvo.expect output type
 
     auto_tidyup_atol : float {1e-14}
@@ -98,8 +95,6 @@ class CoreOptions(QutipOptions):
         "auto_tidyup": True,
         # use auto tidyup dims on multiplication
         "auto_tidyup_dims": True,
-        # detect hermiticity
-        "auto_herm": True,
         # general absolute tolerance
         "atol": 1e-12,
         # general relative tolerance


### PR DESCRIPTION
**Description**
Update the guide for setting to list options still available in v5 and add an example with the using newly added context.
Removed the `auto_herm` options which was removed with `Qobj.isherm` being a property.
`auto_tidyup_dims` is not used anywhere but I left if since it could be useful with the dimensions class.

