### PR TITLE
Disable improved sampling for nm_mcsolve

### DIFF
--- a/doc/changes/2234.bugfix
+++ b/doc/changes/2234.bugfix
@@ -1,0 +1,1 @@
+Disabled broken "improved sampling" for `nm_mcsolve`.

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -471,7 +471,7 @@ class MCSolver(MultiTrajSolver):
         probability is used as a lower-bound for random numbers in future
         monte carlo runs
         """
-        if not self.options["improved_sampling"]:
+        if not self.options.get("improved_sampling", False):
             return super().run(state, tlist, ntraj=ntraj, args=args,
                                e_ops=e_ops, timeout=timeout,
                                target_tol=target_tol, seed=seed)
@@ -526,7 +526,7 @@ class MCSolver(MultiTrajSolver):
 
     @property
     def resultclass(self):
-        if self.options["improved_sampling"]:
+        if self.options.get("improved_sampling", False):
             return McResultImprovedSampling
         else:
             return McResult

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -2,6 +2,7 @@ __all__ = ['nm_mcsolve', 'NonMarkovianMCSolver']
 
 import functools
 import numbers
+import warnings
 
 import numpy as np
 import scipy
@@ -338,6 +339,13 @@ class NonMarkovianMCSolver(MCSolver):
         self, H, ops_and_rates, *_args, args=None, options=None, **kwargs,
     ):
         self.options = options
+
+        if self.options["improved_sampling"]:
+            warnings.warn(
+                "NonMarkovianMCSolver currently does not support 'improved_sampling'. "
+                "Improved sampling has been deactivated.")
+            self.options["improved_sampling"] = False
+            options.update({"improved_sampling": False})
 
         ops_and_rates = [
             _parse_op_and_rate(op, rate, args=args or {})

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -598,13 +598,6 @@ class NonMarkovianMCSolver(MCSolver):
 
     @options.setter
     def options(self, new_options):
-        if (new_options is not None and
-            "improved_sampling" in new_options and
-                new_options["improved_sampling"]):
-            warnings.warn(
-                "NonMarkovianMCSolver currently does not support "
-                "'improved_sampling'. Improved sampling has been deactivated.")
-            new_options["improved_sampling"] = False
         MCSolver.options.fset(self, new_options)
 
     start.__doc__ = MultiTrajSolver.start.__doc__

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -125,7 +125,7 @@ def nm_mcsolve(H, state, tlist, ops_and_rates=(), e_ops=None, ntraj=500, *,
         - martingale_quad_limit : float or int, [100]
           An upper bound on the number of subintervals used in the adaptive
           integration of the martingale.
-    
+
         Note that the 'improved_sampling' option is not currently supported.
 
     seeds : int, SeedSequence, list, [optional]
@@ -535,8 +535,8 @@ class NonMarkovianMCSolver(MCSolver):
 
         progress_bar: str {'text', 'enhanced', 'tqdm', ''}, default="text"
             How to present the solver progress.
-            'tqdm' uses the python module of the same name and raise an error if
-            not installed. Empty string or False will disable the bar.
+            'tqdm' uses the python module of the same name and raise an error
+            if not installed. Empty string or False will disable the bar.
 
         progress_kwargs: dict, default={"chunk_size":10}
             Arguments to pass to the progress_bar. Qutip's bars use
@@ -591,7 +591,7 @@ class NonMarkovianMCSolver(MCSolver):
         martingale_quad_limit: float or int, default=100
             An upper bound on the number of subintervals used in the adaptive
             integration of the martingale.
-    
+
         Note that the 'improved_sampling' option is not currently supported.
         """
         return self._options
@@ -600,7 +600,7 @@ class NonMarkovianMCSolver(MCSolver):
     def options(self, new_options):
         if (new_options is not None and
             "improved_sampling" in new_options and
-            new_options["improved_sampling"]):
+                new_options["improved_sampling"]):
             warnings.warn(
                 "NonMarkovianMCSolver currently does not support "
                 "'improved_sampling'. Improved sampling has been deactivated.")

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -342,8 +342,8 @@ class NonMarkovianMCSolver(MCSolver):
 
         if self.options["improved_sampling"]:
             warnings.warn(
-                "NonMarkovianMCSolver currently does not support 'improved_sampling'. "
-                "Improved sampling has been deactivated.")
+                "NonMarkovianMCSolver currently does not support "
+                "'improved_sampling'. Improved sampling has been deactivated.")
             self.options["improved_sampling"] = False
             options.update({"improved_sampling": False})
 

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -125,6 +125,8 @@ def nm_mcsolve(H, state, tlist, ops_and_rates=(), e_ops=None, ntraj=500, *,
         - martingale_quad_limit : float or int, [100]
           An upper bound on the number of subintervals used in the adaptive
           integration of the martingale.
+    
+        Note that the 'improved_sampling' option is not currently supported.
 
     seeds : int, SeedSequence, list, [optional]
         Seed for the random number generator. It can be a single seed used to
@@ -340,13 +342,6 @@ class NonMarkovianMCSolver(MCSolver):
     ):
         self.options = options
 
