### PR TITLE
Make `data.solve` more robust to singular matrices for `countstat`

### DIFF
--- a/qutip/core/data/solve.py
+++ b/qutip/core/data/solve.py
@@ -3,6 +3,8 @@ import qutip.core.data as _data
 import scipy.sparse.linalg as splinalg
 import numpy as np
 from qutip.settings import settings
+import warnings
+
 if settings.has_mkl:
     from qutip._mkl.spsolve import mkl_spsolve
 else:
@@ -62,6 +64,10 @@ def solve_csr_dense(matrix: CSR, target: Dense, method=None,
 
     if method == "splu":
         solver = _splu
+    elif method == "lstsq":
+        solver = splinalg.lsqr
+    elif method == "solve":
+        solver = splinalg.spsolve
     elif hasattr(splinalg, method):
         solver = getattr(splinalg, method)
     elif method == "mkl_spsolve" and mkl_spsolve is None:
@@ -76,7 +82,12 @@ def solve_csr_dense(matrix: CSR, target: Dense, method=None,
     if options.pop("csc", False):
         M = M.tocsc()
 
-    out = solver(M, b, **options)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        try:
+            out = solver(M, b, **options)
+        except splinalg.MatrixRankWarning:
+            raise ValueError("Matrix is singular")
 
     if isinstance(out, tuple) and len(out) == 2:
         # iterative method return a success flag
@@ -138,7 +149,10 @@ def solve_dense(matrix: Dense, target: Data, method=None,
         b = target.to_array()
 
     if method in ["solve", None]:
-        out = np.linalg.solve(matrix.as_ndarray(), b)
+        try:
+            out = np.linalg.solve(matrix.as_ndarray(), b)
+        except np.linalg.LinAlgError:
+            raise ValueError("Matrix is singular")
     elif method == "lstsq":
         out, *_ = np.linalg.lstsq(
             matrix.as_ndarray(),
@@ -185,6 +199,7 @@ solve.__doc__ = """
         equation Ax=b from scipy.sparse.linalg (CSR ``matrix``) or
         numpy.linalg (Dense ``matrix``) can be used.
         Sparse cases also accept `splu` and `mkl_spsolve`.
+        `solve` and `lstsq` will work for any data-type.
 
     options : dict
         Keywork options to pass to the solver. Refer to the documenentation

--- a/qutip/solver/countstat.py
+++ b/qutip/solver/countstat.py
@@ -10,7 +10,7 @@ import scipy.sparse as sp
 from itertools import product
 from ..core import (
     sprepost, spre, qeye, tensor, expect, Qobj,
-    operator_to_vector, vector_to_operator
+    operator_to_vector, vector_to_operator, CoreOptions
 )
 from ..core import data as _data
 from .steadystate import pseudo_inverse, steadystate
@@ -77,8 +77,8 @@ def countstat_current(L, c_ops=None, rhoss=None, J_ops=None):
 def _solve(A, V):
     try:
         return _data.solve(A, V)
-    except Exception:
-        return _data.solve(A, V, "lsqr")
+    except ValueError:
+        return _data.solve(A, V, "lstsq")
 
 
 def _noise_direct(L, wlist, rhoss, J_ops):
@@ -104,10 +104,10 @@ def _noise_direct(L, wlist, rhoss, J_ops):
             # At zero frequency some solvers fail for small systems.
             # Adding a small finite frequency of order 1e-15
             # helps prevent the solvers from throwing an exception.
-            L_temp = 1e-15j * spre(tr_op) + L
+            with CoreOptions(auto_tidyup=False):
+                L_temp = 1e-15j * spre(tr_op) + L
 
-        A = _data.to(_data.CSR, L_temp.data)
-        X_rho = [_solve(A, op) for op in Q_ops]
+        X_rho = [_solve(L_temp.data, op) for op in Q_ops]
 
         for i, j in product(range(N_j_ops), repeat=2):
             if i == j:

--- a/qutip/tests/core/data/test_linalg.py
+++ b/qutip/tests/core/data/test_linalg.py
@@ -74,8 +74,9 @@ class TestSolve():
     def test_singular(self):
         A = qutip.num(2).data
         b = qutip.basis(2, 1).data
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as err:
             test1 = _data.solve(A, b)
+        assert "singular" in str(err.value).lower()
 
 
     def test_incorrect_shape_non_square(self):


### PR DESCRIPTION
**Description**
In #2120, `countstat` was updated to use `data.solve`.
`countstat` would sometime try to solve a system with singular matrix and has a fallback for it using `try: ... except:`
However, while numpy raises an error when the matrix is singular, `scipy.sparse` raises a warnings, thus the tests only pass because we use the warnings as error flags... Without it, the singular matrix would not be caught and the solution from `countstat` would contain a `NaN` and the tests would fail...

- Redirect the warning from scipy sparse and numpy's `LinAlgError` to a `ValueError`to allow easy catching of these case.
- Add the small `1e-15` in `countstat` with `auto_tidyup` turned off.
- Add support for the method `lstsq` and `solve` for `data.solve_csr`. These methods are supported by numpy, jax, tensorflow, scipy.sparse is the exception which use `spsolve` and `lsqr` instead, probably to avoid name collision the the dense version they also have.