### PR TITLE
Remove warning from numpy 1.25 for qutip-4.7.X

### DIFF
--- a/doc/changes/2178.misc
+++ b/doc/changes/2178.misc
@@ -1,0 +1,1 @@
+Update for numpy 1.25

--- a/qutip/superop_reps.py
+++ b/qutip/superop_reps.py
@@ -224,7 +224,7 @@ def kraus_to_super(kraus_list):
 
 
 def _nq(dims):
-    dim = np.product(dims[0][0])
+    dim = np.prod(dims[0][0])
     nq = int(log2(dim))
     if 2 ** nq != dim:
         raise ValueError("{} is not an integer power of 2.".format(dim))

--- a/qutip/tensor.py
+++ b/qutip/tensor.py
@@ -344,7 +344,7 @@ def tensor_contract(qobj, *pairs):
     # We don't need to check for tensor idxs versus dims idxs here,
     # as column- versus row-stacking will never move an index for the
     # vectorized operator spaces all the way from the left to the right.
-    l_mtx_dims, r_mtx_dims = map(np.product, map(flatten, contracted_dims))
+    l_mtx_dims, r_mtx_dims = map(np.prod, map(flatten, contracted_dims))
 
     # Reshape back into a 2D matrix.
     qmtx = qtens.reshape((l_mtx_dims, r_mtx_dims))

--- a/qutip/tests/test_bofin_solvers.py
+++ b/qutip/tests/test_bofin_solvers.py
@@ -179,7 +179,7 @@ class TestHierarchyADOsState:
 
     def mk_rho_and_soln(self, ados, rho_dims):
         n_ados = len(ados.labels)
-        ado_soln = np.random.rand(n_ados, *[np.product(d) for d in rho_dims])
+        ado_soln = np.random.rand(n_ados, *[np.prod(d) for d in rho_dims])
         rho = Qobj(ado_soln[0, :], dims=rho_dims)
         return rho, ado_soln
 

--- a/qutip/tests/test_countstat.py
+++ b/qutip/tests/test_countstat.py
@@ -35,9 +35,9 @@ def test_dqd_current():
         H = (eps/2 * sz + tc * sx)
         L = qutip.liouvillian(H, c_ops)
         rhoss = qutip.steadystate(L)
-        current[n], noise[n] = qutip.countstat_current_noise(L, [],
-                                                             rhoss=rhoss,
-                                                             J_ops=J_ops)
+        c_, n_ = qutip.countstat_current_noise(L, [], rhoss=rhoss, J_ops=J_ops)
+        current[n] = c_[0]
+        noise[n] = n_[0, 0, 0]
 
         current2 = qutip.countstat_current(L, rhoss=rhoss, J_ops=J_ops)
         assert abs(current[n] - current2) < 1e-8

--- a/qutip/tests/test_graph.py
+++ b/qutip/tests/test_graph.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-from numpy.testing import run_module_suite, assert_equal
+from numpy.testing import assert_equal
 import scipy.sparse as sp
 from scipy.sparse.csgraph import breadth_first_order as BFO
 import pytest
@@ -138,7 +138,3 @@ def test_column_permutation():
     B = sp_permute(A, [], perm)
     counts = np.diff(B.indptr)
     assert_equal(np.all(np.argsort(counts) == np.arange(5)), True)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_mesolve.py
+++ b/qutip/tests/test_mesolve.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 import numpy as np
-from numpy.testing import assert_, run_module_suite, assert_allclose
+from numpy.testing import assert_, assert_allclose
 import pytest
 
 # disable the MC progress bar

--- a/qutip/tests/test_noise.py
+++ b/qutip/tests/test_noise.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, run_module_suite, assert_allclose
+from numpy.testing import assert_, assert_allclose
 import numpy as np
 
 from qutip.qip.device.processor import Processor

--- a/qutip/tests/test_openmp.py
+++ b/qutip/tests/test_openmp.py
@@ -1,11 +1,11 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_, run_module_suite
+from numpy.testing import assert_equal, assert_
 import unittest
 from qutip import *
 import qutip.settings as qset
 if qset.has_openmp:
     from qutip.cy.openmp.benchmark import _spmvpy, _spmvpy_openmp
