### PR TITLE
Update the release action to push to testpypi and allow dev release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,15 @@ on:
 
 
 jobs:
-  # The deploy_test job is part of the test of whether we should deploy to PyPI.
-  # The job will succeed if either the confirmation reference is empty or if the
-  # confirmation is the selected branch or tag name.  It will fail if it is
-  # nonempty and does not match.  All later jobs depend on this job, so that
-  # they will be immediately cancelled if the confirmation is bad.  The
-  # dependency is currently necessary (2021-03) because GitHub Actions does not
-  # have a simpler method of cancelling an entire workflow---the normal use-case
-  # expects to try and run as much as possible despite one or two failures.
+  # The deploy_test job is part of the test of whether we should deploy to PyPI
+  # or test.PyPI. The job will succeed if either the confirmation reference is
+  # empty, 'test' or if the confirmation is the selected branch or tag name.
+  # It will fail if it is nonempty and does not match.  All later jobs depend
+  # on this job, so that they will be immediately cancelled if the confirmation
+  # is bad.  The dependency is currently necessary (2021-03) because GitHub
+  # Actions does not have a simpler method of cancelling an entire workflow---
+  # the normal use-case expects to try and run as much as possible despite one
+  # or two failures.
   deploy_test:
     name: Verify PyPI deployment confirmation
     runs-on: ubuntu-latest
@@ -106,7 +107,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      # Set up wheels matrix.  This is CPython 3.6--3.10 for all OS targets.
+      # Set up wheels matrix.  This is CPython 3.8--3.10 for all OS targets.
       CIBW_BUILD: "cp3{8,9,10,11}-*"
       # Numpy and SciPy do not supply wheels for i686 or win32 for
       # Python 3.10+, so we skip those:
@@ -145,9 +146,9 @@ jobs:
   deploy:
     name: "Deploy to PyPI if desired"
     # The confirmation is tested explicitly in `deploy_test`, so we know it is
-    # either a missing confirmation (so we shouldn't run this job) or a valid
-    # confirmation.  We don't need to retest the value of the confirmation,
-    # beyond checking that one existed.
+    # either a missing confirmation (so we shouldn't run this job), 'test' or a
+    # valid confirmation.  We don't need to retest the value of the
+    # confirmation, beyond checking that one existed.
     if: ${{ github.event.inputs.confirm_ref != '' && github.event.inputs.confirm_ref != 'test' }}
     needs: [deploy_test, build_sdist, build_wheels]
     runs-on: ubuntu-latest
@@ -182,10 +183,6 @@ jobs:
 
   deploy_testpypi:
     name: "Deploy to TestPyPI if desired"
-    # The confirmation is tested explicitly in `deploy_test`, so we know it is
-    # either a missing confirmation (so we shouldn't run this job) or a valid
-    # confirmation.  We don't need to retest the value of the confirmation,
-    # beyond checking that one existed.
     if: ${{ github.event.inputs.confirm_ref == 'test' }}
     needs: [deploy_test, build_sdist, build_wheels]
     runs-on: ubuntu-latest
