### PR TITLE
Enable warning in matmul_csr_dense

### DIFF
--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -25,10 +25,7 @@ except ImportError:
 from scipy.linalg cimport cython_blas as blas
 
 from qutip.core.data cimport base, Dense
-from qutip.core.data.add cimport add_csr, sub_csr
 from qutip.core.data.adjoint cimport adjoint_csr, transpose_csr, conj_csr
-from qutip.core.data.mul cimport mul_csr, neg_csr
-from qutip.core.data.matmul cimport matmul_csr
 from qutip.core.data.trace cimport trace_csr
 from qutip.core.data.tidyup cimport tidyup_csr
 from .base import idxint_dtype

--- a/qutip/core/data/dense.pyx
+++ b/qutip/core/data/dense.pyx
@@ -12,10 +12,7 @@ from scipy.linalg cimport cython_blas as blas
 
 from .base import EfficiencyWarning
 from qutip.core.data cimport base, CSR
-from qutip.core.data.add cimport add_dense, sub_dense
 from qutip.core.data.adjoint cimport adjoint_dense, transpose_dense, conj_dense
-from qutip.core.data.mul cimport mul_dense, neg_dense
-from qutip.core.data.matmul cimport matmul_dense
 from qutip.core.data.trace cimport trace_dense
 
 cnp.import_array()

--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -21,6 +21,7 @@ from qutip.core.data.dense cimport Dense
 from qutip.core.data.csr cimport CSR
 from qutip.core.data cimport csr, dense
 from qutip.core.data.add cimport iadd_dense, add_csr
+from qutip.core.data.dense import OrderEfficiencyWarning
 
 cnp.import_array()
 
@@ -196,7 +197,7 @@ cpdef Dense matmul_csr_dense_dense(CSR left, Dense right,
             "out matrix is {}-ordered".format('Fortran' if out.fortran else 'C')
             + " but input is {}-ordered".format('Fortran' if right.fortran else 'C')
         )
-        warnings.warn(msg, dense.OrderEfficiencyWarning)
+        warnings.warn(msg, OrderEfficiencyWarning)
         # Rather than making loads of copies of the same code, we just moan at
         # the user and then transpose one of the arrays.  We prefer to have
         # `right` in Fortran-order for cache efficiency.

--- a/qutip/tests/core/data/test_dense.py
+++ b/qutip/tests/core/data/test_dense.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from qutip.core import data
-from qutip.core.data import dense
+from qutip.core.data import dense, csr
 
 from . import conftest
 
@@ -286,3 +286,12 @@ class TestFactoryMethods:
             base = data.one_element_dense(shape, position, value)
         assert str(exc.value).startswith("Position of the elements"
                                          " out of bound: ")
+
+
+def test_OrderEfficiencyWarning():
+    N = 5
+    M = csr.identity(N)
+    C_ordered = dense.zeros(N, 1, fortran=False)
+    fortran_ordered = dense.zeros(N, 1, fortran=True)
+    with pytest.warns(dense.OrderEfficiencyWarning):
+        data.matmul_csr_dense_dense(M, C_ordered, out=fortran_ordered)


### PR DESCRIPTION
**Description**
`OrderEfficiencyWarning` was not properly imported in matmul.pyx since `dense` was cimported.
Removed unused import in csr.pyx and dense.pyx that were causing circular import when importing from dense.py at the top of the file.