### PR TITLE
Add `qeye_like` and `qzero_like`

### DIFF
--- a/doc/changes/2153.feature
+++ b/doc/changes/2153.feature
@@ -1,0 +1,1 @@
+Add qeye_like and qzero_like

--- a/qutip/core/data/constant.py
+++ b/qutip/core/data/constant.py
@@ -72,32 +72,20 @@ identity.add_specialisations([
 ], _defer=True)
 
 
-def zeros_like_data(data, /):
+del _Dispatcher, _inspect
+
+
+def zeros_like(data, /):
     """
     Create an zeros matrix of the same type and shape.
     """
     return zeros[type(data)](*data.shape)
 
 
-zeros_like = _Dispatcher(
-    zeros_like_data, name="zeros_like", inputs=('data',), out=False
-)
-zeros_like.add_specialisations([(Data, zeros_like_data)])
-
-
-def identity_like_data(data, /):
+def identity_like(data, /):
     """
-    Create an zeros matrix of the same type and shape.
+    Create an identity matrix of the same type and shape.
     """
     if not data.shape[0] == data.shape[1]:
         raise ValueError("Can't create and identity like a non square matrix.")
     return identity[type(data)](data.shape[0])
-
-
-identity_like = _Dispatcher(
-    identity_like_data, name="identity_like", inputs=('data',), out=False
-)
-identity_like.add_specialisations([(Data, identity_like_data)])
-
-
-del _Dispatcher, _inspect

--- a/qutip/core/data/constant.py
+++ b/qutip/core/data/constant.py
@@ -6,10 +6,11 @@
 from . import csr, dense
 from .csr import CSR
 from .dense import Dense
+from .base import Data
 from .dispatch import Dispatcher as _Dispatcher
 import inspect as _inspect
 
