### PR TITLE
py3.6 tests run without cvxopt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
             # let the old SciPy version select an appropriate numpy version:
             numpy-requirement: ""
             coverage-requirement: "==6.2"  # last coverage that supported 3.6
+            nocvxopt: 1
 
           # No MKL runs.  MKL is now the default for conda installations, but
           # not necessarily for pip.


### PR DESCRIPTION
**Description**

Python 3.6 tests fail to build cvxopt, there was a new version released last week.
This simply run these tests without it.