### PR TITLE
Add tools to list dispatcher specializations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,8 @@
 [run]
 source = qutip
 omit =
+    # Skip dev tools
+    *dev_utils.py
     # QuTiP test files
     */qutip/tests/*
 

--- a/qutip/core/data/dev_utils.py
+++ b/qutip/core/data/dev_utils.py
@@ -1,0 +1,79 @@
+"""
+Tools to help with data layer development.
+"""
+
+from collections import defaultdict
+from qutip.core import data as _data
+
+def all_specialisation():
+    """
+    Create a dict of all specialisations of the dispatcher sorted in number of
+    data layer inputs.
+    """
+    all_dispatchers = qt.data.to.dispatchers
+    dispatchers = defaultdict(list)
+    for dispatcher in all_dispatchers:
+        dispatchers[len(dispatcher.inputs)].append(dispatcher)
+    return dict(sorted(dispatchers.items()))
+
+def _bool2str(entry):
+    if isinstance(entry, str):
+        return entry
+    elif entry:
+        return "True"
+    else:
+        return "False"
+
+def _print_table(lines, title):
+    if len(lines) == 1: return
+    print()
+    print(title)
+    for line in lines:
+        print(f"|{line[0]:<20}|" + "|".join(
+            f"{_bool2str(entry):^10}" for entry in line[1:]) + "|"
+        )
+
+def _extract_specialisation_per_type(N):
+    dispatchers = all_specialisation()
+    all_layers = list(qt.data.to.dtypes)
+    lines_output = [
+        ("Dispatched function",) + tuple(dtype.__name__ for dtype in all_layers)
+    ]
+    lines_no_output = [
+        ("Dispatched function",) + tuple(dtype.__name__ for dtype in all_layers)
+    ]
+    for spec in dispatchers[N]:
+        if spec.output:
+            lines_output += [
+                (spec.__name__,)
+                + tuple((dtype,)*(N+1) in spec._specialisations for dtype in all_layers)
+            ]
+        else:
+            lines_no_output += [
+                (spec.__name__,)
+                + tuple((dtype,)*N in spec._specialisations for dtype in all_layers)
+            ]
+    return lines_output, lines_no_output
+
+def specialisation_table():
+    """
+    Print tables for each dispatched function showing which data layer have a
+    specialisation for it. Only pure specialisations are shown, functions
+    taking mulitiple input types are not shown.
+
+    Output is sorted by number of data layer input.
+    """
+    lines_output, lines_no_output = _extract_specialisation_per_type(0)
+    _print_table(lines_output, "Output only specialisation")
+
+    lines_output, lines_no_output = _extract_specialisation_per_type(1)
+    _print_table(lines_output, "Unitary specialisation")
+    _print_table(lines_no_output, "Matrix -> scalar specialisation")
+
+    lines_output, lines_no_output = _extract_specialisation_per_type(2)
+    _print_table(lines_output, "Binary specialisation")
+    _print_table(lines_no_output, "Binary measurement specialisation")
+
+    lines_output, lines_no_output = _extract_specialisation_per_type(3)
+    _print_table(lines_output, "Ternary specialisation")
+    _print_table(lines_no_output, "Ternary measurement specialisation")

--- a/qutip/core/data/dev_utils.py
+++ b/qutip/core/data/dev_utils.py
@@ -5,16 +5,20 @@ Tools to help with data layer development.
 from collections import defaultdict
 from qutip.core import data as _data
 
+__all__ = ["all_specialisation", "specialisation_table"]
+
+
 def all_specialisation():
     """
     Create a dict of all specialisations of the dispatcher sorted in number of
     data layer inputs.
     """
-    all_dispatchers = qt.data.to.dispatchers
+    all_dispatchers = _data.to.dispatchers
     dispatchers = defaultdict(list)
     for dispatcher in all_dispatchers:
         dispatchers[len(dispatcher.inputs)].append(dispatcher)
     return dict(sorted(dispatchers.items()))
+
 
 def _bool2str(entry):
     if isinstance(entry, str):
@@ -24,18 +28,23 @@ def _bool2str(entry):
     else:
         return "False"
 
+
 def _print_table(lines, title):
-    if len(lines) == 1: return
+    if len(lines) == 1:
+        return
     print()
     print(title)
     for line in lines:
-        print(f"|{line[0]:<20}|" + "|".join(
-            f"{_bool2str(entry):^10}" for entry in line[1:]) + "|"
+        print(
+            f"|{line[0]:<20}|"
+            + "|".join(f"{_bool2str(entry):^10}" for entry in line[1:])
+            + "|"
         )
+
 
 def _extract_specialisation_per_type(N):
     dispatchers = all_specialisation()
-    all_layers = list(qt.data.to.dtypes)
+    all_layers = list(_data.to.dtypes)
     lines_output = [
         ("Dispatched function",) + tuple(dtype.__name__ for dtype in all_layers)
     ]
@@ -46,14 +55,17 @@ def _extract_specialisation_per_type(N):
         if spec.output:
             lines_output += [
                 (spec.__name__,)
-                + tuple((dtype,)*(N+1) in spec._specialisations for dtype in all_layers)
+                + tuple(
+                    (dtype,) * (N + 1) in spec._specialisations for dtype in all_layers
+                )
             ]
         else:
             lines_no_output += [
                 (spec.__name__,)
-                + tuple((dtype,)*N in spec._specialisations for dtype in all_layers)
+                + tuple((dtype,) * N in spec._specialisations for dtype in all_layers)
             ]
     return lines_output, lines_no_output
+
 
 def specialisation_table():
     """

--- a/qutip/core/data/properties.pyx
+++ b/qutip/core/data/properties.pyx
@@ -255,6 +255,7 @@ isherm.__doc__ =\
         `qutip.settings.atol` is used instead.
     """
 isherm.add_specialisations([
+    (Dense, isherm_dense),
     (CSR, isherm_csr),
 ], _defer=True)
 
@@ -277,6 +278,7 @@ isdiag.__doc__ =\
         The matrix to test for diagonality.
     """
 isdiag.add_specialisations([
+    (Dense, isdiag_dense),
     (CSR, isdiag_csr),
 ], _defer=True)
 


### PR DESCRIPTION
**Description**
Add a function that list all dispatched functions and their specialization.
It automatically adapt to new data-layer and dispatched functions.
Only show pure specialization: `solve[Dense, Dense]` not `solve[CSR, Dense]`.

I also register 2 specializations that were created, but not registered.

Example:
```
>>> from qutip.core.data.dev_utils import specialisation_table
>>> specialisation_table()

Output only specialisation
|Dispatched function | JaxArray |   CSR    |  Dense   |
|zeros               |   True   |   True   |   True   |
|identity            |   True   |   True   |   True   |
|diag                |   True   |   True   |   True   |
|one_element         |   True   |   True   |   True   |
...
Binary specialisation
|Dispatched function | JaxArray |   CSR    |  Dense   |
|add                 |   True   |   True   |   True   |
|sub                 |   True   |   True   |   True   |
|matmul              |   True   |   True   |   True   |
|multiply            |   True   |   True   |   True   |
|kron                |   True   |   True   |   True   |
|solve               |  False   |  False   |   True   |
...
```

This could also go into a notebook if it fit better there.
