### PR TITLE
Update links in template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,8 @@ Thank you for contributing to QuTiP! Please make sure you have finished the foll
 - [ ] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
 You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
 - [ ] Please add tests to cover your changes if applicable.
-- [ ] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-notebooks). Feel free to ask if you are not sure.
-- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](http://qutip.org/docs/latest/development/contributing.html#Changelog%20Generation) for more information).
+- [ ] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-tutorials). Feel free to ask if you are not sure.
+- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](http://qutip.org/docs/latest/development/contributing.html#changelog-generation) for more information).
 
 Delete this checklist after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.
 


### PR DESCRIPTION
**Description**
Changed `qutip-notebooks` to `qutip-tutorials` and fixed the typo in the link redirecting to the changelog section in the PR template.

**Related issues or PRs**
Fixes #2106 