### PR TITLE
Fix adding non-square `Qobj` to scalar

### DIFF
--- a/doc/changes/2208.bugfix
+++ b/doc/changes/2208.bugfix
@@ -1,0 +1,1 @@
+Non-oper qobj + scalar raise an error.

--- a/qutip/qobj.py
+++ b/qutip/qobj.py
@@ -386,8 +386,7 @@ class Qobj(object):
                 out.data = self.data + dat * fast_identity(
                     self.shape[0])
             else:
-                out.data = self.data
-                out.data.data = out.data.data + dat
+                raise TypeError("Only operators can be added to a scalar.")
 
             out.dims = self.dims
 
@@ -415,8 +414,7 @@ class Qobj(object):
             if other.type in ['oper', 'super']:
                 out.data = dat * fast_identity(other.shape[0]) + other.data
             else:
-                out.data = other.data
-                out.data.data = out.data.data + dat
+                raise TypeError("Only operators can be added to a scalar.")
             out.dims = other.dims
 
             if settings.auto_tidyup:

--- a/qutip/tests/test_qobj.py
+++ b/qutip/tests/test_qobj.py
@@ -259,6 +259,13 @@ def test_QobjAddition():
     assert np.all(x3.full() == data)
     assert np.all(x4.full() == data)
 
+    ket = Qobj([[1j],[0.]])
+    with pytest.raises(TypeError):
+        out = ket + 1.
+
+    with pytest.raises(TypeError):
+        out = 1. + ket
+
 
 def test_QobjSubtraction():
     "Qobj subtraction"


### PR DESCRIPTION
**Description**

Adding ket to scalar work by adding the scalar to all non-zero entries.
This operation is not well defined and modify the original object, (see #2208).
This fix by having the operation raising an error instead.

**Related issues or PRs**
Fix #2208 