### PR TITLE
Speed up the HEOM RHS construct

### DIFF
--- a/doc/changes/2128.feature
+++ b/doc/changes/2128.feature
@@ -1,0 +1,1 @@
+Speed up the construction of the RHS of the HEOM solver by a factor of 4x by converting the final step to Cython.

--- a/qutip/core/data/csr.pxd
+++ b/qutip/core/data/csr.pxd
@@ -161,3 +161,5 @@ cpdef CSR from_dense(Dense matrix)
 cdef CSR from_coo_pointers(base.idxint *rows, base.idxint *cols, double complex *data,
                            base.idxint n_rows, base.idxint n_cols, base.idxint nnz,
                            double tol=*)
+cpdef CSR from_csr_blocks(base.idxint[:] block_rows, base.idxint[:] block_cols, CSR[:] block_ops,
+                          base.idxint n_blocks, base.idxint block_size)

--- a/qutip/core/data/csr.pxd
+++ b/qutip/core/data/csr.pxd
@@ -161,5 +161,6 @@ cpdef CSR from_dense(Dense matrix)
 cdef CSR from_coo_pointers(base.idxint *rows, base.idxint *cols, double complex *data,
                            base.idxint n_rows, base.idxint n_cols, base.idxint nnz,
                            double tol=*)
