### PR TITLE
Update keyword name for `eigh` for scipy 1.10

### DIFF
--- a/qutip/core/data/eigen.py
+++ b/qutip/core/data/eigen.py
@@ -61,8 +61,9 @@ def _eigs_dense(data, isherm, vecs, eigvals, num_large, num_small):
     N = data.shape[0]
     kwargs = {}
     if eigvals != 0 and isherm:
-        kwargs['eigvals'] = ([0, num_small-1] if num_small
-                             else [N-num_large, N-1])
+        kwargs['subset_by_index'] = (
+            [0, num_small-1] if num_small else [N-num_large, N-1]
+        )
     if vecs:
         driver = eigh if isherm else scipy.linalg.eig
         evals, evecs = driver(data, **kwargs)


### PR DESCRIPTION
**Description**
Since scipy 1.5, the keyword `eigvals` was replaced by `subset_by_index`, but with the recent scipy 1.10, it started giving a warning.
