### PR TITLE
Add a test for progress bar

### DIFF
--- a/doc/changes/2150.misc
+++ b/doc/changes/2150.misc
@@ -1,0 +1,1 @@
+Add a test for progress_bar

--- a/qutip/ipynbtools.py
+++ b/qutip/ipynbtools.py
@@ -273,14 +273,14 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
     else:
         if progress_bar is True:
             progress_bar = HTMLProgressBar(len(ar_list))
-
-        n = len(ar_list)
+        prev_finished = 0
         while True:
             n_finished = sum([ar.progress for ar in ar_list])
-            progress_bar.update()
+            for _ in range(prev_finished, n_finished):
+                progress_bar.update()
+            prev_finished = n_finished
 
             if view.wait(ar_list, timeout=0.5):
-                progress_bar.update()
                 break
         progress_bar.finished()
 

--- a/qutip/ipynbtools.py
+++ b/qutip/ipynbtools.py
@@ -272,16 +272,15 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
         view.wait(ar_list)
     else:
         if progress_bar is True:
-            progress_bar = HTMLProgressBar()
+            progress_bar = HTMLProgressBar(len(ar_list))
 
         n = len(ar_list)
-        progress_bar.start(n)
         while True:
             n_finished = sum([ar.progress for ar in ar_list])
-            progress_bar.update(n_finished)
+            progress_bar.update()
 
             if view.wait(ar_list, timeout=0.5):
-                progress_bar.update(n)
+                progress_bar.update()
                 break
         progress_bar.finished()
 

--- a/qutip/solve/parallel.py
+++ b/qutip/solve/parallel.py
@@ -147,14 +147,13 @@ def serial_map(task, values, task_args=tuple(), task_kwargs={}, **kwargs):
     try:
         progress_bar = kwargs['progress_bar']
         if progress_bar is True:
-            progress_bar = TextProgressBar()
+            progress_bar = TextProgressBar(len(values))
     except:
-        progress_bar = BaseProgressBar()
+        progress_bar = BaseProgressBar(len(values))
 
-    progress_bar.start(len(values))
     results = []
     for n, value in enumerate(values):
-        progress_bar.update(n)
+        progress_bar.update()
         result = task(value, *task_args, **task_kwargs)
         results.append(result)
     progress_bar.finished()
@@ -199,16 +198,15 @@ def parallel_map(task, values, task_args=tuple(), task_kwargs={}, **kwargs):
     try:
         progress_bar = kwargs['progress_bar']
         if progress_bar is True:
-            progress_bar = TextProgressBar()
+            progress_bar = TextProgressBar(len(values))
     except:
-        progress_bar = BaseProgressBar()
+        progress_bar = BaseProgressBar(len(values))
 
-    progress_bar.start(len(values))
     nfinished = [0]
 
     def _update_progress_bar(x):
         nfinished[0] += 1
-        progress_bar.update(nfinished[0])
+        progress_bar.update()
 
     try:
         pool = Pool(processes=kw['num_cpus'])

--- a/qutip/solve/pdpsolve.py
+++ b/qutip/solve/pdpsolve.py
@@ -162,9 +162,6 @@ class StochasticSolverOptions:
         if options is None:
             options = SolverOptions()
 
-        if progress_bar is None:
-            progress_bar = TextProgressBar()
-
         self.H = H
         self.d1 = d1
         self.d2 = d2
@@ -199,6 +196,9 @@ class StochasticSolverOptions:
             self.map_func = map_func
         else:
             self.map_func = serial_map
+
+        if progress_bar is None:
+            self.progress_bar = TextProgressBar(self.ntraj)
 
         self.map_kwargs = map_kwargs if map_kwargs is not None else {}
 
@@ -352,7 +352,6 @@ def _ssepdpsolve_generic(sso, options, progress_bar):
     for c in sso.c_ops:
         Heff += -0.5j * c.dag() * c
 
-    progress_bar.start(sso.ntraj)
     for n in range(sso.ntraj):
         progress_bar.update(n)
         psi_t = _data.dense.fast_from_numpy(sso.state0.full().ravel())
