### PR TITLE
Update for numpy 1.25 deprecations

### DIFF
--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -333,7 +333,7 @@ def tensor_contract(qobj, *pairs):
     # We don't need to check for tensor idxs versus dims idxs here,
     # as column- versus row-stacking will never move an index for the
     # vectorized operator spaces all the way from the left to the right.
-    l_mtx_dims, r_mtx_dims = map(np.product, map(flatten, contracted_dims))
+    l_mtx_dims, r_mtx_dims = map(np.prod, map(flatten, contracted_dims))
 
     # Reshape back into a 2D matrix.
     qmtx = qtens.reshape((l_mtx_dims, r_mtx_dims))

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -317,11 +317,10 @@ def test_QobjMultiplication():
 
 # Allowed mul operations (scalar)
 @pytest.mark.parametrize("scalar",
-                         [2+2j,  np.array(2+2j), np.array([2+2j])],
+                         [2+2j,  np.array(2+2j)],
                          ids=[
                              "python_number",
                              "scalar_like_array_shape_0",
-                             "scalar_like_array_shape_1",
                          ])
 def test_QobjMulValidScalar(scalar):
     "Tests multiplication of Qobj times scalar."
@@ -359,11 +358,10 @@ def test_QobjMulNotValidScalar(not_scalar):
 
 # Allowed division operations (scalar)
 @pytest.mark.parametrize("scalar",
-                         [2+2j,  np.array(2+2j), np.array([2+2j])],
+                         [2+2j,  np.array(2+2j)],
                          ids=[
                              "python_number",
                              "scalar_like_array_shape_0",
-                             "scalar_like_array_shape_1",
                          ])
 def test_QobjDivisionValidScalar(scalar):
     "Tests multiplication of Qobj times scalar."

--- a/qutip/tests/solver/heom/test_bofin_solvers.py
+++ b/qutip/tests/solver/heom/test_bofin_solvers.py
@@ -204,7 +204,7 @@ class TestHierarchyADOsState:
 
     def mk_rho_and_soln(self, ados, rho_dims):
         n_ados = len(ados.labels)
-        ado_soln = np.random.rand(n_ados, *[np.product(d) for d in rho_dims])
+        ado_soln = np.random.rand(n_ados, *[np.prod(d) for d in rho_dims])
         rho = Qobj(ado_soln[0, :], dims=rho_dims)
         return rho, ado_soln
 
@@ -1289,7 +1289,7 @@ class TestHEOMResult:
 
     def mk_rho_and_soln(self, ados, rho_dims):
         n_ados = len(ados.labels)
-        ado_soln = np.random.rand(n_ados, *[np.product(d) for d in rho_dims])
+        ado_soln = np.random.rand(n_ados, *[np.prod(d) for d in rho_dims])
         rho = Qobj(ado_soln[0, :], dims=rho_dims)
         return rho, ado_soln
 

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -225,7 +225,7 @@ class TestHusimiQ:
         naive = np.empty(alphas.shape, dtype=np.float64)
         for i, alpha in enumerate(alphas.flat):
             coh = qutip.coherent(size, alpha, method='analytic').full()
-            naive.flat[i] = (coh.conj().T @ state_np @ coh).real
+            naive.flat[i] = (coh.conj().T @ state_np @ coh).real[0, 0]
         naive *= (0.5*g)**2 / np.pi
         np.testing.assert_allclose(naive, qutip.qfunc(state, xs, ys, g))
         np.testing.assert_allclose(naive, qutip.QFunc(xs, ys, g)(state))


### PR DESCRIPTION
**Description**
Fix for the numpy 1.25 release.
- `np.product` deprecated, `np.prod` suggested instead.
- Single elements array can no longer be implicitly converted to scalar: `a[i] = bra @ ket` raise a warning since `bra @ ket` is a one elements array.
- Some tests where removed since they expected one element array to be used as a scalar.