### PR TITLE
Clean up qutip.settings.Settings

### DIFF
--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -128,7 +128,8 @@ class Settings:
             self.tmproot = os.path.join(os.path.expanduser("~"), '.qutip')
         except OSError:
             self._tmproot = "."
-        self.core = None
+        self.core = None  # set in qutip.core.options
+        self.compile = None  # set in qutip.core.coefficient
         self._debug = False
         self._log_handler = "default"
         self._colorblind_safe = False


### PR DESCRIPTION
**Description**

The `Settings` class unnecessarily implements a singleton pattern and has a few unused underscore attributes (e.g. `_integartors`). This PR removes the unused / necessary code and simplifies the class.

**Related issues or PRs**

- None