### PR TITLE
Add early termination in map functions according to reduce_map output

### DIFF
--- a/doc/changes/2222.feature
+++ b/doc/changes/2222.feature
@@ -1,0 +1,1 @@
+Add early end of support in map functions.

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -1,6 +1,7 @@
 """
 This module provides functions for parallel execution of loops and function
-mappings, using the builtin Python module multiprocessing or the loky parallel execution library.
+mappings, using the builtin Python module multiprocessing or the loky parallel
+execution library.
 """
 __all__ = ['parallel_map', 'serial_map', 'loky_pmap']
 
@@ -70,7 +71,9 @@ def serial_map(task, values, task_args=None, task_kwargs=None,
         The optional additional keyword argument to the ``task`` function.
     reduce_func : func (optional)
         If provided, it will be called with the output of each tasks instead of
-        storing a them in a list.
+        storing a them in a list. It should return None or a number.
+        When returning a number, it represent the estimation of the number of
+        task left. On a return >= 0, the map will end early.
     progress_bar : string
         Progress bar options's string for showing progress.
     progress_bar_kwargs : dict
@@ -94,6 +97,7 @@ def serial_map(task, values, task_args=None, task_kwargs=None,
     if task_kwargs is None:
         task_kwargs = {}
     map_kw = _read_map_kw(map_kw)
+    remaining_ntraj = None
     progress_bar = progress_bars[progress_bar](
         len(values), **progress_bar_kwargs
     )
@@ -115,9 +119,11 @@ def serial_map(task, values, task_args=None, task_kwargs=None,
                 errors[n] = err
         else:
             if reduce_func is not None:
-                reduce_func(result)
+                remaining_ntraj = reduce_func(result)
             else:
                 results[n] = result
+        if remaining_ntraj is not None and remaining_ntraj <= 0:
+            end_time = 0
     progress_bar.finished()
 
     if errors:
@@ -149,7 +155,9 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
     reduce_func : func (optional)
         If provided, it will be called with the output of each tasks instead of
         storing a them in a list. Note that the order in which results are
-        passed to ``reduce_func`` is not defined.
+        passed to ``reduce_func`` is not defined. It should return None or a
+        number. When returning a number, it represent the estimation of the
+        number of task left. On a return >= 0, the map will end early.
     progress_bar : string
         Progress bar options's string for showing progress.
     progress_bar_kwargs : dict
@@ -183,6 +191,7 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
     )
 
     errors = {}
+    finished = []
     if reduce_func is not None:
         results = None
         result_func = lambda i, value: reduce_func(value)
@@ -196,7 +205,9 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
                 result = future.result()
             except Exception as e:
                 errors[future._i] = e
-        result_func(future._i, result)
+        remaining_ntraj = result_func(future._i, result)
+        if remaining_ntraj is not None and remaining_ntraj <= 0:
+            finished.append(True)
         progress_bar.update()
 
     if sys.version_info >= (3, 7):
@@ -226,7 +237,11 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
                         timeout=timeout,
                         return_when=concurrent.futures.FIRST_COMPLETED,
                     )
-                if time.time() >= end_time or (errors and map_kw['fail_fast']):
+                if (
+                    time.time() >= end_time
+                    or (errors and map_kw['fail_fast'])
+                    or finished
+                ):
                     # no time left, exit the loop
                     break
                 while len(waiting) < map_kw['num_cpus'] and i < len(values):
@@ -284,7 +299,9 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
         The optional additional keyword argument to the ``task`` function.
     reduce_func : func (optional)
         If provided, it will be called with the output of each tasks instead of
-        storing a them in a list.
+        storing a them in a list. It should return None or a number.  When
+        returning a number, it represent the estimation of the number of task
+        left. On a return >= 0, the map will end early.
     progress_bar : string
         Progress bar options's string for showing progress.
     progress_bar_kwargs : dict
@@ -321,6 +338,7 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
     end_time = map_kw['timeout'] + time.time()
     job_time = map_kw['job_timeout']
     results = None
+    remaining_ntraj = None
     errors = {}
     if reduce_func is None:
         results = [None] * len(values)
@@ -340,10 +358,12 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
                     errors[n] = err
             else:
                 if reduce_func is not None:
-                    reduce_func(result)
+                    remaining_ntraj = reduce_func(result)
                 else:
                     results[n] = result
             progress_bar.update()
+            if remaining_ntraj is not None and remaining_ntraj <= 0:
+                break
 
     except KeyboardInterrupt as e:
         [job.cancel() for job in jobs]

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -73,7 +73,7 @@ def serial_map(task, values, task_args=None, task_kwargs=None,
         If provided, it will be called with the output of each tasks instead of
         storing a them in a list. It should return None or a number.
         When returning a number, it represent the estimation of the number of
-        task left. On a return >= 0, the map will end early.
+        task left. On a return <= 0, the map will end early.
     progress_bar : string
         Progress bar options's string for showing progress.
     progress_bar_kwargs : dict
@@ -157,7 +157,7 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
         storing a them in a list. Note that the order in which results are
         passed to ``reduce_func`` is not defined. It should return None or a
         number. When returning a number, it represent the estimation of the
-        number of task left. On a return >= 0, the map will end early.
+        number of task left. On a return <= 0, the map will end early.
     progress_bar : string
         Progress bar options's string for showing progress.
     progress_bar_kwargs : dict
@@ -301,7 +301,7 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
         If provided, it will be called with the output of each tasks instead of
         storing a them in a list. It should return None or a number.  When
         returning a number, it represent the estimation of the number of task
-        left. On a return >= 0, the map will end early.
+        left. On a return <= 0, the map will end early.
     progress_bar : string
         Progress bar options's string for showing progress.
     progress_bar_kwargs : dict

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -431,7 +431,7 @@ def test_MCSolver_run():
         e_ops=[qutip.qeye(size)], args={'coupling': 1},
         ntraj=1000, target_tol=0.1
     )
-    assert res.num_trajectories == 1001
+    assert 1 < res.num_trajectories and res.num_trajectories < 1001
 
 
 def test_MCSolver_stepping():

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -431,7 +431,7 @@ def test_MCSolver_run():
         e_ops=[qutip.qeye(size)], args={'coupling': 1},
         ntraj=1000, target_tol=0.1
     )
