### PR TITLE
Fix dtype in `imatmul`

### DIFF
--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -471,4 +471,4 @@ cdef void imatmul_data_dense(Data left, Dense right, double complex scale, Dense
     elif type(left) is Dense:
         matmul_dense(left, right, scale, out)
     else:
-        iadd_dense(out, matmul(left, right), scale)
+        iadd_dense(out, matmul(left, right, dtype=Dense), scale)


### PR DESCRIPTION
**Description**
We use `imatmul_data_dense`  for cython only, in-place `matmul` operation since the dispatcher can't handle in-place operation but they can't have nice impact on performance.
`imatmul_data_dense` had a bug that when data is not `Dense` or `CSR` it would use a wrong specialization of `matmul` and raise an error. 

It work fine with all data layer in qutip/qutip so we can test it here, but some tests fails in qutip-jax (qutip/qutip-jax#14) because of it.

**Related issues or PRs**
Blocking qutip/qutip-jax#14