### PR TITLE
Documentation for v5 mcsolve

### DIFF
--- a/doc/apidoc/classes.rst
+++ b/doc/apidoc/classes.rst
@@ -42,10 +42,10 @@ Distributions
 Solver
 ------
 
-.. autoclass:: qutip.solver.sesolve.SeSolver
+.. autoclass:: qutip.solver.sesolve.SESolver
     :members:
 
-.. autoclass:: qutip.solver.mesolve.MeSolver
+.. autoclass:: qutip.solver.mesolve.MESolver
     :members:
 
 .. autoclass:: qutip.solver.brmesolve.BRSolver

--- a/doc/apidoc/functions.rst
+++ b/doc/apidoc/functions.rst
@@ -141,12 +141,8 @@ Master Equation
 Monte Carlo Evolution
 ---------------------
 
-.. automodule:: qutip.solve.mcsolve
+.. automodule:: qutip.solver.mcsolve
     :members: mcsolve
-
-.. ignore f90 stuff for now
-    .. automodule:: qutip.fortran.mcsolve_f90
-        :members: mcsolve_f90
 
 
 Krylov Subspace Solver

--- a/doc/guide/dynamics/dynamics-master.rst
+++ b/doc/guide/dynamics/dynamics-master.rst
@@ -33,17 +33,17 @@ For example, the time evolution of a quantum spin-1/2 system with tunneling rate
     >>> H = 2*np.pi * 0.1 * sigmax()
     >>> psi0 = basis(2, 0)
     >>> times = np.linspace(0.0, 10.0, 20)
-    >>> result = sesolve(H, psi0, times, [sigmaz()])
+    >>> result = sesolve(H, psi0, times, e_ops=[sigmaz()])
 
 
 The brackets in the fourth argument is an empty list of collapse operators, since we consider unitary evolution in this example. See the next section for examples on how dissipation is included by defining a list of collapse operators.
 
-The function returns an instance of :class:`qutip.solve.solver.Result`, as described in the previous section :ref:`solver_result`. The attribute ``expect`` in ``result`` is a list of expectation values for the operators that are included in the list in the fifth argument. Adding operators to this list results in a larger output list returned by the function (one array of numbers, corresponding to the times in times, for each operator)
+The function returns an instance of :class:`qutip.Result`, as described in the previous section :ref:`solver_result`. The attribute ``expect`` in ``result`` is a list of expectation values for the operators that are included in the list in the fifth argument. Adding operators to this list results in a larger output list returned by the function (one array of numbers, corresponding to the times in times, for each operator)
 
 .. plot::
     :context:
 
