### PR TITLE
Update dynamic documentation for dev.major

### DIFF
--- a/doc/guide/dynamics/dynamics-data.rst
+++ b/doc/guide/dynamics/dynamics-data.rst
@@ -134,19 +134,21 @@ For a fix output format, ``average_expect`` return the average, while ``runs_sta
 The ``runs_`` output will return ``None`` when the trajectories are not saved.
 Standard derivation of the expectation values is also available:
 
-+-------------------------+----------------------+
-| Reduced result          | Trajectories results |
-+=========================+======================+
-| ``average_states``      | ``runs_states``      |
-+-------------------------+----------------------+
-| ``average_final_state`` | ``runs_final_state`` |
-+-------------------------+----------------------+
-| ``average_expect`     ` | ``runs_expect``      |
-| ``std_expect`           |                      |
-+-------------------------+----------------------+
-| ``average_e_data``      | ``runs_e_data``      |
-| ``std_e_data``          |                      |
-+-------------------------+----------------------+
++-------------------------+----------------------+------------------------------------------------------------------------+
+| Reduced result          | Trajectories results | Description                                                            |
++=========================+======================+========================================================================+
+| ``average_states``      | ``runs_states``      | State vectors or density matrices calculated at each times of tlist    |
++-------------------------+----------------------+------------------------------------------------------------------------+
+| ``average_final_state`` | ``runs_final_state`` | State vectors or density matrices calculated at the last time of tlist |
++-------------------------+----------------------+------------------------------------------------------------------------+
+| ``average_expect``      | ``runs_expect``      | List/array of expectation values, if requested.                        |
++-------------------------+----------------------+------------------------------------------------------------------------+
+| ``std_expect``          |                      | List/array of standard derivation of the expectation values.           |
++-------------------------+----------------------+------------------------------------------------------------------------+
+| ``average_e_data``      | ``runs_e_data``      | Dictionary of expectation values, if requested.                        |
++-------------------------+----------------------+------------------------------------------------------------------------+
+| ``std_e_data``          |                      | Dictionary of standard derivation of the expectation values.           |
++-------------------------+----------------------+------------------------------------------------------------------------+
 
 Multiple trajectories results also keep the trajectories seeds to allows recomputing the results.
 

--- a/doc/guide/dynamics/dynamics-data.rst
+++ b/doc/guide/dynamics/dynamics-data.rst
@@ -9,7 +9,9 @@ Dynamics Simulation Results
 The solver.Result Class
 =======================
 
-Before embarking on simulating the dynamics of quantum systems, we will first look at the data structure used for returning the simulation results to the user. This object is a :func:`qutip.solve.solver.Result` class that stores all the crucial data needed for analyzing and plotting the results of a simulation.  Like the :func:`qutip.Qobj` class, the ``Result`` class has a collection of properties for storing information.  However, in contrast to the ``Qobj`` class, this structure contains no methods, and is therefore nothing but a container object.  A generic ``Result`` object ``result`` contains the following properties for storing simulation data:
+Before embarking on simulating the dynamics of quantum systems, we will first look at the data structure used for returning the simulation results.
+This object is a :func:`qutip.Result` class that stores all the crucial data needed for analyzing and plotting the results of a simulation.
+A generic ``Result`` object ``result`` contains the following properties for storing simulation data:
 
 .. cssclass:: table-striped
 
@@ -22,21 +24,15 @@ Before embarking on simulating the dynamics of quantum systems, we will first lo
 +------------------------+-----------------------------------------------------------------------+
 | ``result.expect``      | List/array of expectation values, if requested.                       |
 +------------------------+-----------------------------------------------------------------------+
+| ``result.e_data``      | Dictionary of expectation values, if requested.                       |
++------------------------+-----------------------------------------------------------------------+
 | ``result.states``      | List/array of state vectors/density matrices calculated at ``times``, |
 |                        | if requested.                                                         |
 +------------------------+-----------------------------------------------------------------------+
-| ``result.num_expect``  | The number of expectation value operators in the simulation.          |
+| ``result.final_state`` | State vector or density matrix at the last time of the evolution.     |
 +------------------------+-----------------------------------------------------------------------+
-| ``result.num_collapse``| The number of collapse operators in the simulation.                   |
-+------------------------+-----------------------------------------------------------------------+
-| ``result.ntraj``       | Number of Monte Carlo trajectories run.                               |
-+------------------------+-----------------------------------------------------------------------+
-| ``result.col_times``   | Times at which state collapse occurred. Only for Monte Carlo solver.  |
-+------------------------+-----------------------------------------------------------------------+
-| ``result.col_which``   | Which collapse operator was responsible for each collapse in          |
-|                        | in ``col_times``. Only used by Monte Carlo solver.                    |
-+------------------------+-----------------------------------------------------------------------+
-| ``result.seeds``       | Seeds used in generating random numbers for Monte Carlo solver.       |
+| ``result.stats``       | Various statistics about the evolution including the integration      |
+|                        | method used, number of collapse operators etc.                        |
 +------------------------+-----------------------------------------------------------------------+
 
 
@@ -45,18 +41,32 @@ Before embarking on simulating the dynamics of quantum systems, we will first lo
 Accessing Result Data
 ======================
 
-To understand how to access the data in a Result object we will use an example as a guide, although we do not worry about the simulation details at this stage.  Like all solvers, the Monte Carlo solver used in this example returns an Result object, here called simply ``result``.  To see what is contained inside ``result`` we can use the print function:
+To understand how to access the data in a Result object we will use an example as a guide, although we do not worry about the simulation details at this stage.
+Like all solvers, the Master Equation solver used in this example returns an Result object, here called simply ``result``.
+To see what is contained inside ``result`` we can use the print function:
 
 .. doctest::
   :options: +SKIP
 
   >>> print(result)
-  Result object with mcsolve data.
-  ---------------------------------
-  expect = True
-  num_expect = 2, num_collapse = 2, ntraj = 500
+  <Result
+    Solver: mesolve
+    Solver stats:
+      method: 'scipy zvode adams'
+      init time: 0.0001876354217529297
+      preparation time: 0.007544517517089844
+      run time: 0.001268625259399414
+      solver: 'Master Equation Evolution'
+      num_collapse: 1
+    Time interval: [0, 1.0] (2 steps)
+    Number of e_ops: 1
+    State not saved.
+  >
 
-The first line tells us that this data object was generated from the Monte Carlo solver ``mcsolve`` (discussed in :ref:`monte`).  The next line (not the ``---`` line of course) indicates that this object contains expectation value data.  Finally, the last line gives the number of expectation value and collapse operators used in the simulation, along with the number of Monte Carlo trajectories run.  Note that the number of trajectories ``ntraj`` is only displayed when using the Monte Carlo solver.
+The first line tells us that this data object was generated from the Master Equation solver :func:`mesolve`.
+Next we have the statistics including the ODE solver used, setup time, number of collpases.
+Then the integration interval is described, followed with the number of expectation value computed.
+Finally, it says whether the states are stored.
 
 Now we have all the information needed to analyze the simulation results.
 To access the data for the two expectation values one can do:
@@ -68,7 +78,18 @@ To access the data for the two expectation values one can do:
   expt0 = result.expect[0]
   expt1 = result.expect[1]
 
-Recall that Python uses C-style indexing that begins with zero (i.e., [0] => 1st collapse operator data). Together with the array of times at which these expectation values are calculated:
+Recall that Python uses C-style indexing that begins with zero (i.e., [0] => 1st collapse operator data).
+Alternatively, expectation values can be obtained as a dictionary:
+
+.. testcode::
+  :skipif: True
+
+  e_ops = {"sx": sigmax(), "sy": sigmay(), "sz": sigmaz()}
+  ...
+  expt_sx = result.e_data["sx"]
+
+When ``e_ops`` is a list, ``e_data`` ca be used with the list index.
+Together with the array of times at which these expectation values are calculated:
 
 .. testcode::
   :skipif: True
@@ -80,45 +101,56 @@ we can plot the resulting expectation values:
 .. testcode::
   :skipif: True
 
-  plot(times, expt0, times, expt1)
+  plot(times, expt0)
+  plot(times, expt1)
   show()
 
 
-State vectors, or density matrices, as well as ``col_times`` and ``col_which``, are accessed in a similar manner, although typically one does not need an index (i.e [0]) since there is only one list for each of these components.  The one exception to this rule is if you choose to output state vectors from the Monte Carlo solver, in which case there are ``ntraj`` number of state vector arrays.
+State vectors, or density matrices, are accessed in a similar manner, although typically one does not need an index (i.e [0]) since there is only one list for each of these components.
+Some other solver can have other output, :func:`heomsolve`'s results can have ``ado_states`` output if the options ``store_ados`` is set, similarly, :func:`fmesolve` can return `floquet_states`.
 
-.. _odedata-saving:
 
-Saving and Loading Result Objects
-==================================
+Multiple Trajectories Solver Results
+====================================
 
-The main advantage in using the Result class as a data storage object comes from the simplicity in which simulation data can be stored and later retrieved. The :func:`qutip.fileio.qsave` and :func:`qutip.fileio.qload` functions are designed for this task.  To begin, let us save the ``data`` object from the previous section into a file called "cavity+qubit-data" in the current working directory by calling:
 
-.. testcode::
-  :skipif: True
-
-  qsave(result, 'cavity+qubit-data')
-
-All of the data results are then stored in a single file of the same name with a ".qu" extension.  Therefore, everything needed to later this data is stored in a single file.  Loading the file is just as easy as saving:
+Solver which compute multiple trajectories such as the Monte Carlo Equations Solvers or the Stochastics Solvers result will differ depending on whether the trajectories are flags to be saved.
+For example:
 
 .. doctest::
   :options: +SKIP
 
-  >>> stored_result = qload('cavity+qubit-data')
-  Loaded Result object:
-  Result object with mcsolve data.
-  ---------------------------------
-  expect = True
-  num_expect = 2, num_collapse = 2, ntraj = 500
+  >>> mcsolve(H, psi, np.linspace(0, 1, 11), c_ops, e_ops=[num(N)], ntraj=25, options={"keep_runs_results": False})
+  >>> np.shape(result.expect)
+  (1, 11)
 
-where ``stored_result`` is the new name of the Result object.  We can then extract the data and plot in the same manner as before:
+  >>> mcsolve(H, psi, np.linspace(0, 1, 11), c_ops, e_ops=[num(N)], ntraj=25, options={"keep_runs_results": True})
+  >>> np.shape(result.expect)
+  (1, 25, 11)
+
+
+When the runs are not saved, the expectation values and states are averaged over all trajectories, while a list over the runs are given when they are stored.
+For a fix output format, ``average_expect`` return the average, while ``runs_states`` return the list over trajectories.
+The ``runs_`` output will return ``None`` when the trajectories are not saved.
+Standard derivation of the expectation values is also available:
+
++-------------------------+----------------------+
+| Reduced result          | Trajectories results |
++=========================+======================+
+| ``average_states``      | ``runs_states``      |
++-------------------------+----------------------+
+| ``average_final_state`` | ``runs_final_state`` |
++-------------------------+----------------------+
+| ``average_expect`     ` | ``runs_expect``      |
+| ``std_expect`           |                      |
++-------------------------+----------------------+
+| ``average_e_data``      | ``runs_e_data``      |
+| ``std_e_data``          |                      |
++-------------------------+----------------------+
+
+Multiple trajectories results also keep the trajectories seeds to allows recomputing the results.
 
 .. testcode::
