### PR TITLE
scipy 1.11 fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,7 @@ jobs:
             os: ubuntu-latest
             python-version: "3.10"
             condaforge: 1
+            nocvxopt: 1
             pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper -W ignore:Absolute:DeprecationWarning"
 
           # Python 3.11 and latest numpy
@@ -135,9 +136,12 @@ jobs:
         # rather than in the GitHub Actions file directly, because bash gives us
         # a proper programming language to use.
         run: |
-          QUTIP_TARGET="tests,graphics,semidefinite,ipython"
+          QUTIP_TARGET="tests,graphics,ipython"
           if [[ -z "${{ matrix.nocython }}" ]]; then
             QUTIP_TARGET="$QUTIP_TARGET,runtime_compilation"
+          fi
+          if [[ -z "${{ matrix.nocvxopt }}" ]]; then
+            QUTIP_TARGET="$QUTIP_TARGET,semidefinite"
           fi
           export CI_QUTIP_WITH_OPENMP=${{ matrix.openmp }}
           if [[ -z "${{ matrix.nomkl }}" ]]; then

--- a/doc/changes/2083.misc
+++ b/doc/changes/2083.misc
@@ -1,0 +1,1 @@
+Fix for scipy 1.11.0

--- a/qutip/fastsparse.py
+++ b/qutip/fastsparse.py
@@ -52,7 +52,11 @@ class fast_csr_matrix(csr_matrix):
                 self._shape = tuple(int(s) for s in shape)
         self.dtype = complex
         self.maxprint = 50
-        self.format = 'csr'
+        if hasattr(self, "_format"):
+            # format is readonly since 1.11
+            self._format = 'csr'
+        else:
+            self.format = 'csr'
 
     def _binopt(self, other, op):
         """


### PR DESCRIPTION
Fix for scipy 1.11.
`cvxpy` does not work yet with the latest scipy version. I changed one of the test to run with the latest scipy but no `cvxpy` to confirm the fix is working.

Close #2182 

(Nothing to fix for v5)