@@ -208,11 +205,11 @@ jobs:
         shell: bash
         run: |
           python -m pip install wheels/*-cp38-cp38-manylinux*.whl
-          python -c 'import qutip; print(qutip.__version__); assert "+" not in qutip.__version__'
+          python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on
       # our end, but PyPI only needs the tarball.
       - name: Upload sdist and wheels to TestPyPI
         run: |
           python -m pip install "twine"
-          echo python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz
+          python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
     # either a missing confirmation (so we shouldn't run this job) or a valid
     # confirmation.  We don't need to retest the value of the confirmation,
     # beyond checking that one existed.
-    if: ${{ endswith(github.ref, github.event.inputs.confirm_ref) }}
+    if: ${{ ithub.event.inputs.confirm_ref != '' && github.event.inputs.confirm_ref != 'test' }}
     needs: [deploy_test, build_sdist, build_wheels]
     runs-on: ubuntu-latest
     env:
@@ -170,7 +170,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install wheels/*-cp37-cp37m-*.manylinux2010_x86_64.whl
-          python -c 'import qutip; print(qutip.__version__); assert "+" not in qutip.__version__'
+          python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on
       # our end, but PyPI only needs the tarball.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,6 @@ jobs:
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.TESTPYPI_TOKEN }}
       TWINE_NON_INTERACTIVE: 1
-      TWINE_REPOSITORY: testpypi  # https://test.pypi.org/legacy/
 
     steps:
       - name: Download build artifacts to local runner
@@ -212,4 +211,4 @@ jobs:
       - name: Upload sdist and wheels to TestPyPI
         run: |
           python -m pip install "twine"
-          python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz
+          python -m twine upload --repository testpypi --verbose wheels/*.whl sdist/*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           # For the sdist we should be as conservative as possible with our
           # Python version.  This should be the lowest supported version.  This
           # means that no unsupported syntax can sneak through.
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install pip build
         run: |
@@ -107,7 +107,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
       # Set up wheels matrix.  This is CPython 3.6--3.10 for all OS targets.
-      CIBW_BUILD: "cp3{6,7,8,9,10,11}-*"
+      CIBW_BUILD: "cp3{8,9,10,11}-*"
       # Numpy and SciPy do not supply wheels for i686 or win32 for
       # Python 3.10+, so we skip those:
       CIBW_SKIP: "*-musllinux* cp3{8,9,10,11}-manylinux_i686 cp3{8,9,10,11}-win32"
@@ -120,7 +120,7 @@ jobs:
         name: Install Python
         with:
           # This is about the build environment, not the released wheel version.
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install cibuildwheel
         run: |
@@ -148,7 +148,7 @@ jobs:
     # either a missing confirmation (so we shouldn't run this job) or a valid
     # confirmation.  We don't need to retest the value of the confirmation,
     # beyond checking that one existed.
-    if: ${{ ithub.event.inputs.confirm_ref != '' && github.event.inputs.confirm_ref != 'test' }}
+    if: ${{ github.event.inputs.confirm_ref != '' && github.event.inputs.confirm_ref != 'test' }}
     needs: [deploy_test, build_sdist, build_wheels]
     runs-on: ubuntu-latest
     env:
@@ -164,12 +164,12 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp37-cp37m-*.manylinux2010_x86_64.whl
+          python -m pip install wheels/*-cp38-cp38-*.manylinux2010_x86_64.whl
           python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on
@@ -202,12 +202,12 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp37-cp37m-*.manylinux2010_x86_64.whl
+          python -m pip install wheels/*-cp38-cp38-*.manylinux2010_x86_64.whl
           python -c 'import qutip; print(qutip.__version__); assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,10 @@ jobs:
       - name: Compare confirmation to current reference
         shell: bash
         run: |
-          [[ -z $CONFIRM_REF || $GITHUB_REF =~ ^refs/(heads|tags)/$CONFIRM_REF$ ]]
-          if [[ -z $CONFIRM_REF ]]; then
+          [[ -z $CONFIRM_REF || $GITHUB_REF =~ ^refs/(heads|tags)/$CONFIRM_REF$ || $CONFIRM_REF == "test" ]]
+          if [[ $CONFIRM_REF == "test" ]]; then
+            echo "Build and deploy to testpypi."
+          elif [[ -z $CONFIRM_REF ]]; then
             echo "Build only.  Nothing will be uploaded to PyPI."
           else
             echo "Full build and deploy.  Wheels and source will be uploaded to PyPI."
@@ -146,7 +148,7 @@ jobs:
     # either a missing confirmation (so we shouldn't run this job) or a valid
     # confirmation.  We don't need to retest the value of the confirmation,
     # beyond checking that one existed.
-    if: ${{ github.event.inputs.confirm_ref != '' }}
+    if: ${{ endswith(github.ref, github.event.inputs.confirm_ref) }}
     needs: [deploy_test, build_sdist, build_wheels]
     runs-on: ubuntu-latest
     env:
@@ -168,11 +170,49 @@ jobs:
         shell: bash
         run: |
           python -m pip install wheels/*-cp37-cp37m-*.manylinux2010_x86_64.whl
-          python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
+          python -c 'import qutip; print(qutip.__version__); assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on
       # our end, but PyPI only needs the tarball.
       - name: Upload sdist and wheels to PyPI
         run: |
           python -m pip install "twine"
-          python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz
+          echo python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz
+
+
+  deploy_testpypi:
+    name: "Deploy to TestPyPI if desired"
+    # The confirmation is tested explicitly in `deploy_test`, so we know it is
+    # either a missing confirmation (so we shouldn't run this job) or a valid
+    # confirmation.  We don't need to retest the value of the confirmation,
+    # beyond checking that one existed.
+    if: ${{ github.event.inputs.confirm_ref == 'test' }}
+    needs: [deploy_test, build_sdist, build_wheels]
+    runs-on: ubuntu-latest
+    env:
+      TWINE_USERNAME: __token__
+      TWINE_PASSWORD: ${{ secrets.TESTPYPI_TOKEN }}
+      TWINE_NON_INTERACTIVE: 1
+      TWINE_REPOSITORY: testpypi
+
+    steps:
+      - name: Download build artifacts to local runner
+        uses: actions/download-artifact@v3
+
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Verify this is not a dev version
+        shell: bash
+        run: |
+          python -m pip install wheels/*-cp37-cp37m-*.manylinux2010_x86_64.whl
+          python -c 'import qutip; print(qutip.__version__); assert "+" not in qutip.__version__'
+
+      # We built the zipfile for convenience distributing to Windows users on
+      # our end, but PyPI only needs the tarball.
+      - name: Upload sdist and wheels to TestPyPI
+        run: |
+          python -m pip install "twine"
+          echo python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Upload sdist and wheels to PyPI
         run: |
           python -m pip install "twine"
-          echo python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz
+          python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz
 
 
   deploy_testpypi:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.TESTPYPI_TOKEN }}
       TWINE_NON_INTERACTIVE: 1
-      TWINE_REPOSITORY: testpypi
+      TWINE_REPOSITORY: testpypi  # https://test.pypi.org/legacy/
 
     steps:
       - name: Download build artifacts to local runner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp38-cp38-*.manylinux2010_x86_64.whl
+          python -m pip install wheels/*-cp38-cp38-manylinux*.whl
           python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on
@@ -207,7 +207,7 @@ jobs:
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp38-cp38-*.manylinux2010_x86_64.whl
+          python -m pip install wheels/*-cp38-cp38-manylinux*.whl
           python -c 'import qutip; print(qutip.__version__); assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on


### PR DESCRIPTION
**Description**
- Added a job that update to testpypi when the "test" is entered as the branch name.
- Removed the check that stopped release with `dev` in the version number.
- Added a token for testpypi.

While it's a draft PR, the action will only print, not run the upload command.