-    >>> result = sesolve(H, psi0, times, [sigmaz(), sigmay()])
+    >>> result = sesolve(H, psi0, times, e_ops=[sigmaz(), sigmay()])
     >>> result.expect # doctest: +NORMALIZE_WHITESPACE
     [array([ 1.        ,  0.78914057,  0.24548559, -0.40169513, -0.8794735 ,
         -0.98636142, -0.67728219, -0.08258023,  0.54694721,  0.94581685,
@@ -169,7 +169,7 @@ the previously empty list in the fourth parameter to the :func:`qutip.mesolve` f
     :context:
 
     >>> times = np.linspace(0.0, 10.0, 100)
-    >>> result = mesolve(H, psi0, times, [np.sqrt(0.05) * sigmax()], [sigmaz(), sigmay()])
+    >>> result = mesolve(H, psi0, times, [np.sqrt(0.05) * sigmax()], e_ops=[sigmaz(), sigmay()])
     >>> fig, ax = plt.subplots()
     >>> ax.plot(times, result.expect[0]) # doctest: +SKIP
     >>> ax.plot(times, result.expect[1]) # doctest: +SKIP
@@ -192,7 +192,7 @@ Now a slightly more complex example: Consider a two-level atom coupled to a leak
     >>> a  = tensor(qeye(2), destroy(10))
     >>> sm = tensor(destroy(2), qeye(10))
     >>> H = 2 * np.pi * a.dag() * a + 2 * np.pi * sm.dag() * sm + 2 * np.pi * 0.25 * (sm * a.dag() + sm.dag() * a)
-    >>> result = mesolve(H, psi0, times, [np.sqrt(0.1)*a], [a.dag()*a, sm.dag()*sm])
+    >>> result = mesolve(H, psi0, times, [np.sqrt(0.1)*a], e_ops=[a.dag()*a, sm.dag()*sm])
     >>> plt.figure() # doctest: +SKIP
     >>> plt.plot(times, result.expect[0]) # doctest: +SKIP
     >>> plt.plot(times, result.expect[1]) # doctest: +SKIP

--- a/doc/guide/dynamics/dynamics-monte.rst
+++ b/doc/guide/dynamics/dynamics-monte.rst
@@ -4,10 +4,6 @@
 Monte Carlo Solver
 *******************************************
 
-.. plot::
-      :include-source: False
-
-      from qutip.solver.mcsolve import *
 
 .. _monte-intro:
 
@@ -75,6 +71,8 @@ To illustrate the use of the Monte Carlo evolution of quantum systems in QuTiP, 
 .. plot::
     :context:
 
+    from qutip.solver.mcsolve import MCSolver, mcsolve
+
     times = np.linspace(0.0, 10.0, 200)
     psi0 = tensor(fock(2, 0), fock(10, 5))
     a  = tensor(qeye(2), destroy(10))
@@ -110,7 +108,7 @@ If we want to run 1000 trajectories in the above example, we can simply modify t
 .. plot::
     :context: close-figs
 
-    data = mcsolve(H, psi0, times, [np.sqrt(0.1) * a], [a.dag() * a, sm.dag() * sm], ntraj=1000)
+    data = mcsolve(H, psi0, times, [np.sqrt(0.1) * a], e_ops=[a.dag() * a, sm.dag() * sm], ntraj=1000)
 
 where we have added the keyword argument ``ntraj=1000`` at the end of the inputs.
 Now, the Monte Carlo solver will calculate expectation values for both operators, ``a.dag() * a, sm.dag() * sm`` averaging over 1000 trajectories.
@@ -132,17 +130,22 @@ we can extract the relevant expectation values using:
     expt100 = data.expect_traj_avg(100)
     expt1000 = data.expect_traj_avg(1000)
 
-		plt.figure()
-    plt.plot(times, expt1, label="ntraj=1")
-		plt.plot(times, expt10, label="ntraj=10")
-		plt.plot(times, expt100, label="ntraj=100")
-		plt.plot(times, expt1000, label="ntraj=1000")
+    plt.figure()
+    plt.plot(times, expt1[0], label="ntraj=1")
+    plt.plot(times, expt10[0], label="ntraj=10")
+    plt.plot(times, expt100[0], label="ntraj=100")
+    plt.plot(times, expt1000[0], label="ntraj=1000")
     plt.title('Monte Carlo time evolution')
     plt.xlabel('Time')
     plt.ylabel('Expectation values')
     plt.legend()
     plt.show()
 
+
+Monte Carlo Solver Result
+-------------------------
+
+...
 
 .. _monte-reuse:
 
@@ -196,7 +199,7 @@ In addition to the initial state, one may reuse the Hamiltonian data when adding
     sm = tensor(destroy(2), qeye(10))
 
     H = 2*np.pi*a.dag()*a + 2*np.pi*sm.dag()*sm + 2*np.pi*0.25*(sm*a.dag() + sm.dag()*a)
-    solver = MCSolver(H, c_ops=[np.sqrt(0.1) * a])
+    # solver = MCSolver(H, c_ops=[np.sqrt(0.1) * a])
     data1 = solver.run(psi0, times, e_ops=[a.dag() * a, sm.dag() * sm], ntraj=10)
     data2 = solver.run(psi0, times, e_ops=[a.dag() * a, sm.dag() * sm], ntraj=10)
     data_merged = data1 + data2

--- a/doc/guide/dynamics/dynamics-monte.rst
+++ b/doc/guide/dynamics/dynamics-monte.rst
@@ -4,6 +4,11 @@
 Monte Carlo Solver
 *******************************************
 
+.. plot::
+      :include-source: False
+
+      from qutip.solver.mcsolve import *
+
 .. _monte-intro:
 
 Introduction
@@ -75,7 +80,7 @@ To illustrate the use of the Monte Carlo evolution of quantum systems in QuTiP, 
     a  = tensor(qeye(2), destroy(10))
     sm = tensor(destroy(2), qeye(10))
     H = 2*np.pi*a.dag()*a + 2*np.pi*sm.dag()*sm + 2*np.pi*0.25*(sm*a.dag() + sm.dag()*a)
-    data = mcsolve(H, psi0, times, [np.sqrt(0.1) * a], [a.dag() * a, sm.dag() * sm])
+    data = mcsolve(H, psi0, times, [np.sqrt(0.1) * a], e_ops=[a.dag() * a, sm.dag() * sm])
 
     plt.figure()
     plt.plot(times, data.expect[0], times, data.expect[1])
@@ -89,7 +94,7 @@ To illustrate the use of the Monte Carlo evolution of quantum systems in QuTiP, 
 
 The advantage of the Monte Carlo method over the master equation approach is that only the state vector is required to be kept in the computers memory, as opposed to the entire density matrix. For large quantum system this becomes a significant advantage, and the Monte Carlo solver is therefore generally recommended for such systems. For example, simulating a Heisenberg spin-chain consisting of 10 spins with random parameters and initial states takes almost 7 times longer using the master equation rather than Monte Carlo approach with the default number of trajectories running on a quad-CPU machine.  Furthermore, it takes about 7 times the memory as well. However, for small systems, the added overhead of averaging a large number of stochastic trajectories to obtain the open system dynamics, as well as starting the multiprocessing functionality, outweighs the benefit of the minor (in this case) memory saving. Master equation methods are therefore generally more efficient when Hilbert space sizes are on the order of a couple of hundred states or smaller.
 
-Like the master equation solver :func:`qutip.mesolve`, the Monte Carlo solver returns a :class:`qutip.solve.solver.Result` object consisting of expectation values, if the user has defined expectation value operators in the 5th argument to ``mcsolve``, or state vectors if no expectation value operators are given.  If state vectors are returned, then the :class:`qutip.solve.solver.Result` returned by :func:`qutip.mcsolve` will be an array of length ``ntraj``, with each element containing an array of ket-type qobjs with the same number of elements as ``times``.  Furthermore, the output :class:`qutip.solve.solver.Result` object will also contain a list of times at which collapse occurred, and which collapse operators did the collapse, in the ``col_times`` and ``col_which`` properties, respectively.
+Like the master equation solver :func:`qutip.mesolve`, the Monte Carlo solver returns a :class:`qutip.Result` object consisting of expectation values, if the user has defined expectation value operators in the 5th argument to ``mcsolve``, or state vectors if no expectation value operators are given.  If state vectors are returned, then the :class:`qutip.Result` returned by :func:`qutip.mcsolve` will be an array of length ``ntraj``, with each element containing an array of ket-type qobjs with the same number of elements as ``times``.  Furthermore, the output :class:`qutip.Result` object will also contain a list of times at which collapse occurred, and which collapse operators did the collapse, in the ``col_times`` and ``col_which`` properties, respectively.
 
 
 .. _monte-ntraj:
@@ -97,36 +102,46 @@ Like the master equation solver :func:`qutip.mesolve`, the Monte Carlo solver re
 Changing the Number of Trajectories
 -----------------------------------
 
-As mentioned earlier, by default, the ``mcsolve`` function runs 500 trajectories.  This value was chosen because it gives good accuracy, Monte Carlo errors scale as :math:`1/n` where :math:`n` is the number of trajectories, and simultaneously does not take an excessive amount of time to run.  However, like many other options in QuTiP you are free to change the number of trajectories to fit your needs.  If we want to run 1000 trajectories in the above example, we can simply modify the call to ``mcsolve`` like:
+As mentioned earlier, by default, the ``mcsolve`` function runs 500 trajectories.
+This value was chosen because it gives good accuracy, Monte Carlo errors scale as :math:`1/n` where :math:`n` is the number of trajectories, and simultaneously does not take an excessive amount of time to run.
+However, like many other options in QuTiP you are free to change the number of trajectories to fit your needs.
+If we want to run 1000 trajectories in the above example, we can simply modify the call to ``mcsolve`` like:
 
 .. plot::
     :context: close-figs
 
     data = mcsolve(H, psi0, times, [np.sqrt(0.1) * a], [a.dag() * a, sm.dag() * sm], ntraj=1000)
 
-where we have added the keyword argument ``ntraj=1000`` at the end of the inputs.  Now, the Monte Carlo solver will calculate expectation values for both operators, ``a.dag() * a, sm.dag() * sm`` averaging over 1000 trajectories.  Sometimes one is also interested in seeing how the Monte Carlo trajectories converge to the master equation solution by calculating expectation values over a range of trajectory numbers.  If, for example, we want to average over 1, 10, 100, and 1000 trajectories, then we can input this into the solver using:
+where we have added the keyword argument ``ntraj=1000`` at the end of the inputs.
+Now, the Monte Carlo solver will calculate expectation values for both operators, ``a.dag() * a, sm.dag() * sm`` averaging over 1000 trajectories.
+Sometimes one is also interested in seeing how the Monte Carlo trajectories converge to the master equation solution by calculating expectation values over a range of trajectory numbers.
+If, for example, we want to average over 1, 10, 100, and 1000 trajectories, we must first run the solver keeping expectation values for each trajectories:
 
 .. plot::
     :context:
 
-    ntraj = [1, 10, 100, 1000]
-
-Keep in mind that the input list must be in ascending order since the total number of trajectories run by ``mcsolve`` will be calculated using the last element of ``ntraj``.  In this case, we need to use an extra index when getting the expectation values from the :class:`qutip.solve.solver.Result` object returned by ``mcsolve``.  In the above example using:
-
-.. plot::
-    :context:
-
-    data = mcsolve(H, psi0, times, [np.sqrt(0.1) * a], [a.dag() * a, sm.dag() * sm], ntraj=[1, 10, 100, 1000])
+    data = mcsolve(H, psi0, times, [np.sqrt(0.1) * a], e_ops=[a.dag() * a, sm.dag() * sm], options={"keep_runs_results": True}, ntraj=1000)
 
 we can extract the relevant expectation values using:
 
 .. plot::
     :context:
 
-    expt1 = data.expect[0]
-    expt10 = data.expect[1]
-    expt100 = data.expect[2]
-    expt1000 = data.expect[3]
+    expt1 = data.expect_traj_avg(1)
+    expt10 = data.expect_traj_avg(10)
+    expt100 = data.expect_traj_avg(100)
+    expt1000 = data.expect_traj_avg(1000)
+
+		plt.figure()
+    plt.plot(times, expt1, label="ntraj=1")
+		plt.plot(times, expt10, label="ntraj=10")
+		plt.plot(times, expt100, label="ntraj=100")
+		plt.plot(times, expt1000, label="ntraj=1000")
+    plt.title('Monte Carlo time evolution')
+    plt.xlabel('Time')
+    plt.ylabel('Expectation values')
+    plt.legend()
+    plt.show()
 
 
 .. _monte-reuse:
@@ -136,12 +151,16 @@ Reusing Hamiltonian Data
 
 .. note:: This section covers a specialized topic and may be skipped if you are new to QuTiP.
 
-In order to solve a given simulation as fast as possible, the solvers in QuTiP take the given input operators and break them down into simpler components before passing them on to the ODE solvers.  Although these operations are reasonably fast, the time spent organizing data can become appreciable when repeatedly solving a system over, for example, many different initial conditions. In cases such as this, the Hamiltonian and other operators may be reused after the initial configuration, thus speeding up calculations.  Note that, unless you are planning to reuse the data many times, this functionality will not be very useful.
+
+In order to solve a given simulation as fast as possible, the solvers in QuTiP take the given input operators and break them down into simpler components before passing them on to the ODE solvers.
+Although these operations are reasonably fast, the time spent organizing data can become appreciable when repeatedly solving a system over, for example, many different initial conditions.
+In cases such as this, the Monte Carlo Solver may be reused after the initial configuration, thus speeding up calculations.
+
 
 Using the previous example, we will calculate the dynamics for two different initial states, with the Hamiltonian data being reused on the second call
 
 .. plot::
-    :context:
+    :context: close-figs
 
     times = np.linspace(0.0, 10.0, 200)
     psi0 = tensor(fock(2, 0), fock(10, 5))
@@ -149,10 +168,10 @@ Using the previous example, we will calculate the dynamics for two different ini
     sm = tensor(destroy(2), qeye(10))
 
     H = 2*np.pi*a.dag()*a + 2*np.pi*sm.dag()*sm + 2*np.pi*0.25*(sm*a.dag() + sm.dag()*a)
-    data1 = mcsolve(H, psi0, times, [np.sqrt(0.1) * a], [a.dag() * a, sm.dag() * sm])
+    solver = MCSolver(H, c_ops=[np.sqrt(0.1) * a])
+    data1 = solver.run(psi0, times, e_ops=[a.dag() * a, sm.dag() * sm], ntraj=1000)
     psi1 = tensor(fock(2, 0), coherent(10, 2 - 1j))
-    opts = SolverOptions() # Run a second time, reusing RHS
-    data2 = mcsolve(H, psi1, times, [np.sqrt(0.1) * a], [a.dag() * a, sm.dag() * sm], options=opts)
+    data2 = solver.run(psi1, times, e_ops=[a.dag() * a, sm.dag() * sm], ntraj=1000)
 
     plt.figure()
     plt.plot(times, data1.expect[0], times, data1.expect[1], lw=2)
@@ -165,4 +184,29 @@ Using the previous example, we will calculate the dynamics for two different ini
 
 .. guide-dynamics-mc2:
 
-In addition to the initial state, one may reuse the Hamiltonian data when changing the number of trajectories ``ntraj`` or simulation times ``times``.  The reusing of Hamiltonian data is also supported for time-dependent Hamiltonians.  See :ref:`time` for further details.
+In addition to the initial state, one may reuse the Hamiltonian data when adding more trajectories to the result or changing simulation times ``times``.
+
+
+.. plot::
+    :context: close-figs
+
+    times = np.linspace(0.0, 10.0, 200)
+    psi0 = tensor(fock(2, 0), fock(10, 5))
+    a  = tensor(qeye(2), destroy(10))
+    sm = tensor(destroy(2), qeye(10))
+
+    H = 2*np.pi*a.dag()*a + 2*np.pi*sm.dag()*sm + 2*np.pi*0.25*(sm*a.dag() + sm.dag()*a)
+    solver = MCSolver(H, c_ops=[np.sqrt(0.1) * a])
+    data1 = solver.run(psi0, times, e_ops=[a.dag() * a, sm.dag() * sm], ntraj=10)
+    data2 = solver.run(psi0, times, e_ops=[a.dag() * a, sm.dag() * sm], ntraj=10)
+    data_merged = data1 + data2
+
+    plt.figure()
+    plt.plot(times, data1.expect[0], times, data1.expect[1], lw=2)
+    plt.plot(times, data2.expect[0], '--', times, data2.expect[1], '--', lw=2)
+    plt.plot(times, data_merged.expect[0], ':', times, data_merged.expect[1], ':', lw=2)
+    plt.title('Monte Carlo time evolution')
+    plt.xlabel('Time', fontsize=14)
+    plt.ylabel('Expectation values', fontsize=14)
+    plt.legend(("cavity photon number", "atom excitation probability"))
+    plt.show()

--- a/doc/guide/dynamics/dynamics-options.rst
+++ b/doc/guide/dynamics/dynamics-options.rst
@@ -6,7 +6,7 @@ Setting Options for the Dynamics Solvers
 
 .. testsetup:: [dynamics_options]
 
-   from qutip.solver.mesolve import MeSolver, mesolve
+   from qutip.solver.mesolve import MESolver, mesolve
    import numpy as np
 
 Occasionally it is necessary to change the built in parameters of the dynamics solvers used by for example the :func:`qutip.mesolve` and :func:`qutip.mcsolve` functions.
@@ -21,13 +21,13 @@ Supported solver options and their default can be seen using the class interface
 
 .. testcode:: [dynamics_options]
 
-   help(MeSolver.options)
+   help(MESolver.options)
 
 Options supported by the ODE integration depend on the "method" options of the solver, they can be listed through the integrator method of the solvers:
 
 .. testcode:: [dynamics_options]
 
-   help(MeSolver.integrator("adams").options)
+   help(MESolver.integrator("adams").options)
 
 See `Integrator <../../apidoc/classes.html#classes-ode>`_ for a list of supported methods.
 
@@ -44,4 +44,4 @@ To use these new settings we can use the keyword argument ``options`` in either 
 
 or::
 
-    >>> McSolver(H0, c_op_list, options=options)
+    >>> MCSolver(H0, c_op_list, options=options)

--- a/qutip/solver/correlation.py
+++ b/qutip/solver/correlation.py
@@ -11,8 +11,8 @@ from ..core import (
     qeye, Qobj, QobjEvo, liouvillian, spre, unstack_columns, stack_columns,
     tensor, qzero, expect
 )
-from .mesolve import MeSolver
-from .mcsolve import McSolver
+from .mesolve import MESolver
+from .mcsolve import MCSolver
 from .brmesolve import BRSolver
 from .heom.bofin_solvers import HEOMSolver
 
@@ -419,10 +419,10 @@ def _make_solver(H, c_ops, args, options, solver):
     H = QobjEvo(H, args=args)
     c_ops = [QobjEvo(c_op, args=args) for c_op in c_ops]
     if solver == "me":
-        solver_instance = MeSolver(H, c_ops, options=options)
+        solver_instance = MESolver(H, c_ops, options=options)
     elif solver == "es":
         options = {"method": "diag"}
-        solver_instance = MeSolver(H, c_ops, options=options)
+        solver_instance = MESolver(H, c_ops, options=options)
     elif solver == "mc":
         raise ValueError("MC solver for correlation has been removed")
     return solver_instance
@@ -441,7 +441,7 @@ def correlation_3op(solver, state0, tlist, taulist, A=None, B=None, C=None):
 
     Parameters
     ----------
-    solver : :class:`MeSolver`, :class:`BRSolver`
+    solver : :class:`MESolver`, :class:`BRSolver`
         Qutip solver for an open system.
     state0 : :class:`Qobj`
         Initial state density matrix :math:`\rho(t_0)` or state vector
@@ -472,9 +472,9 @@ def correlation_3op(solver, state0, tlist, taulist, A=None, B=None, C=None):
     B = QobjEvo(qeye(dims) if B in [None, 1] else B)
     C = QobjEvo(qeye(dims) if C in [None, 1] else C)
 
-    if isinstance(solver, (MeSolver, BRSolver)):
+    if isinstance(solver, (MESolver, BRSolver)):
         out = _correlation_3op_dm(solver, state0, tlist, taulist, A, B, C)
-    elif isinstance(solver, McSolver):
+    elif isinstance(solver, MCSolver):
         raise TypeError("Monte Carlo support for correlation was removed. "
                         "Please, tell us on GitHub issues if you need it!")
     elif isinstance(solver, HEOMSolver):

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -103,6 +103,7 @@ def mcsolve(H, state, tlist, c_ops=(), e_ops=None, ntraj=500, *,
         Seed for the random number generator. It can be a single seed used to
         spawn seeds for each trajectory or a list of seeds, one for each
         trajectory. Seeds are saved in the result and they can be reused with::
+
             seeds=prev_result.seeds
 
     target_tol : {float, tuple, list}, optional

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -1,4 +1,4 @@
-__all__ = ['mcsolve', "McSolver"]
+__all__ = ['mcsolve', "MCSolver"]
 
 import warnings
 
@@ -8,7 +8,7 @@ from ..core import QobjEvo, spre, spost, Qobj, unstack_columns, liouvillian
 from .multitraj import MultiTrajSolver
 from .solver_base import Solver
 from .result import McResult, Result
-from .mesolve import mesolve, MeSolver
+from .mesolve import mesolve, MESolver
 import qutip.core.data as _data
 from time import time
 
@@ -138,7 +138,7 @@ def mcsolve(H, state, tlist, c_ops=(), e_ops=None, ntraj=500, *,
         options = {
             key: options[key]
             for key in options
-            if key in MeSolver.solver_options
+            if key in MESolver.solver_options
         }
         return mesolve(H, state, tlist, e_ops=e_ops, args=args,
                        options=options)
@@ -149,7 +149,7 @@ def mcsolve(H, state, tlist, c_ops=(), e_ops=None, ntraj=500, *,
             "with the options `keep_runs_results=True`."
         )
 
-    mc = McSolver(H, c_ops, options=options)
+    mc = MCSolver(H, c_ops, options=options)
     result = mc.run(state, tlist=tlist, ntraj=ntraj, e_ops=e_ops,
                     seed=seeds, target_tol=target_tol, timeout=timeout)
     return result
@@ -317,7 +317,7 @@ class MCIntegrator:
 # -----------------------------------------------------------------------------
 # MONTE CARLO CLASS
 # -----------------------------------------------------------------------------
-class McSolver(MultiTrajSolver):
+class MCSolver(MultiTrajSolver):
     r"""
     Monte Carlo Solver of a state vector :math:`|\psi \rangle` for a
     given Hamiltonian and sets of collapse operators. Options for the

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -3,7 +3,7 @@ This module provides solvers for the Lindblad master equation and von Neumann
 equation.
 """
 
-__all__ = ['mesolve', 'MeSolver']
+__all__ = ['mesolve', 'MESolver']
 
 import numpy as np
 from time import time
@@ -11,7 +11,7 @@ from .. import (Qobj, QobjEvo, isket, liouvillian, ket2dm, lindblad_dissipator)
 from ..core import stack_columns, unstack_columns
 from ..core.data import to
 from .solver_base import Solver
-from .sesolve import sesolve, SeSolver
+from .sesolve import sesolve, SESolver
 
 
 def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None):
@@ -138,12 +138,12 @@ def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None):
         return sesolve(H, rho0, tlist, e_ops=e_ops, args=args,
                        options=options)
 
-    solver = MeSolver(H, c_ops, options=options)
+    solver = MESolver(H, c_ops, options=options)
 
     return solver.run(rho0, tlist, e_ops=e_ops)
 
 
-class MeSolver(SeSolver):
+class MESolver(SESolver):
     """
     Master equation evolution of a density matrix for a given Hamiltonian and
     set of collapse operators, or a Liouvillian.
@@ -170,7 +170,7 @@ class MeSolver(SeSolver):
         of Liouvillian superoperators. None is equivalent to an empty list.
 
     options : dict, optional
-        Options for the solver, see :obj:`SeSolver.options` and
+        Options for the solver, see :obj:`SESolver.options` and
         `Integrator <./classes.html#classes-ode>`_ for a list of all options.
 
     attributes

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -5,9 +5,8 @@ import numpy as np
 
 from .. import Qobj, qeye, unstack_columns, QobjEvo
 from ..core import data as _data
-from .mesolve import mesolve, MeSolver
-from .sesolve import sesolve, SeSolver
-from .mcsolve import McSolver
+from .mesolve import mesolve, MESolver
+from .sesolve import sesolve, SESolver
 from .heom.bofin_solvers import HEOMSolver
 from .solver_base import Solver
 from .multitraj import MultiTrajSolver
@@ -116,12 +115,12 @@ class Propagator:
     ----------
     system : :class:`Qobj`, :class:`QobjEvo`, :class:`Solver`
         Possibly time-dependent system driving the evolution, either already
-        packaged in a solver, such as :class:`SeSolver` or :class:`BrSolver`,
+        packaged in a solver, such as :class:`SESolver` or :class:`BRSolver`,
         or the Liouvillian or Hamiltonian as a :class:`Qobj`, :class:`QobjEvo`.
         ``list`` of [:class:`Qobj`, :class:`Coefficient`] or callable that can
         be made into :class:`QobjEvo` are also accepted.
 
-        Solvers that run non-deterministacilly, such as :class:`McSolver`, are
+        Solvers that run non-deterministacilly, such as :class:`MCSolver`, are
         not supported.
 
     c_ops : list, optional
@@ -163,9 +162,9 @@ class Propagator:
             Hevo = QobjEvo(system, args=args)
             c_ops = [QobjEvo(op, args=args) for op in c_ops]
             if Hevo.issuper or c_ops:
-                self.solver = MeSolver(Hevo, c_ops=c_ops, options=options)
+                self.solver = MESolver(Hevo, c_ops=c_ops, options=options)
             else:
-                self.solver = SeSolver(Hevo, options=options)
+                self.solver = SESolver(Hevo, options=options)
 
         self.times = [0]
         self.invs = [None]

--- a/qutip/solver/sesolve.py
+++ b/qutip/solver/sesolve.py
@@ -2,7 +2,7 @@
 This module provides solvers for the unitary Schrodinger equation.
 """
 
-__all__ = ['sesolve', 'SeSolver']
+__all__ = ['sesolve', 'SESolver']
 
 import numpy as np
 from time import time
@@ -99,11 +99,11 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None):
         is an empty list of `store_states=True` in options].
     """
     H = QobjEvo(H, args=args, tlist=tlist)
-    solver = SeSolver(H, options=options)
+    solver = SESolver(H, options=options)
     return solver.run(psi0, tlist, e_ops=e_ops)
 
 
-class SeSolver(Solver):
+class SESolver(Solver):
     """
     Schrodinger equation evolution of a state vector or unitary matrix
     for a given Hamiltonian.
@@ -116,7 +116,7 @@ class SeSolver(Solver):
         that can be made into :class:`QobjEvo` are also accepted.
 
     options : dict, optional
-        Options for the solver, see :obj:`SeSolver.options` and
+        Options for the solver, see :obj:`SESolver.options` and
         `Integrator <./classes.html#classes-ode>`_ for a list of all options.
 
     attributes

--- a/qutip/tests/solver/test_correlation.py
+++ b/qutip/tests/solver/test_correlation.py
@@ -286,7 +286,7 @@ def test_correlation_timedependant_op():
 
 
 def test_alternative_solver():
-    from qutip.solver.mesolve import MeSolver
+    from qutip.solver.mesolve import MESolver
     from qutip.solver.brmesolve import BRSolver
 
     H = qutip.num(5)
@@ -294,7 +294,7 @@ def test_alternative_solver():
     a_ops = [(a+a.dag(), qutip.coefficient(lambda _, w: w>0, args={"w":0}))]
 
     br = BRSolver(H, a_ops)
-    me = MeSolver(H, [a])
+    me = MESolver(H, [a])
     times = np.arange(4)
 
     br_corr = qutip.correlation_3op(br, qutip.basis(5), [0], times, a, a.dag())

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -1,5 +1,6 @@
-from qutip.solver.sesolve import SeSolver
-from qutip.solver.mesolve import MeSolver
+from qutip.solver.sesolve import SESolver
+from qutip.solver.mesolve import MESolver
+from qutip.solver.mcsolve import MCSolver
 from qutip.solver.solver_base import Solver
 from qutip.solver.ode.scipy_integrator import *
 import qutip
@@ -15,21 +16,21 @@ class TestIntegratorCte():
     me_system = qutip.liouvillian(qutip.QobjEvo(qutip.qeye(2)),
                                   c_ops=[qutip.destroy(2)])
 
-    @pytest.fixture(params=list(SeSolver.avail_integrators().keys()))
+    @pytest.fixture(params=list(SESolver.avail_integrators().keys()))
     def se_method(self, request):
         return request.param
 
-    @pytest.fixture(params=list(MeSolver.avail_integrators().keys()))
+    @pytest.fixture(params=list(MESolver.avail_integrators().keys()))
     def me_method(self, request):
         return request.param
 
-    # TODO: Change when the McSolver is added
-    @pytest.fixture(params=list(Solver.avail_integrators().keys()))
+    # TODO: Change when the MCSolver is added
+    @pytest.fixture(params=list(MCSolver.avail_integrators().keys()))
     def mc_method(self, request):
         return request.param
 
     def test_se_integration(self, se_method):
-        evol = SeSolver.avail_integrators()[se_method](self.se_system, {})
+        evol = SESolver.avail_integrators()[se_method](self.se_system, {})
         state0 = qutip.core.unstack_columns(qutip.basis(6,0).data, (2, 3))
         evol.set_state(0, state0)
         for t, state in evol.run(np.linspace(0, 2, 21)):
@@ -38,7 +39,7 @@ class TestIntegratorCte():
             assert state.shape == (2, 3)
 
     def test_me_integration(self, me_method):
-        evol = MeSolver.avail_integrators()[me_method](self.me_system, {})
+        evol = MESolver.avail_integrators()[me_method](self.me_system, {})
         state0 = qutip.operator_to_vector(qutip.fock_dm(2,1)).data
         evol.set_state(0, state0)
         for t in np.linspace(0, 2, 21):
@@ -48,7 +49,7 @@ class TestIntegratorCte():
                             state.to_array()[0, 0], atol=2e-5)
 
     def test_mc_integration(self, mc_method):