-    
+
 
 @unittest.skipIf(qset.has_openmp == False, 'OPENMP not available.')
 def test_openmp_spmv():
@@ -51,7 +51,7 @@ def test_openmp_mesolve():
     rate = gamma
     if rate > 0.0:
         c_op_list.append(np.sqrt(rate) * sm)
-    
+
     n = N - 2
     psi0 = tensor(basis(N, n), basis(2, 1))
     tlist = np.linspace(0, 1, 100)
@@ -80,9 +80,9 @@ def test_openmp_mesolve_td():
     # Hamiltonian
     H0 = wc * a.dag() * a + wa * sm.dag() * sm
     H1 = g * (a.dag() + a) * (sm + sm.dag())
-    
+
     H = [H0, [H1,'sin(t)']]
-    
+
     c_op_list = []
 
     rate = kappa * (1 + n_th_a)
@@ -96,7 +96,7 @@ def test_openmp_mesolve_td():
     rate = gamma
     if rate > 0.0:
         c_op_list.append(np.sqrt(rate) * sm)
-    
+
     n = N - 10
     psi0 = tensor(basis(N, n), basis(2, 1))
     tlist = np.linspace(0, 1, 100)
@@ -106,6 +106,3 @@ def test_openmp_mesolve_td():
     out = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a, sm.dag() * sm], options=opts)
     assert_(np.allclose(out.expect[0],out_omp.expect[0]))
     assert_(np.allclose(out.expect[1],out_omp.expect[1]))
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_optpulseprocessor.py
+++ b/qutip/tests/test_optpulseprocessor.py
@@ -1,7 +1,6 @@
 import os
 
-from numpy.testing import (assert_, run_module_suite, assert_allclose,
-                           assert_equal)
+from numpy.testing import (assert_, assert_allclose, assert_equal)
 import numpy as np
 
 from qutip.qip.device.optpulseprocessor import OptPulseProcessor
@@ -129,7 +128,3 @@ class TestOptPulseProcessor:
         rho1 = U * rho0
         result = test.run_state(rho0)
         assert_(fidelity(result.states[-1], rho1) > 1-1.0e-6)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_parallel.py
+++ b/qutip/tests/test_parallel.py
@@ -1,6 +1,6 @@
 import numpy as np
 import time
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 
 from qutip.parallel import parfor, parallel_map, serial_map
 
