### PR TITLE
Add signal check in vern integrator

### DIFF
--- a/qutip/core/cy/_element.pxd
+++ b/qutip/core/cy/_element.pxd
@@ -6,6 +6,7 @@ from qutip.core.data.base cimport idxint
 from libcpp cimport bool
 
 cdef class _BaseElement:
+    cdef Data _data
     cpdef Data data(self, t)
     cpdef object qobj(self, t)
     cpdef object coeff(self, t)

--- a/qutip/core/cy/_element.pyx
+++ b/qutip/core/cy/_element.pyx
@@ -273,6 +273,7 @@ cdef class _ConstantElement(_BaseElement):
     """
     def __init__(self, qobj):
         self._qobj = qobj
+        self._data = self._qobj.data
 
     def __mul__(left, right):
         if type(left) is _ConstantElement:
@@ -290,7 +291,7 @@ cdef class _ConstantElement(_BaseElement):
         return NotImplemented
 
     cpdef Data data(self, t):
-        return self._qobj.data
+        return self._data
 
     cpdef object qobj(self, t):
         return self._qobj
@@ -318,6 +319,7 @@ cdef class _EvoElement(_BaseElement):
     """
     def __init__(self, qobj, coefficient):
         self._qobj = qobj
+        self._data = self._qobj.data
         self._coefficient = coefficient
 
     def __mul__(left, right):
@@ -343,7 +345,7 @@ cdef class _EvoElement(_BaseElement):
         return _EvoElement(left._qobj * right._qobj, coefficient)
 
     cpdef Data data(self, t):
-        return self._qobj.data
+        return self._data
 
     cpdef object qobj(self, t):
         return self._qobj

--- a/qutip/core/data/norm.pxd
+++ b/qutip/core/data/norm.pxd
@@ -12,4 +12,4 @@ cpdef double l2_csr(CSR matrix) nogil except -1
 cpdef double frobenius_dense(Dense matrix) nogil
 cpdef double l2_dense(Dense matrix) nogil except -1
 
-cpdef double frobenius_data(Data state)
+cpdef double frobenius_data(Data state) except -1

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -220,7 +220,7 @@ trace.add_specialisations([
 ], _defer=True)
 
 
-cpdef double frobenius_data(Data state):
+cpdef double frobenius_data(Data state) except -1:
     if type(state) is Dense:
         return frobenius_dense(state)
     elif type(state) is CSR:

--- a/qutip/solver/integrator/explicit_rk.pxd
+++ b/qutip/solver/integrator/explicit_rk.pxd
@@ -39,24 +39,24 @@ cdef class Explicit_RungeKutta:
     cdef double [:, ::1] a
     cdef double [:, ::1] bi
 
-    cpdef integrate(Explicit_RungeKutta self, double t, bint step=*)
+    cpdef void integrate(Explicit_RungeKutta self, double t, bint step=*) except *
 
-    cpdef void set_initial_value(self, Data y0, double t)
+    cpdef void set_initial_value(self, Data y0, double t) except *
 
-    cdef int _step_in_err(self, double t, int max_step)
+    cdef int _step_in_err(self, double t, int max_step) except -1
 
-    cdef double _compute_step(self, double dt)
+    cdef double _compute_step(self, double dt) except -1
 
-    cdef double _error(self, Data y_new, double dt)
+    cdef double _error(self, Data y_new, double dt) except -1
 
-    cdef void _prep_dense_out(self)
+    cdef void _prep_dense_out(self) except *
 
     cdef Data _interpolate_step(self, double t, Data out)
 
     cdef inline Data _accumulate(self, Data target, double[:] factors,
                                  double dt, int size)
 
-    cdef double _estimate_first_step(self, double t, Data y0)
+    cdef double _estimate_first_step(self, double t, Data y0) except -1
 
     cdef double _get_timestep(self, double t)
 

--- a/qutip/solver/integrator/explicit_rk.pyx
+++ b/qutip/solver/integrator/explicit_rk.pyx
@@ -11,6 +11,7 @@ from qutip.core.data.tidyup import tidyup_csr
 from qutip.core.data.norm import frobenius_data
 from .verner7efficient import vern7_coeff
 from .verner9efficient import vern9_coeff
+from cpython.exc cimport PyErr_CheckSignals
 cimport cython
 import numpy as np
 
@@ -198,7 +199,7 @@ cdef class Explicit_RungeKutta:
         self.b_factor_np = np.empty(self.rk_extra_step, dtype=np.float64)
         self.b_factor = self.b_factor_np
 
-    cpdef void set_initial_value(self, Data y0, double t):
+    cpdef void set_initial_value(self, Data y0, double t) except *:
         """
         Set the initial state and time of the integration.
         """
@@ -222,7 +223,7 @@ cdef class Explicit_RungeKutta:
         else:
             self._dt_safe = self.first_step
 
-    cdef double _estimate_first_step(self, double t, Data y0):
+    cdef double _estimate_first_step(self, double t, Data y0) except -1:
         if not self.adaptative_step:
             return 0.
 