-    assert 1 < res.num_trajectories and res.num_trajectories < 1001
+    assert 1 < res.num_trajectories < 1001
 
 
 def test_MCSolver_stepping():

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -598,7 +598,7 @@ def test_NonMarkovianMCSolver_run():
         e_ops=[qutip.qeye(size)], args={'coupling': 1},
         ntraj=1000, target_tol=0.1
     )
-    assert res.num_trajectories == 1001
+    assert 1 < res.num_trajectories and res.num_trajectories < 1001
 
 
 def test_NonMarkovianMCSolver_stepping():

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -598,7 +598,7 @@ def test_NonMarkovianMCSolver_run():
         e_ops=[qutip.qeye(size)], args={'coupling': 1},
         ntraj=1000, target_tol=0.1
     )
-    assert 1 < res.num_trajectories and res.num_trajectories < 1001
+    assert 1 < res.num_trajectories < 1001
 
 
 def test_NonMarkovianMCSolver_stepping():

--- a/qutip/tests/solver/test_parallel.py
+++ b/qutip/tests/solver/test_parallel.py
@@ -119,3 +119,23 @@ def test_map_store_error(map):
             assert result == n
         else:
             assert result is None
+
+
+@pytest.mark.parametrize('map', [
+    pytest.param(parallel_map, id='parallel_map'),
+    pytest.param(loky_pmap, id='loky_pmap'),
+    pytest.param(serial_map, id='serial_map'),
+])
+def test_map_early_end(map):
+    if map is loky_pmap:
+        loky = pytest.importorskip("loky")
+
+    results = []
+
+    def reduce_func(result):
+        results.append(result)
+        return 5 - len(results)
+
+    map(_func1, range(100), reduce_func=reduce_func)
+
+    assert len(results) < 100


### PR DESCRIPTION
**Description**
When making #1710, we had the capacity for multi trajectory solvers to end up early when a certain precision is reached.
But when splitting it into 2 PRs: #1889 and #1972. `parallel.py` changes where forgotten... Thus even if `MultiTrajResult.add` properly sent the signal to stop, it did not...