### PR TITLE
Momentum and position default isherm values.

### DIFF
--- a/doc/changes/2032.bugfix
+++ b/doc/changes/2032.bugfix
@@ -1,0 +1,1 @@
+Added default _isherm value (True) for momentum and position operators.

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -624,7 +624,7 @@ def momentum(N, offset=0, *, dtype=_data.CSR):
     """
     a = destroy(N, offset=offset, dtype=dtype)
     momentum = -1j * np.sqrt(0.5) * (a - a.dag())
-    momentum._isherm = True
+    momentum.isherm = True
     return momentum
 
 

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -595,7 +595,9 @@ def position(N, offset=0, *, dtype=_data.CSR):
         Position operator as Qobj.
     """
     a = destroy(N, offset=offset, dtype=dtype)
-    return np.sqrt(0.5) * (a + a.dag())
+    position = np.sqrt(0.5) * (a + a.dag())
+    position._isherm = True
+    return position
 
 
 def momentum(N, offset=0, *, dtype=_data.CSR):
@@ -621,7 +623,9 @@ def momentum(N, offset=0, *, dtype=_data.CSR):
         Momentum operator as Qobj.
     """
     a = destroy(N, offset=offset, dtype=dtype)
-    return -1j * np.sqrt(0.5) * (a - a.dag())
+    momentum = -1j * np.sqrt(0.5) * (a - a.dag())
+    momentum._isherm = True
+    return momentum
 
 
 def num(N, offset=0, *, dtype=_data.CSR):

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -596,7 +596,7 @@ def position(N, offset=0, *, dtype=_data.CSR):
     """
     a = destroy(N, offset=offset, dtype=dtype)
     position = np.sqrt(0.5) * (a + a.dag())
-    position._isherm = True
+    position.isherm = True
     return position
 
 

--- a/qutip/tests/core/test_operators.py
+++ b/qutip/tests/core/test_operators.py
@@ -146,6 +146,7 @@ def test_position():
     expected = (np.diag((np.arange(1, N) / 2)**0.5, k=-1) +
                 np.diag((np.arange(1, N) / 2)**0.5, k=1))
     np.testing.assert_allclose(operator.full(), expected)
+    assert operator._isherm == True
 
 
 def test_momentum():
@@ -153,6 +154,7 @@ def test_momentum():
     expected = (np.diag((np.arange(1, N) / 2)**0.5, k=-1) -
                 np.diag((np.arange(1, N) / 2)**0.5, k=1)) * 1j
     np.testing.assert_allclose(operator.full(), expected)
+    assert operator._isherm == True
 
 
 def test_squeeze():


### PR DESCRIPTION
**Description**
The momentum and position did not have the _isherm attribute set to True. Setting it by default to True means hamiltonians created with those operators only will also have the attribute set to True and, for example, eigenvalues computed will, by default, return a real value (and I think be computed faster but I am not completely sure if we take this into account in our algorithms).