### PR TITLE
Update minimum versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      # Set up wheels matrix.  This is CPython 3.8--3.10 for all OS targets.
+      # Set up wheels matrix.  This is CPython 3.10--3.12 for all OS targets.
       CIBW_BUILD: "cp3{10,11,12}-*"
       # Numpy and SciPy do not supply wheels for i686 or win32 for
       # Python 3.10+, so we skip those:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           # For the sdist we should be as conservative as possible with our
           # Python version.  This should be the lowest supported version.  This
           # means that no unsupported syntax can sneak through.
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Install pip build
         run: |
@@ -108,10 +108,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
       # Set up wheels matrix.  This is CPython 3.8--3.10 for all OS targets.
-      CIBW_BUILD: "cp3{8,9,10,11}-*"
+      CIBW_BUILD: "cp3{10,11,12}-*"
       # Numpy and SciPy do not supply wheels for i686 or win32 for
       # Python 3.10+, so we skip those:
-      CIBW_SKIP: "*-musllinux* cp3{8,9,10,11}-manylinux_i686 cp3{8,9,10,11}-win32"
+      CIBW_SKIP: "*-musllinux* cp3{10,11,12}-manylinux_i686 cp3{10,11,12}-win32"
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
@@ -121,7 +121,7 @@ jobs:
         name: Install Python
         with:
           # This is about the build environment, not the released wheel version.
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Install cibuildwheel
         run: |
