### PR TITLE
Issue2099

### DIFF
--- a/doc/changes/2099.feature
+++ b/doc/changes/2099.feature
@@ -1,0 +1,1 @@
+Added __repr__ to QobjEvo

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -233,7 +233,6 @@ cdef class QobjEvo:
 
     def __repr__(self):
         cls = self.__class__.__name__
-        
         return f'<{cls} dims = {self.dims}, shape= {self.shape}, type = {self.type}, superrep = {self.superrep}, isconstant = {self.isconstant}, num_elements = {self.num_elements}>'
 
     def _read_element(self, op, copy, tlist, args, order, function_style):

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -231,6 +231,11 @@ cdef class QobjEvo:
         if compress:
             self.compress()
 
+    def __repr__(self):
+        cls = self.__class__.__name__
+        
+        return f'<{cls} dims = {self.dims}, shape= {self.shape}, type = {self.type}, superrep = {self.superrep}, isconstant = {self.isconstant}, num_elements = {self.num_elements}>'
+
     def _read_element(self, op, copy, tlist, args, order, function_style):
         """ Read a Q_object item and return an element for that item. """
         if isinstance(op, Qobj):


### PR DESCRIPTION
**Help needed in the following**
- [ ] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).

>I did the `pycodestyle` on my code, but it is highlighting errors that were there in the original code. It returned lines that have >linespace errors and more, should I edit them too?
>Output:

> ```
> D:\qutip\qutip\core\cy>pycodestyle --first qobjevo.pyx
> qobjevo.pyx:1:1: E265 block comment should start with '# '
> qobjevo.pyx:2:80: E501 line too long (83 > 79 characters)
> qobjevo.pyx:20:37: E211 whitespace before '('
> qobjevo.pyx:46:56: W605 invalid escape sequence '\s'
> qobjevo.pyx:190:30: E225 missing whitespace around operator
> qobjevo.pyx:423:5: E303 too many blank lines (2)
> qobjevo.pyx:426:5: E301 expected 1 blank line, found 0
> qobjevo.pyx:451:34: E127 continuation line over-indented for visual indent
> qobjevo.pyx:572:21: E128 continuation line under-indented for visual indent
> qobjevo.pyx:987:39: E231 missing whitespace after ','
> qobjevo.pyx:989:20: E124 closing bracket does not match visual indentation
> ```

- [ ] Please add tests to cover your changes if applicable.

> The issue was to add `__repr__` function to `QobjEvo` class. Do I need to add a test? If so, can someone help me with it?

- [ ] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-tutorials). Feel free to ask if you are not sure.

> I am not sure in what bracket this issue falls. The issue was labeled as `ENH`.

- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](http://qutip.org/docs/latest/development/contributing.html#changelog-generation) for more information).

> Related to the previous point.

**Description**
Added `__repr__` to `QobjEvo`

It is showing the following attributes: `dims`, `shape`, `type`, `superop` (if a super operator is present), `isconstant` and `num_elements`.

Output:
```
>>> import qutip
>>> qutip.QobjEvo([qutip.qeye(2), lambda t: t])
<QobjEvo dims = [[2], [2]], shape= (2, 2), type = oper, superrep = None, isconstant = False, num_elements = 1>
```



**Related issues or PRs**
Fix #2099 
