### PR TITLE
Add warning for missing Filelock

### DIFF
--- a/doc/guide/dynamics/dynamics-time.rst
+++ b/doc/guide/dynamics/dynamics-time.rst
@@ -342,10 +342,10 @@ Any function or method that can be called by ``f(t, args)``, ``f(t, **args)`` is
 **String coefficients** :
 Use a string containing a simple Python expression.
 The variable ``t``, common mathematical functions such as ``sin`` or ``exp`` an variable in args will be available.
-If available, the string will be compiled using cython, fixing variable type when possible, allowing slightly faster excution than function.
+If available, the string will be compiled using cython, fixing variable type when possible, allowing slightly faster execution than function.
 While the speed up is usually very small, in long evolution, numerous calls to the functions are made and it's can accumulate.
 From version 5, compilation of the coefficient is done only once and saved between sessions.
-When Cython is not available, the code will be executed in python with the same environment.
+When either the cython or filelock modules are not available, the code will be executed in python using ``exec`` with the same environment .
 This, however, as no advantage over using python function.
 
 

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -199,6 +199,9 @@ def const(value):
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # %%%%%%%%%      Everything under this is for string compilation      %%%%%%%%%
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+WARN_MISSING_MODULE = [0]
+
+
 class CompilationOptions(QutipOptions):
     """
     Compilation options:
@@ -259,6 +262,7 @@ class CompilationOptions(QutipOptions):
         _use_cython = True
     except ImportError:
         _use_cython = False
+        WARN_MISSING_MODULE[0] = 1
 
     _options = {
         "use_cython": _use_cython,
@@ -369,6 +373,12 @@ def coeff_from_str(base, args, args_ctypes, compile_opt=None, **_):
     coeff = None
     # Do we compile?
     if not compile_opt['use_cython']:
+        if WARN_MISSING_MODULE[0]:
+            warnings.warn(
+                "Both `cython` and `filelock` are required for compilation of "
+                "string coefficents. Falling back on `eval`.")
+            # Only warns once.
+            WARN_MISSING_MODULE[0] = 0
         return StrFunctionCoefficient(base, args)
     # Parsing tries to make the code in common pattern
     parsed, variables, constants, raw = try_parse(base, args,

--- a/qutip/tests/conftest.py
+++ b/qutip/tests/conftest.py
@@ -28,6 +28,7 @@ def _skip_cython_tests_if_unavailable(item):
         # importorskip rather than mark.skipif because this way we get pytest's
         # version-handling semantics.
         pytest.importorskip('Cython', minversion='0.14')
+        pytest.importorskip('filelock')
 
 
 @pytest.hookimpl(trylast=True)

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -6,8 +6,10 @@ import scipy.interpolate as interp
 from functools import partial
 from qutip.core.coefficient import (coefficient, norm, conj, const,
                                     CompilationOptions, Coefficient,
-                                    clean_compiled_coefficient
+                                    clean_compiled_coefficient,
+                                    WARN_MISSING_MODULE,
                                     )
+
 
 # Ensure the latest version is tested
 clean_compiled_coefficient(True)
@@ -238,6 +240,14 @@ def test_CoeffOptions():
     for coeff1, coeff2 in combinations(coeffs, 2):
         assert not isinstance(coeff1, coeff2.__class__)
 
+
+def test_warn_no_cython():
+    option = CompilationOptions(use_cython=False)
+    WARN_MISSING_MODULE[0] = 1
+    with pytest.warns(
+        UserWarning, match="`cython` and `filelock` are required"
+    ):
+        coefficient("t", compile_opt=option)
 
 @pytest.mark.requires_cython
 @pytest.mark.parametrize(['codestring', 'args', 'reference'], [

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -8,6 +8,10 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
+# Deactivate warning for test without cython
+from qutip.core.coefficient import WARN_MISSING_MODULE
+WARN_MISSING_MODULE[0] = 0
+
 
 class TestIntegratorCte():
     _analytical_se = lambda _, t: np.cos(t * np.pi)
@@ -90,7 +94,6 @@ class TestIntegratorCte():
         )
 
 
-@pytest.mark.filterwarnings("ignore:Both `cython` and `filelock`")
 class TestIntegrator(TestIntegratorCte):
     _analytical_se = lambda _, t: np.cos(t**2/2 * np.pi)
     se_system = qutip.QobjEvo([-1j * qutip.sigmax() * np.pi, "t"])

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -90,6 +90,7 @@ class TestIntegratorCte():
         )
 
 
+@pytest.mark.filterwarnings("ignore:Both `cython` and `filelock`")
 class TestIntegrator(TestIntegratorCte):
     _analytical_se = lambda _, t: np.cos(t**2/2 * np.pi)
     se_system = qutip.QobjEvo([-1j * qutip.sigmax() * np.pi, "t"])

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -20,6 +20,7 @@ def fidelitycheck(out1, out2, rho0vec):
     return fid
 
 
+@pytest.mark.filterwarnings("ignore:Both `cython` and `filelock`")
 class TestMESolveDecay:
     N = 10
     a = qutip.destroy(N)

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -7,6 +7,11 @@ from qutip.solver.solver_base import Solver
 import pickle
 import pytest
 
+# Deactivate warning for test without cython
+from qutip.core.coefficient import WARN_MISSING_MODULE
+WARN_MISSING_MODULE[0] = 0
+
+
 all_ode_method = [
     method for method, integrator in MESolver.avail_integrators().items()
     if integrator.support_time_dependant
@@ -20,7 +25,6 @@ def fidelitycheck(out1, out2, rho0vec):
     return fid
 
 
-@pytest.mark.filterwarnings("ignore:Both `cython` and `filelock`")
 class TestMESolveDecay:
     N = 10
     a = qutip.destroy(N)

--- a/qutip/tests/solver/test_sesolve.py
+++ b/qutip/tests/solver/test_sesolve.py
@@ -6,6 +6,11 @@ from qutip.solver.sesolve import sesolve, SESolver
 from qutip.solver.krylovsolve import krylovsolve
 from qutip.solver.solver_base import Solver
 
+# Deactivate warning for test without cython
+from qutip.core.coefficient import WARN_MISSING_MODULE
+WARN_MISSING_MODULE[0] = 0
+
+
 all_ode_method = [
     method for method, integrator in SESolver.avail_integrators().items()
     if integrator.support_time_dependant
@@ -15,7 +20,6 @@ def _analytic(t, alpha):
     return ((1 - np.exp(-alpha * t)) / alpha)
 
 
-@pytest.mark.filterwarnings("ignore:Both `cython` and `filelock`")
 class TestSeSolve():
     H0 = 0.2 * np.pi * qutip.sigmaz()
     H1 = np.pi * qutip.sigmax()

--- a/qutip/tests/solver/test_sesolve.py
+++ b/qutip/tests/solver/test_sesolve.py
@@ -15,6 +15,7 @@ def _analytic(t, alpha):
     return ((1 - np.exp(-alpha * t)) / alpha)
 
 
+@pytest.mark.filterwarnings("ignore:Both `cython` and `filelock`")
 class TestSeSolve():
     H0 = 0.2 * np.pi * qutip.sigmaz()
     H1 = np.pi * qutip.sigmax()


### PR DESCRIPTION
**Description**
- Add a mention that filelock is needed for string coefficient compilation in the guide.
- When a string coefficient is used, a warning will be raised (once) if either cython or filelock is missing.
- Skip string coefficient compilation test when cython is present by filelock is not instead of only checking for cython.

**Related issues or PRs**
fix #2162