### PR TITLE
Add missing properties specialization

### DIFF
--- a/qutip/core/data/properties.pyx
+++ b/qutip/core/data/properties.pyx
@@ -255,6 +255,7 @@ isherm.__doc__ =\
         `qutip.settings.atol` is used instead.
     """
 isherm.add_specialisations([
+    (Dense, isherm_dense),
     (CSR, isherm_csr),
 ], _defer=True)
 
@@ -277,6 +278,7 @@ isdiag.__doc__ =\
         The matrix to test for diagonality.
     """
 isdiag.add_specialisations([
+    (Dense, isdiag_dense),
     (CSR, isdiag_csr),
 ], _defer=True)
 


### PR DESCRIPTION
**Description**
Add missing specialization that were created, but not registered.
The test already call the dispatched function using both data layer, thus adding the specialization will have the added function tested.