-    :skipif: True
+  :skipif: True
 
-    expt0 = stored_result.expect[0]
-    expt1 = stored_result.expect[1]
-    times = stored_result.times
-    plot(times, expt0, times, expt1)
-    show()
-
-Also see :ref:`saving` for more information on saving quantum objects, as well as arrays for use in other programs.
+  seeds = result.seeds

--- a/doc/guide/dynamics/dynamics-options.rst
+++ b/doc/guide/dynamics/dynamics-options.rst
@@ -17,7 +17,7 @@ The options for all dynamics solvers may be changed by using the dictionaries.
    options = {"store_states": True, "atol": 1e-12}
 
 Supported items come from 2 sources, the solver and the ODE integration method.
-Supported solver options and their default can be seen with the class interface:
+Supported solver options and their default can be seen using the class interface:
 
 .. testcode:: [dynamics_options]
 
@@ -27,23 +27,21 @@ Options supported by the ODE integration depend on the "method" options of the s
 
 .. testcode:: [dynamics_options]
 
-   help(MeSolver.integrator("adams"))
+   help(MeSolver.integrator("adams").options)
 
 See `Integrator <../../apidoc/classes.html#classes-ode>`_ for a list of supported methods.
 
 
-As an example, let us consider changing the number of processors used, turn the GUI off, and strengthen the absolute tolerance.  There are two equivalent ways to do this using the SolverOptions class.  First way,
+As an example, let us consider changing the integrator, turn the GUI off, and strengthen the absolute tolerance.
 
 .. testcode:: [dynamics_options]
 
