### PR TITLE
Add a default max_step to processors using the smallest gate time

### DIFF
--- a/doc/changes/2040.bugfix
+++ b/doc/changes/2040.bugfix
@@ -1,0 +1,1 @@
+Add a default max_step to processors

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -742,7 +742,7 @@ class Processor(object):
         # set the max step size as 1/2 of the smallest gate time.
         options = kwargs.get("options", Options())
         if options.max_step == 0.:
-            options.max_step = np.min(np.diff(self.get_full_tlist())) / 22
+            options.max_step = np.min(np.diff(self.get_full_tlist())) / 2
         kwargs["options"] = options
         # choose solver:
         if solver == "mesolve":

--- a/qutip/qip/device/processor.py
+++ b/qutip/qip/device/processor.py
@@ -12,6 +12,7 @@ from qutip.qip.operations.gates import expand_operator, globalphase
 from qutip.tensor import tensor
 from qutip.mesolve import mesolve
 from qutip.mcsolve import mcsolve
+from qutip import Options
 from qutip.qip.circuit import QubitCircuit
 from qutip.qip.noise import (
     Noise, RelaxationNoise, DecoherenceNoise,
@@ -738,6 +739,11 @@ class Processor(object):
         else:
             kwargs["c_ops"] = sys_c_ops
 
+        # set the max step size as 1/2 of the smallest gate time.
+        options = kwargs.get("options", Options())
+        if options.max_step == 0.:
+            options.max_step = np.min(np.diff(self.get_full_tlist())) / 22
+        kwargs["options"] = options
         # choose solver:
         if solver == "mesolve":
             evo_result = mesolve(

--- a/qutip/tests/test_device.py
+++ b/qutip/tests/test_device.py
@@ -91,7 +91,7 @@ def test_numerical_evolution(
         init_state = qutip.tensor(extra, state)
     else:
         init_state = state
-    options = qutip.Options(store_final_state=True, nsteps=50_000)
+    options = qutip.Options(store_final_state=True, nsteps=100_000)
     result = device.run_state(init_state=init_state,
                               analytical=False,
                               options=options)
@@ -138,7 +138,7 @@ def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
         init_state = qutip.tensor(extra, state)
     else:
         init_state = state
-    options = qutip.Options(store_final_state=True, nsteps=50_000)
+    options = qutip.Options(store_final_state=True, nsteps=100_000)
     result = device.run_state(init_state=init_state,
                               analytical=False,
                               options=options)


### PR DESCRIPTION
**Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.

- [x] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](http://qutip.org/docs/latest/development/contributing.html#Changelog%20Generation) for more information).

**Description**
Add a default max_step to processors using the smallest gate time.

**Related issues or PRs**
fix #2003