### PR TITLE
Simplify version parsing (v5).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,12 +141,7 @@ def _determine_version(options):
     version_filename = os.path.join(options['rootdir'], 'VERSION')
     with open(version_filename, "r") as version_file:
         version_string = version_file.read().strip()
-    version = packaging.version.parse(version_string)
-    # LegacyVersion was removed in packaging 22, but is still returned by
-    # packing <= 21
-    LegacyVersion = getattr(packaging.version, "LegacyVersion", type(None))
-    if isinstance(version, LegacyVersion):
-        raise ValueError("invalid version: " + version_string)    
+    version = packaging.version.Version(version_string)
     options['short_version'] = str(version.public)
     options['release'] = not version.is_devrelease
     if not options['release']:


### PR DESCRIPTION
**Description**

Calling Version directly has given the strict parsing we require since the Version class was created and the class predates the parse(...) function itself. This simpler code should give the correct behaviour on all versions of packaging since 2014.

**Related issues or PRs**
- See #2039
- See #2043