-    options = {method="bdf", "atol": 1e-10}
+    options = {method="bdf", "atol": 1e-10, "progress_bar": False}
 
-To use these new settings we can use the keyword argument ``options`` in either the func:`qutip.mesolve` and :func:`qutip.mcsolve` function.  We can modify the last example as::
+To use these new settings we can use the keyword argument ``options`` in either the :func:`qutip.mesolve` and :func:`qutip.mcsolve` function::
 
     >>> mesolve(H0, psi0, tlist, c_op_list, [sigmaz()], options=options)
-    >>> MeSolver(hamiltonian_t, c_op_list, options=options)
 
 or::
 
-    >>> mcsolve(H0, psi0, tlist, ntraj,c_op_list, [sigmaz()], options=options)
-    >>> mcsolve(hamiltonian_t, psi0, tlist, ntraj, c_op_list, [sigmaz()], H_args, options=options)
+    >>> McSolver(H0, c_op_list, options=options)

--- a/doc/guide/dynamics/dynamics-time.rst
+++ b/doc/guide/dynamics/dynamics-time.rst
@@ -73,7 +73,7 @@ As an example, we will look at a case with a time-dependent Hamiltonian of the f
 The following code sets up the problem
 
 .. plot::
-    :context:
+    :context: close-figs
 
     ustate = basis(3, 0)
     excited = basis(3, 1)
@@ -107,7 +107,7 @@ The following code sets up the problem
 Given that we have a single time-dependent Hamiltonian term, and constant collapse terms, we need to specify a single Python function for the coefficient :math:`f(t)`.  In this case, one can simply do
 
 .. plot::
-    :context:
+    :context: close-figs
 
     def H1_coeff(t):
         return 9 * np.exp(-(t / 5.) ** 2)
@@ -116,7 +116,7 @@ In this case, the return value depends only on time.  However it is possible to 
 Having specified our coefficient function, we can now specify the Hamiltonian in list format and call the solver (in this case :func:`qutip.mesolve`)
 
 .. plot::
-    :context:
+    :context: close-figs
 
     H = [H0, [H1, H1_coeff]]
     output = mesolve(H, psi0, t, c_ops, [ada, sigma_UU, sigma_GG])
@@ -136,7 +136,7 @@ The output from the master equation solver is identical to that shown in the exa
 In addition, we can also consider the decay of a simple Harmonic oscillator with time-varying decay rate
 
 .. plot::
-    :context:
+    :context: close-figs
 
     kappa = 0.5
 
@@ -158,7 +158,8 @@ Qobjevo
 
 :class:`QobjEvo` as a time dependent quantum system, as it's main functionality create a :class:`Qobj` at a time:
 
-.. code-block:: python
+.. doctest:: [basics]
+    :options: +NORMALIZE_WHITESPACE
 
     >>> print(H_t(np.pi / 2))
     Quantum object: dims=[[2], [2]], shape=(2, 2), type='oper', isherm=True
@@ -166,7 +167,8 @@ Qobjevo
     [[0. 1.]
      [1. 1.]]
 
- :class:`QobjEvo` shares a lot of properties with the :class:`Qobj`.
+
+:class:`QobjEvo` shares a lot of properties with the :class:`Qobj`.
 
 +---------------+------------------+----------------------------------------+
 | Property      | Attribute        | Description                            |
@@ -217,7 +219,7 @@ For instance, instead of explicitly writing 9 for the amplitude and 5 for the wi
 
 
 .. plot::
-    :context:
+    :context: close-figs
 
     def H1_coeff(t, args):
         return args['A'] * np.exp(-(t/args['sigma'])**2)