@@ -265,7 +266,7 @@ cdef class Explicit_RungeKutta:
             dt = max(self.min_step, dt)
         return dt
 
-    cpdef integrate(Explicit_RungeKutta self, double t, bint step=False):
+    cpdef void integrate(Explicit_RungeKutta self, double t, bint step=False) except *:
         """
         Do the integration to t.
         If ``step`` is True, it will make a maximum 1 step and may not reach
@@ -300,6 +301,7 @@ cdef class Explicit_RungeKutta:
             self._t_prev = self._t_front
             self._norm_prev = self._norm_front
             nsteps_left -= self._step_in_err(t, nsteps_left)
+            PyErr_CheckSignals()
             if step:
                 break
 
@@ -316,7 +318,7 @@ cdef class Explicit_RungeKutta:
             self._t = self._t_front
             self._y = copy_to(self._y_front, self._y)
 
-    cdef int _step_in_err(self, double t, int max_step):
+    cdef int _step_in_err(self, double t, int max_step) except -1:
         """
         Do compute one step, repeating until the error is within tolerance.
         """
@@ -338,7 +340,7 @@ cdef class Explicit_RungeKutta:
                 break
         return nsteps
 
-    cdef double _compute_step(self, double dt):
+    cdef double _compute_step(self, double dt) except -1:
         """
         Do compute one step with fixed ``dt``, return the error.
         Use (_t_prev, _y_prev) to create (_t_front, _y_front)
@@ -368,7 +370,7 @@ cdef class Explicit_RungeKutta:
 
         return self._error(self._y_front, dt)
 
-    cdef double _error(self, Data y_new, double dt):
+    cdef double _error(self, Data y_new, double dt) except -1:
         """ Compute the normalized error. (error/tol) """
         if not self.adaptative_step:
             return 0.
@@ -378,7 +380,7 @@ cdef class Explicit_RungeKutta:
         return frobenius_data(self._y_temp) / (self.atol +
                 max(self._norm_prev, self._norm_front) * self.rtol)
 
-    cdef void _prep_dense_out(self):
+    cdef void _prep_dense_out(self) except *:
         """
         Compute derivative for the interpolation step.
         """

--- a/qutip/solver/sode/_sode.pyx
+++ b/qutip/solver/sode/_sode.pyx
@@ -27,7 +27,7 @@ cdef class Euler:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef step(self, double t, Data state, double dt, double[:, :] dW):
+    cdef Data step(self, double t, Data state, double dt, double[:, :] dW):
         """
         Integration scheme:
         Basic Euler order 0.5
@@ -50,7 +50,7 @@ cdef class Platen(Euler):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef step(self, double t, Data state, double dt, double[:, :] dW):
+    cdef Data step(self, double t, Data state, double dt, double[:, :] dW):
         """
         Platen rhs function for both master eq and schrodinger eq.
         dV = -iH* (V+Vt)/2 * dt + (d1(V)+d1(Vt))/2 * dt
@@ -109,7 +109,7 @@ cdef class Explicit15(Euler):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef step(self, double t, Data state, double dt, double[:, :] dW):
+    cdef Data step(self, double t, Data state, double dt, double[:, :] dW):
         """
         Chapter 11.2 Eq. (2.13)
         Numerical Solution of Stochastic Differential Equations
@@ -254,7 +254,7 @@ cdef class Milstein:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef step(self, double t, Dense state, double dt, double[:, :] dW, Dense out):
+    cdef Data step(self, double t, Dense state, double dt, double[:, :] dW, Dense out):
         """
         Chapter 10.3 Eq. (3.12)
         Numerical Solution of Stochastic Differential Equations
@@ -311,7 +311,7 @@ cdef class PredCorr:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef step(self, double t, Dense state, double dt, double[:, :] dW, Dense out):
+    cdef Data step(self, double t, Dense state, double dt, double[:, :] dW, Dense out):
         """
         Chapter 15.5 Eq. (5.4)
         Numerical Solution of Stochastic Differential Equations
@@ -352,7 +352,7 @@ cdef class PredCorr:
 cdef class Taylor15(Milstein):
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef step(self, double t, Dense state, double dt, double[:, :] dW, Dense out):
+    cdef Data step(self, double t, Dense state, double dt, double[:, :] dW, Dense out):
         """
         Chapter 10.4 Eq. (4.6),
         Numerical Solution of Stochastic Differential Equations


### PR DESCRIPTION
**Description**
In cython code, signals (Keyboard Interrupt) are not automatically checked.
And when checked, if error are not properly passed (`expect *`) the signal can be last.

This happened in the Runge Kutta integrator, which did not properly passed errors and only when back to python space at time in `tlist` which can be far apart.

The stochastic solver stop on (Keyboard Interrupt), the `except` are not needed since the output is a class. I made it explicit for clarity.

Doing a few tests, I saw that the error was often caught in the `Qobj.data` property called by `QobjEvo.matmul`. This means more back and forth between python and cython was done than needed.