-cpdef CSR from_csr_blocks(base.idxint[:] block_rows, base.idxint[:] block_cols, CSR[:] block_ops,
+
+cpdef CSR _from_csr_blocks(base.idxint[:] block_rows, base.idxint[:] block_cols, CSR[:] block_ops,
                           base.idxint n_blocks, base.idxint block_size)

--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -897,6 +897,9 @@ cpdef CSR _from_csr_blocks(
             " the same length."
         )
 
+    if n_ops == 0:
+        return zeros(shape, shape)
+
     # check op shapes and calculate nnz
     for op in block_ops:
         nnz_ += nnz(op)
@@ -904,10 +907,6 @@ cpdef CSR _from_csr_blocks(
             raise ValueError(
                 "Block operators (block_ops) do not have the correct shape."
             )
-
-    cdef CSR out = empty(shape, shape, nnz_)
-    if n_ops == 0:
-        return out
 
     # check ops are ordered by (row, column)
     row_idx = block_rows[0]
@@ -925,8 +924,9 @@ cpdef CSR _from_csr_blocks(
         col_idx = block_cols[i]
 
     if nnz_ == 0:
-        return out
+        return zeros(shape, shape)
 
+    cdef CSR out = empty(shape, shape, nnz_)
     cdef base.idxint op_idx = 0
     cdef base.idxint prev_op_idx = 0
     cdef base.idxint end = 0

--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -902,15 +902,15 @@ cpdef CSR from_csr_blocks(
 
     cdef base.idxint rowpos, colpos
     cdef base.idxint row_idx, col_idx
-    cdef base.idxint op_i, op_row, op_row_start, op_row_end, op_row_len
+    cdef base.idxint op_i, op_row, op_row_start, op_row_end, op_row_len, i
 
     out.row_index[0] = 0
 
     for row_idx in range(n_blocks):
         prev_op_idx = op_idx
         while op_idx < op_len:
-            #if block_rows[op_idx] < row_idx:
-            #    raise ValueError("Block row indexes (block_rows) are not sorted.")
+            if block_rows[op_idx] < row_idx:
+                raise ValueError("Block row indexes (block_rows) are not sorted.")
             if block_rows[op_idx] != row_idx:
                 break
             op_idx += 1

--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -846,7 +846,7 @@ def diags(diagonals, offsets=None, shape=None):
     )
 
 
-cpdef CSR from_csr_blocks(
+cpdef CSR _from_csr_blocks(
     base.idxint[:] block_rows, base.idxint[:] block_cols, CSR[:] block_ops,
     base.idxint n_blocks, base.idxint block_size
 ):

--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -877,7 +877,7 @@ cpdef CSR _from_csr_blocks(
 
     n_blocks : base.idxint
         Number of blocks. The shape of the final matrix is
-        (N * block, N * block).
+        (n_blocks * block, n_blocks * block).
 
     block_size : base.idxint
         Size of each block. The shape of matrices in ``block_ops`` is
@@ -945,8 +945,13 @@ cpdef CSR _from_csr_blocks(
         row_pos = row_idx * block_size
         for op_row in range(block_size):
             for i in range(prev_op_idx, op_idx):
-                col_idx = block_cols[i]
                 op = block_ops[i]
+                if nnz(op) == 0:
+                    # empty CSR matrices have uninitialized row_index entries.
+                    # it's unclear whether users should ever see such matrixes
+                    # but we support them here anyway.
+                    continue
+                col_idx = block_cols[i]
                 col_pos = col_idx * block_size
                 op_row_start = op.row_index[op_row]
                 op_row_end = op.row_index[op_row + 1]

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -580,6 +580,12 @@ class HEOMSolver(Solver):
     ados : :obj:`HierarchyADOs`
         The description of the hierarchy constructed from the given bath
         and maximum depth.
+
+    rhs : :obj:`QobjEvo`
+        The right-hand side (RHS) of the hierarchy evolution ODE. Internally
+        the system and bath coupling operators are converted to
+        :class:`qutip.data.CSR` instances during construction of the RHS,
+        so the operators in the ``rhs`` will all be sparse.
     """
 
     name = "heomsolver"

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -1308,7 +1308,7 @@ class _GatherHEOMRHS:
         ops = np.array(self._ops, dtype=[
             ("row", _data.base.idxint_dtype),
             ("col", _data.base.idxint_dtype),
-            ("op", object),
+            ("op", _data.CSR),
         ])
         return _csr._from_csr_blocks(
             ops["row"], ops["col"], ops["op"],

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -1311,7 +1311,7 @@ class _GatherHEOMRHS:
             [op[2] for op in self._ops],
             dtype=object,
         )
-        return _csr.from_csr_blocks(
+        return _csr._from_csr_blocks(
             block_rows, block_cols, block_ops,
             self._n_blocks, self._block_size,
         )

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -1299,19 +1299,12 @@ class _GatherHEOMRHS:
                 A combined matrix of shape ``(block * nhe, block * ne)``.
         """
         self._ops.sort()
-        block_rows = np.array(
-            [op[0] for op in self._ops],
-            dtype=_data.base.idxint_dtype,
-        )
-        block_cols = np.array(
-            [op[1] for op in self._ops],
-            dtype=_data.base.idxint_dtype,
-        )
-        block_ops = np.array(
-            [op[2] for op in self._ops],
-            dtype=object,
-        )
+        ops = np.array(self._ops, dtype=[
+            ("row", _data.base.idxint_dtype),
+            ("col", _data.base.idxint_dtype),
+            ("op", object),
+        ])
         return _csr._from_csr_blocks(
-            block_rows, block_cols, block_ops,
+            ops["row"], ops["col"], ops["op"],
             self._n_blocks, self._block_size,
         )

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -119,6 +119,7 @@ class HierarchyADOs:
 
         self.labels = list(state_number_enumerate(self.dims, max_depth))
         self._label_idx = {s: i for i, s in enumerate(self.labels)}
+        self.idx = self._label_idx.__getitem__
 
     def idx(self, label):
         """
@@ -134,6 +135,13 @@ class HierarchyADOs:
         -------
         int
             The index of the label within the list of ADO labels.
+
+        Note
+        ----
+        This implementation of the ``.idx(...)`` method is just for
+        reference and documentation. To avoid the cost of a Python
+        function call, it is replaced with
+        ``self._label_idx.__getitem__`` when the instance is created.
         """
         return self._label_idx[label]
 
@@ -810,10 +818,8 @@ class HEOMSolver(Solver):
 
     def _rhs(self):
         """ Make the RHS for the HEOM. """
-        # XXX: TODO -- make this an explicit function
-        f_idx = self.ados._label_idx.__getitem__
         ops = _GatherHEOMRHS(
-            f_idx, block=self._sup_shape, nhe=self._n_ados
+            self.ados.idx, block=self._sup_shape, nhe=self._n_ados
         )
 
         for he_n in self.ados.labels:

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -825,8 +825,6 @@ class HEOMSolver(Solver):
         for he_n in self.ados.labels:
             op = self._grad_n(he_n)
             ops.add_op(he_n, he_n, op)
-            if isinstance(op, _data.Dense):
-                breakpoint()
             for k in range(len(self.ados.dims)):
                 next_he = self.ados.next(he_n, k)
                 if next_he is not None:

--- a/qutip/tests/core/data/test_csr.py
+++ b/qutip/tests/core/data/test_csr.py
@@ -430,7 +430,7 @@ class TestFromCSRBlocks:
     def test_construct_kron(self):
         A = np.array([[1, 2], [3, 4]])
         B = np.array([[0.3, 0.35], [0.4, 0.45]])
-        B_op = data.to("csr", data.Dense(A))
+        B_op = data.to("csr", data.Dense(B))
         blocks = self._blocks(
             [0, 0, 1, 1], [0, 1, 0, 1], [
                 A[0, 0] * B_op, A[0, 1] * B_op,
@@ -438,7 +438,7 @@ class TestFromCSRBlocks:
             ]
         )
         out = blocks.from_csr_blocks()
-        assert out == data.kron(data.Dense(A), data.Dense(A))
+        assert out == data.kron(data.Dense(A), data.Dense(B))
         assert csr.nnz(out) == 16
 
 

--- a/qutip/tests/core/data/test_csr.py
+++ b/qutip/tests/core/data/test_csr.py
@@ -343,6 +343,105 @@ class TestFactoryMethods:
                                          " out of bound: ")
 
 
+class TestFromCSRBlocks:
+    class _blocks:
+        def __init__(self, rows, cols, ops, n_blocks=2, block_size=2):
+            self.rows = np.array(rows, dtype=data.base.idxint_dtype)
+            self.cols = np.array(cols, dtype=data.base.idxint_dtype)
+            if isinstance(ops, int):
+                ops = [csr.empty(block_size, block_size, 0)] * ops
+            self.ops = np.array(ops, dtype=object)
+            self.n_blocks = n_blocks
+            self.block_size = block_size
+
+        def from_csr_blocks(self):
+            return csr._from_csr_blocks(
+                self.rows, self.cols, self.ops,
+                self.n_blocks, self.block_size,
+            )
+
+    @pytest.mark.parametrize(['blocks'], [
+        pytest.param(_blocks((0, 1), (0,), 1), id='rows neq ops'),
+        pytest.param(_blocks((0,), (0, 1), 1), id='cols neq ops'),
+    ])
+    def test_input_length_error(self, blocks):
+        with pytest.raises(ValueError) as exc:
+            blocks.from_csr_blocks()
+        assert str(exc.value) == (
+            "The arrays block_rows, block_cols and block_ops should have"
+            " the same length."
+        )
+
+    def test_op_shape_error(self):
+        blocks = self._blocks(
+            (0, 1), (0, 1),
+            (csr.empty(2, 2, 0), csr.empty(3, 3, 0)),
+        )
+        with pytest.raises(ValueError) as exc:
+            blocks.from_csr_blocks()
+        assert str(exc.value) == (
+            "Block operators (block_ops) do not have the correct shape."
+        )
+
+    @pytest.mark.parametrize(['blocks'], [
+        pytest.param(_blocks((1, 0), (0, 1), 2), id='rows not ordered'),
+        pytest.param(_blocks((1, 1), (1, 0), 2), id='cols not ordered'),
+        pytest.param(_blocks((1, 0), (1, 0), 2), id='non-unique block'),
+    ])
+    def test_op_ordering_error(self, blocks):
+        with pytest.raises(ValueError) as exc:
+            blocks.from_csr_blocks()
+        assert str(exc.value) == (
+            "The arrays block_rows and block_cols must be sorted"
+            " by (row, column)."
+        )
+
+    @pytest.mark.parametrize(['blocks'], [
+        pytest.param(_blocks((), (), ()), id='no ops'),
+        pytest.param(_blocks((0, 1), (1, 0), 2), id='empty ops'),
+    ])
+    def test_empty_output_fast_paths(self, blocks):
+        out = blocks.from_csr_blocks()
+        assert out == csr.empty(2 * 2, 2 * 2, 0)
+        assert csr.nnz(out) == 0
+
+    def test_construct_identity_with_empty(self):
+        blocks = self._blocks(
+            [0, 0, 1, 1], [0, 1, 0, 1], [
+                csr.identity(2), csr.empty(2, 2, 0),
+                csr.empty(2, 2, 0), csr.identity(2),
+            ],
+        )
+        out = blocks.from_csr_blocks()
+        assert out == csr.identity(4)
+        assert csr.nnz(out) == 4
+
+    def test_construct_identity_with_zeros(self):
+        blocks = self._blocks(
+            [0, 0, 1, 1], [0, 1, 0, 1], [
+                csr.identity(2), csr.zeros(2, 2),
+                csr.zeros(2, 2), csr.identity(2),
+            ],
+        )
+        out = blocks.from_csr_blocks()
+        assert out == csr.identity(4)
+        assert csr.nnz(out) == 4
+
+    def test_construct_kron(self):
+        A = np.array([[1, 2], [3, 4]])
+        B = np.array([[0.3, 0.35], [0.4, 0.45]])
+        B_op = data.to("csr", data.Dense(A))
+        blocks = self._blocks(
+            [0, 0, 1, 1], [0, 1, 0, 1], [
+                A[0, 0] * B_op, A[0, 1] * B_op,
+                A[1, 0] * B_op, A[1, 1] * B_op,
+            ]
+        )
+        out = blocks.from_csr_blocks()
+        assert out == data.kron(data.Dense(A), data.Dense(A))
+        assert csr.nnz(out) == 16
+
+
 def test_tidyup():
     small = qeye(1) * 1e-5
     with CoreOptions(auto_tidyup_atol=1e-3):


### PR DESCRIPTION
**Description**

Adds a `_from_csr_blocks` constructor to speed up the construction of the HEOM RHS by a factor of ~4x.

What allows `from_csr_blocks` to be fast is that we can order the blocks in a way that makes it possible to write the rows of the output one after the other without a lot of work, and we never have to add a new non-zero element into a row or make a copy of the big output matrix.

The implementation in Python was slow just because there is a lot of Python looping and arithmetic when the number of operators being combined becomes large.

`_from_csr_blocks` is a private constructor for now. If use cases emerge we can consider making something similar part of the public interface later.

**Related issues or PRs**
- None