@@ -227,7 +229,7 @@ or, new from v5, add the extra parameter directly:
 
 
 .. plot::
-    :context:
+    :context: close-figs
 
     def H1_coeff(t, A, sigma):
         return A * np.exp(-(t / sigma)**2)
@@ -239,7 +241,7 @@ In the last example, ``args = {'A': a, 'sigma': b}`` where ``a`` and ``b`` are t
 This ``args`` dictionary need to be given at creation of the :class:`QobjEvo` when function using then are included:
 
 .. plot::
-    :context:
+    :context: close-figs
 
     system = [H0, [H1, H1_coeff]]
     args={'A': 9, 'sigma': 5}
@@ -248,7 +250,7 @@ This ``args`` dictionary need to be given at creation of the :class:`QobjEvo` wh
 But without ``args``, the :class:`QobjEvo` creation will fail:
 
 .. plot::
-    :context:
+    :context: close-figs
 
     try:
         QobjEvo(system)
@@ -258,7 +260,7 @@ But without ``args``, the :class:`QobjEvo` creation will fail:
 When evaluation the :class:`QobjEvo` at a time, new arguments can be passed either with the ``args`` dictionary positional arguments, or with specific keywords arguments:
 
 .. plot::
-    :context:
+    :context: close-figs
 
     print(qevo(1))
     print(qevo(1, {"A": 5, "sigma": 0.2}))
@@ -283,7 +285,7 @@ To update arguments of an existing time dependent quantum system, you can pass t
 
 
 .. plot::
-    :context:
+    :context: close-figs
 
     print(qevo(1))
     print(qevo(1, {"A": 5, "sigma": 0.2}))
@@ -306,10 +308,10 @@ When merging two or more :class:`QobjEvo`, each will keep it arguments, but call
 
 
 .. plot::
-    :context:
+    :context: close-figs
 
-    qevo1 = QobjEvo([[qt.sigmap(), lambda t, a: a], [qt.sigmam(), lambda t, a, b: a+1j*b]], args={"a": 1, "b":2})
-    qevo2 = QobjEvo([[qt.num(2), lambda t, a, c: a+1j*c]], args={"a": 2, "c":2})
+    qevo1 = QobjEvo([[sigmap(), lambda t, a: a], [sigmam(), lambda t, a, b: a+1j*b]], args={"a": 1, "b":2})
+    qevo2 = QobjEvo([[num(2), lambda t, a, c: a+1j*c]], args={"a": 2, "c":2})
     summed_evo = qevo1 + qevo2
     print(summed_evo(0))
     print(summed_evo(0, a=3, b=1))
@@ -378,20 +380,22 @@ Per default, a cubic spline interpolation is used, but the order of the interpol
 Outside the interpolation range, the first or last value are used.
 
 .. plot::
-    :context:
+    :context: close-figs
 
     times = np.array([0, 0.1, 0.3, 0.6, 1.0])
-    coeff = times**2
+    coeff = times * (1.1 - times)
     tlist = np.linspace(-0.1, 1.1, 25)
 
     H = QobjEvo([qeye(1), coeff], tlist=times)
-    plt.plot(tlist, [H(t).norm() for t in tlist])
+    plt.plot(tlist, [H(t).norm() for t in tlist], label="CubicSpline")
 
     H = QobjEvo([qeye(1), coeff], tlist=times, order=0)
-    plt.plot(tlist, [H(t).norm() for t in tlist])
+    plt.plot(tlist, [H(t).norm() for t in tlist], label="step")
 
     H = QobjEvo([qeye(1), coeff], tlist=times, order=1)
-    plt.plot(tlist, [H(t).norm() for t in tlist])
+    plt.plot(tlist, [H(t).norm() for t in tlist], label="linear")
+
+    plt.legend()
 
 
 When using array coefficients in solver, if the time dependent quantum system is in list format, the solver tlist is used as times of the array.
@@ -400,406 +404,33 @@ It is therefore better to create the QobjEvo using an extended range prior to th
 
 
 .. plot::
-    :context:
+    :context: close-figs
 
     N = 5
     times = np.linspace(-0.1, 1.1, 13)
     coeff = np.exp(-times)
 