@@ -482,8 +481,6 @@ def _smepdpsolve_generic(sso, options, progress_bar):
     # Liouvillian for the deterministic part.
     # needs to be modified for TD systems
     L = liouvillian(sso.H, sso.c_ops)
-
-    progress_bar.start(sso.ntraj)
 
     for n in range(sso.ntraj):
         progress_bar.update(n)

--- a/qutip/solve/stochastic.py
+++ b/qutip/solve/stochastic.py
@@ -300,9 +300,6 @@ class StochasticSolverOptions:
         if options is None:
             options = SolverOptions()
 
-        if progress_bar is None:
-            progress_bar = TextProgressBar()
-
         # System
         # Cast to QobjEvo so the code has only one version for both the
         # constant and time-dependent case.
@@ -420,6 +417,8 @@ class StochasticSolverOptions:
             self.noise_type = 0
 
         # Map
+        if progress_bar is None:
+            progress_bar = TextProgressBar(self.ntraj)
         self.progress_bar = progress_bar
         if self.ntraj > 1 and map_func:
             self.map_func = map_func

--- a/qutip/solver/correlation.py
+++ b/qutip/solver/correlation.py
@@ -17,7 +17,7 @@ from .brmesolve import BRSolver
 from .heom.bofin_solvers import HEOMSolver
 
 from .steadystate import steadystate
-from ..ui.progressbar import progess_bars
+from ..ui.progressbar import progress_bars
 
 # -----------------------------------------------------------------------------
 # PUBLIC API
@@ -495,8 +495,9 @@ def _correlation_3op_dm(solver, state0, tlist, taulist, A, B, C):
         solver.options["normalize_output"] = False
         solver.options["progress_bar"] = False
 
-        progress_bar = progess_bars[old_opt['progress_bar']]()
-        progress_bar.start(len(taulist) + 1, **old_opt['progress_kwargs'])
+        progress_bar = progress_bars[old_opt['progress_bar']](
+            len(taulist) + 1, **old_opt['progress_kwargs']
+        )
         rho_t = solver.run(state0, tlist).states
         corr_mat = np.zeros([np.size(tlist), np.size(taulist)], dtype=complex)
         progress_bar.update()

--- a/qutip/solver/floquet.py
+++ b/qutip/solver/floquet.py
@@ -15,7 +15,7 @@ from .solver_base import Solver
 from .integrator import Integrator
 from .result import Result
 from time import time
-from ..ui.progressbar import progess_bars
+from ..ui.progressbar import progress_bars
 
 
 class FloquetBasis:
@@ -918,8 +918,9 @@ class FMESolver(MESolver):
         results.add(tlist[0], self._restore_state(_data0, copy=False))
         stats["preparation time"] += time() - _time_start
 
-        progress_bar = progess_bars[self.options["progress_bar"]]()
-        progress_bar.start(len(tlist) - 1, **self.options["progress_kwargs"])
+        progress_bar = progress_bars[self.options["progress_bar"]](
+            len(tlist) - 1, **self.options["progress_kwargs"]
+        )
         for t, state in self._integrator.run(tlist):
             progress_bar.update()
             results.add(t, self._restore_state(state, copy=False))

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -10,7 +10,7 @@ import sys
 import time
 import threading
 import concurrent.futures
-from qutip.ui.progressbar import progess_bars
+from qutip.ui.progressbar import progress_bars
 from qutip.settings import available_cpu_count
 
 if sys.platform == 'darwin':
