### PR TITLE
Set version requirement to exclude cython 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "packaging",
     "wheel",
-    "cython>=0.29.20",
+    "cython>=0.29.20,<3.0.0",
     # See https://numpy.org/doc/stable/user/depending_on_numpy.html for
     # the recommended way to build against numpy's C API:
     "oldest-supported-numpy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cython>=0.29.20
+cython>=0.29.20,<3.0.0
 numpy>=1.16.6
 scipy>=1.5
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
 setup_requires =
     numpy>=1.13.3
     scipy>=1.0
-    cython>=0.29.20
+    cython>=0.29.20,<3.0.0
     packaging
 
 [options.packages.find]
@@ -46,7 +46,7 @@ include = qutip*
 [options.extras_require]
 graphics = matplotlib>=1.2.1
 runtime_compilation =
-    cython>=0.29.20
+    cython>=0.29.20,<3.0.0
     filelock
 semidefinite =
     cvxpy>=1.0


### PR DESCRIPTION
**Description**
Cython 3 has been released, but has a bug that stop us from using it. See #2151.
This fix the version to 0.29.X