-        evol = Solver.avail_integrators()[mc_method](self.se_system, {})
+        evol = MCSolver.avail_integrators()[mc_method](self.se_system, {})
         state = qutip.basis(2,0).data
         evol.set_state(0, state)
         t = 0
@@ -99,21 +100,21 @@ class TestIntegrator(TestIntegratorCte):
     )
 
     @pytest.fixture(
-        params=[key for key, integrator in SeSolver.avail_integrators().items()
+        params=[key for key, integrator in SESolver.avail_integrators().items()
                 if integrator.support_time_dependant]
     )
     def se_method(self, request):
         return request.param
 
     @pytest.fixture(
-        params=[key for key, integrator in MeSolver.avail_integrators().items()
+        params=[key for key, integrator in MESolver.avail_integrators().items()
                 if integrator.support_time_dependant]
     )
     def me_method(self, request):
         return request.param
 
     @pytest.fixture(
-        params=[key for key, integrator in Solver.avail_integrators().items()
+        params=[key for key, integrator in MCSolver.avail_integrators().items()
                 if integrator.support_time_dependant]
     )
     def mc_method(self, request):

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 import qutip
 from copy import copy
-from qutip.solver.mcsolve import mcsolve, McSolver
+from qutip.solver.mcsolve import mcsolve, MCSolver
 from qutip.solver.solver_base import Solver
 
 def _return_constant(t, args):
@@ -341,7 +341,7 @@ class TestSeeds:
         size = 10
         a = qutip.QobjEvo([qutip.destroy(size), 'alpha'], args={'alpha': 0})
         H = qutip.num(size)
-        mcsolver = McSolver(H, a, options={'map': 'serial'})
+        mcsolver = MCSolver(H, a, options={'map': 'serial'})
         mcsolver.start(qutip.basis(size, size-1), 0, seed=5)
         state_1 = mcsolver.step(1, args={'alpha':1})
 
@@ -389,7 +389,7 @@ def test_McSolver_run():
     size = 10
     a = qutip.QobjEvo([qutip.destroy(size), 'coupling'], args={'coupling':0})
     H = qutip.num(size)
-    solver = McSolver(H, a)
+    solver = MCSolver(H, a)
     solver.options = {'store_final_state': True}
     res = solver.run(qutip.basis(size, size-1), np.linspace(0, 5.0, 11),
                      e_ops=[qutip.qeye(size)], args={'coupling': 1})
@@ -409,7 +409,7 @@ def test_McSolver_stepping():
     size = 10
     a = qutip.QobjEvo([qutip.destroy(size), 'coupling'], args={'coupling':0})
     H = qutip.num(size)
-    solver = McSolver(H, a)
+    solver = MCSolver(H, a)
     solver.start(qutip.basis(size, size-1), 0, seed=0)
     solver.options = {'method': 'lsoda'}
     state = solver.step(1)

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -2,13 +2,13 @@ import numpy as np
 from types import FunctionType
 
 import qutip
-from qutip.solver.mesolve import mesolve, MeSolver
+from qutip.solver.mesolve import mesolve, MESolver
 from qutip.solver.solver_base import Solver
 import pickle
 import pytest
 
 all_ode_method = [
-    method for method, integrator in MeSolver.avail_integrators().items()
+    method for method, integrator in MESolver.avail_integrators().items()
     if integrator.support_time_dependant
 ]
 
@@ -222,7 +222,7 @@ class TestMESolveDecay:
 
     def test_mesolver_pickling(self):
         options = {"progress_bar": None}
-        solver_obj = MeSolver(self.ada, c_ops=[self.a], options=options)
+        solver_obj = MESolver(self.ada, c_ops=[self.a], options=options)
         solver_copy = pickle.loads(pickle.dumps(solver_obj))
         e1 = solver_obj.run(qutip.basis(self.N, 9), [0, 1, 2, 3],
                             e_ops=[self.ada]).expect[0]
@@ -234,7 +234,7 @@ class TestMESolveDecay:
                              all_ode_method, ids=all_ode_method)
     def test_mesolver_stepping(self, method):
         options = {"method": method, "progress_bar": None}
-        solver_obj = MeSolver(
+        solver_obj = MESolver(
             self.ada,
             c_ops=qutip.QobjEvo(
                 [self.a, lambda t, kappa: np.sqrt(kappa * np.exp(-t))],
@@ -661,17 +661,17 @@ def test_num_collapse_set():
 
 def test_mesolve_bad_H():
     with pytest.raises(TypeError):
-        MeSolver([qutip.qeye(3), 't'], [])
+        MESolver([qutip.qeye(3), 't'], [])
     with pytest.raises(TypeError):
-        MeSolver(qutip.qeye(3), [[qutip.qeye(3), 't']])
+        MESolver(qutip.qeye(3), [[qutip.qeye(3), 't']])
 
 
 def test_mesolve_bad_state():
-    solver = MeSolver(qutip.qeye(4), [])
+    solver = MESolver(qutip.qeye(4), [])
     with pytest.raises(TypeError):
         solver.start(qutip.basis(2,1) & qutip.basis(2,0), 0)
 
 
 def test_mesolve_bad_options():
     with pytest.raises(TypeError):
-        MeSolver(qutip.qeye(4), [], options=False)
+        MESolver(qutip.qeye(4), [], options=False)

--- a/qutip/tests/solver/test_options.py
+++ b/qutip/tests/solver/test_options.py
@@ -89,7 +89,7 @@ def test_print():
 
 def test_in_solver():
     opt = {"method": "adams", "store_states": True, "atol": 1}
-    solver = qutip.solver.sesolve.SeSolver(qutip.qeye(1), options=opt)
+    solver = qutip.solver.sesolve.SESolver(qutip.qeye(1), options=opt)
     adams = qutip.solver.ode.scipy_integrator.IntegratorScipyAdams
     lsoda = qutip.solver.ode.scipy_integrator.IntegratorScipylsoda
     bdf = qutip.solver.ode.scipy_integrator.IntegratorScipyBDF
@@ -119,7 +119,7 @@ def test_in_solver():
 
 def test_options_update_solver():
     opt = {"method": "adams", "normalize_output": False}
-    solver = qutip.solver.sesolve.SeSolver(1j * qutip.qeye(1), options=opt)
+    solver = qutip.solver.sesolve.SESolver(1j * qutip.qeye(1), options=opt)
 
     solver.start(qutip.basis(1), 0)
     err_atol_def = (solver.step(1) - np.exp(1)).norm()

--- a/qutip/tests/solver/test_propagator.py
+++ b/qutip/tests/solver/test_propagator.py
@@ -4,9 +4,9 @@ from qutip import (destroy, propagator, Propagator, propagator_steadystate,
 import qutip
 import pytest
 from qutip.solver.brmesolve import BRSolver
-from qutip.solver.mesolve import MeSolver
-from qutip.solver.sesolve import SeSolver
-from qutip.solver.mcsolve import McSolver
+from qutip.solver.mesolve import MESolver
+from qutip.solver.sesolve import SESolver
+from qutip.solver.mcsolve import MCSolver
 
 
 def testPropHOB():
@@ -71,7 +71,7 @@ def testPropHOSteady():
     kappa = 0.1
     n_th = 2
     rate = kappa * (1 + n_th)
-    c_op_list.append(np.sqrt(rate) * a)
+    c_op_list.append(np.sqrt(rate) * a)e
     rate = kappa * n_th
     c_op_list.append(np.sqrt(rate) * a.dag())
     U = propagator(H, 2*np.pi, c_op_list)
@@ -101,11 +101,11 @@ def testPropEvo():
 
 
 def _make_se(H, a):
-    return SeSolver(H)
+    return SESolver(H)
 
 
 def _make_me(H, a):
-    return MeSolver(H, [a])
+    return MESolver(H, [a])
 
 
 def _make_br(H, a):
@@ -114,8 +114,8 @@ def _make_br(H, a):
 
 
 @pytest.mark.parametrize('solver', [
-    pytest.param(_make_se, id='SeSolver'),
-    pytest.param(_make_me, id='MeSolver'),
+    pytest.param(_make_se, id='SESolver'),
+    pytest.param(_make_me, id='MESolver'),
     pytest.param(_make_br, id='BRSolver'),
 ])
 def testPropSolver(solver):
@@ -134,7 +134,7 @@ def testPropSolver(solver):
 def testPropMcSolver():
     a = destroy(5)
     H = a.dag()*a
-    solver = McSolver(H, [a])
+    solver = MCSolver(H, [a])
     with pytest.raises(TypeError) as err:
         Propagator(solver)
     assert str(err.value).startswith("Non-deterministic")

--- a/qutip/tests/solver/test_sesolve.py
+++ b/qutip/tests/solver/test_sesolve.py
@@ -2,11 +2,11 @@ import pytest
 import pickle
 import qutip
 import numpy as np
-from qutip.solver.sesolve import sesolve, SeSolver
+from qutip.solver.sesolve import sesolve, SESolver
 from qutip.solver.solver_base import Solver
 
 all_ode_method = [
-    method for method, integrator in SeSolver.avail_integrators().items()
+    method for method, integrator in SESolver.avail_integrators().items()
     if integrator.support_time_dependant
 ]
 
@@ -200,7 +200,7 @@ class TestSeSolve():
 
     def test_sesolver_args(self):
         options = {"progress_bar": None}
-        solver_obj = SeSolver(qutip.QobjEvo([self.H0, [self.H1,'a']],
+        solver_obj = SESolver(qutip.QobjEvo([self.H0, [self.H1,'a']],
                                             args={'a': 1}),
                               options=options)
         res = solver_obj.run(qutip.basis(2,1), [0, 1, 2, 3],
@@ -210,7 +210,7 @@ class TestSeSolve():
     def test_sesolver_pickling(self):
         e_ops = [qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()]
         options = {"progress_bar": None}
-        solver_obj = SeSolver(self.H0 + self.H1,
+        solver_obj = SESolver(self.H0 + self.H1,
                               options=options)
         solver_copy = pickle.loads(pickle.dumps(solver_obj))
         sx, sy, sz = solver_obj.run(qutip.basis(2,1), [0, 1, 2, 3],
@@ -229,7 +229,7 @@ class TestSeSolve():
             "rtol": 1e-8,
             "progress_bar": None
         }
-        solver_obj = SeSolver(
+        solver_obj = SESolver(
             qutip.QobjEvo([self.H1, lambda t, a: a], args={"a":0.25}),
             options=options
         )
@@ -268,13 +268,13 @@ class TestSeSolve():
 
 def test_sesolve_bad_H():
     with pytest.raises(TypeError):
-        SeSolver(np.eye(3))
+        SESolver(np.eye(3))
     with pytest.raises(ValueError):
-        SeSolver(qutip.basis(3,1))
+        SESolver(qutip.basis(3,1))
 
 
 def test_sesolve_bad_state():
-    solver = SeSolver(qutip.qeye(4))
+    solver = SESolver(qutip.qeye(4))
     with pytest.raises(TypeError):
         solver.start(qutip.basis(4,1).dag(), 0)
     with pytest.raises(TypeError):
@@ -282,6 +282,6 @@ def test_sesolve_bad_state():
 
 
 def test_sesolve_step_no_start():
-    solver = SeSolver(qutip.qeye(4))
+    solver = SESolver(qutip.qeye(4))
     with pytest.raises(RuntimeError):
         solver.step(1)


### PR DESCRIPTION
**Description**
- In `SeSolver`,   `MeSolver`,   `McSolver`, only capitalized 2 letters while `BRSolver` and `HEOMSolver` capitalized all abbreviated terms. Changed it use the same capitalization everywhere: `SESolver`,   `MESolver`,   `MCSolver`.

- Update dynamics-master for v5. Only changing a few links is needed. No reference to the class interface is added since it comes before the explanation to time dependent system.

- Updated dynamics-monte: Add description for new results, with photocurrent, average and runs version of expect and state. The class interface was quickly introduced in the `Reusing Hamiltonian Data` section.