-__all__ = ['zeros', 'identity']
+__all__ = ['zeros', 'identity', 'zeros_like', 'identity_like']
 
 zeros = _Dispatcher(
     _inspect.Signature([
@@ -69,5 +70,30 @@ identity.add_specialisations([
     (CSR, csr.identity),
     (Dense, dense.identity),
 ], _defer=True)
+
+
+def zeros_like_data(data, /):
+    """
+    Create an zeros matrix of the same type and shape.
+    """
+    return zeros[type(data)](*data.shape)
+
+
+zeros_like = _Dispatcher(zeros_like_data, inputs=('data',), out=False)
+zeros_like.add_specialisations([(Data, zeros_like_data)])
+
+
+def identity_like_data(data, /):
+    """
+    Create an zeros matrix of the same type and shape.
+    """
+    if not data.shape[0] == data.shape[1]:
+        raise ValueError("Can't create and identity like a non square matrix.")
+    return identity[type(data)](*data.shape[0])
+
+
+identity_like = _Dispatcher(identity_like_data, inputs=('data',), out=False)
+identity_like.add_specialisations([(Data, identity_like_data)])
+
 
 del _Dispatcher, _inspect

--- a/qutip/core/data/constant.py
+++ b/qutip/core/data/constant.py
@@ -79,7 +79,9 @@ def zeros_like_data(data, /):
     return zeros[type(data)](*data.shape)
 
 
-zeros_like = _Dispatcher(zeros_like_data, inputs=('data',), out=False)
+zeros_like = _Dispatcher(
+    zeros_like_data, name="zeros_like", inputs=('data',), out=False
+)
 zeros_like.add_specialisations([(Data, zeros_like_data)])
 
 
@@ -89,10 +91,12 @@ def identity_like_data(data, /):
     """
     if not data.shape[0] == data.shape[1]:
         raise ValueError("Can't create and identity like a non square matrix.")
-    return identity[type(data)](*data.shape[0])
+    return identity[type(data)](data.shape[0])
 
 
-identity_like = _Dispatcher(identity_like_data, inputs=('data',), out=False)
+identity_like = _Dispatcher(
+    identity_like_data, name="identity_like", inputs=('data',), out=False
+)
 identity_like.add_specialisations([(Data, identity_like_data)])
 
 

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -532,12 +532,12 @@ def qzero(dimensions, *, dtype=None):
 
 def qzero_like(qobj):
     """
-    Zero operator of the same dims and type as the original.
+    Zero operator of the same dims and type as the reference.
 
     Parameters
     ----------
     qobj : Qobj
-        Qobj to copy the dims from.
+        Reference ``Qobj`` to copy the dims from.
 
     Returns
     -------
@@ -604,42 +604,18 @@ identity = qeye
 
 def qeye_like(qobj):
     """
-    Identity operator.
+    Identity operator with the same dims and type as the reference quantum
+    object.
 
     Parameters
     ----------
-    dimensions : (int) or (list of int) or (list of list of int)
-        Dimension of Hilbert space. If provided as a list of ints, then the
-        dimension is the product over this list, but the ``dims`` property of
-        the new Qobj are set to this list.  This can produce either `oper` or
-        `super` depending on the passed `dimensions`.
-
-    dtype : type or str
-        Storage representation. Any data-layer known to `qutip.data.to` is
-        accepted.
+    qobj : Qobj
+        Reference ``Qobj`` to copy the dims from.
 
     Returns
     -------
     oper : qobj
         Identity operator Qobj.
-
-    Examples
-    --------
-    >>> qeye(3) # doctest: +SKIP
-    Quantum object: dims = [[3], [3]], shape = (3, 3), type = oper, \
-    isherm = True
-    Qobj data =
-    [[ 1.  0.  0.]
-     [ 0.  1.  0.]
-     [ 0.  0.  1.]]
-    >>> qeye([2,2]) # doctest: +SKIP
-    Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, \
-    isherm = True
-    Qobj data =
-    [[1. 0. 0. 0.]
-     [0. 1. 0. 0.]
-     [0. 0. 1. 0.]
-     [0. 0. 0. 1.]]
 
     """
     return Qobj(

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -5,10 +5,11 @@ of commonly occuring quantum operators.
 
 __all__ = ['jmat', 'spin_Jx', 'spin_Jy', 'spin_Jz', 'spin_Jm', 'spin_Jp',
            'spin_J_set', 'sigmap', 'sigmam', 'sigmax', 'sigmay', 'sigmaz',
-           'destroy', 'create', 'qeye', 'identity', 'position', 'momentum',
-           'num', 'squeeze', 'squeezing', 'swap', 'displace', 'commutator',
-           'qutrit_ops', 'qdiags', 'phase', 'qzero', 'enr_destroy',
-           'enr_identity', 'charge', 'tunneling', 'qft']
+           'destroy', 'create', 'qeye', 'qeye_like', 'identity', 'position',
+           'momentum', 'num', 'squeeze', 'squeezing', 'swap', 'displace',
+           'commutator', 'qutrit_ops', 'qdiags', 'phase', 'qzero',
+           'qzero_like', 'enr_destroy', 'enr_identity', 'charge', 'tunneling',
+           'qft']
 
 import numbers
 
@@ -529,6 +530,27 @@ def qzero(dimensions, *, dtype=None):
                 isherm=True, isunitary=False, copy=False)
 
 
+def qzero_like(qobj):
+    """
+    Zero operator of the same dims and type as the original.
+
+    Parameters
+    ----------
+    qobj : Qobj
+        Qobj to copy the dims from.
+
+    Returns
+    -------
+    qzero : qobj
+        Zero operator Qobj.
+
+    """
+    return Qobj(
+        _data.zeros_like(qobj.data), dims=qobj.dims, type=qobj.type,
+        superrep=qobj.superrep, isherm=True, isunitary=False, copy=False
+    )
+
+
 def qeye(dimensions, *, dtype=None):
     """
     Identity operator.
@@ -578,6 +600,52 @@ isherm = True
 
 # Name alias.
 identity = qeye
+
+
+def qeye_like(qobj):
+    """
+    Identity operator.
+
+    Parameters
+    ----------
+    dimensions : (int) or (list of int) or (list of list of int)
+        Dimension of Hilbert space. If provided as a list of ints, then the
+        dimension is the product over this list, but the ``dims`` property of
+        the new Qobj are set to this list.  This can produce either `oper` or
+        `super` depending on the passed `dimensions`.
+
+    dtype : type or str
+        Storage representation. Any data-layer known to `qutip.data.to` is
+        accepted.
+
+    Returns
+    -------
+    oper : qobj
+        Identity operator Qobj.
+
+    Examples
+    --------
+    >>> qeye(3) # doctest: +SKIP
+    Quantum object: dims = [[3], [3]], shape = (3, 3), type = oper, \
+    isherm = True
+    Qobj data =
+    [[ 1.  0.  0.]
+     [ 0.  1.  0.]
+     [ 0.  0.  1.]]
+    >>> qeye([2,2]) # doctest: +SKIP
+    Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, \
+    isherm = True
+    Qobj data =
+    [[1. 0. 0. 0.]
+     [0. 1. 0. 0.]
+     [0. 0. 1. 0.]
+     [0. 0. 0. 1.]]
+
+    """
+    return Qobj(
+        _data.identity_like(qobj.data), dims=qobj.dims, type=qobj.type,
+        superrep=qobj.superrep, isherm=True, isunitary=True, copy=False
+    )
 
 
 def position(N, offset=0, *, dtype=None):

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -950,3 +950,26 @@ class TestInv(UnaryOpMixin):
         pytest.param(_inv_csr, CSR, CSR),
         pytest.param(_inv_dense, Dense, Dense),
     ]
+
+
+class TestZeros_like(UnaryOpMixin):
+    def op_numpy(self, matrix):
+        return np.zeros_like(matrix)
+
+    specialisations = [
+        pytest.param(data.zeros_like, CSR, CSR),
+        pytest.param(data.zeros_like, Dense, Dense),
+    ]
+
+
+class TestIdentity_like(UnaryOpMixin):
+    def op_numpy(self, matrix):
+        return np.eye(matrix.shape[0])
+
+    shapes = shapes_square()
+    bad_shapes = shapes_not_square()
+
+    specialisations = [
+        pytest.param(data.identity_like, CSR, CSR),
+        pytest.param(data.identity_like, Dense, Dense),
+    ]

--- a/qutip/tests/core/test_operators.py
+++ b/qutip/tests/core/test_operators.py
@@ -302,3 +302,35 @@ def test_swap(N, M):
     ket2 = qutip.rand_ket(M)
 
     assert qutip.swap(N, M) @ (ket1 & ket2) == (ket2 & ket1)
+
+
+@pytest.mark.parametrize(["dims", "superrep"], [
+    pytest.param([2], None, id="simple"),
+    pytest.param([2, 3], None, id="tensor"),
+    pytest.param([[2], [2]], None, id="super"),
+    pytest.param([[2], [2]], "chi", id="chi"),
+])
+@pytest.mark.parametrize('dtype', ["CSR", "Dense"])
+def test_qeye_like(dims, superrep, dtype):
+    op = qutip.rand_herm(dims, dtype=dtype)
+    op.superrep = superrep
+    new = qutip.qeye_like(op)
+    expected = qutip.qeye(dims, dtype=dtype)
+    expected.superrep = superrep
+    assert new == expected
+
+
+@pytest.mark.parametrize(["dims", "superrep"], [
+    pytest.param([2], None, id="simple"),
+    pytest.param([2, 3], None, id="tensor"),
+    pytest.param([[2], [2]], None, id="super"),
+    pytest.param([[2], [2]], "chi", id="chi"),
+])
+@pytest.mark.parametrize('dtype', ["CSR", "Dense"])
+def test_qzero_like(dims, superrep, dtype):
+    op = qutip.rand_herm(dims, dtype=dtype)
+    op.superrep = superrep
+    new = qutip.qzero_like(op)
+    expected = qutip.qzero(dims, dtype=dtype)
+    expected.superrep = superrep
+    assert new == expected


### PR DESCRIPTION
**Description**
 `qeye_like`, `qzero_like` and the data layer version, `identity_like` and `zeros_like` came up as useful in multiple conversation.
I added them with tests, but I did not go through the code to use them.