@@ -57,6 +57,3 @@ def test_serial_map():
 
     y2 = serial_map(_func2, x, args, kwargs, num_cpus=2)
     assert_((np.array(y1) == np.array(y2)).all())
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_partial_transpose.py
+++ b/qutip/tests/test_partial_transpose.py
@@ -3,7 +3,7 @@ Unit tests for QuTiP partial transpose functions.
 """
 
 import numpy as np
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 
 from qutip import Qobj, partial_transpose, tensor, rand_dm
 from qutip.partial_transpose import _partial_transpose_reference
@@ -72,7 +72,3 @@ def test_partial_transpose_randomized():
 
     rho_pt2 = partial_transpose(rho, mask, method="sparse")
     np.abs(np.max(rho_pt2.full() - rho_pt_ref.full())) < 1e-12
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_piqs.py
+++ b/qutip/tests/test_piqs.py
@@ -4,7 +4,6 @@ Tests for Permutational Invariant Quantum solver (PIQS).
 import numpy as np
 from numpy.testing import (
     assert_,
-    run_module_suite,
     assert_raises,
     assert_array_equal,
     assert_array_almost_equal,
@@ -1534,7 +1533,3 @@ class TestPim:
         no_hamiltonian_system = Dicke(4, emission=0.1)
         result = no_hamiltonian_system.pisolve(diag_initial_state, tlist)
         assert_equal(True, len(result.states) > 0)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_processor.py
+++ b/qutip/tests/test_processor.py
@@ -1,7 +1,6 @@
 import os
 
-from numpy.testing import (
-    assert_, run_module_suite, assert_allclose, assert_equal)
+from numpy.testing import (assert_, assert_allclose, assert_equal)
 import numpy as np
 
 from qutip.qip.device import Processor, LinearSpinChain
@@ -353,7 +352,3 @@ class TestCircuitProcessor:
         final_state = processor.run_state(init_state).states[-1]
         expected_state = tensor([basis(2, 0), basis(2, 1)])
         assert pytest.approx(fidelity(final_state, expected_state), 0.001) == 1
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_propagator.py
+++ b/qutip/tests/test_propagator.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_, assert_equal, run_module_suite
+from numpy.testing import assert_, assert_equal
 from qutip import *
 
 
@@ -140,7 +140,3 @@ def testPropHWithCopsParallel():
     rho_fs = [vector_to_operator(F * operator_to_vector(rho0)) for F in Fs]
     expected_rho_fs = mesolve(H, rho0, tlist, c_ops=c_ops).states
     assert rho_fs == expected_rho_fs
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_pulse.py
+++ b/qutip/tests/test_pulse.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_, run_module_suite, assert_allclose
+from numpy.testing import assert_,  assert_allclose
 
 from qutip.qobj import Qobj
 from qutip.qip.pulse import Pulse, Drift
@@ -142,7 +142,3 @@ def TestDrift():
     drift.add_drift(sigmaz(), targets=1)
     assert_allclose(
         drift.get_ideal_qobjevo(dims=[3, 2]).cte, tensor(identity(3), sigmaz()))
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_qft.py
+++ b/qutip/tests/test_qft.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, assert_equal, assert_string_equal, run_module_suite
+from numpy.testing import assert_, assert_equal, assert_string_equal
 from qutip.qip.algorithms.qft import qft, qft_steps, qft_gate_sequence
 from qutip.qip.operations.gates import gate_sequence_product
 
@@ -49,6 +49,3 @@ class TestQFT:
 
             for i in range(phases, phases + swaps):
                 assert_string_equal(circuit.gates[i].name, "SWAP")
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_qobjevo.py
+++ b/qutip/tests/test_qobjevo.py
@@ -4,7 +4,7 @@ from qutip import *
 import qutip.settings as settings
 import numpy as np
 from numpy.testing import (assert_equal, assert_, assert_almost_equal,
-                            run_module_suite, assert_allclose)
+                           assert_allclose)
 from functools import partial
 from types import FunctionType, BuiltinFunctionType
 from qutip.interpolate import Cubic_Spline

--- a/qutip/tests/test_qpt.py
+++ b/qutip/tests/test_qpt.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 import scipy.linalg as la
 
 from qutip import (spre, spost, qeye, sigmax, sigmay, sigmaz, qpt)
@@ -45,6 +45,3 @@ def test_qpt_cnot():
     chi2[13, 12] = chi2[12, 13] = -0.25
 
     assert_(la.norm(chi2 - chi1) < 1e-8)
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_qubit_evolution.py
+++ b/qutip/tests/test_qubit_evolution.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import run_module_suite, assert_equal
+from numpy.testing import assert_equal
 import pytest
 
 from qutip import (
@@ -148,7 +148,3 @@ def test_MCSolverCase2():
     assert_equal(max(abs(sx - sx_analytic)) < 0.25, True)
     assert_equal(max(abs(sy - sy_analytic)) < 0.25, True)
     assert_equal(max(abs(sz - sz_analytic)) < 0.25, True)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_qubits.py
+++ b/qutip/tests/test_qubits.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 from qutip.qip.qubits import qubit_states
 from qutip.tensor import tensor
 from qutip.states import basis
@@ -23,7 +23,3 @@ class TestQubits:
         psi01_a = tensor(psi0_a, psi1_a)
         psi01_b = qubit_states(N=2, states=[0, 1])
         assert_(psi01_a == psi01_b)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_rhs_reuse.py
+++ b/qutip/tests/test_rhs_reuse.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_, assert_equal, run_module_suite
+from numpy.testing import assert_, assert_equal
 import qutip as qt
 from qutip.solver import config
 
@@ -47,6 +47,4 @@ def test_rhs_reuse():
 
     assert_(config.tdname == _temp_config_name)
 
-if __name__ == "__main__":
-    run_module_suite()
 """

