### PR TITLE
expect as a array

### DIFF
--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -126,9 +126,10 @@ class Result(_BaseResult):
         operator given the state at ``t``. If the element is a function, ``f``,
         the value recorded is ``f(t, state)``.
 
-        The values are recorded in the ``.expect`` attribute of this result
-        object. ``.expect`` is a list, where each item contains the values
-        of the corresponding ``e_op``.
+        The values are recorded in the ``e_data`` and ``expect`` attributes of
+        this result object. ``e_data`` is a dictionary and ``expect`` is a
+        list, where each item contains the values of the corresponding
+        ``e_op``.
 
     options : dict
         The options for this result class.
@@ -156,7 +157,7 @@ class Result(_BaseResult):
     final_state : :obj:`~Qobj`:
         The final state (if the recording of the final state was requested).
 
-    expect : list of lists of expectation values
+    expect : list of arrays of expectation values
         A list containing the values of each ``e_op``. The list is in
         the same order in which the ``e_ops`` were supplied and empty if
         no ``e_ops`` were given.
@@ -197,7 +198,6 @@ class Result(_BaseResult):
         super().__init__(options, solver=solver, stats=stats)
         raw_ops = self._e_ops_to_dict(e_ops)
         self.e_data = {k: [] for k in raw_ops}
-        self.expect = list(self.e_data.values())
         self.e_ops = {}
         for k, op in raw_ops.items():
             f = self._e_op_func(op)
@@ -325,6 +325,10 @@ class Result(_BaseResult):
         lines.append(">")
         return "\n".join(lines)
 
+    @property
+    def expect(self):
+        return [np.array(e_op) for e_op in self.e_data.values()]
+
 
 class MultiTrajResult(_BaseResult):
     """
@@ -345,7 +349,7 @@ class MultiTrajResult(_BaseResult):
 
         Function ``e_ops`` must return a number so the average can be computed.
 
-    options : :obj:`~SolverResultsOptions`
+    options : dict
         The options for this result class.
 
     solver : str or None
@@ -462,13 +466,9 @@ class MultiTrajResult(_BaseResult):
         self._target_tols = None
 
         self.average_e_data = {}
-        self.average_expect = []
         self.e_data = {}
-        self.expect = []
         self.std_e_data = {}
-        self.std_expect = []
         self.runs_e_data = {}
-        self.runs_expect = []
 
         self._post_init(**kw)
 
@@ -492,17 +492,20 @@ class MultiTrajResult(_BaseResult):
             state = trajectory.final_state
             self._sum_final_states = qzero(state.dims[0])
 
-        self._sum_expect = np.array(trajectory.expect) * 0.
-        self._sum2_expect = np.array(trajectory.expect) * 0.
+        self._sum_expect = [expect * 0 for expect in trajectory.expect]
+        self._sum2_expect = [expect * 0 for expect in trajectory.expect]
 
         self.e_ops = trajectory.e_ops
 
         self.average_e_data = {
-            k: avg_expect if np.iscomplexobj(expect) else avg_expect.real
-            for k, avg_expect, expect
-            in zip(self._raw_ops, self._sum_expect, trajectory.expect)
+            k: list(avg_expect)
+            for k, avg_expect
+            in zip(self._raw_ops, self._sum_expect)
         }
-        self.average_expect = list(self.average_e_data.values())
+        self.e_data = self.average_e_data
+        if self.options['keep_runs_results']:
+            self.runs_e_data = {k: [] for k in self._raw_ops}
+            self.e_data = self.runs_e_data
 
     def _store_trajectory(self, trajectory):
         self.trajectories.append(trajectory)
@@ -522,38 +525,23 @@ class MultiTrajResult(_BaseResult):
         Compute the average of the expectation values and store it in it's
         multiple formats.
         """
-        self._sum_expect += np.array(trajectory.expect)
-        self._sum2_expect += np.abs(np.array(trajectory.expect))**2
+        for i, k in enumerate(self._raw_ops):
+            expect_traj = trajectory.expect[i]
 
-        avg = self._sum_expect / self.num_trajectories
-        avg2 = self._sum2_expect / self.num_trajectories
+            self._sum_expect[i] += expect_traj
+            self._sum2_expect[i] += expect_traj**2
 
-        self.average_e_data = {
-            k: avg_expect if np.iscomplexobj(expect) else avg_expect.real
-            for k, avg_expect, expect
-            in zip(self._raw_ops, avg, self.average_expect)
-        }
-        self.average_expect = list(self.average_e_data.values())
+            avg = self._sum_expect[i] / self.num_trajectories
+            avg2 = self._sum2_expect[i] / self.num_trajectories
 
-        self.expect = self.average_expect
-        self.e_data = self.average_e_data
+            self.average_e_data[k] = list(avg)
 
-        # mean(expect**2) - mean(expect)**2 can something be very small
-        # negative (-1e-15) which raise an error for float sqrt.
-        self.std_e_data = {
-            k: np.sqrt(np.abs(avg_expect2 - np.abs(avg_expect**2)))
-            for k, avg_expect, avg_expect2 in zip(self._raw_ops, avg, avg2)
-        }
-        self.std_expect = list(self.std_e_data.values())
+            # mean(expect**2) - mean(expect)**2 can something be very small
+            # negative (-1e-15) which raise an error for float sqrt.
+            self.std_e_data[k] = list(np.sqrt(np.abs(avg2 - np.abs(avg**2))))
 