-    c_ops = [QobjEvo([qt.destroy(N), coeff], tlist=times)]
+    c_ops = [QobjEvo([destroy(N), coeff], tlist=times)]
     plt.plot(
-        mesolve(qt.qeye(N), qt.basis(N, N-1), np.linspace(0, 1, 11), c_ops=c_ops, e_ops=[qt.num(N)]).expect
+        mesolve(qeye(N), basis(N, N-1), np.linspace(0, 1, 11), c_ops=c_ops, e_ops=[num(N)]).expect
     )
 
 
 Different coefficient types can be mixed in a :class:`QobjEvo`.
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-The Hamiltonian and/or collapse operators are expressed as a list of [qobj, string] pairs, where the time-dependent coefficients are represented as strings.  The resulting Hamiltonian is then compiled into C code using Cython and executed.
-The Hamiltonian and/or collapse operators are expressed as a list of [qobj, np.array] pairs. The arrays are 1 dimensional and dtype are complex or float. They must contain one value for each time in the tlist given to the solver. Cubic spline interpolation will be used between the given times.
-
-
-Give the multiple choices of input style, the first question that arises is which option to choose?
-In short, the function based method (option #1) is the most general,
+Given the multiple choices of input style, the first question that arises is which option to choose?
+In short, the function based method (first option) is the most general,
 allowing for essentially arbitrary coefficients expressed via user defined functions.
 However, by automatically compiling your system into C++ code,
-the second option (string based) tends to be more efficient and will run faster
-[This is also the only format that is supported in the :func:`qutip.solve.brmesolve` solver].
+the second option (string based) tends to be more efficient and run faster.
 Of course, for small system sizes and evolution times, the difference will be minor.
-Although this method does not support all time-dependent coefficients that one can think of,
-it does support essentially all problems that one would typically encounter.
-Time-dependent coefficients using any of the following functions,
-or combinations thereof (including constants) can be compiled directly into C++-code::
-
-  'abs', 'acos', 'acosh', 'arg', 'asin', 'asinh', 'atan', 'atanh', 'conj',
-  'cos', 'cosh','exp', 'erf', 'zerf', 'imag', 'log', 'log10', 'norm', 'pi',
-  'proj', 'real', 'sin', 'sinh', 'sqrt', 'tan', 'tanh'
-
-In addition, QuTiP supports cubic spline based interpolation functions [:ref:`time-interp`].
-
-If you require mathematical functions other than those listed above,
-it is possible to call any of the functions in the NumPy library using the prefix ``np.``
-before the function name in the string, i.e ``'np.sin(t)'`` and  ``scipy.special`` imported as ``spe``.
-This includes a wide range of functionality, but comes with a small overhead created by going from C++->Python->C++.
-
-Finally option #4, expressing the Hamiltonian as a Python function,
-is the original method for time dependence in QuTiP 1.x.
-However, this method is somewhat less efficient then the previously mentioned methods.
-However, in contrast to the other options
-this method can be used in implementing time-dependent Hamiltonians that cannot be
-expressed as a function of constant operators with time-dependent coefficients.
-
-A collection of examples demonstrating the simulation of time-dependent problems can be found on the `tutorials <https://qutip.org/tutorials.html>`_ web page.
-
-.. _time-function:
-
-Function Based Time Dependence
-==============================
-
-A very general way to write a time-dependent Hamiltonian or collapse operator is by using Python functions as the time-dependent coefficients.  To accomplish this, we need to write a Python function that returns the time-dependent coefficient.  Additionally, we need to tell QuTiP that a given Hamiltonian or collapse operator should be associated with a given Python function.  To do this, one needs to specify operator-function pairs in list format: ``[Op, py_coeff]``, where ``Op`` is a given Hamiltonian or collapse operator and ``py_coeff`` is the name of the Python function representing the coefficient.  With this format, the form of the Hamiltonian for both ``mesolve`` and ``mcsolve`` is:
-
->>> H = [H0, [H1, py_coeff1], [H2, py_coeff2], ...] # doctest: +SKIP
-
-where ``H0`` is a time-independent Hamiltonian, while ``H1``and ``H2`` are time dependent. The same format can be used for collapse operators:
-
->>> c_ops = [[C0, py_coeff0], C1, [C2, py_coeff2], ...] # doctest: +SKIP
-
-Here we have demonstrated that the ordering of time-dependent and time-independent terms does not matter.  In addition, any or all of the collapse operators may be time dependent.
-
-.. note:: While, in general, you can arrange time-dependent and time-independent terms in any order you like, it is best to place all time-independent terms first.
-
-As an example, we will look at an example that has a time-dependent Hamiltonian of the form :math:`H=H_{0}-f(t)H_{1}` where :math:`f(t)` is the time-dependent driving strength given as :math:`f(t)=A\exp\left[-\left( t/\sigma \right)^{2}\right]`.  The following code sets up the problem
-
-.. plot::
-    :context:
-
-    ustate = basis(3, 0)
-    excited = basis(3, 1)
-    ground = basis(3, 2)
-
-    N = 2 # Set where to truncate Fock state for cavity
-    sigma_ge = tensor(qeye(N), ground * excited.dag())  # |g><e|
-    sigma_ue = tensor(qeye(N), ustate * excited.dag())  # |u><e|
-    a = tensor(destroy(N), qeye(3))
-    ada = tensor(num(N), qeye(3))
-
-    c_ops = []  # Build collapse operators
-    kappa = 1.5 # Cavity decay rate
-    c_ops.append(np.sqrt(kappa) * a)
-    gamma = 6  # Atomic decay rate
-    c_ops.append(np.sqrt(5*gamma/9) * sigma_ue) # Use Rb branching ratio of 5/9 e->u
-    c_ops.append(np.sqrt(4*gamma/9) * sigma_ge) # 4/9 e->g
-
-    t = np.linspace(-15, 15, 100) # Define time vector
-    psi0 = tensor(basis(N, 0), ustate) # Define initial state
-
-    state_GG = tensor(basis(N, 1), ground) # Define states onto which to project
-    sigma_GG = state_GG * state_GG.dag()
-    state_UU = tensor(basis(N, 0), ustate)
-    sigma_UU = state_UU * state_UU.dag()
-
-    g = 5  # coupling strength
-    H0 = -g * (sigma_ge.dag() * a + a.dag() * sigma_ge)  # time-independent term
-    H1 = (sigma_ue.dag() + sigma_ue)  # time-dependent term
-
-Given that we have a single time-dependent Hamiltonian term, and constant collapse terms, we need to specify a single Python function for the coefficient :math:`f(t)`.  In this case, one can simply do
-
-.. plot::
-    :context:
-
-    def H1_coeff(t, args):
-        return 9 * np.exp(-(t / 5.) ** 2)
-
-In this case, the return value dependents only on time.  However, when specifying Python functions for coefficients, **the function must have (t,args) as the input variables, in that order**.  Having specified our coefficient function, we can now specify the Hamiltonian in list format and call the solver (in this case :func:`qutip.mesolve`)
-
-.. plot::
-    :context:
-
-    H = [H0,[H1, H1_coeff]]
-    output = mesolve(H, psi0, t, c_ops, [ada, sigma_UU, sigma_GG])
-
-We can call the Monte Carlo solver in the exact same way (if using the default ``ntraj=500``):
-
-
-..
-  Hacky fix because plot has complicated conditional code execution
-
-.. doctest::
-    :skipif: True
-
-    output = mcsolve(H, psi0, t, c_ops, [ada, sigma_UU, sigma_GG])
-
-The output from the master equation solver is identical to that shown in the examples, the Monte Carlo however will be noticeably off, suggesting we should increase the number of trajectories for this example.  In addition, we can also consider the decay of a simple Harmonic oscillator with time-varying decay rate
-
-.. plot::
-    :context:
-
-    kappa = 0.5
-
-    def col_coeff(t, args):  # coefficient function
-        return np.sqrt(kappa * np.exp(-t))
-
-    N = 10  # number of basis states
-    a = destroy(N)
-    H = a.dag() * a  # simple HO
-    psi0 = basis(N, 9)  # initial state
-    c_ops = [[a, col_coeff]]  # time-dependent collapse term
-    times = np.linspace(0, 10, 100)
-    output = mesolve(H, psi0, times, c_ops, [a.dag() * a])
-
-
-Using the args variable
-------------------------
-In the previous example we hardcoded all of the variables, driving amplitude :math:`A` and width :math:`\sigma`, with their numerical values.  This is fine for problems that are specialized, or that we only want to run once.  However, in many cases, we would like to change the parameters of the problem in only one location (usually at the top of the script), and not have to worry about manually changing the values on each run.  QuTiP allows you to accomplish this using the keyword ``args`` as an input to the solvers.  For instance, instead of explicitly writing 9 for the amplitude and 5 for the width of the gaussian driving term, we can make us of the args variable
-
-.. plot::
-    :context:
-
-    def H1_coeff(t, args):
-        return args['A'] * np.exp(-(t/args['sigma'])**2)
-
-or equivalently,
-
-.. plot::
-    :context:
-
-    def H1_coeff(t, args):
-          A = args['A']
-          sig = args['sigma']
-          return A * np.exp(-(t / sig) ** 2)
-
-where args is a Python dictionary of ``key: value`` pairs ``args = {'A': a, 'sigma': b}`` where ``a`` and ``b`` are the two parameters for the amplitude and width, respectively.  Of course, we can always hardcode the values in the dictionary as well ``args = {'A': 9, 'sigma': 5}``, but there is much more flexibility by using variables in ``args``.  To let the solvers know that we have a set of args to pass we append the ``args`` to the end of the solver input:
-
-.. plot::
-    :context:
-
-    output = mesolve(H, psi0, times, c_ops, [a.dag() * a], args={'A': 9, 'sigma': 5})
-
-or to keep things looking pretty
-
-.. plot::
-    :context:
-
-    args = {'A': 9, 'sigma': 5}
-    output = mesolve(H, psi0, times, c_ops, [a.dag() * a], args=args)
-
-Once again, the Monte Carlo solver :func:`qutip.mcsolve` works in an identical manner.
-
-.. _time-string:
-
-String Format Method
-=====================
-
-.. note:: You must have Cython installed on your computer to use this format.  See :ref:`install` for instructions on installing Cython.
-
-The string-based time-dependent format works in a similar manner as the previously discussed Python function method.
-That being said, the underlying code does something completely different.
-When using this format, the strings used to represent the time-dependent coefficients,
-as well as Hamiltonian and collapse operators, are rewritten as Cython code using a code generator class and then compiled into C code.
-The details of this meta-programming will be published in due course.
-however, in short, this can lead to a substantial reduction in time for complex time-dependent problems, or when simulating over long intervals.
-
-Like the previous method, the string-based format uses a list pair format
- ``[Op, str]`` where ``str`` is now a string representing the time-dependent coefficient.
- For our first example, this string would be ``'9 * exp(-(t / 5.) ** 2)'``.  The Hamiltonian in this format would take the form:
-
-.. plot::
-   :context:
-
-   ustate = basis(3, 0)
-   excited = basis(3, 1)
-   ground = basis(3, 2)
-
-   N = 2 # Set where to truncate Fock state for cavity
-
-   sigma_ge = tensor(qeye(N), ground * excited.dag())  # |g><e|
-   sigma_ue = tensor(qeye(N), ustate * excited.dag())  # |u><e|
-   a = tensor(destroy(N), qeye(3))
-   ada = tensor(num(N), qeye(3))
-
-   c_ops = []  # Build collapse operators
-   kappa = 1.5 # Cavity decay rate
-   c_ops.append(np.sqrt(kappa) * a)
-   gamma = 6  # Atomic decay rate
-   c_ops.append(np.sqrt(5*gamma/9) * sigma_ue) # Use Rb branching ratio of 5/9 e->u
-   c_ops.append(np.sqrt(4*gamma/9) * sigma_ge) # 4/9 e->g
-
-   t = np.linspace(-15, 15, 100) # Define time vector
-   psi0 = tensor(basis(N, 0), ustate) # Define initial state
-   state_GG = tensor(basis(N, 1), ground) # Define states onto which to project
-   sigma_GG = state_GG * state_GG.dag()
-   state_UU = tensor(basis(N, 0), ustate)
-   sigma_UU = state_UU * state_UU.dag()
-
-   g = 5  # coupling strength
-   H0 = -g * (sigma_ge.dag() * a + a.dag() * sigma_ge)  # time-independent term
-   H1 = (sigma_ue.dag() + sigma_ue)  # time-dependent term
-
-
-.. plot::
-    :context:
-
-    H = [H0, [H1, '9 * exp(-(t / 5) ** 2)']]
-
-Notice that this is a valid Hamiltonian for the string-based format as ``exp`` is included in the above list of suitable functions. Calling the solvers is the same as before:
-
-.. plot::
-   :context:
-
-   output = mesolve(H, psi0, t, c_ops, [a.dag() * a])
-
-We can also use the ``args`` variable in the same manner as before, however we must rewrite our string term to read: ``'A * exp(-(t / sig) ** 2)'``
-
-.. plot::
-    :context:
-
-    H = [H0, [H1, 'A * exp(-(t / sig) ** 2)']]
-    args = {'A': 9, 'sig': 5}
-    output = mesolve(H, psi0, times, c_ops, [a.dag()*a], args=args)
-
-
-.. important:: Naming your ``args`` variables ``exp``, ``sin``, ``pi`` etc. will cause errors when using the string-based format.
-
-Collapse operators are handled in the exact same way.
-
-
-.. _time-interp:
-
-Modeling Non-Analytic and/or Experimental Time-Dependent Parameters using Interpolating Functions
-=================================================================================================
-
-Sometimes it is necessary to model a system where the time-dependent parameters are non-analytic functions, or are derived from experimental data (i.e. a collection of data points).
-In these situations, one can use interpolating functions as an approximate functional form for input into a time-dependent solver.
-QuTiP support spline interpolation in it's :class:`qutip.Coefficient`.
-To see how this works, lets first generate some noisy data:
-
-.. plot::
-    :context:
-
-    times = np.linspace(-15, 15, 100)
-    func = lambda t: 9 * np.exp(-(t / 5)** 2)
-    noisy_data = func(times) * (1 + 0.05 * np.random.randn(len(times)))
-
-    plt.figure()
-    plt.plot(times, func(times))
-    plt.plot(times, noisy_data, 'o')
-    plt.show()
-
-
-To turn these data points into a function we call the QuTiP :func:`qutip.coefficient` using the array of data points, times to which these are measured and spline interpolation order :
-
-
-.. plot::
-    :context: close-figs
-
-    S = coefficient(noisy_data, tlist=times, order=3)
-
-    plt.figure()
-    plt.plot(times, func(times))
-    plt.plot(times, noisy_data, 'o')
-    plt.plot(times, [S(t).real for t in times], lw=2)
-    plt.show()
-
-
-This :class:`qutip.Coefficient` instance can now be used in any of the solver supporting time-dependent operators, such as the ``mesolve``, ``mcsolve``, or ``sesolve`` functions.
-Taking the problem from the previous section as an example.
-We would make the replacement:
-
-.. code-block:: python
-
-    H = [H0, [H1, '9 * exp(-(t / 5) ** 2)']]
-
-to
-
-.. code-block:: python
-
-    H = [H0, [H1, S]]
-
-
-When combining interpolating functions with other Python functions or strings, the interpolating class will automatically pick the appropriate method for calling the class.  That is to say that, if for example, you have other time-dependent terms that are given in the string-format, then the cubic spline representation will also be passed in a string-compatible format.  In the string-format, the interpolation function is compiled into c-code, and thus is quite fast.  This is the default method if no other time-dependent terms are present.
+Lastly the spline method is usually as fast the string method, but it cannot be modified once created.
 
 
 .. _time-dynargs:
 
-Accesing the state from solver
-==============================
+Accessing the state from solver
+===============================
 
-New in QuTiP 4.4
-
-The state of the system, the ket vector or the density matrix,
-is available to time-dependent Hamiltonian and collapse operators in ``args``.
-Some keys of the argument dictionary are understood by the solver to be values
-to be updated with the evolution of the system.
-The state can be obtained in 3 forms: ``Qobj``, vector (1d ``np.array``), matrix (2d ``np.array``),
-expectation values and collapse can also be obtained.
-
-+-------------------+-------------------------+----------------------+------------------------------------------------------------------+
-|                   | Preparation             | usage                | Notes                                                            |
-+-------------------+-------------------------+----------------------+------------------------------------------------------------------+
-| state as Qobj     | ``name+"=Qobj":psi0``   | ``psi_t=args[name]`` | The ket or density matrix as a Qobj with ``psi0``'s dimensions   |
-+-------------------+-------------------------+----------------------+------------------------------------------------------------------+
-| state as matrix   | ``name+"=mat":psi0``    | ``mat_t=args[name]`` | The state as a matrix, equivalent to ``state.full()``            |
-+-------------------+-------------------------+----------------------+------------------------------------------------------------------+
-| state as vector   | ``name+"=vec":psi0``    | ``vec_t=args[name]`` | The state as a vector, equivalent to ``state.full().ravel('F')`` |
-+-------------------+-------------------------+----------------------+------------------------------------------------------------------+
-| expectation value | ``name+"=expect":O``    | ``e=args[name]``     | Expectation value of the operator ``O``, either                  |
-|                   |                         |                      | :math:`\left<\psi(t)|O|\psi(t)\right>`                           |
-|                   |                         |                      | or :math:`\rm{tr}\left(O \rho(t)\right)`                         |
-+-------------------+-------------------------+----------------------+------------------------------------------------------------------+
-| collpases         | ``name+"=collapse":[]`` | ``col=args[name]``   | List of collapse,                                                |
-|                   |                         |                      | each collapse is a tuple of the pair ``(time, which)``           |
-|                   |                         |                      | ``which`` being the indice of the collapse operator.             |
-|                   |                         |                      | ``mcsolve`` only.                                                |
-+-------------------+-------------------------+----------------------+------------------------------------------------------------------+
-
-Here ``psi0`` is the initial value used for tests before the evolution begins.
-:func:`qutip.brmesolve` does not support these arguments.
-
-Reusing Time-Dependent Hamiltonian Data
-=======================================
-
-.. note:: This section covers a specialized topic and may be skipped if you are new to QuTiP.
-
-When repeatedly simulating a system where only the time-dependent variables, or initial state change, it is possible to reuse the Hamiltonian data stored in QuTiP and there by avoid spending time needlessly preparing the Hamiltonian and collapse terms for simulation.
-To turn on the reuse features, we must use the class interface of the solver:
-
-.. plot::
-    :context: close-figs
-
-    from qutip.solver.mesolve import MeSolver
-    H = QobjEvo([H0, [H1, 'A * exp(-(t / sig)**2)']], args={'A': 0, 'sig': 1})
-    solver = MeSolver(H, c_ops)
-    args = {'A': 9, 'sig': 5}
-    output = solver.run(psi0, times, e_ops=[a.dag()*a], args=args)
-    args = {'A': 10, 'sig': 3}
-    output = solver.run(psi0, times, e_ops=[a.dag()*a], args=args)
-
-The preparation of the Liouvillian and in the case of the string format, compilation of the Cython code, is done once in the initialization of the solver instance.
-For the small system here, the savings in computation time is quite small, however, if you need to call the solvers many times for different parameters, this savings will obviously start to add up.
+Not available in v5 yet

--- a/doc/guide/dynamics/dynamics-time.rst
+++ b/doc/guide/dynamics/dynamics-time.rst
@@ -46,7 +46,7 @@ Solvers will accept a :class:`QobjEvo`: when an operator is expected: this inclu
 Exception are :func:`krylovsolve`'s Hamiltonian and HEOM's Bath operators.
 
 
-Most solver will accept any format that could be made into a  for the Hamiltonian.
+Most solvers will accept any format that could be made into a :class:`QobjEvo`: for the Hamiltonian.
 All of the following are equivalent:
 
 
@@ -112,7 +112,7 @@ Given that we have a single time-dependent Hamiltonian term, and constant collap
     def H1_coeff(t):
         return 9 * np.exp(-(t / 5.) ** 2)
 
-In this case, the return value depends only on time.  However it is possible to add optional arguments to the call, see **Insert link to arguments***.
+In this case, the return value depends only on time.  However it is possible to add optional arguments to the call, see `Using arguments`_.
 Having specified our coefficient function, we can now specify the Hamiltonian in list format and call the solver (in this case :func:`qutip.mesolve`)
 
 .. plot::
@@ -433,4 +433,4 @@ Lastly the spline method is usually as fast the string method, but it cannot be 
 Accessing the state from solver
 ===============================
 
-Not available in v5 yet
+In QuTiP 4.4 to 4.7, it was possible to request that the solver pass the state, expectation values or collapse operators via arguments to :class:`QobjEvo`. Support for this is not yet available in QuTiP 5.

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -706,7 +706,7 @@ class MultiTrajResult(_BaseResult):
         """
         States of every runs as ``states[run][t]``.
         """
-        if self.trajectories:
+        if self.trajectories and self.trajectories[0].states:
             return [traj.states for traj in self.trajectories]
         else:
             return None
@@ -732,7 +732,7 @@ class MultiTrajResult(_BaseResult):
         """
         Last states of each trajectories.
         """
-        if self.trajectories:
+        if self.trajectories and self.trajectories[0].final_state:
             return [traj.final_state for traj in self.trajectories]
         else:
             return None
@@ -843,11 +843,34 @@ class MultiTrajResult(_BaseResult):
         return list(self.e_data_traj_std(ntraj).values())
 
     def __repr__(self):
-        repr = super().__repr__()
-        lines = repr.split("\n")
-        lines.insert(-1, f"  Number of trajectories: {self.num_trajectories}")
+        lines = [
+            f"<{self.__class__.__name__}",
+            f"  Solver: {self.solver}",
+        ]
+        if self.stats:
+            lines.append("  Solver stats:")
+            lines.extend(
+                f"    {k}: {v!r}"
+                for k, v in self.stats.items()
+            )
+        if self.times:
+            lines.append(
+                f"  Time interval: [{self.times[0]}, {self.times[-1]}]"
+                f" ({len(self.times)} steps)"
+            )
+        lines.append(f"  Number of e_ops: {len(self.e_ops)}")
+        if self.states:
+            lines.append("  States saved.")
+        elif self.final_state is not None:
+            lines.append("  Final state saved.")
+        else:
+            lines.append("  State not saved.")
+        lines.append(f"  Number of trajectories: {self.num_trajectories}")
         if self.trajectories:
-            lines.insert(-1, "  Trajectories saved.")
+            lines.append("  Trajectories saved.")
+        else:
+            lines.append("  Trajectories not saved.")
+        lines.append(">")
         return "\n".join(lines)
 
     def __add__(self, other):


### PR DESCRIPTION
**Description**
Update the guides for solver options, results and time-dependent system.
In `dynamics-data`, I added example of the `e_data` property and explained the difference between results for one and multiple trajectories.

`dynamics-time` as been mostly rewritten to explain how to use `QobjEvo`. It explain most features needed to use them in solvers, but it's quite dry.