--- a/qutip/tests/test_scattering.py
+++ b/qutip/tests/test_scattering.py
@@ -7,7 +7,7 @@ module. Tests are approximate with low resolution to minimize runtime.
 # Contact: benbartlett@stanford.edu
 
 import numpy as np
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 from qutip.operators import create, destroy
 from qutip.states import basis
 from qutip.scattering import *
@@ -93,7 +93,3 @@ class TestScattering:
         P1_split = scattering_probability(Htls, psi0, 1, c_ops_split, tlist)
         tolerance = 1e-7
         assert_(1 - tolerance < P1 / P1_split < 1 + tolerance)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_sesolve.py
+++ b/qutip/tests/test_sesolve.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 
 # disable the progress bar
 import os

--- a/qutip/tests/test_sp_eigs.py
+++ b/qutip/tests/test_sp_eigs.py
@@ -1,6 +1,6 @@
 import scipy
 import numpy as np
-from numpy.testing import assert_equal, run_module_suite, assert_
+from numpy.testing import assert_equal, assert_
 import unittest
 
 from qutip import num, rand_herm, expect, rand_unitary
@@ -214,7 +214,3 @@ def test_BigDenseValsOnly():
     H = rand_herm(dimension, density=1e-2)
     spvals = H.eigenenergies()
     assert abs(H.tr() - spvals.sum()) < tol
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_sparse.py
+++ b/qutip/tests/test_sparse.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import run_module_suite, assert_equal, assert_almost_equal
+from numpy.testing import assert_equal, assert_almost_equal
 import scipy.sparse as sp
 
 from qutip.random_objects import (rand_dm, rand_herm,
@@ -163,7 +163,7 @@ def test_sp_one_norm():
         nrm = sp_one_norm(H)
         ans = max(abs(H).sum(axis=0).flat)
         assert_almost_equal(nrm,ans)
-        
+
 def test_sp_inf_norm():
     "Sparse: inf-norm"
     for kk in range(10):
@@ -171,7 +171,3 @@ def test_sp_inf_norm():
         nrm = sp_inf_norm(H)
         ans = max(abs(H).sum(axis=1).flat)
         assert_almost_equal(nrm,ans)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_spmath.py
+++ b/qutip/tests/test_spmath.py
@@ -1,6 +1,5 @@
 import numpy as np
-from numpy.testing import (run_module_suite, assert_,
-                        assert_equal, assert_almost_equal)
+from numpy.testing import (assert_, assert_equal, assert_almost_equal)
 import scipy.sparse as sp
 
 from qutip.fastsparse import fast_csr_matrix, fast_identity
@@ -321,7 +320,3 @@ def test_issue_1998():
     base = fast_csr_matrix((base.data, base.indices, base.indptr), base.shape)
     assert not zcsr_isherm(base, tol=tol)
     assert not zcsr_isherm(base.T, tol=tol)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_stochastic_me.py
+++ b/qutip/tests/test_stochastic_me.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 
 from qutip import (smesolve, mesolve, photocurrent_mesolve, liouvillian,
                    QobjEvo, spre, spost, destroy, coherent, parallel_map,

--- a/qutip/tests/test_stochastic_se.py
+++ b/qutip/tests/test_stochastic_se.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_,  run_module_suite
+from numpy.testing import assert_
 
 from qutip import (ssesolve, destroy, coherent, mesolve, fock, qeye,
                    parallel_map, photocurrent_sesolve, num)

--- a/qutip/tests/test_subsys_apply.py
+++ b/qutip/tests/test_subsys_apply.py
@@ -1,5 +1,5 @@
 from numpy.linalg import norm
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 
 from qutip.random_objects import rand_dm, rand_unitary, rand_kraus_map
 from qutip.subsystem_apply import subsystem_apply
@@ -135,7 +135,3 @@ class TestSubsysApply(object):
                 msg="ComplexSuper: efficient_diff_norm {} "
                     "is beyond tolerance {}".format(
                         efficient_diff_norm, tol))
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_superoper.py
+++ b/qutip/tests/test_superoper.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.random import rand
 import scipy.linalg as la
-from numpy.testing import assert_, assert_equal, run_module_suite
+from numpy.testing import assert_, assert_equal
 import scipy
 
 from qutip import (rand_dm, rand_unitary, spre, spost, vector_to_operator,
@@ -239,8 +239,3 @@ class TestSuper_td:
                 lindblad_dissipator(self.t2(.5), self.q1))
         assert_(lindblad_dissipator(self.q1, self.t2)(.5) ==
                 lindblad_dissipator(self.q1, self.t2(.5)))
-
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_td_formats.py
+++ b/qutip/tests/test_td_formats.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 
 from qutip import rand_herm, qeye
 from qutip.rhs_generate import _td_format_check
@@ -55,7 +55,3 @@ def test_setTDFormatCheckMC():
     # check func H and func C_ops
     time_type, h_stuff, c_stuff = _td_format_check(f_H, [f_c_op], 'mc')
     # assert_(time_type==22)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_tensor.py
+++ b/qutip/tests/test_tensor.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from numpy.testing import assert_equal, assert_, run_module_suite
+from numpy.testing import assert_equal, assert_
 
 from qutip.qobj import Qobj
 from qutip.operators import identity, sigmax, sigmay
@@ -25,8 +25,8 @@ def test_tensor_contract_ident():
     assert_equal(correct_dims, tensor_contract(sqobj, (1, 4), (7, 10)).dims)
 
 def case_tensor_contract_other(left, right, pairs, expected_dims, expected_data=None):
-    dat = np.arange(np.product(left) * np.product(right)).reshape((np.product(left), np.product(right)))
-    
+    dat = np.arange(np.prod(left) * np.prod(right)).reshape((np.prod(left), np.prod(right)))
+
     qobj = Qobj(dat, dims=[left, right])
     cqobj = tensor_contract(qobj, *pairs)
 
@@ -93,7 +93,3 @@ def test_tensor_swap_other():
         # Swapping the inner indices on a superoperator should give a Choi matrix.
         J = to_choi(S)
         case_tensor_swap(S, [(1, 2)], [[[dim], [dim]], [[dim], [dim]]], J)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_three_level.py
+++ b/qutip/tests/test_three_level.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_, assert_equal, run_module_suite
+from numpy.testing import assert_, assert_equal
 from qutip.states import basis
 from qutip.three_level_atom import *
 
@@ -22,6 +22,3 @@ def testThreeOps():
     assert_equal((three_ops[2]*three_states[2]).full(), three_check[2].full())
     assert_equal((three_ops[3]*three_states[1]).full(), three_check[0].full())
     assert_equal((three_ops[4]*three_states[1]).full(), three_check[2].full())
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -3,7 +3,7 @@ import numpy as np
 import itertools
 from scipy.special import laguerre
 from numpy.random import rand
-from numpy.testing import assert_, run_module_suite, assert_equal, \
+from numpy.testing import assert_, assert_equal, \
     assert_almost_equal, assert_allclose
 
 import qutip
@@ -226,7 +226,7 @@ class TestHusimiQ:
         naive = np.empty(alphas.shape, dtype=np.float64)
         for i, alpha in enumerate(alphas.flat):
             coh = qutip.coherent(size, alpha, method='analytic').full()
-            naive.flat[i] = (coh.conj().T @ state_np @ coh).real
+            naive.flat[i] = (coh.conj().T @ state_np @ coh).real[0, 0]
         naive *= (0.5*g)**2 / np.pi
         np.testing.assert_allclose(naive, qutip.qfunc(state, xs, ys, g))
         np.testing.assert_allclose(naive, qutip.QFunc(xs, ys, g)(state))
@@ -691,6 +691,3 @@ def test_spin_wigner_overlap(spin, pure, n=5):
         W_overlap = np.trapz(
             np.trapz(W_state * W * np.sin(THETA), theta), phi).real
         assert_almost_equal(W_overlap, state_overlap, decimal=4)
-
-if __name__ == "__main__":
-    run_module_suite()


### PR DESCRIPTION
**Description**
Fix warning / error for numpy 1.25
- `np.product` is deprecated, changed to `np.prod`.
- Single elements array can no longer be implicitly converted to scalar.
- Remove `run_module_suite`