-        if self.trajectories:
-            self.runs_e_data = {
-                k: np.stack([traj.e_data[k] for traj in self.trajectories])
-                for k in self._raw_ops
-            }
-            self.runs_expect = list(self.runs_e_data.values())
-            self.expect = self.runs_expect
-            self.e_data = self.runs_e_data
+            if self.runs_e_data:
+                self.runs_e_data[k].append(trajectory.e_data[k])
 
     def _increment_traj(self, trajectory):
         if self.num_trajectories == 0:
@@ -584,8 +572,8 @@ class MultiTrajResult(_BaseResult):
         """
         if self.num_trajectories <= 1:
             return np.inf
-        avg = self._sum_expect / self.num_trajectories
-        avg2 = self._sum2_expect / self.num_trajectories
+        avg = np.array(self._sum_expect) / self.num_trajectories
+        avg2 = np.array(self._sum2_expect) / self.num_trajectories
         target = np.array([
             atol + rtol * mean
             for mean, (atol, rtol)
@@ -753,6 +741,22 @@ class MultiTrajResult(_BaseResult):
         """
         return self.runs_final_states or self.average_final_state
 
+    @property
+    def average_expect(self):
+        return [np.array(val) for val in self.average_e_data.values()]
+
+    @property
+    def std_expect(self):
+        return [np.array(val) for val in self.std_e_data.values()]
+
+    @property
+    def runs_expect(self):
+        return [np.array(val) for val in self.runs_e_data.values()]
+
+    @property
+    def expect(self):
+        return [np.array(val) for val in self.e_data.values()]
+
     def steady_state(self, N=0):
         """
         Average the states of the last ``N`` times of every runs as a density
@@ -830,37 +834,26 @@ class MultiTrajResult(_BaseResult):
             )
         new._target_tols = None
 
-        if self._raw_ops:
-            new._sum_expect = self._sum_expect + other._sum_expect
-            new._sum2_expect = self._sum2_expect + other._sum2_expect
+        new._sum_expect = []
+        new._sum2_expect = []
+        new.average_e_data = {}
+        new.std_e_data = {}
 
-            avg = new._sum_expect / new.num_trajectories
-            avg2 = new._sum2_expect / new.num_trajectories
+        for i, k in enumerate(self._raw_ops):
+            new._sum_expect.append(self._sum_expect[i] + other._sum_expect[i])
+            new._sum2_expect.append(self._sum2_expect[i]
+                                    + other._sum2_expect[i])
 
-            new.average_e_data = {
-                k: avg_expect
-                for k, avg_expect in zip(self._raw_ops, avg)
-            }
-            new.average_expect = list(new.average_e_data.values())
+            avg = new._sum_expect[i] / new.num_trajectories
+            avg2 = new._sum2_expect[i] / new.num_trajectories
 
-            new.expect = new.average_expect
+            new.average_e_data[k] = list(avg)
             new.e_data = new.average_e_data
 
-            new.std_e_data = {}
-            for i, key in enumerate(self._raw_ops):
-                std2 = avg2[i] - abs(avg[i]**2)
-                std2[std2 < 0] = 0.
-                new.std_e_data[key] = np.sqrt(std2)
-
-            new.std_expect = list(new.std_e_data.values())
+            new.std_e_data[k] = np.sqrt(np.abs(avg2 - np.abs(avg**2)))
 
             if new.trajectories:
-                new.runs_e_data = {
-                    k: np.stack([traj.e_data[k] for traj in new.trajectories])
-                    for k in new._raw_ops
-                }
-                new.runs_expect = list(new.runs_e_data.values())
-                new.expect = new.runs_expect
+                new.runs_e_data[k] = self.runs_e_data[k] + other.runs_e_data[k]
                 new.e_data = new.runs_e_data
 
         new.stats["run time"] += other.stats["run time"]

--- a/qutip/tests/core/test_expect.py
+++ b/qutip/tests/core/test_expect.py
@@ -148,17 +148,17 @@ def test_compatibility_with_solver(solve):
     assert len(direct)-1 == len(indirect)
     for direct_, indirect_ in zip(direct, indirect):
         assert len(direct_) == len(indirect_)
-        assert isinstance(direct_, list)
+        assert isinstance(direct_, np.ndarray)
         assert isinstance(indirect_, np.ndarray)
-        assert np.array(direct_).dtype == indirect_.dtype
+        assert direct_.dtype == indirect_.dtype
         np.testing.assert_allclose(np.array(direct_), indirect_, atol=1e-12)
         # test measurement operators based on lambda functions
         direct_ = direct[-1]
         indirect_ = np.sin(times)
         assert len(direct_) == len(indirect_)
-        assert isinstance(direct_, list)
+        assert isinstance(direct_, np.ndarray)
         assert isinstance(indirect_, np.ndarray)
-        assert np.array(direct_).dtype == indirect_.dtype
+        assert direct_.dtype == indirect_.dtype
         np.testing.assert_allclose(np.array(direct_), indirect_, atol=1e-12)
 
 

--- a/qutip/tests/solver/test_results.py
+++ b/qutip/tests/solver/test_results.py
@@ -99,7 +99,7 @@ class TestResult:
                 res.e_ops[k](i, qutip.basis(N, i)) for i in range(N)
             ]
             if isinstance(res.expect[i][0], qutip.Qobj):
-                assert res.expect[i] == results[k]
+                assert (res.expect[i] == results[k]).all()
                 assert res.e_data[k] == results[k]
                 assert e_op_call_values == results[k]
             else:


### PR DESCRIPTION
**Description**
Change back `Result.expect`to be a `list of np.array` as it was in v4.
`Result.e_data` is still a `dict of list`.

Expectation result for multi trajectories solver use the same output types.

`np.array` being called on each expectation values individually should allow function `e_ops` to return other types than scalar. However this may fails for multi trajectories result when averaging expectation between trajectories or using `target_tol`.