@@ -94,8 +94,9 @@ def serial_map(task, values, task_args=None, task_kwargs=None,
     if task_kwargs is None:
         task_kwargs = {}
     map_kw = _read_map_kw(map_kw)
-    progress_bar = progess_bars[progress_bar]()
-    progress_bar.start(len(values), **progress_bar_kwargs)
+    progress_bar = progress_bars[progress_bar](
+        len(values), **progress_bar_kwargs
+    )
     end_time = map_kw['timeout'] + time.time()
     results = None
     if reduce_func is None:
@@ -104,7 +105,7 @@ def serial_map(task, values, task_args=None, task_kwargs=None,
     for n, value in enumerate(values):
         if time.time() > end_time:
             break
-        progress_bar.update(n)
+        progress_bar.update()
         try:
             result = task(value, *task_args, **task_kwargs)
         except Exception as err:
@@ -177,8 +178,9 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
     end_time = map_kw['timeout'] + time.time()
     job_time = map_kw['job_timeout']
 
-    progress_bar = progess_bars[progress_bar]()
-    progress_bar.start(len(values), **progress_bar_kwargs)
+    progress_bar = progress_bars[progress_bar](
+        len(values), **progress_bar_kwargs
+    )
 
     errors = {}
     if reduce_func is not None:
@@ -311,8 +313,9 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
     os.environ['QUTIP_IN_PARALLEL'] = 'TRUE'
     from loky import get_reusable_executor, TimeoutError
 
-    progress_bar = progess_bars[progress_bar]()
-    progress_bar.start(len(values), **progress_bar_kwargs)
+    progress_bar = progress_bars[progress_bar](
+        len(values), **progress_bar_kwargs
+    )
 
     executor = get_reusable_executor(max_workers=map_kw['num_cpus'])
     end_time = map_kw['timeout'] + time.time()

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -5,7 +5,7 @@ from .options import _SolverOptions
 from ..core import stack_columns, unstack_columns
 from .result import Result
 from .integrator import Integrator
-from ..ui.progressbar import progess_bars
+from ..ui.progressbar import progress_bars
 from time import time
 
 
@@ -150,8 +150,9 @@ class Solver:
         results.add(tlist[0], self._restore_state(_data0, copy=False))
         stats['preparation time'] += time() - _time_start
 
-        progress_bar = progess_bars[self.options['progress_bar']]()
-        progress_bar.start(len(tlist)-1, **self.options['progress_kwargs'])
+        progress_bar = progress_bars[self.options['progress_bar']](
+            len(tlist)-1, **self.options['progress_kwargs']
+        )
         for t, state in self._integrator.run(tlist):
             progress_bar.update()
             results.add(t, self._restore_state(state, copy=False))

--- a/qutip/tests/test_progressbar.py
+++ b/qutip/tests/test_progressbar.py
@@ -13,11 +13,13 @@ for alias, bar in progress_bars.items():
 
 
 @pytest.mark.parametrize("pbar", names)
-def test_progressbar(pbar):
+def test_progressbar(pbar, capsys):
     N = 5
+
     try:
         bar = progress_bars[pbar](N)
     except ImportError:
+        # ipython or tqdm could be missing
         pytest.skip(reason="module not available")
     assert bar.total_time() < 0
     for _ in range(N):
@@ -25,3 +27,8 @@ def test_progressbar(pbar):
         bar.update()
     bar.finished()
     assert bar.total_time() > 0
+    out, err = capsys.readouterr()
+    if pbar.lower() not in ["base"]:
+        # Has an non error output
+        # tqdm use error out
+        assert out != "" or err != ""

--- a/qutip/tests/test_progressbar.py
+++ b/qutip/tests/test_progressbar.py
@@ -1,0 +1,27 @@
+from qutip.ui.progressbar import progress_bars
+import pytest
+import time
+
+
+# We offer multiple alias for each progressbar.
+names = []
+bars = []
+for alias, bar in progress_bars.items():
+    if bar not in bars:
+        names.append(alias)
+        bars.append(bar)
+
+
+@pytest.mark.parametrize("pbar", names)
+def test_progressbar(pbar):
+    N = 5
+    try:
+        bar = progress_bars[pbar](N)
+    except ImportError:
+        pytest.skip(reason="module not available")
+    assert bar.total_time() < 0
+    for _ in range(N):
+        time.sleep(0.25)
+        bar.update()
+    bar.finished()
+    assert bar.total_time() > 0

--- a/qutip/ui/progressbar.py
+++ b/qutip/ui/progressbar.py
@@ -1,10 +1,11 @@
 __all__ = ['BaseProgressBar', 'TextProgressBar',
            'EnhancedTextProgressBar', 'TqdmProgressBar',
-           'HTMLProgressBar', 'progess_bars']
+           'HTMLProgressBar', 'progress_bars']
 
 import time
 import datetime
 import sys
+from qutip import settings
 
 
 class BaseProgressBar(object):
@@ -16,16 +17,16 @@ class BaseProgressBar(object):
         n_vec = linspace(0, 10, 100)
         pbar = TextProgressBar(len(n_vec))
         for n in n_vec:
-            pbar.update(n)
+            pbar.update()
             compute_with_n(n)
         pbar.finished()
 
     """
 
-    def __init__(self, iterations=0, chunk_size=10):
-        pass
+    def __init__(self, iterations=0, chunk_size=10, **kwargs):
+        self._start(iterations, chunk_size)
 
-    def start(self, iterations, chunk_size=10, **kwargs):
+    def _start(self, iterations, chunk_size=10, **kwargs):
         self.N = float(iterations)
         self.n = 0
         self.p_chunk_size = chunk_size
@@ -33,7 +34,7 @@ class BaseProgressBar(object):
         self.t_start = time.time()
         self.t_done = self.t_start - 1
 
-    def update(self, n=None):
+    def update(self):
         pass
 
     def total_time(self):
@@ -63,14 +64,10 @@ class TextProgressBar(BaseProgressBar):
     A simple text-based progress bar.
     """
 
-    def __init__(self, iterations=0, chunk_size=10):
-        pass
-        # super(TextProgressBar, self).start(iterations, chunk_size)
+    def __init__(self, iterations=0, chunk_size=10, **kwargs):
+        super()._start(iterations, chunk_size)
 
-    def start(self, iterations, chunk_size=10, **kwargs):
-        super(TextProgressBar, self).start(iterations, chunk_size)
-
-    def update(self, n=None):
+    def update(self):
         self.n += 1
         n = self.n
         p = (n / self.N) * 100.0
@@ -91,16 +88,12 @@ class EnhancedTextProgressBar(BaseProgressBar):
     An enhanced text-based progress bar.
     """
 
-    def __init__(self, iterations=0, chunk_size=10):
-        pass
-        # super(EnhancedTextProgressBar, self).start(iterations, chunk_size)
-
-    def start(self, iterations, chunk_size=10, **kwargs):
-        super(EnhancedTextProgressBar, self).start(iterations, chunk_size)
+    def __init__(self, iterations=0, chunk_size=10, **kwargs):
+        super()._start(iterations, chunk_size)
         self.fill_char = '*'
         self.width = 25
 
-    def update(self, n=None):
+    def update(self):
         self.n += 1
         n = self.n
         percent_done = int(round(n / self.N * 100.0))
@@ -128,16 +121,13 @@ class TqdmProgressBar(BaseProgressBar):
     A progress bar using tqdm module
     """
 
-    def __init__(self, iterations=0, chunk_size=10):
+    def __init__(self, iterations=0, chunk_size=10, **kwargs):
         from tqdm.auto import tqdm
-        self.tqdm = tqdm
-
-    def start(self, iterations, **kwargs):
-        self.pbar = self.tqdm(total=iterations, **kwargs)
+        self.pbar = tqdm(total=iterations, **kwargs)
         self.t_start = time.time()
         self.t_done = self.t_start - 1
 
-    def update(self, n=None):
+    def update(self):
         self.pbar.update()
 
     def finished(self):
@@ -156,36 +146,43 @@ class HTMLProgressBar(BaseProgressBar):
         n_vec = linspace(0, 10, 100)
         pbar = HTMLProgressBar(len(n_vec))
         for n in n_vec:
-            pbar.update(n)
+            pbar.update()
             compute_with_n(n)
     """
 
-    def __init__(self, iterations=0, chunk_size=1.0):
+    def __init__(self, iterations=0, chunk_size=1.0, **kwargs):
+        if not settings.ipython:
+            raise ValueError(
+                "HTMLProgressBar is only available when using ipython"
+            )
+        from IPython.display import HTML, Javascript, display
+        import uuid
+
+        self.display = display
+        self.Javascript = Javascript
         self.divid = str(uuid.uuid4())
         self.textid = str(uuid.uuid4())
-        self.pb = HTML("""\
-<div style="border: 2px solid grey; width: 600px">
-  <div id="%s" \
-style="background-color: rgba(121,195,106,0.75); width:0%%">&nbsp;</div>
-</div>
-<p id="%s"></p>
-""" % (self.divid, self.textid))
-        display(self.pb)
-        super(HTMLProgressBar, self).start(iterations, chunk_size)
+        self.pb = HTML(
+            '<div style="border: 2px solid grey; width: 600px">\n  '
+            f'<div id="{self.divid}" '
+            'style="background-color: rgba(121,195,106,0.75); '
+            'width:0%">&nbsp;</div>\n'
+            '</div>\n'
+            f'<p id="{self.textid}"></p>\n'
+        )
+        self.display(self.pb)
+        super()._start(iterations, chunk_size)
 
-    def start(self, iterations=0, chunk_size=1.0):
-        super(HTMLProgressBar, self).start(iterations, chunk_size)
-
-    def update(self, n):
+    def update(self):
+        self.n += 1
+        n = self.n
         p = (n / self.N) * 100.0
         if p >= self.p_chunk:
             lbl = ("Elapsed time: %s. " % self.time_elapsed() +
                    "Est. remaining time: %s." % self.time_remaining_est(p))
             js_code = ("$('div#%s').width('%i%%');" % (self.divid, p) +
                        "$('p#%s').text('%s');" % (self.textid, lbl))
-            display(Javascript(js_code))
-            # display(Javascript("$('div#%s').width('%i%%')" % (self.divid,
-            # p)))
+            self.display(self.Javascript(js_code))
             self.p_chunk += self.p_chunk_size
 
     def finished(self):
@@ -193,10 +190,10 @@ style="background-color: rgba(121,195,106,0.75); width:0%%">&nbsp;</div>
         lbl = "Elapsed time: %s" % self.time_elapsed()
         js_code = ("$('div#%s').width('%i%%');" % (self.divid, 100.0) +
                    "$('p#%s').text('%s');" % (self.textid, lbl))
-        display(Javascript(js_code))
+        self.display(self.Javascript(js_code))
 
 
-progess_bars = {
+progress_bars = {
     "Enhanced": EnhancedTextProgressBar,
     "enhanced": EnhancedTextProgressBar,
     "Text": TextProgressBar,

--- a/qutip/ui/progressbar.py
+++ b/qutip/ui/progressbar.py
@@ -151,10 +151,10 @@ class HTMLProgressBar(BaseProgressBar):
     """
 
     def __init__(self, iterations=0, chunk_size=1.0, **kwargs):
-        if not settings.ipython:
+        """if not settings.ipython:
             raise ValueError(
                 "HTMLProgressBar is only available when using ipython"
-            )
+            )"""
         from IPython.display import HTML, Javascript, display
         import uuid
 
@@ -203,6 +203,7 @@ progress_bars = {
     "tqdm": TqdmProgressBar,
     "Html": HTMLProgressBar,
     "html": HTMLProgressBar,
+    "base": BaseProgressBar,
     "": BaseProgressBar,
     False: BaseProgressBar,
     None: BaseProgressBar,

--- a/qutip/ui/progressbar.py
+++ b/qutip/ui/progressbar.py
@@ -151,10 +151,6 @@ class HTMLProgressBar(BaseProgressBar):
     """
 
     def __init__(self, iterations=0, chunk_size=1.0, **kwargs):
-        """if not settings.ipython:
-            raise ValueError(
-                "HTMLProgressBar is only available when using ipython"
-            )"""
         from IPython.display import HTML, Javascript, display
         import uuid
 


### PR DESCRIPTION
**Description**
- Add a test for progress bars.
- Make `start` private. `start` was mostly used right after the initialization. The docstring indicated that it was not needed, but it was for most bars. #2148
- Remove the iteration argument in update.
- Have `HTMLProgressBar` import ipython.

**Related issues or PRs**
Fix the issue #2148 for master.
Replace #2127