### PR TITLE
sort args of sphereplot

### DIFF
--- a/doc/changes/2219.misc
+++ b/doc/changes/2219.misc
@@ -1,0 +1,1 @@
+sort args of sphereplot and looks similar to those of plot_spin_distribution

--- a/qutip/animation.py
+++ b/qutip/animation.py
@@ -134,20 +134,20 @@ def anim_hinton(rhos, x_basis=None, y_basis=None, color_style="scaled",
     return fig, ani
 
 
-def anim_sphereplot(theta, phi, V, *, cmap=None,
+def anim_sphereplot(V, theta, phi, *, cmap=None,
                     colorbar=True, fig=None, ax=None):
     """animation of a matrices of values on a sphere
 
     Parameters
     ----------
+    V : list of array instances
+        Data set to be plotted
+
     theta : float
         Angle with respect to z-axis. Its range is between 0 and pi
 
     phi : float
         Angle in x-y plane. Its range is between 0 and 2*pi
-
-    V : list of array instances
-        Data set to be plotted
 
     cmap : a matplotlib colormap instance, optional
         Color map to use when plotting.
@@ -168,7 +168,7 @@ def anim_sphereplot(theta, phi, V, *, cmap=None,
         used to produce the figure.
     """
 
-    fig, ani = sphereplot(theta, phi, V, cmap=cmap,
+    fig, ani = sphereplot(V, theta, phi, cmap=cmap,
                           colorbar=colorbar, fig=fig, ax=ax)
 
     return fig, ani

--- a/qutip/tests/test_animation.py
+++ b/qutip/tests/test_animation.py
@@ -56,7 +56,7 @@ def test_anim_sphereplot():
     theta = np.linspace(0, np.pi, 90)
     phi = np.linspace(0, 2 * np.pi, 60)
     values = qutip.orbital(theta, phi, qutip.basis(3, 0)).T
-    fig, ani = qutip.anim_sphereplot(theta, phi, [values]*2)
+    fig, ani = qutip.anim_sphereplot([values]*2, theta, phi)
     plt.close()
 
     assert isinstance(fig, mpl.figure.Figure)

--- a/qutip/tests/test_visualization.py
+++ b/qutip/tests/test_visualization.py
@@ -35,9 +35,8 @@ def test_sequential():
     qutip.settings.colorblind_safe = True
     theta = np.linspace(0, np.pi, 90)
     phi = np.linspace(0, 2 * np.pi, 60)
-
-    fig, ax = qutip.sphereplot(theta, phi,
-                               qutip.orbital(theta, phi, qutip.basis(3, 0)).T)
+    values = qutip.orbital(theta, phi, qutip.basis(3, 0)).T
+    fig, ax = qutip.sphereplot(values, theta, phi)
     plt.close()
 
     qutip.settings.colorblind_safe = False
@@ -200,10 +199,8 @@ def test_hinton_ValueError1(transform, args, error_message):
 def test_sphereplot(args):
     theta = np.linspace(0, np.pi, 90)
     phi = np.linspace(0, 2 * np.pi, 60)
-
-    fig, ax = qutip.sphereplot(theta, phi,
-                               qutip.orbital(theta, phi, qutip.basis(3, 0)).T,
-                               **args)
+    values = qutip.orbital(theta, phi, qutip.basis(3, 0)).T
+    fig, ax = qutip.sphereplot(values, theta, phi, **args)
     plt.close()
 
     assert isinstance(fig, mpl.figure.Figure)
@@ -214,7 +211,7 @@ def test_sphereplot_anim():
     theta = np.linspace(0, np.pi, 90)
     phi = np.linspace(0, 2 * np.pi, 60)
     values = qutip.orbital(theta, phi, qutip.basis(3, 0)).T
-    fig, ani = qutip.sphereplot(theta, phi, [values]*2)
+    fig, ani = qutip.sphereplot([values]*2, theta, phi)
     plt.close()
 
     assert isinstance(fig, mpl.figure.Figure)
@@ -340,7 +337,6 @@ def test_matrix_histogram_anim():
       "invalid key(s) found in options: e2, e1")),
 ])
 def test_matrix_histogram_ValueError(args, expected):
-    text = "options must be a dictionary"
 
     with pytest.raises(ValueError) as exc_info:
         fig, ax = qutip.matrix_histogram(qutip.rand_dm(5),
@@ -486,10 +482,8 @@ def test_plot_expectation_values(n_of_results, n_of_e_ops, one_axes, args):
 ])
 def test_plot_spin_distribution(color, args):
     j = 5
-    psi = qutip.spin_state(j, -j)
     psi = qutip.spin_coherent(j, np.random.rand() * np.pi,
                               np.random.rand() * 2 * np.pi)
-    rho = qutip.ket2dm(psi)
     theta = np.linspace(0, np.pi, 50)
     phi = np.linspace(0, 2 * np.pi, 50)
     Q, THETA, PHI = qutip.spin_q_function(psi, theta, phi)
@@ -509,10 +503,8 @@ def test_plot_spin_distribution(color, args):
 )
 def test_plot_spin_distribution_anim():
     j = 5
-    psi = qutip.spin_state(j, -j)
     psi = qutip.spin_coherent(j, np.random.rand() * np.pi,
                               np.random.rand() * 2 * np.pi)
-    rho = qutip.ket2dm(psi)
     theta = np.linspace(0, np.pi, 50)
     phi = np.linspace(0, 2 * np.pi, 50)
     Q, THETA, PHI = qutip.spin_q_function(psi, theta, phi)
@@ -527,10 +519,8 @@ def test_plot_spin_distribution_anim():
 def test_plot_spin_distribution_ValueError():
     text = "Unexpected value of projection keyword argument"
     j = 5
-    psi = qutip.spin_state(j, -j)
     psi = qutip.spin_coherent(j, np.random.rand() * np.pi,
                               np.random.rand() * 2 * np.pi)
-    rho = qutip.ket2dm(psi)
     theta = np.linspace(0, np.pi, 50)
     phi = np.linspace(0, 2 * np.pi, 50)
     Q, THETA, PHI = qutip.spin_q_function(psi, theta, phi)

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -484,20 +484,20 @@ def hinton(rho, x_basis=None, y_basis=None, color_style="scaled",
     return fig, output
 
 
-def sphereplot(theta, phi, values, *,
+def sphereplot(values, theta, phi, *,
                cmap=None, colorbar=True, fig=None, ax=None):
     """Plots a matrix of values on a sphere
 
     Parameters
     ----------
+    values : array
+        Data set to be plotted
+
     theta : float
         Angle with respect to z-axis. Its range is between 0 and pi
 
     phi : float
         Angle in x-y plane. Its range is between 0 and 2*pi
-
-    values : array
-        Data set to be plotted
 
     cmap : a matplotlib colormap instance, optional
         Color map to use when plotting.


### PR DESCRIPTION
**Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to QuTiP Development](http://qutip.org/docs/latest/development/contributing.html)
- [x] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
- [x] Please add tests to cover your changes if applicable.
- [x] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-tutorials). Feel free to ask if you are not sure.
- [x] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](http://qutip.org/docs/latest/development/contributing.html#changelog-generation) for more information).

**Description**
sphereplot and plot_spin_distribution accepts a matrix of values, theta and phi, but the order of them is different and not intuitive to users.
```
def sphereplot(theta, phi, values, ...
```
```
def plot_spin_distribution(P, THETA, PHI, ...
```