### PR TITLE
Optimize dispatcher by using positional only arguments

### DIFF
--- a/doc/changes/2135.misc
+++ b/doc/changes/2135.misc
@@ -1,0 +1,1 @@
+Optimize dispatcher by dispatching on positional only args.

--- a/qutip/core/data/add.pyx
+++ b/qutip/core/data/add.pyx
@@ -230,8 +230,8 @@ import inspect as _inspect
 
 add = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('scale', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
                            default=1),
     ]),
@@ -254,8 +254,8 @@ add.add_specialisations([
 
 sub = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='sub',
     module=__name__,

--- a/qutip/core/data/adjoint.pyx
+++ b/qutip/core/data/adjoint.pyx
@@ -114,7 +114,7 @@ import inspect as _inspect
 
 adjoint = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='adjoint',
     module=__name__,
@@ -129,7 +129,7 @@ adjoint.add_specialisations([
 
 transpose = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='transpose',
     module=__name__,
@@ -144,7 +144,7 @@ transpose.add_specialisations([
 
 conj = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='conj',
     module=__name__,

--- a/qutip/core/data/dispatch.pyx
+++ b/qutip/core/data/dispatch.pyx
@@ -13,208 +13,6 @@ from libcpp cimport bool
 
 __all__ = ['Dispatcher']
 
-cdef class _bind:
-    """
-    Cythonised implementation of inspect.Signature.bind, supporting faster
-    binding and handling of default arguments.  On construction, the signature
-    of the base function is extracted, and all parameters are parsed into
-    positional or keyword slots, using positional wherever possible, and their
-    defaults are stored.
-    """
-    # Instance of inpsect.Signature representing the function.
-    cdef object signature
-    cdef object inputs
-    # Mapping of (str: int), where str is the name of any argument which may be
-    # specified by a keyword, and int is its location in `self._pos` if
-    # available, or -1 if it is keyword-only.
-    cdef dict _locations
-    # Default values (or inspect.Parameter.empty) for every parameter which
-    # may be passed as a positional argument.
-    cdef list _pos
-    # For each dispatcher input which can be given as a positional argument,
-    # these two lists hold the index of the input in the given tuple of input
-    # names and the corresponding index into the positional arguments after
-    # binding is complete.  {_pos_inputs_pos[n]: _pos_inputs_input[n]} is
-    # effectively the same mapping as _kw_inputs (but for positional
-    # arguments), but we use two lists rather than a dictionary for speed.
-    cdef list _pos_inputs_input, _pos_inputs_pos
-    # Default values (or inspect.Parameter.empty) for every parameter which
-    # _must_ be passed as a keyword argument.
-    cdef dict _kw
-    # Mapping of (name, index into the input tuple) for each input which must
-    # be specified as a keyword argument
-    cdef list _kw_inputs
-    # Names of the keyword arguments which have default values.
-    cdef set _default_kw_names
-    # Respectively, numbers of positional parameters, keyword-only parameters
-    # and dispatcher inputs.
-    cdef Py_ssize_t n_args, n_kwargs, n_inputs
-    # Respectively, numbers of inputs which are positional and keyword-only.
-    cdef Py_ssize_t _n_pos_inputs, _n_kw_inputs
-    # Respectively, numbers of positional arguments without a default, and
-    # number of keyword-only arguments which _have_ a default.
-    cdef Py_ssize_t _n_pos_no_default, _n_kw_default
-
-
-    def __init__(self, signature, tuple inputs):
-        for arg in inputs:
-            if arg not in signature.parameters:
-                raise AttributeError("No argument matches '{}'.".format(arg))
-        self.signature = signature
-        self.inputs = inputs
-        self._locations = {}
-        self._pos = []
-        self._pos_inputs_input = []
-        self._pos_inputs_pos = []
-        self._kw = {}
-        self._kw_inputs = []
-        self._default_kw_names = set()
-        self._n_pos_no_default = 0
-        # signature.parameters is ordered for all Python versions.
-        for i, (name, parameter) in enumerate(signature.parameters.items()):
-            kind = parameter.kind
-            if (kind == parameter.VAR_POSITIONAL
-                    or kind == parameter.VAR_KEYWORD):
-                raise TypeError("Cannot dispatch with *args or **kwargs.")
-            if kind == parameter.KEYWORD_ONLY:
-                self._kw[name] = parameter.default
-                self._locations[name] = -1
-                if parameter.default is not parameter.empty:
-                    self._default_kw_names.add(name)
-                if name in inputs:
-                    self._kw_inputs.append((name, inputs.index(name)))
-            else:
-                self._pos.append(parameter.default)
-                if kind != parameter.POSITIONAL_ONLY:
-                    self._locations[name] = i
-                if parameter.default is parameter.empty:
-                    self._n_pos_no_default += 1
-                if name in inputs:
-                    # Effectively a mapping.
-                    self._pos_inputs_input.append(inputs.index(name))
-                    self._pos_inputs_pos.append(len(self._pos) - 1)
-        self.n_args = len(self._pos)
-        self.n_kwargs = len(self._kw)
-        self.n_inputs = len(inputs)
-        self._n_pos_inputs = len(self._pos_inputs_input)
-        self._n_kw_inputs = len(self._kw_inputs)
-        self._n_kw_default = len(self._default_kw_names)
-
-
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
-    cdef tuple bind(self, tuple args, dict kwargs):
-        """
-        Cython reimplementation of inspect.Signature.bind for binding the
-        collected `*args` and `**kwargs` of a generic call to a specific
-        signature, checking that everything matches.
-
-        The output is a parsed tuple (args, kwargs), where `args` is a list and
-        `kwargs` is a dict, however all arguments which _can_ be passed
-        positionally will be moved from `kwargs` into `args` for the output.
-        The resultant `args` and `kwargs` can be unpacked into the underlying
-        function call safely.  Default values are not filled in by this method.
-
-        This is necessary to allow a generic `Dispatcher` class to work with
-        all type signatures.  The result of this function can be fed to
-        `_bind.convert_types` and `_bind.dispatch_types`.
-        """
-        cdef Py_ssize_t location, got_pos=0, got_kw=0
-        cdef Py_ssize_t n_passed_args = len(args)
-        if n_passed_args > self.n_args:
-            raise TypeError(
-                "Too many arguments: expected at most {} but received {}."
-                .format(n_passed_args, self.n_args)
-            )
-        # _pos and _kw are filled with their defaults at initialisation, and
-        # _pos is already the correct length (no-default parameters have
-        # sentinel values).
-        cdef list out_pos = self._pos.copy()
-        cdef dict out_kw = self._kw.copy()
-        got_pos = self.n_args - self._n_pos_no_default
-        got_kw = self._n_kw_default
-        # Positional arguments unambiguously fill the first positional slots.
-        for location in range(n_passed_args):
-            out_pos[location] = args[location]
-        # How many arguments that we didn't have defaults for did we just get?
-        # Positionals with a default are always after those without one.
-        if n_passed_args > self._n_pos_no_default:
-            got_pos += self._n_pos_no_default
-        else:
-            got_pos += n_passed_args
-        # Everything else has been passed by keyword, but it may be allowed to
-        # be passed positionally, which is the case we prefer.  dict.items() is
-        # (relatively) expensive, so we use a boolean test for the fast path.
-        cdef str kw
-        cdef object arg
-        if kwargs:
-            for kw, arg in kwargs.items():
-                try:
-                    location = self._locations[kw]
-                except KeyError:
-                    raise TypeError("Unknown argument '{}'.".format(kw)) from None
-                # _locations[kw] = -1 if kw is keyword-only, otherwise the
-                # corresponding positional location.
-                if location >= 0:
-                    if location < n_passed_args:
-                        raise TypeError("Multiple values for '{}'".format(kw))
-                    out_pos[location] = arg
-                    if location < self._n_pos_no_default:
-                        got_pos += 1
-                else:
-                    out_kw[kw] = arg
-                    if kw not in self._default_kw_names:
-                        got_kw += 1
-        if got_pos < self.n_args:
-            raise TypeError("Too few positional arguments passed.")
-        if got_kw < self.n_kwargs:
-            raise TypeError("Not all keyword arguments were filled.")
-        return out_pos, out_kw
-
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
-    cdef list dispatch_types(self, list args, dict kwargs):
-        """
-        Get a list of the types which the dispatch should operate over, given
-        the output of `_bind.bind`.  The return value is a list of the _input_
-        types to be dispatched on, in order that they were specified at
-        `Dispatcher` creation.  The output type is not returned as part of this
-        list, because there is no way for `_bind` to know it.
-        """
-        cdef list dispatch = [None] * self.n_inputs
-        cdef str kw
-        cdef Py_ssize_t location, i
-        for location in range(self._n_pos_inputs):
-            dispatch[self._pos_inputs_input[location]]\
-                = type(args[self._pos_inputs_pos[location]])
-        for i in range(self._n_kw_inputs):
-            kw, location = self._kw_inputs[i]
-            dispatch[location] = type(kwargs[kw])
-        return dispatch
-
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
-    cdef tuple convert_types(self, list args, dict kwargs, tuple converters):
-        """
-        Apply the type converters `converters` to the parsed arguments `args`
-        and `kwargs`.
-
-        If there are `n` inputs which are dispatched on, `converters` should be
-        a tuple whose first `n` elements are converters (such as those obtained
-        from `data.to[to_type, from_type]`) to the desired types.
-
-        `args` and `kwargs` should be the output of `_bind.bind`; the function
-        will likely fail if called on unparsed arguments.
-        """
-        cdef str kw
-        cdef Py_ssize_t location, i
-        for location in range(self._n_pos_inputs):
-            args[location] = converters[location](args[location])
-        for i in range(self._n_kw_inputs):
-            kw, location = self._kw_inputs[i]
-            kwargs[kw] = converters[location](kwargs[kw])
-        return args, kwargs
-
 
 cdef double _conversion_weight(tuple froms, tuple tos, dict weight_map, bint out) except -1:
     """
@@ -248,13 +46,12 @@ cdef class _constructed_specialisation:
     See `self.__signature__` or `self.__text_signature__` for the call
     signature of this object.
     """
-    cdef _bind _parameters
-    cdef bint _output
+    cdef readonly Py_ssize_t _output
     cdef object _call
-    cdef Py_ssize_t _n_dispatch
+    cdef readonly Py_ssize_t _n_input_converters
     cdef readonly tuple types
-    cdef tuple _converters
-    cdef str _short_name
+    cdef readonly tuple _converters
+    cdef readonly str _short_name
     cdef public str __doc__
     cdef public str __name__
     cdef public str __module__
@@ -274,31 +71,22 @@ cdef class _constructed_specialisation:
         self.__module__ = dispatcher.__module__
         self.__signature__ = dispatcher.__signature__
         self.__text_signature__ = dispatcher.__text_signature__
-        self._parameters = dispatcher._parameters
-        self._output = out
+        self._output = len(types) - 1 if out else -1
         self._call = base
-        self._n_dispatch = len(types)
         self.types = types
         self.direct = direct
         self._converters = converters
-
-    cdef object prebound(self, list args, dict kwargs):
-        """
-        Call this specialisation with pre-parsed arguments and keyword
-        arguments.  `args` and `kwargs` must be the output of the relevant
-        `_bind.bind` method for this function.
-        """
-        self._parameters.convert_types(args, kwargs, self._converters)
-        out = self._call(*args, **kwargs)
-        if self._output:
-            out = self._converters[self._n_dispatch - 1](out)
-        return out
+        self._n_input_converters = len(converters) - out
 
     def __call__(self, *args, **kwargs):
-        cdef list args_
-        cdef dict kwargs_
-        args_, kwargs_ = self._parameters.bind(args, kwargs)
-        return self.prebound(args_, kwargs_)
+        cdef int i
+        cdef list datas = []
+        for i in range(self._n_input_converters):
+            datas.append(self._converters[i](args[i]))
+        out = self._call(*datas, *args[self._n_input_converters:], **kwargs)
+        if self._output != -1:
+            out = self._converters[self._output](out)
+        return out
 
     def __repr__(self):
         if len(self.types) == 1:
@@ -328,12 +116,11 @@ cdef class Dispatcher:
     where `type1`, `type2`, etc are the dispatched arguments (with the output
     type on the end, if this is a dispatcher over the output type.
     """
-    cdef _bind _parameters
     cdef readonly dict _specialisations
-    cdef Py_ssize_t _n_dispatch
+    cdef readonly Py_ssize_t _n_dispatch
     cdef readonly dict _lookup
-    cdef set _dtypes
-    cdef bint _pass_on_dtype
+    cdef readonly set _dtypes
+    cdef readonly bint _pass_on_dtype
     cdef readonly tuple inputs
     cdef readonly bint output
     cdef public str __doc__
@@ -394,7 +181,6 @@ cdef class Dispatcher:
             self.__signature__ = signature_source
         else:
             self.__signature__ = inspect.signature(signature_source)
-        self._parameters = _bind(self.__signature__, inputs)
         if name is not None:
             self.__name__ = name
         elif not isinstance(signature_source, inspect.Signature):
@@ -411,7 +197,7 @@ cdef class Dispatcher:
         self.output = out
         self._specialisations = {}
         self._lookup = {}
-        self._n_dispatch = self._parameters.n_inputs + self.output
+        self._n_dispatch = len(self.inputs) + self.output
         self._pass_on_dtype = 'dtype' in self.__signature__.parameters
         # Add ourselves to the list of dispatchers to be updated.
         _to.dispatchers.append(self)
@@ -471,7 +257,7 @@ cdef class Dispatcher:
                 raise ValueError(
                     "specialisation " + str(arg)
                     + " has wrong number of parameters: needed types for "
-                    + str(self._parameters.inputs)
+                    + str(self.inputs)
                     + (", an output type" if self.output else "")
                     + " and a callable"
                 )
@@ -513,17 +299,21 @@ cdef class Dispatcher:
                     weight = cur
                     types = out_types
                     function = out_function
-            if self.output:
-                converters = tuple(
-                    [_to[pair] for pair in zip(types[:-1], in_types[:-1])]
-                    + [_to[in_types[-1], types[-1]]]
-                )
+
+            if weight == 0:
+                self._lookup[in_types] = function
             else:
-                converters = tuple(_to[pair] for pair in zip(types, in_types))
-            self._lookup[in_types] =\
-                _constructed_specialisation(function, self, in_types,
-                                            converters, self.output,
-                                            weight == 0)
+                if self.output:
+                    converters = tuple(
+                        [_to[pair] for pair in zip(types[:-1], in_types[:-1])]
+                        + [_to[in_types[-1], types[-1]]]
+                    )
+                else:
+                    converters = tuple(_to[pair] for pair in zip(types, in_types))
+                self._lookup[in_types] =\
+                    _constructed_specialisation(function, self, in_types,
+                                                converters, self.output,
+                                                weight == 0)
         # Now build the lookup table in the case that we dispatch on the output
         # type as well, but the user has called us without specifying it.
         # TODO: option to control default output type choice if unspecified?
@@ -539,12 +329,19 @@ cdef class Dispatcher:
                         weight = cur
                         types = out_types
                         function = out_function
-                converters = tuple(_to[pair] for pair in zip(types, in_types))
-                self._lookup[in_types] =\
-                    _constructed_specialisation(function, self,
-                                                in_types + (types[-1],),
-                                                converters, False,
-                                                weight == 0)
+
+                if weight == 0:
+                    self._lookup[in_types] = function
+                else:
+                    converters = tuple(
+                        _to[pair]
+                        for pair in zip(types, in_types)
+                    )
+                    self._lookup[in_types] =\
+                        _constructed_specialisation(function, self,
+                                                    in_types + (types[-1],),
+                                                    converters, False,
+                                                    weight == 0)
 
     def __getitem__(self, types):
         """
@@ -564,20 +361,23 @@ cdef class Dispatcher:
         return "<dispatcher: " + self.__text_signature__ + ">"
 
     def __call__(self, *args, dtype=None, **kwargs):
-        cdef list args_, dispatch
-        cdef dict kwargs_
+        cdef list dispatch
         if self._pass_on_dtype:
             kwargs['dtype'] = dtype
         if not (self._pass_on_dtype or self.output) and dtype is not None:
             raise TypeError("unknown argument 'dtype'")
-        args_, kwargs_ = self._parameters.bind(args, kwargs)
-        dispatch = self._parameters.dispatch_types(args_, kwargs_)
+        if len(args) < len(self.inputs):
+            raise TypeError(
+                "All dispatched data input must be passed "
+                "as positional arguments."
+            )
+        dispatch = [type(var) for var in args[:len(self.inputs)]]
+
         if self.output and dtype is not None:
             dtype = _to.parse(dtype)
             dispatch.append(dtype)
-        cdef _constructed_specialisation function
         try:
             function = self._lookup[tuple(dispatch)]
         except KeyError:
             raise TypeError("unknown types to dispatch on: " + str(dispatch)) from None
-        return function.prebound(args_, kwargs_)
+        return function(*args, **kwargs)

--- a/qutip/core/data/eigen.py
+++ b/qutip/core/data/eigen.py
@@ -207,7 +207,7 @@ def _eigs_fix_eigvals(data, eigvals, sort):
     return eigvals, num_large, num_small
 
 
-def eigs_csr(data, isherm=None, vecs=True, sort='low', eigvals=0,
+def eigs_csr(data, /, isherm=None, vecs=True, sort='low', eigvals=0,
              tol=0, maxiter=100000):
     """
     Return eigenvalues and eigenvectors for a CSR matrix.  This specialisation
@@ -257,7 +257,7 @@ def eigs_csr(data, isherm=None, vecs=True, sort='low', eigvals=0,
     return (evals, Dense(evecs, copy=False)) if vecs else evals
 
 
-def eigs_dense(data, isherm=None, vecs=True, sort='low', eigvals=0):
+def eigs_dense(data, /, isherm=None, vecs=True, sort='low', eigvals=0):
     """
     Return eigenvalues and eigenvectors for a Dense matrix.  Takes no special
     keyword arguments; see the primary documentation in :func:`.eigs`.
@@ -412,7 +412,7 @@ def svd_dense(data, vecs=True, **kw):
 
 svd = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('data', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('data', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('vecs', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
     ]),
     name='svd',

--- a/qutip/core/data/expect.pyx
+++ b/qutip/core/data/expect.pyx
@@ -254,8 +254,8 @@ import inspect as _inspect
 
 expect = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('op', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('state', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('op', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('state', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='expect',
     module=__name__,
@@ -280,8 +280,8 @@ expect.add_specialisations([
 
 expect_super = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('op', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('state', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('op', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('state', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='expect_super',
     module=__name__,

--- a/qutip/core/data/expm.py
+++ b/qutip/core/data/expm.py
@@ -55,7 +55,7 @@ import inspect as _inspect
 
 expm = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='expm',
     module=__name__,
@@ -78,7 +78,7 @@ def logm_dense(matrix: Dense) -> Dense:
 
 logm = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='logm',
     module=__name__,

--- a/qutip/core/data/inner.pyx
+++ b/qutip/core/data/inner.pyx
@@ -193,8 +193,8 @@ import inspect as _inspect
 
 inner = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('scalar_is_ket', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
                            default=False),
     ]),
@@ -236,9 +236,9 @@ inner.add_specialisations([
 
 inner_op = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('op', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('op', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('scalar_is_ket', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
                            default=False),
     ]),

--- a/qutip/core/data/kron.pyx
+++ b/qutip/core/data/kron.pyx
@@ -70,8 +70,8 @@ import inspect as _inspect
 
 kron = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='kron',
     module=__name__,

--- a/qutip/core/data/linalg.py
+++ b/qutip/core/data/linalg.py
@@ -6,7 +6,7 @@ from .csr import CSR
 __all__ = ['inv', 'inv_csr', 'inv_dense']
 
 
-def inv_dense(data):
+def inv_dense(data, /):
     """Compute the inverse of a matrix"""
     if not isinstance(data, Dense):
         raise TypeError("expected data in Dense format but got "
@@ -17,7 +17,7 @@ def inv_dense(data):
     return Dense(scipy.linalg.inv(data.as_ndarray()), copy=False)
 
 
-def inv_csr(data):
+def inv_csr(data, /):
     """Compute the inverse of a sparse matrix"""
     if not isinstance(data, CSR):
         raise TypeError("expected data in CSR format but got "

--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -398,8 +398,8 @@ import inspect as _inspect
 
 matmul = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('scale', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
                            default=1),
     ]),
@@ -435,8 +435,8 @@ matmul.add_specialisations([
 
 multiply = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('left', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('right', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='multiply',
     module=__name__,

--- a/qutip/core/data/mul.pyx
+++ b/qutip/core/data/mul.pyx
@@ -71,7 +71,7 @@ import inspect as _inspect
 
 mul = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('value', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
     ]),
     name='mul',
@@ -91,7 +91,7 @@ imul = _Dispatcher(
     # give expected results if used as:
     # mat = imul(mat, x)
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('value', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
     ]),
     name='imul',
@@ -108,7 +108,7 @@ imul.add_specialisations([
 
 neg = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='neg',
     module=__name__,

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -139,7 +139,7 @@ import inspect as _inspect
 
 l2 = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('vector', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('vector', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='l2',
     module=__name__,
@@ -158,7 +158,7 @@ l2.add_specialisations([
 ], _defer=True)
 
 _norm_signature = _inspect.Signature([
-    _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
 ])
 
 frobenius = _Dispatcher(_norm_signature, name='frobenius', module=__name__, inputs=('matrix',))
@@ -201,7 +201,7 @@ one.add_specialisations([
 
 trace = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     inputs=('matrix',),
     name='trace',

--- a/qutip/core/data/permute.pyx
+++ b/qutip/core/data/permute.pyx
@@ -320,7 +320,7 @@ import inspect as _inspect
 
 dimensions = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('dimensions', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
         _inspect.Parameter('order', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
     ]),
@@ -367,7 +367,7 @@ dimensions.add_specialisations([
 
 indices = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('row_perm', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
                            default=None),
         _inspect.Parameter('col_perm', _inspect.Parameter.POSITIONAL_OR_KEYWORD,

--- a/qutip/core/data/pow.pyx
+++ b/qutip/core/data/pow.pyx
@@ -56,7 +56,7 @@ import inspect as _inspect
 
 pow = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('n', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
     ]),
     name='pow',

--- a/qutip/core/data/project.pyx
+++ b/qutip/core/data/project.pyx
@@ -119,7 +119,7 @@ import inspect as _inspect
 
 project = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('state', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('state', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='project',
     module=__name__,

--- a/qutip/core/data/properties.pyx
+++ b/qutip/core/data/properties.pyx
@@ -227,7 +227,7 @@ import inspect as _inspect
 
 isherm = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('tol', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
                            default=-1),
     ]),
@@ -261,7 +261,7 @@ isherm.add_specialisations([
 
 isdiag = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='isdiag',
     module=__name__,
@@ -284,7 +284,7 @@ isdiag.add_specialisations([
 
 iszero = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('tol', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
                            default=-1),
     ]),

--- a/qutip/core/data/ptrace.pyx
+++ b/qutip/core/data/ptrace.pyx
@@ -169,7 +169,7 @@ import inspect as _inspect
 
 ptrace = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('dims', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
         _inspect.Parameter('sel', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
     ]),

--- a/qutip/core/data/reshape.pyx
+++ b/qutip/core/data/reshape.pyx
@@ -135,7 +135,7 @@ import inspect as _inspect
 
 reshape = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('n_rows_out', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
         _inspect.Parameter('n_cols_out', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
     ]),
@@ -169,7 +169,7 @@ reshape.add_specialisations([
 
 column_stack = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='column_stack',
     module=__name__,
@@ -208,7 +208,7 @@ column_stack.add_specialisations([
 
 column_unstack = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('rows', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
     ]),
     name='column_unstack',
@@ -249,7 +249,7 @@ column_unstack.add_specialisations([
 
 split_columns = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('copy', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
                            default=1),
     ]),

--- a/qutip/core/data/solve.py
+++ b/qutip/core/data/solve.py
@@ -154,8 +154,8 @@ import inspect as _inspect
 
 solve = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
-        _inspect.Parameter('target', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('target', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('method', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
                            default=None),
         _inspect.Parameter('options', _inspect.Parameter.POSITIONAL_OR_KEYWORD,

--- a/qutip/core/data/tidyup.pyx
+++ b/qutip/core/data/tidyup.pyx
@@ -63,7 +63,7 @@ import inspect as _inspect
 
 tidyup = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
         _inspect.Parameter('tol', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
         _inspect.Parameter('inplace', _inspect.Parameter.POSITIONAL_OR_KEYWORD,
                            default=True),

--- a/qutip/core/data/trace.pyx
+++ b/qutip/core/data/trace.pyx
@@ -76,7 +76,7 @@ import inspect as _inspect
 
 trace = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='trace',
     module=__name__,
@@ -92,7 +92,7 @@ trace.add_specialisations([
 
 trace_oper_ket = _Dispatcher(
     _inspect.Signature([
-        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
     ]),
     name='trace_oper_ket',
     module=__name__,


### PR DESCRIPTION
**Description**
I optimized the dispatched by only supporting positional arguments for matrix to dispatch on:

The dispatcher was supporting any signature for dispatched functions.
Since each dispatchers is an instance of the `Dispatcher` class and cython does not support patching methods, it had to find the inputs matrix to convert from `__call__(*args, **kwargs)` and re-implemented the `_bind` method to do so.
But all our dispatched functions have the matrix as the first positional argument, by embracing this we get a nice speed up for small matrices.

Also when the specialization existed, it would not call it directly, but call  a `_constructed_specialisation` that called ti. Adding another unneeded layer to each calls. This was changed so it would call the function directly.

For a 2x2 matrix:
|                  | Before | After |
|------------------|--------|-------|
| data.add_dense   | 214ns  | 210ns |
| data.add (dense) | 774ns  | 388ns |
| data.add[Dense, Dense] | 541ns  | 182ns |
| data.add_csr     | 429ns  | 447ns |
| data.add (csr)   | 986ns  | 649ns |
| data.add[CSR. CSR]  | 744ns  | 401ns |
| numpy | 473ns | - |

Sadly it will not improve the benchmarks that much since the `Qobj` operations overhead is quite large:
|                  | Before | After |
|------------------|--------|-------|
| Qboj + Qobj (dense)   | 2430ns  | 2070ns |
| Qboj + Qobj (csr)   | 3070ns  | 2330ns |