-        if self.options["improved_sampling"]:
-            warnings.warn(
-                "NonMarkovianMCSolver currently does not support "
-                "'improved_sampling'. Improved sampling has been deactivated.")
-            self.options["improved_sampling"] = False
-            options.update({"improved_sampling": False})
-
         ops_and_rates = [
             _parse_op_and_rate(op, rate, args=args or {})
             for op, rate in ops_and_rates
@@ -523,6 +518,94 @@ class NonMarkovianMCSolver(MCSolver):
         self._martingale.reset()
 
         return result
+
+    @property
+    def options(self):
+        """
+        Options for non-Markovian Monte Carlo solver:
+
+        store_final_state: bool, default=False
+            Whether or not to store the final state of the evolution in the
+            result class.
+
+        store_states: bool, default=None
+            Whether or not to store the state vectors or density matrices.
+            On `None` the states will be saved if no expectation operators are
+            given.
+
+        progress_bar: str {'text', 'enhanced', 'tqdm', ''}, default="text"
+            How to present the solver progress.
+            'tqdm' uses the python module of the same name and raise an error if
+            not installed. Empty string or False will disable the bar.
+
+        progress_kwargs: dict, default={"chunk_size":10}
+            Arguments to pass to the progress_bar. Qutip's bars use
+            ``chunk_size``.
+
+        keep_runs_results: bool
+          Whether to store results from all trajectories or just store the
+          averages.
+
+        method: str, default="adams"
+            Which ODE integrator methods are supported.
+
+        map: str {"serial", "parallel", "loky"}
+            How to run the trajectories. "parallel" uses concurent module to
+            run in parallel while "loky" use the module of the same name to do
+            so.
+
+        job_timeout: None, int
+            Maximum time to compute one trajectory.
+
+        num_cpus: None, int
+            Number of cpus to use when running in parallel. ``None`` detect the
+            number of available cpus.
+
+        bitgenerator: {None, "MT19937", "PCG64", "PCG64DXSM", ...}
+            Which of numpy.random's bitgenerator to use. With ``None``, your
+            numpy version's default is used.
+
+        mc_corr_eps: float
+            Small number used to detect non-physical collapse caused by
+            numerical imprecision.
+
+        norm_t_tol: float
+            Tolerance in time used when finding the collapse.
+
+        norm_tol: float
+            Tolerance in norm used when finding the collapse.
+
+        norm_steps: int
+            Maximum number of tries to find the collapse.
+
+        completeness_rtol: float, default=1e-5
+            Used in determining whether the given Lindblad operators satisfy
+            a certain completeness relation. If they do not, an additional
+            Lindblad operator is added automatically (with zero rate).
+
+        completeness_atol: float, default=1e-8
+            Used in determining whether the given Lindblad operators satisfy
+            a certain completeness relation. If they do not, an additional
+            Lindblad operator is added automatically (with zero rate).
+
+        martingale_quad_limit: float or int, default=100
+            An upper bound on the number of subintervals used in the adaptive
+            integration of the martingale.
+    
+        Note that the 'improved_sampling' option is not currently supported.
+        """
+        return self._options
+
+    @options.setter
+    def options(self, new_options):
+        if (new_options is not None and
+            "improved_sampling" in new_options and
+            new_options["improved_sampling"]):
+            warnings.warn(
+                "NonMarkovianMCSolver currently does not support "
+                "'improved_sampling'. Improved sampling has been deactivated.")
+            new_options["improved_sampling"] = False
+        MCSolver.options.fset(self, new_options)
 
     start.__doc__ = MultiTrajSolver.start.__doc__
     step.__doc__ = MultiTrajSolver.step.__doc__

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -7,7 +7,11 @@ import qutip
 from qutip.solver.nm_mcsolve import nm_mcsolve, NonMarkovianMCSolver
 
 
-@pytest.mark.parametrize("improved_sampling", [True, False])
+parametrize_for_improved_sampling = pytest.mark.parametrize(
+    "improved_sampling", [pytest.param(True, marks=pytest.mark.xfail), False])
+
+
+@parametrize_for_improved_sampling
 def test_agreement_with_mesolve_for_negative_rates(improved_sampling):
     """
     A rough test that nm_mcsolve agress with mesolve in the
@@ -174,7 +178,7 @@ class StatesAndExpectOutputCase:
         for test, expected_part in zip(result.expect, expected):
             np.testing.assert_allclose(test, expected_part, rtol=tol)
 
-    @pytest.mark.parametrize("improved_sampling", [True, False])
+    @parametrize_for_improved_sampling
     def test_states_and_expect(
         self, hamiltonian, args, ops_and_rates, expected, tol,
         improved_sampling
@@ -225,7 +229,7 @@ class TestNoCollapse(StatesAndExpectOutputCase):
     # runtimes shorter.  The known-good cases are still tested in the other
     # test cases, this is just testing the single-output behaviour.
 
-    @pytest.mark.parametrize("improved_sampling", [True, False])
+    @parametrize_for_improved_sampling
     def test_states_only(
         self, hamiltonian, args, ops_and_rates, expected, tol,
         improved_sampling
@@ -239,7 +243,7 @@ class TestNoCollapse(StatesAndExpectOutputCase):
         )
         self._assert_states(result, expected, tol)
 
-    @pytest.mark.parametrize("improved_sampling", [True, False])
+    @parametrize_for_improved_sampling
     def test_expect_only(
         self, hamiltonian, args, ops_and_rates, expected, tol,
         improved_sampling
@@ -402,7 +406,7 @@ def test_states_outputs(keep_runs_results):
     assert data.stats['end_condition'] == "ntraj reached"
 
 
-@pytest.mark.parametrize("improved_sampling", [True, False])
+@parametrize_for_improved_sampling
 @pytest.mark.parametrize('keep_runs_results', [True, False])
 def test_expectation_outputs(keep_runs_results, improved_sampling):
     # We're just testing the output value, so it's important whether certain
@@ -473,7 +477,7 @@ class TestSeeds:
         (qutip.tensor(qutip.qeye(sizes[:2]), a[2]), 2 * dampings[2]),
     ]
 
-    @pytest.mark.parametrize("improved_sampling", [True, False])
+    @parametrize_for_improved_sampling
     def test_seeds_can_be_reused(self, improved_sampling):
         args = (self.H, self.state, self.times)
         kwargs = {'ops_and_rates': self.ops_and_rates, 'ntraj': self.ntraj,
@@ -485,7 +489,7 @@ class TestSeeds:
         for first_w, second_w in zip(first.col_which, second.col_which):
             np.testing.assert_equal(first_w, second_w)
 
-    @pytest.mark.parametrize("improved_sampling", [True, False])
+    @parametrize_for_improved_sampling
     def test_seeds_are_not_reused_by_default(self, improved_sampling):
         args = (self.H, self.state, self.times)
         kwargs = {'ops_and_rates': self.ops_and_rates, 'ntraj': self.ntraj,
@@ -499,7 +503,7 @@ class TestSeeds:
                        for first_w, second_w in zip(first.col_which,
                                                     second.col_which))
 
-    @pytest.mark.parametrize("improved_sampling", [True, False])
+    @parametrize_for_improved_sampling
     @pytest.mark.parametrize('seed', [1, np.random.SeedSequence(2)])
     def test_seed_type(self, seed, improved_sampling):
         args = (self.H, self.state, self.times)
@@ -510,7 +514,7 @@ class TestSeeds:
         for f_seed, s_seed in zip(first.seeds, second.seeds):
             assert f_seed.state == s_seed.state
 
-    @pytest.mark.parametrize("improved_sampling", [True, False])
+    @parametrize_for_improved_sampling
     def test_bad_seed(self, improved_sampling):
         args = (self.H, self.state, self.times)
         kwargs = {'ops_and_rates': self.ops_and_rates, 'ntraj': self.ntraj,
@@ -518,7 +522,7 @@ class TestSeeds:
         with pytest.raises(ValueError):
             nm_mcsolve(*args, seeds=[1], **kwargs)
 
-    @pytest.mark.parametrize("improved_sampling", [True, False])
+    @parametrize_for_improved_sampling
     def test_generator(self, improved_sampling):
         args = (self.H, self.state, self.times)
         kwargs = {'ops_and_rates': self.ops_and_rates, 'ntraj': self.ntraj}
@@ -553,7 +557,7 @@ class TestSeeds:
         assert state_1 == state_2
 
 
-@pytest.mark.parametrize("improved_sampling", [True, False])
+@parametrize_for_improved_sampling
 def test_timeout(improved_sampling):
     size = 10
     ntraj = 1000
@@ -575,7 +579,7 @@ def test_timeout(improved_sampling):
     assert res.stats['end_condition'] == 'timeout'
 
 
-@pytest.mark.parametrize("improved_sampling", [True, False])
+@parametrize_for_improved_sampling
 def test_super_H(improved_sampling):
     size = 10
     ntraj = 1000


### PR DESCRIPTION
**Description**
The `improved_sampling` option was recently added to the `MCSolver`. `NonMarkovianMCSolver` extends `MCSolver` and can therefore be called with `improved_sampling=True`. Without this PR, it would then silently return wrong results.

The technical reason is that `nm_mcsolve` calculates the value of an influence martingale, which is factored into the calculation of expectation values in the custom result class `NmmcResult`. If `improved_sampling` is enabled, `McResultImprovedSampling` is used instead.

I here only disable the `improved_sampling` option for `nm_mcsolve` and print a warning if a user tries to use it. I have created a new issue to discuss ways to implement the improved sampling for `nm_mcsolve`.

**Related issue**
https://github.com/qutip/qutip/issues/2235