### PR TITLE
Re-enable all cvxpy and pyximport warnings on Python 3.10 and 3.11 tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,8 +69,6 @@ jobs:
 
           # Python 3.10 and numpy 1.22
           # Use conda-forge to provide numpy 1.22
-          # Ignore DeprecationWarnings raised by cvxpy importing scipy.sparse.X
-          # under SciPy 1.8.0+.
           # Ignore DeprecationWarnings raised by versions of
           # setuptools >= 65.0.0 during pyximport imports This can be removed
           # once https://github.com/cython/cython/issues/4985
@@ -79,12 +77,10 @@ jobs:
             os: ubuntu-latest
             python-version: "3.10"
             condaforge: 1
-            pytest-extra-options: "-W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper -W ignore:Absolute:DeprecationWarning"
+            pytest-extra-options: "-W ignore:Absolute:DeprecationWarning"
 
           # Python 3.11 and latest numpy
           # Use conda-forge to provide Python 3.11 and latest numpy
-          # Ignore DeprecationWarnings raised by cvxpy importing scipy.sparse.X
-          # under SciPy 1.8.0+.
           # Ignore DeprecationWarnings raised by versions of
           # setuptools >= 65.0.0 during pyximport imports This can be removed
           # once https://github.com/cython/cython/issues/4985
@@ -94,7 +90,7 @@ jobs:
             python-version: "3.11"
             condaforge: 1
             conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
-            pytest-extra-options: "-W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper -W ignore:Absolute:DeprecationWarning -W ignore::DeprecationWarning:Cython.Tempita"
+            pytest-extra-options: "-W ignore:Absolute:DeprecationWarning -W ignore::DeprecationWarning:Cython.Tempita"
 
           # Windows. Once all tests pass without special options needed, this
           # can be moved to the main os list in the test matrix. All the tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,11 +76,16 @@ jobs:
 
           # Python 3.11 and latest numpy
           # Use conda-forge to provide Python 3.11 and latest numpy
+          # Ignore deprecation of the cgi module in Python 3.11 that is
+          # still imported by Cython.Tempita. This was addressed in
+          # https://github.com/cython/cython/pull/5128 but not backported
+          # to any currently released version.
           - case-name: Python 3.11
             os: ubuntu-latest
             python-version: "3.11"
             condaforge: 1
             conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
+            pytest-extra-options: "-W ignore::DeprecationWarning:Cython.Tempita"
 
           # Windows. Once all tests pass without special options needed, this
           # can be moved to the main os list in the test matrix. All the tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,28 +69,18 @@ jobs:
 
           # Python 3.10 and numpy 1.22
           # Use conda-forge to provide numpy 1.22
-          # Ignore DeprecationWarnings raised by versions of
-          # setuptools >= 65.0.0 during pyximport imports This can be removed
-          # once https://github.com/cython/cython/issues/4985
-          # is fixed and released.
           - case-name: Python 3.10
             os: ubuntu-latest
             python-version: "3.10"
             condaforge: 1
-            pytest-extra-options: "-W ignore:Absolute:DeprecationWarning"
 
           # Python 3.11 and latest numpy
           # Use conda-forge to provide Python 3.11 and latest numpy
-          # Ignore DeprecationWarnings raised by versions of
-          # setuptools >= 65.0.0 during pyximport imports This can be removed
-          # once https://github.com/cython/cython/issues/4985
-          # is fixed and released.
           - case-name: Python 3.11
             os: ubuntu-latest
             python-version: "3.11"
             condaforge: 1
             conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
-            pytest-extra-options: "-W ignore:Absolute:DeprecationWarning -W ignore::DeprecationWarning:Cython.Tempita"
 
           # Windows. Once all tests pass without special options needed, this
           # can be moved to the main os list in the test matrix. All the tests


### PR DESCRIPTION
**Description**
- Remove disabling of cvxpy warnings. These were fixed in cvxpy 1.3.
- Remove disabling of pyximport absolute path warnings (QuTiP 5 no longer uses pyximport).

**Related issues or PRs**
- None