### PR TITLE
Fix test requirement

### DIFF
--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -9,14 +9,11 @@ from qutip import ket, ket2dm
 try:
     import matplotlib.pyplot as plt
     from matplotlib.testing.decorators import check_figures_equal
+    import IPython
+    check_pngs_equal = check_figures_equal(extensions=["png"])
 except ImportError:
-    def check_figures_equal(*args, **kw):
-        def _error(*args, **kw):
-            raise RuntimeError("matplotlib is not installed")
     plt = None
-
-
-check_pngs_equal = check_figures_equal(extensions=["png"])
+    check_pngs_equal = pytest.mark.skip(reason="matplotlib not installed")
 
 
 class RefBloch(Bloch):
@@ -474,6 +471,8 @@ class TestBloch:
 
 
 def test_repr_svg():
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("ipython")
     svg = Bloch()._repr_svg_()
     assert isinstance(svg, str)
     assert svg.startswith("<?xml")

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ tests =
     pytest-rerunfailures
 ipython =
     ipython
-extra =
+extras =
     loky
     tqdm
 ; This uses ConfigParser's string interpolation to include all the above
@@ -67,4 +67,4 @@ full =
     %(semidefinite)s
     %(tests)s
     %(ipython)s
-    %(extra)s
+    %(extras)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,9 @@ tests =
     pytest-rerunfailures
 ipython =
     ipython
+extra =
+    loky
+    tqdm
 ; This uses ConfigParser's string interpolation to include all the above
 ; dependencies into one single target, convenient for testing full builds.
 full =
@@ -64,3 +67,4 @@ full =
     %(semidefinite)s
     %(tests)s
     %(ipython)s
+    %(extra)s


### PR DESCRIPTION
**Description**
Test for the bloch sphere require matplotlib and ipython to pass, but these were not installed with `qutip[tests]`.
These tests are now skipped when these packages are missing instead of failing.

Also add `loky` and `tqdm` to extra require as they can now be used in solvers.