### PR TITLE
Fix for 2216

### DIFF
--- a/doc/changes/2216.bugfix
+++ b/doc/changes/2216.bugfix
@@ -1,0 +1,1 @@
+ssesolve average states to density matrices

--- a/qutip/stochastic.py
+++ b/qutip/stochastic.py
@@ -1321,7 +1321,10 @@ def _sesolve_generic(sso, options, progress_bar):
     # ajgpitch 2019-10-25: np.any(res.states) seems to error
     # I guess there may be a potential exception if there are no states?
     # store individual trajectory states
-    res.traj_states = res.states
+    if options.store_states:
+        res.traj_states = res.states
+    else:
+        res.traj_states = None
     res.avg_states = None
     if options.average_states:
         avg_states_list = []

--- a/qutip/tests/test_stochastic_me.py
+++ b/qutip/tests/test_stochastic_me.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_
 from qutip import (smesolve, mesolve, photocurrent_mesolve, liouvillian,
                    QobjEvo, spre, spost, destroy, coherent, parallel_map,
                    qeye, fock_dm, general_stochastic, ket2dm, num,
-                   basis, sigmax, sigmay, sigmaz, sigmam)
+                   basis, sigmax, sigmay, sigmaz, sigmam, Options)
 
 def f(t, args):
     return args["a"] * t
@@ -144,6 +144,7 @@ def test_smesolve_homodyne():
     psi0 = coherent(N, 0.5)
     sc_ops = [np.sqrt(gamma) * a, np.sqrt(gamma) * a * 0.5]
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
+    options = Options(average_states=True, store_states=True)
 
     times = np.linspace(0, 1.0, 21)
     res_ref = mesolve(H, psi0, times, sc_ops, e_ops, args={"a":2})
@@ -161,12 +162,14 @@ def test_smesolve_homodyne():
         res = smesolve(H, psi0, times, [], sc_ops, e_ops,
                        ntraj=ntraj, nsubsteps=nsubsteps, args={"a":2},
                        method='homodyne', store_measurement=True,
-                       solver=solver, map_func=parallel_map)
+                       solver=solver, map_func=parallel_map,
+                       options=options)
         assert_(all([np.mean(abs(res.expect[idx] - res_ref.expect[idx])) < tol
                      for idx in range(len(e_ops))]))
         assert_(len(res.measurement) == ntraj)
         assert_(all([m.shape == (len(times), len(sc_ops))
                      for m in res.measurement]))
+        assert_(np.array(res.states).shape == (len(times), N, N))
 
 
 @pytest.mark.slow

--- a/qutip/tests/test_stochastic_me.py
+++ b/qutip/tests/test_stochastic_me.py
@@ -169,7 +169,10 @@ def test_smesolve_homodyne():
         assert_(len(res.measurement) == ntraj)
         assert_(all([m.shape == (len(times), len(sc_ops))
                      for m in res.measurement]))
-        assert_(np.array(res.states).shape == (len(times), N, N))
+        assert_(
+            np.array([state.full() for state in res.states]).shape
+            == (len(times), N, N)
+        )
 
 
 @pytest.mark.slow

--- a/qutip/tests/test_stochastic_se.py
+++ b/qutip/tests/test_stochastic_se.py
@@ -156,7 +156,10 @@ def test_ssesolve_homodyne():
     assert_(len(res.measurement) == ntraj)
     assert_(all([m.shape == (len(times), len(sc_ops))
                  for m in res.measurement]))
-    assert_(np.array(res.states).shape == (len(times), N, N))
+    assert_(
+        np.array([state.full() for state in res.states]).shape
+        == (len(times), N, N)
+    )
 
 
 @pytest.mark.slow


### PR DESCRIPTION
**Description**
Fix a few issues with the stochastic solver state output:
- States were stored even when `options.store_states = False`.
- `options.average_states` needed `options.store_states` to be also set to take effect.
- `ssesolve` would average ket directly instead of using density matrices.

With this, `result.traj_states` will only be set when `options.store_states` is and `result.avg_states` is always set when `options.average_states` is.

**Related issues or PRs**
fix #2216