@@ -165,12 +165,12 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp38-cp38-manylinux*.whl
+          python -m pip install wheels/*-cp310-cp310-manylinux*.whl
           python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on
@@ -198,12 +198,12 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp38-cp38-manylinux*.whl
+          python -m pip install wheels/*-cp310-cp310-manylinux*.whl
           python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Install documentation dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
           # Scipy 1.8
           - case-name: old SciPy
             os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.10"
             numpy-requirement: ">=1.22,<1.23"
             scipy-requirement: ">=1.8,<1.9"
             condaforge: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 # The name is short because we mostly care how it appears in the pull request
 # "checks" dialogue box - it looks like
-#     Tests / ubuntu-latest, python-3.9, defaults
+#     Tests / ubuntu-latest, python-3.11, defaults
 # or similar.
 name: Tests
 
@@ -27,7 +27,7 @@ jobs:
         os: [ubuntu-latest]
         # Test other versions of Python in special cases to avoid exploding the
         # matrix size; make sure to test all supported versions in some form.
-        python-version: ["3.9"]
+        python-version: ["3.11"]
         case-name: [defaults]
         numpy-requirement: [">=1.20,<1.21"]
         coverage-requirement: ["==6.5"]
@@ -44,12 +44,12 @@ jobs:
             condaforge: 1
             nomkl: 1
 
-          # Scipy 1.5
+          # Scipy 1.8
           - case-name: old SciPy
             os: ubuntu-latest
             python-version: "3.8"
-            numpy-requirement: ">=1.20,<1.21"
-            scipy-requirement: ">=1.5,<1.6"
+            numpy-requirement: ">=1.22,<1.23"
+            scipy-requirement: ">=1.8,<1.9"
             condaforge: 1
             oldcython: 1
 
@@ -57,15 +57,15 @@ jobs:
           # not necessarily for pip.
           - case-name: no MKL
             os: ubuntu-latest
-            python-version: "3.9"
-            numpy-requirement: ">=1.20,<1.21"
+            python-version: "3.10"
+            numpy-requirement: ">=1.22,<1.23"
             nomkl: 1
 
           # Builds without Cython at runtime.  This is a core feature;
           # everything should be able to run this.
           - case-name: no Cython
             os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.11"
             nocython: 1
 
           # Python 3.10 and numpy 1.22
@@ -76,15 +76,15 @@ jobs:
             condaforge: 1
             oldcython: 1
 
-          # Python 3.11 and latest numpy
-          # Use conda-forge to provide Python 3.11 and latest numpy
-          # Ignore deprecation of the cgi module in Python 3.11 that is
+          # Python 3.12 and latest numpy
+          # Use conda-forge to provide Python 3.12 and latest numpy
+          # Ignore deprecation of the cgi module in Python 3.12 that is
           # still imported by Cython.Tempita. This was addressed in
           # https://github.com/cython/cython/pull/5128 but not backported
           # to any currently released version.
-          - case-name: Python 3.11
+          - case-name: Python 3.12
             os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             condaforge: 1
             conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
             pytest-extra-options: "-W ignore::DeprecationWarning:Cython.Tempita"
@@ -97,7 +97,7 @@ jobs:
           # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
           - case-name: Windows Latest
             os: windows-latest
-            python-version: "3.10"
+            python-version: "3.11"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.11"]
         case-name: [defaults]
-        numpy-requirement: [">=1.20,<1.21"]
+        numpy-requirement: [">=1.22"]
         coverage-requirement: ["==6.5"]
         # Extra special cases.  In these, the new variable defined should always
         # be a truth-y value (hence 'nomkl: 1' rather than 'mkl: 0'), because

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     # See https://numpy.org/doc/stable/user/depending_on_numpy.html for
     # the recommended way to build against numpy's C API:
     "oldest-supported-numpy",
-    "scipy>=1.0",
+    "scipy>=1.8",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -16,12 +16,6 @@ manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 # Change in future version to "build"
 build-frontend = "pip"
-
-[[tool.cibuildwheel.overrides]]
-# NumPy and SciPy support manylinux2010 on CPython 3.6 and 3.7
-select = "cp3{6,7}-*"
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
 
 [tool.towncrier]
 directory = "doc/changes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ requires = [
     "cython>=0.29.20",
     # See https://numpy.org/doc/stable/user/depending_on_numpy.html for
     # the recommended way to build against numpy's C API:
-    "oldest-supported-numpy",
+    # "oldest-supported-numpy",
+    "numpy>=1.22",
     "scipy>=1.8",
 ]
 build-backend = "setuptools.build_meta"

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -17,14 +17,10 @@ try:
     from mpl_toolkits.mplot3d import proj3d
 
     # Define a custom _axes3D function based on the matplotlib version.
-    # The auto_add_to_figure keyword is new for matplotlib>=3.4.
-    if parse_version(matplotlib.__version__) >= parse_version('3.4'):
-        def _axes3D(fig, *args, **kwargs):
-            ax = Axes3D(fig, *args, auto_add_to_figure=False, **kwargs)
-            return fig.add_axes(ax)
-    else:
-        def _axes3D(*args, **kwargs):
-            return Axes3D(*args, **kwargs)
+    def _axes3D(fig, *args, **kwargs):
+        ax = Axes3D(fig, *args, auto_add_to_figure=False, **kwargs)
+        return fig.add_axes(ax)
+
 
     class Arrow3D(FancyArrowPatch):
         def __init__(self, xs, ys, zs, *args, **kwargs):
@@ -666,9 +662,7 @@ class Bloch:
             self.axes.set_ylim3d(-0.7, 0.7)
             self.axes.set_zlim3d(-0.7, 0.7)
         # Manually set aspect ratio to fit a square bounding box.
-        # Matplotlib did this stretching for < 3.3.0, but not above.
-        if parse_version(matplotlib.__version__) >= parse_version('3.3'):
-            self.axes.set_box_aspect((1, 1, 1))
+        self.axes.set_box_aspect((1, 1, 1))
         if not self.background:
             self.plot_axes()
 

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -161,17 +161,9 @@ class Settings:
         Whether `eigh` call is reliable.
         Some implementation of blas have some issues on some OS.
         """
-        from packaging import version as pac_version
-        import scipy
-        is_old_scipy = (
-            pac_version.parse(scipy.__version__) < pac_version.parse("1.5")
-        )
         return (
             # macOS OpenBLAS eigh is unstable, see #1288
             (_blas_info() == "OPENBLAS" and platform.system() == 'Darwin')
-            # The combination of scipy<1.5 and MKL causes wrong results when
-            # calling eigh for big matrices.  See #1495, #1491 and #1498.
-            or (is_old_scipy and (_blas_info() == 'INTEL MKL'))
         )
 
     @property

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -32,14 +32,10 @@ try:
     from mpl_toolkits.mplot3d import Axes3D
 
     # Define a custom _axes3D function based on the matplotlib version.
-    # The auto_add_to_figure keyword is new for matplotlib>=3.4.
-    if parse_version(mpl.__version__) >= parse_version('3.4'):
-        def _axes3D(fig, *args, **kwargs):
-            ax = Axes3D(fig, *args, auto_add_to_figure=False, **kwargs)
-            return fig.add_axes(ax)
-    else:
-        def _axes3D(*args, **kwargs):
-            return Axes3D(*args, **kwargs)
+    def _axes3D(fig, *args, **kwargs):
+        ax = Axes3D(fig, *args, auto_add_to_figure=False, **kwargs)
+        return fig.add_axes(ax)
+
 except:
     pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython>=0.29.20
-numpy>=1.16.6
-scipy>=1.5
+numpy>=1.22
+scipy>=1.8
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,12 @@ packages = find:
 include_package_data = True
 zip_safe = False
 install_requires =
-    numpy>=1.16.6
-    scipy>=1.0
+    numpy>=1.22
+    scipy>=1.8
     packaging
 setup_requires =
-    numpy>=1.13.3
-    scipy>=1.0
+    numpy>=1.22
+    scipy>=1.8
     cython>=0.29.20
     packaging
 
@@ -44,7 +44,7 @@ setup_requires =
 include = qutip*
 
 [options.extras_require]
-graphics = matplotlib>=1.2.1
+graphics = matplotlib>=3.5
 runtime_compilation =
     cython>=0.29.20
     filelock


### PR DESCRIPTION
**Description**
Update minimum version supported 
- python >= 3.10
- numpy >= 1.22
- scipy >= 1.8
- matplotlib >= 3.5

According to scientific python spec 0.

Cython 3.0.3 does not support python under 3.9. The changelog does not seems to indicate if it is intentional or not.
It also simplify some parts where we branch over module versions.