### PR TITLE
Clean semidefinite.py

### DIFF
--- a/doc/changes/2138.misc
+++ b/doc/changes/2138.misc
@@ -1,0 +1,1 @@
+Clean semidefinite

--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -538,7 +538,7 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
     # If we're still here, we need to actually solve the problem.
 
     # Assume square...
-    dim = np.prod(J.dims[0][0])
+    dim = int(np.prod(J.dims[0][0]))
 
     # Load the parameters with the Choi matrix passed in.
     J_dat = _data.to('csr', J.data).as_scipy()

--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -540,16 +540,10 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
     # Assume square...
     dim = np.prod(J.dims[0][0])
 
-    # The constraints only depend on the dimension, so
-    # we can cache them efficiently.
-    problem, Jr, Ji, *_ = dnorm_problem(dim)
-
     # Load the parameters with the Choi matrix passed in.
     J_dat = _data.to('csr', J.data).as_scipy()
 
     if not sparse:
-        # The parameters and constraints only depend on the dimension, so
-        # we can cache them efficiently.
         problem, Jr, Ji = dnorm_problem(dim)
 
         # Load the parameters with the Choi matrix passed in.
@@ -561,9 +555,6 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
                                   J_dat.indptr),
                                  shape=J_dat.shape).toarray()
     else:
-
-        # The parameters do not depend solely on the dimension,
-        # so we can not cache them efficiently.
         problem = dnorm_sparse_problem(dim, J_dat)
 
     problem.solve(solver=solver, verbose=verbose)

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -1075,7 +1075,7 @@ def qft(dimensions, *, dtype="dense"):
 
 def swap(N, M, *, dtype=None):
     """
-    Operator that exchange the order of tensored spaces:
+    Operator that exchanges the order of tensored spaces:
 
         swap(N, M) @ tensor(ketN, ketM) == tensor(ketM, ketN)
 
@@ -1093,10 +1093,10 @@ def swap(N, M, *, dtype=None):
         return qeye([1, 1], dtype=dtype)
 
     data = np.ones(N * M)
-    rows = np.arange(N * M)
+    rows = np.arange(N * M + 1)  # last entry is nnz
     cols = (np.arange(N * M) * M) % (N * M - 1)
     cols[-1] += (M * N - 1)
     return Qobj(
-        scipy.sparse.coo_matrix((data, (rows, cols))),
+        _data.CSR((data, cols, rows), (N * M, N * M)),
         dims=[[M, N], [N, M]]
     ).to(dtype)

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -1088,6 +1088,10 @@ def swap(N, M, *, dtype=None):
         Number of basis states in the second Hilbert space.
     """
     dtype = dtype or settings.core["default_dtype"] or _data.CSR
+
+    if N == 1 and M == 1:
+        return qeye([1, 1], dtype=dtype)
+
     data = np.ones(N * M)
     rows = np.arange(N * M)
     cols = (np.arange(N * M) * M) % (N * M - 1)

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -1094,8 +1094,7 @@ def swap(N, M, *, dtype=None):
 
     data = np.ones(N * M)
     rows = np.arange(N * M + 1)  # last entry is nnz
-    cols = (np.arange(N * M) * M) % (N * M - 1)
-    cols[-1] += (M * N - 1)
+    cols = np.ravel(M * np.arange(N)[None, :] + np.arange(M)[:, None])
     return Qobj(
         _data.CSR((data, cols, rows), (N * M, N * M)),
         dims=[[M, N], [N, M]]

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -6,7 +6,7 @@ of commonly occuring quantum operators.
 __all__ = ['jmat', 'spin_Jx', 'spin_Jy', 'spin_Jz', 'spin_Jm', 'spin_Jp',
            'spin_J_set', 'sigmap', 'sigmam', 'sigmax', 'sigmay', 'sigmaz',
            'destroy', 'create', 'qeye', 'identity', 'position', 'momentum',
-           'num', 'squeeze', 'squeezing', 'displace', 'commutator',
+           'num', 'squeeze', 'squeezing', 'swap', 'displace', 'commutator',
            'qutrit_ops', 'qdiags', 'phase', 'qzero', 'enr_destroy',
            'enr_identity', 'charge', 'tunneling', 'qft']
 
@@ -1071,3 +1071,28 @@ def qft(dimensions, *, dtype="dense"):
     L, M = np.meshgrid(arr, arr)
     data = np.exp(phase * (L * M)) / np.sqrt(N2)
     return Qobj(data, dims=dimensions).to(dtype)
+
+
+def swap(N, M, *, dtype=None):
+    """
+    Operator that exchange the order of tensored spaces:
+
+        swap(N, M) @ tensor(ketN, ketM) == tensor(ketM, ketN)
+
+    parameters
+    ----------
+    N : int
+        Number of basis states in the first Hilbert space.
+
+    M : int
+        Number of basis states in the second Hilbert space.
+    """
+    dtype = dtype or settings.core["default_dtype"] or _data.CSR
+    data = np.ones(N * M)
+    rows = np.arange(N * M)
+    cols = (np.arange(N * M) * M) % (N * M - 1)
+    cols[-1] += (M * N - 1)
+    return Qobj(
+        scipy.sparse.coo_matrix((data, (rows, cols))),
+        dims=[[M, N], [N, M]]
+    ).to(dtype)

--- a/qutip/core/semidefinite.py
+++ b/qutip/core/semidefinite.py
@@ -73,7 +73,7 @@ def _conj(W, A):
     )
 
 
-@functools.cache
+@functools.lru_cache
 def initialize_constraints_on_dnorm_problem(dim):
     # Start assembling constraints and variables.
     constraints = []

--- a/qutip/tests/core/test_operators.py
+++ b/qutip/tests/core/test_operators.py
@@ -297,8 +297,8 @@ def test_qft(dims):
 
 @pytest.mark.parametrize('N', [1, 3, 5, 8])
 @pytest.mark.parametrize('M', [1, 3, 5, 8])
-def test_qft(N, M):
+def test_swap(N, M):
     ket1 = qutip.rand_ket(N)
     ket2 = qutip.rand_ket(M)
 
-    assert swap(N, M) @ (ket1 & ket2) == (ket2 & ket1)
+    assert qutip.swap(N, M) @ (ket1 & ket2) == (ket2 & ket1)

--- a/qutip/tests/core/test_operators.py
+++ b/qutip/tests/core/test_operators.py
@@ -293,3 +293,12 @@ def test_qft(dims):
         fft = np.fft.fft(qft[:,i])
         fft /= np.sum(fft)
         np.testing.assert_allclose(fft, target, atol=1e-16 * N)
+
+
+@pytest.mark.parametrize('N', [1, 3, 5, 8])
+@pytest.mark.parametrize('M', [1, 3, 5, 8])
+def test_qft(N, M):
+    ket1 = qutip.rand_ket(N)
+    ket2 = qutip.rand_ket(M)
+
+    assert swap(N, M) @ (ket1 & ket2) == (ket2 & ket1)


### PR DESCRIPTION
**Description**
Did some cleaning in `semidefinite.py`:

- Renamed functions that should be private: `kron` -> `_kron`, `conj` -> `_conj`, etc.
- Removed `dag`, and `bmat`: never used.
- Moved `qudit_swap` as `swap` in operator.py and added tests.
- Use `functools.lru_cache` instead of re implementing a memoize decorator. This used to be done in `dnorm`, comments were still present, removed.
- Merged `herm` `pos_noherm`, `pos` and `dens` into `_make_constraints`.
- Removed the logger call. 
- black the file.

@hodgestar Now only qutip-ctrl use the logger, can we move logging_utils.py there?
