### PR TITLE
Simplify initiating options in solver

### DIFF
--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -245,15 +245,7 @@ class BRSolver(Solver):
 
         self.rhs = None
         self.sec_cutoff = sec_cutoff
-        self._options = _SolverOptions(
-            self.solver_options,
-            self._apply_options,
-            self.name,
-            self.__class__.options.__doc__
-        )
-        self._options.ode = {}
-        if options is not None:
-            self.options = options
+        self.options = options
 
         if not isinstance(H, (Qobj, QobjEvo)):
             raise TypeError("The Hamiltonian must be a Qobj or QobjEvo")

--- a/qutip/solver/floquet.py
+++ b/qutip/solver/floquet.py
@@ -766,8 +766,7 @@ class FMESolver(MESolver):
     def __init__(
         self, floquet_basis, a_ops, w_th=0.0, *, kmax=5, nT=None, options=None
     ):
-        self._options = {}
-        self.options = {} if options is None else options
+        self.options = options
         if isinstance(floquet_basis, FloquetBasis):
             self.floquet_basis = floquet_basis
         else:

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -444,7 +444,7 @@ class MCSolver(MultiTrajSolver):
 
     def _get_integrator(self):
         _time_start = time()
-        method = self._options["method"]
+        method = self.options["method"]
         if method in self.avail_integrators():
             integrator = self.avail_integrators()[method]
         elif issubclass(method, Integrator):
@@ -461,7 +461,7 @@ class MCSolver(MultiTrajSolver):
     @property
     def options(self):
         """
-        Options for bloch redfield solver:
+        Options for monte carlo solver:
 
         store_final_state: bool, default=False
             Whether or not to store the final state of the evolution in the

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -49,8 +49,7 @@ class MultiTrajSolver(Solver):
 
     def __init__(self, rhs, *, options=None):
         self.rhs = rhs
-        self._options = {}
-        self.options = {} if options is None else options
+        self.options = options
         self.seed_sequence = np.random.SeedSequence()
         self._integrator = self._get_integrator()
         self._state_metadata = {}
@@ -175,7 +174,7 @@ class MultiTrajSolver(Solver):
         )
         result.add_end_condition(ntraj, target_tol)
 
-        map_func = _get_map[self._options['map']]
+        map_func = _get_map[self.options['map']]
         map_kw = {
             'timeout': timeout,
             'job_timeout': self.options['job_timeout'],

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -46,8 +46,7 @@ class Solver:
             self.rhs = QobjEvo(rhs)
         else:
             TypeError("The rhs must be a QobjEvo")
-        self._options = {}
-        self.options = {} if options is None else options
+        self.options = options
         self._integrator = self._get_integrator()
         self._state_metadata = {}
         self.stats = self._initialize_stats()
@@ -276,6 +275,10 @@ class Solver:
 
     @options.setter
     def options(self, new_options):
+        if not hasattr(self, "_options"):
+            self._options = {}
+        if new_options is None:
+            new_options = {}
         if not isinstance(new_options, dict):
             raise TypeError("options most to be a dictionary.")
         new_solver_options, new_ode_options = self._parse_options(


### PR DESCRIPTION
**Description**
Options in solver are usually set in `Solver.__init__`, but solver that needed options at the building of the rhs needed to initiate them themselves and it was more complex than needed.
Allow to use `self.options = options` at anytime without having to set `_options` and filter `None` first.