### PR TITLE
Fix for matplotlib 3.8

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -809,6 +809,7 @@ class Bloch:
                 length = np.ceil(num_points/len(self.point_default_color))
                 color = np.tile(self.point_default_color, length.astype(int))
                 color = color[indperm]
+                color = list(color)
 
             if self.point_style[k] in ['s', 'm']:
                 self.axes.scatter(np.real(points[1]),

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -213,6 +213,7 @@ class TestBloch:
                                  np.ceil(points.shape[1]/len(point_colors)
                                          ).astype(int))
                 colors = colors[:points.shape[1]]
+                colors = list(colors)
             point_size = point_sizes[idx % len(point_sizes)]
             point_marker = point_markers[idx % len(point_markers)]
             point_alpha = kw.get("alpha", 1.0)

--- a/qutip/tests/test_visualization.py
+++ b/qutip/tests/test_visualization.py
@@ -85,6 +85,7 @@ def test_set_ticklabels():
     with pytest.raises(Exception) as exc_info:
         fig, ax = qutip.hinton(rho, x_basis=[1])
     assert str(exc_info.value) == text
+    plt.close()
 
 
 def test_equal_shape():
@@ -94,6 +95,7 @@ def test_equal_shape():
     with pytest.raises(Exception) as exc_info:
         fig, ax = qutip.hinton(rhos)
     assert str(exc_info.value) == text
+    plt.close()
 
 
 @pytest.mark.parametrize('args', [
@@ -178,6 +180,7 @@ def test_hinton_ValueError0():
     with pytest.raises(ValueError) as exc_info:
         fig, ax = qutip.hinton(rho)
     assert str(exc_info.value) == text
+    plt.close()
 
 
 @pytest.mark.parametrize('transform, args, error_message', [
@@ -192,6 +195,7 @@ def test_hinton_ValueError1(transform, args, error_message):
     with pytest.raises(ValueError) as exc_info:
         fig, ax = qutip.hinton(rho, **args)
     assert str(exc_info.value) == error_message
+    plt.close()
 
 
 @pytest.mark.parametrize('args', [
@@ -241,6 +245,7 @@ def test_update_yaxis(response):
                                              y_basis=[1])
 
         assert str(exc_info.value) == text
+        plt.close()
 
 
 @pytest.mark.parametrize('response', [
@@ -261,6 +266,7 @@ def test_update_xaxis(response):
             fig, ax = qutip.matrix_histogram(qutip.rand_dm(5),
                                              x_basis=[1])
         assert str(exc_info.value) == text
+        plt.close()
 
 
 def test_get_matrix_components():
@@ -346,6 +352,7 @@ def test_matrix_histogram_ValueError(args, expected):
         fig, ax = qutip.matrix_histogram(qutip.rand_dm(5),
                                          **args)
     assert str(exc_info.value) in expected
+    plt.close()
 
 
 @pytest.mark.parametrize('args', [
@@ -368,6 +375,7 @@ def test_plot_energy_levels_ValueError():
     with pytest.raises(ValueError) as exc_info:
         fig, ax = qutip.plot_energy_levels(1)
     assert str(exc_info.value) == "H_list must be a list of Qobj instances"
+    plt.close()
 
 
 @pytest.mark.parametrize('rho_type, args', [
@@ -440,6 +448,7 @@ def test_plot_wigner_ValueError():
 
         fig, ax = qutip.plot_wigner(rho, projection=1)
     assert str(exc_info.value) == text
+    plt.close()
 
 
 @pytest.mark.parametrize('n_of_results, n_of_e_ops, one_axes, args', [
@@ -532,6 +541,7 @@ def test_plot_spin_distribution_ValueError():
     with pytest.raises(ValueError) as exc_info:
         fig, ax = qutip.plot_spin_distribution(Q, THETA, PHI, projection=1)
     assert str(exc_info.value) == text
+    plt.close()
 
 
 @pytest.mark.parametrize('args', [
@@ -595,6 +605,7 @@ def test_plot_qubism_Error(ket, args, expected):
     with pytest.raises(Exception) as exc_info:
         fig, ax = qutip.plot_qubism(state, **args)
     assert str(exc_info.value) == expected
+    plt.close()
 
 
 def test_plot_qubism_dimension():
@@ -605,6 +616,7 @@ def test_plot_qubism_dimension():
     with pytest.raises(Exception) as exc_info:
         qutip.plot_qubism(ket, how='pairs_skewed')
     assert str(exc_info.value) == text
+    plt.close()
 
 
 @pytest.mark.parametrize('args', [
@@ -638,3 +650,4 @@ def test_plot_schmidt_Error():
     with pytest.raises(Exception) as exc_info:
         fig, ax = qutip.plot_schmidt(state)
     assert str(exc_info.value) == text
+    plt.close()

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -1209,8 +1209,11 @@ def plot_wigner(rho, xvec=None, yvec=None, method='clenshaw',
     artist_list = list()
     for W in Ws:
         if projection == '2d':
-            cf = ax.contourf(xvec, yvec, W, 100, norm=norm,
-                             cmap=cmap).collections
+            if parse_version(mpl.__version__) >= parse_version('3.8'):
+                cf = [ax.contourf(xvec, yvec, W, 100, norm=norm, cmap=cmap)]
+            else:
+                cf = ax.contourf(xvec, yvec, W, 100, norm=norm,
+                                 cmap=cmap).collections
         else:
             X, Y = np.meshgrid(xvec, yvec)
             cf = [ax.plot_surface(X, Y, W, rstride=5, cstride=5, linewidth=0.5,


### PR DESCRIPTION
**Description**
Fix warnings and errors coming from matplotlip 3.8 release.
- Close figure in errors tests. Lot of empty figures were created and never closed.
- `plt.contourf` can be used as an artist instead of extracting the artists list from it.
- `color` cannot be a numpy array anymore, convert the arrays to list.