### PR TITLE
Use `qeye_like`

### DIFF
--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -248,7 +248,7 @@ cdef class QobjEvo:
         repr_str += f'isconstant = {self.isconstant}, num_elements = {self.num_elements}'
         return repr_str
 
-    def _read_element(self, op, copy, tlist, args, order, function_style, 
+    def _read_element(self, op, copy, tlist, args, order, function_style,
                       boundary_conditions):
         """ Read a Q_object item and return an element for that item. """
         if isinstance(op, Qobj):
@@ -257,7 +257,7 @@ cdef class QobjEvo:
         elif isinstance(op, list):
             out = _EvoElement(
                 op[0].copy() if copy else op[0],
-                coefficient(op[1], tlist=tlist, args=args, order=order, 
+                coefficient(op[1], tlist=tlist, args=args, order=order,
                             boundary_conditions=boundary_conditions)
             )
             qobj = op[0]
@@ -475,7 +475,7 @@ cdef class QobjEvo:
             isinstance(other, numbers.Number) and
             self.dims[0] == self.dims[1]
         ):
-            self.elements.append(_ConstantElement(other * qutip.qeye(self.dims[0])))
+            self.elements.append(_ConstantElement(other * qutip.qeye_like(self)))
         else:
             return NotImplemented
         return self

--- a/qutip/core/gates.py
+++ b/qutip/core/gates.py
@@ -4,7 +4,7 @@ from operator import mul
 
 import numpy as np
 import scipy.sparse as sp
-from . import Qobj, qeye, sigmax, fock_dm, qdiags
+from . import Qobj, qeye, sigmax, fock_dm, qdiags, qeye_like
 
 
 __all__ = [
@@ -690,7 +690,7 @@ def _powers(op, N):
     Generator that yields powers of an operator `op`,
     through to `N`.
     """
-    acc = qeye(op.dims[0])
+    acc = qeye_like(op)
     yield acc
 
     for _ in range(N - 1):

--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -17,7 +17,7 @@ import scipy.sparse as sp
 from .superop_reps import (to_kraus, to_choi, _to_superpauli, to_super,
                            kraus_to_choi)
 from .superoperator import operator_to_vector, vector_to_operator
-from .operators import qeye
+from .operators import qeye, qeye_like
 from .states import ket2dm
 from .semidefinite import dnorm_problem, dnorm_sparse_problem
 from . import data as _data
@@ -494,7 +494,7 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
     ):
         # Make an identity the same size as A and B to
         # compare against.
-        I = qeye(A.dims[0])
+        I = qeye_like(A)
         # Compare to B first, so that an error is raised
         # as soon as possible.
         Bd = B.dag()

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -536,8 +536,8 @@ def qzero_like(qobj):
 
     Parameters
     ----------
-    qobj : Qobj
-        Reference ``Qobj`` to copy the dims from.
+    qobj : Qobj, QobjEvo
+        Reference quantum object to copy the dims from.
 
     Returns
     -------
@@ -545,6 +545,9 @@ def qzero_like(qobj):
         Zero operator Qobj.
 
     """
+    from .cy.qobjevo import QobjEvo
+    if isinstance(qobj, QobjEvo):
+        qobj = qobj(0)
     return Qobj(
         _data.zeros_like(qobj.data), dims=qobj.dims, type=qobj.type,
         superrep=qobj.superrep, isherm=True, isunitary=False, copy=False
@@ -609,8 +612,8 @@ def qeye_like(qobj):
 
     Parameters
     ----------
-    qobj : Qobj
-        Reference ``Qobj`` to copy the dims from.
+    qobj : Qobj, QobjEvo
+        Reference quantum object to copy the dims from.
 
     Returns
     -------
@@ -618,6 +621,9 @@ def qeye_like(qobj):
         Identity operator Qobj.
 
     """
+    from .cy.qobjevo import QobjEvo
+    if isinstance(qobj, QobjEvo):
+        qobj = qobj(0)
     return Qobj(
         _data.identity_like(qobj.data), dims=qobj.dims, type=qobj.type,
         superrep=qobj.superrep, isherm=True, isunitary=True, copy=False

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1754,7 +1754,7 @@ class Qobj:
         if not self.isoper or self._data.shape[0] != self._data.shape[1]:
             return False
         cmp = _data.matmul(self._data, self._data.adjoint())
-        iden = _data.identity(self.shape[0], dtype=type(cmp))
+        iden = _data.identity_like(cmp)
         return _data.iszero(_data.sub(cmp, iden),
                             tol=settings.core['atol'])
 

--- a/qutip/core/superoperator.py
+++ b/qutip/core/superoperator.py
@@ -311,7 +311,7 @@ def spost(A):
     if not A.isoper:
         raise TypeError('Input is not a quantum operator')
     data = _data.kron(A.data.transpose(),
-                      _data.identity(A.shape[0], dtype=type(A.data)))
+                      _data.identity_like(A.data))
     return Qobj(data,
                 dims=[A.dims, A.dims],
                 type='super',
@@ -336,7 +336,7 @@ def spre(A):
     """
     if not A.isoper:
         raise TypeError('Input is not a quantum operator')
-    data = _data.kron(_data.identity(A.shape[0], dtype=type(A.data)), A.data)
+    data = _data.kron(_data.identity_like(A.data), A.data)
     return Qobj(data,
                 dims=[A.dims, A.dims],
                 type='super',

--- a/qutip/solver/correlation.py
+++ b/qutip/solver/correlation.py
@@ -8,8 +8,8 @@ import numpy as np
 import scipy.fftpack
 
 from ..core import (
-    qeye, Qobj, QobjEvo, liouvillian, spre, unstack_columns, stack_columns,
-    tensor, qzero, expect
+    Qobj, QobjEvo, liouvillian, spre, unstack_columns, stack_columns,
+    tensor, expect, qeye_like, isket
 )
 from .mesolve import MESolver
 from .mcsolve import MCSolver
@@ -466,11 +466,12 @@ def correlation_3op(solver, state0, tlist, taulist, A=None, B=None, C=None):
         is returned instead.
     """
     taulist = np.asarray(taulist)
+    if isket(state0):
+        state0 = state0.proj()
 
-    dims = state0.dims[0]
-    A = QobjEvo(qeye(dims) if A in [None, 1] else A)
-    B = QobjEvo(qeye(dims) if B in [None, 1] else B)
-    C = QobjEvo(qeye(dims) if C in [None, 1] else C)
+    A = QobjEvo(qeye_like(state0) if A in [None, 1] else A)
+    B = QobjEvo(qeye_like(state0) if B in [None, 1] else B)
+    C = QobjEvo(qeye_like(state0) if C in [None, 1] else C)
 
     if isinstance(solver, (MESolver, BRSolver)):
         out = _correlation_3op_dm(solver, state0, tlist, taulist, A, B, C)

--- a/qutip/solver/countstat.py
+++ b/qutip/solver/countstat.py
@@ -89,7 +89,7 @@ def _noise_direct(L, wlist, rhoss, J_ops):
     current = np.zeros(N_j_ops)
     noise = np.zeros((N_j_ops, N_j_ops, len(wlist)))
 
-    tr_op = tensor(qeye(L.dims[0][0]))
+    tr_op = qeye(L.dims[0][0])
     tr_op_vec = operator_to_vector(tr_op)
 
     Pop = _data.kron(rhoss_vec, tr_op_vec.data.transpose())

--- a/qutip/solver/countstat.py
+++ b/qutip/solver/countstat.py
@@ -89,7 +89,7 @@ def _noise_direct(L, wlist, rhoss, J_ops):
     current = np.zeros(N_j_ops)
     noise = np.zeros((N_j_ops, N_j_ops, len(wlist)))
 
-    tr_op = tensor([qeye(n) for n in L.dims[0][0]])
+    tr_op = tensor(qeye(L.dims[0][0]))
     tr_op_vec = operator_to_vector(tr_op)
 
     Pop = _data.kron(rhoss_vec, tr_op_vec.data.transpose())

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -1,6 +1,6 @@
 """ Class for solve function results"""
 import numpy as np
-from ..core import Qobj, QobjEvo, expect, qzero
+from ..core import Qobj, QobjEvo, expect, qzero_like
 
 __all__ = ["Result", "MultiTrajResult", "McResult"]
 
@@ -486,11 +486,11 @@ class MultiTrajResult(_BaseResult):
 
         if trajectory.states:
             state = trajectory.states[0]
-            self._sum_states = [qzero(state.dims[0])
+            self._sum_states = [qzero_like(self._to_dm(state))
                                 for state in trajectory.states]
         if trajectory.final_state:
             state = trajectory.final_state
-            self._sum_final_states = qzero(state.dims[0])
+            self._sum_final_states = qzero_like(self._to_dm(state))
 
         self._sum_expect = [
             np.zeros_like(expect) for expect in trajectory.expect

--- a/qutip/solver/steadystate.py
+++ b/qutip/solver/steadystate.py
@@ -1,4 +1,4 @@
-from qutip import liouvillian, lindblad_dissipator, Qobj, qeye, qzero
+from qutip import liouvillian, lindblad_dissipator, Qobj, qzero_like, qeye_like
 from qutip import vector_to_operator, operator_to_vector
 from qutip import settings
 import qutip.core.data as _data
@@ -377,8 +377,8 @@ def steadystate_floquet(H_0, c_ops, Op_t, w_d=1.0, n_it=3, sparse=False,
     # L_p and L_m correspond to the positive and negative
     # frequency terms respectively.
     # They are independent in the model, so we keep both names.
-    Id = qeye(L_0.dims[0], dtype=type(L_0.data))
-    S = T = qzero(L_0.dims[0], dtype=type(L_0.data))
+    Id = qeye_like(L_0)
+    S = T = qzero_like(L_0)
 
     if isinstance(H_0.data, _data.CSR) and not sparse:
         L_0 = L_0.to("Dense")
@@ -478,11 +478,11 @@ def pseudo_inverse(L, rhoss=None, w=None, method='splu', *, use_rcm=False,
     dtype = type(L.data)
     rhoss_vec = operator_to_vector(rhoss)
 
-    tr_op = qeye(L.dims[0][0])
+    tr_op = qeye_like(rhoss)
     tr_op_vec = operator_to_vector(tr_op)
 
     P = _data.kron(rhoss_vec.data, tr_op_vec.data.transpose(), dtype=dtype)
-    I = _data.csr.identity(N * N)
+    I = _data.identity_like(P)
     Q = _data.sub(I, P)
 
     if w in [None, 0.0]:

--- a/qutip/tests/core/test_gates.py
+++ b/qutip/tests/core/test_gates.py
@@ -35,7 +35,7 @@ def _make_random_three_qubit_gate():
 
 
 def _make_controled(op):
-    out = qutip.tensor(qutip.fock_dm(2, 0), qutip.qeye(op.dims[0]))
+    out = qutip.tensor(qutip.fock_dm(2, 0), qutip.qeye_like(op))
     out += qutip.tensor(qutip.fock_dm(2, 1), op)
     return out
 

--- a/qutip/tests/core/test_operators.py
+++ b/qutip/tests/core/test_operators.py
@@ -319,6 +319,10 @@ def test_qeye_like(dims, superrep, dtype):
     expected.superrep = superrep
     assert new == expected
 
+    opevo = qutip.QobjEvo(op)
+    new = qutip.qeye_like(op)
+    assert new == expected
+
 
 @pytest.mark.parametrize(["dims", "superrep"], [
     pytest.param([2], None, id="simple"),
@@ -333,4 +337,8 @@ def test_qzero_like(dims, superrep, dtype):
     new = qutip.qzero_like(op)
     expected = qutip.qzero(dims, dtype=dtype)
     expected.superrep = superrep
+    assert new == expected
+
+    opevo = qutip.QobjEvo(op)
+    new = qutip.qzero_like(op)
     assert new == expected

--- a/qutip/tests/solver/test_propagator.py
+++ b/qutip/tests/solver/test_propagator.py
@@ -1,6 +1,7 @@
 import numpy as np
 from qutip import (destroy, propagator, Propagator, propagator_steadystate,
-                   steadystate, tensor, qeye, basis, QobjEvo, sesolve)
+                   steadystate, tensor, qeye, basis, QobjEvo, sesolve,
+                   liouvillian)
 import qutip
 import pytest
 from qutip.solver.brmesolve import BRSolver
@@ -85,6 +86,13 @@ def testPropHDims():
     H = tensor([qeye(2), qeye(2)])
     U = propagator(H, 1)
     assert U.dims == H.dims
+
+
+def testPropHSuper():
+    "Propagator: preserve super_oper dims"
+    L = liouvillian(qeye(2) & qeye(2), [destroy(2) & destroy(2)])
+    U = propagator(L, 1)
+    assert U.dims == L.dims
 
 
 def testPropEvo():


### PR DESCRIPTION
**Description**
Change `qeye` to `qeye_like` and `qzero` to `qzero_like` when appropriate.

`qeye_like` is now able to accept `QobjEvo` to use it in propagator etc.
Fix the bug in propagator with super-operator input found in #2152...


