### PR TITLE
Fix cython version to pre 3.0.0

### DIFF
--- a/doc/changes/2204.misc
+++ b/doc/changes/2204.misc
@@ -1,0 +1,1 @@
+Exclude cython 3.0.0 from requirement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "packaging",
     "wheel",
-    "cython>=0.29.20",
+    "cython>=0.29.20,<3.0.0",
     # See https://numpy.org/doc/stable/user/depending_on_numpy.html for
     # the recommended way to build against numpy's C API:
     "oldest-supported-numpy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cython>=0.29.20
+cython>=0.29.20,<3.0.0
 numpy>=1.16.6
 scipy>=1.0
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
 setup_requires =
     numpy>=1.13.3
     scipy>=1.0
-    cython>=0.29.20
+    cython>=0.29.20,<3.0.0
     packaging
 
 [options.packages.find]
@@ -45,7 +45,7 @@ include = qutip*
 
 [options.extras_require]
 graphics = matplotlib>=1.2.1
-runtime_compilation = cython>=0.29.20
+runtime_compilation = cython>=0.29.20,<3.0.0
 semidefinite =
     cvxpy>=1.0
     cvxopt


### PR DESCRIPTION
**Description**
Couldn't make #2202 work...
There are segfault in brmesolve with cython 3.0.0 and the new compilation method does not work properly on windows. 
This replace the PR with a simple limitation to not use cython 3.0.0.