### PR TITLE
Add deprecation warnings to solver

### DIFF
--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -12,12 +12,12 @@ from .. import Qobj, QobjEvo, coefficient, Coefficient
 from ..core.blochredfield import bloch_redfield_tensor, SpectraCoefficient
 from ..core.cy.coefficient import InterCoefficient
 from ..core import data as _data
-from .solver_base import Solver
+from .solver_base import Solver, _solver_deprecation
 from .options import _SolverOptions
 
 
 def brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[],
-              args={}, sec_cutoff=0.1, options=None):
+              args={}, sec_cutoff=0.1, options=None, **kwargs):
     """
     Solves for the dynamics of a system using the Bloch-Redfield master
     equation, given an input Hamiltonian, Hermitian bath-coupling terms and
@@ -142,6 +142,7 @@ def brmesolve(H, psi0, tlist, a_ops=[], e_ops=[], c_ops=[],
         the ``a_ops``, but it is usually less efficient than manually choosing
         it.
     """
+    options = _solver_deprecation(kwargs, options, "br")
     H = QobjEvo(H, args=args, tlist=tlist)
 
     c_ops = c_ops if c_ops is not None else []

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -3,7 +3,7 @@ __all__ = ['mcsolve', "MCSolver"]
 import numpy as np
 from ..core import QobjEvo, spre, spost, Qobj, unstack_columns
 from .multitraj import MultiTrajSolver
-from .solver_base import Solver, Integrator
+from .solver_base import Solver, Integrator, _solver_deprecation
 from .result import McResult, McTrajectoryResult, McResultImprovedSampling
 from .mesolve import mesolve, MESolver
 import qutip.core.data as _data
@@ -11,7 +11,8 @@ from time import time
 
 
 def mcsolve(H, state, tlist, c_ops=(), e_ops=None, ntraj=500, *,
-            args=None, options=None, seeds=None, target_tol=None, timeout=None):
+            args=None, options=None, seeds=None, target_tol=None, timeout=None,
+            **kwargs):
     r"""
     Monte Carlo evolution of a state vector :math:`|\psi \rangle` for a
     given Hamiltonian and sets of collapse operators. Options for the
@@ -130,6 +131,7 @@ def mcsolve(H, state, tlist, c_ops=(), e_ops=None, ntraj=500, *,
         The simulation will end when the first end condition is reached between
         ``ntraj``, ``timeout`` and ``target_tol``.
     """
+    options = _solver_deprecation(kwargs, options, "mc")
     H = QobjEvo(H, args=args, tlist=tlist)
     if not isinstance(c_ops, (list, tuple)):
         c_ops = [c_ops]

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -10,11 +10,12 @@ from time import time
 from .. import (Qobj, QobjEvo, isket, liouvillian, ket2dm, lindblad_dissipator)
 from ..core import stack_columns, unstack_columns
 from ..core.data import to
-from .solver_base import Solver
+from .solver_base import Solver, _solver_deprecation
 from .sesolve import sesolve, SESolver
 
 
-def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None):
+def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None,
+            **kwargs):
     """
     Master equation evolution of a density matrix for a given Hamiltonian and
     set of collapse operators, or a Liouvillian.
@@ -125,6 +126,7 @@ def mesolve(H, rho0, tlist, c_ops=None, e_ops=None, args=None, options=None):
         is an empty list of `store_states=True` in options].
 
     """
+    options = _solver_deprecation(kwargs, options)
     H = QobjEvo(H, args=args, tlist=tlist)
 
     c_ops = c_ops if c_ops is not None else []

--- a/qutip/solver/sesolve.py
+++ b/qutip/solver/sesolve.py
@@ -7,10 +7,10 @@ __all__ = ['sesolve', 'SESolver']
 import numpy as np
 from time import time
 from .. import Qobj, QobjEvo
-from .solver_base import Solver
+from .solver_base import Solver, _solver_deprecation
 
 
-def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None):
+def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None, **kwargs):
     """
     Schrodinger equation evolution of a state vector or unitary matrix
     for a given Hamiltonian.
@@ -98,6 +98,7 @@ def sesolve(H, psi0, tlist, e_ops=None, args=None, options=None):
         or density matrices corresponding to the times in `tlist` [if `e_ops`
         is an empty list of `store_states=True` in options].
     """
+    options = _solver_deprecation(kwargs, options)
     H = QobjEvo(H, args=args, tlist=tlist)
     solver = SESolver(H, options=options)
     return solver.run(psi0, tlist, e_ops=e_ops)

--- a/qutip/solver/stochastic.py
+++ b/qutip/solver/stochastic.py
@@ -7,7 +7,7 @@ from .. import Qobj, QobjEvo, liouvillian, lindblad_dissipator
 import numpy as np
 from collections.abc import Iterable
 from functools import partial
-
+from .solver_base import _solver_deprecation
 
 class StochasticTrajResult(Result):
     def _post_init(self, m_ops=(), dw_factor=(), heterodyne=False):
@@ -223,7 +223,7 @@ class _StochasticRHS:
 def smesolve(
     H, rho0, tlist, c_ops=(), sc_ops=(), heterodyne=False, *,
     e_ops=(), args={}, ntraj=500, options=None,
-    seeds=None, target_tol=None, timeout=None,
+    seeds=None, target_tol=None, timeout=None, **kwargs
 ):
     """
     Solve stochastic master equation.
@@ -335,6 +335,7 @@ def smesolve(
 
         An instance of the class :class:`qutip.solver.Result`.
     """
+    options = _solver_deprecation(kwargs, options, "stoc")
     H = QobjEvo(H, args=args, tlist=tlist)
     c_ops = [QobjEvo(c_op, args=args, tlist=tlist) for c_op in c_ops]
     sc_ops = [QobjEvo(c_op, args=args, tlist=tlist) for c_op in sc_ops]
@@ -350,7 +351,7 @@ def smesolve(
 def ssesolve(
     H, psi0, tlist, sc_ops=(), heterodyne=False, *,
     e_ops=(), args={}, ntraj=500, options=None,
-    seeds=None, target_tol=None, timeout=None,
+    seeds=None, target_tol=None, timeout=None, **kwargs
 ):
     """
     Solve stochastic Schrodinger equation.
@@ -455,6 +456,7 @@ def ssesolve(
     output: :class:`qutip.solver.Result`
         An instance of the class :class:`qutip.solver.Result`.
     """
+    options = _solver_deprecation(kwargs, options, "stoc")
     H = QobjEvo(H, args=args, tlist=tlist)
     sc_ops = [QobjEvo(c_op, args=args, tlist=tlist) for c_op in sc_ops]
     sol = SSESolver(H, sc_ops, options=options, heterodyne=heterodyne)

--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -316,3 +316,27 @@ def test_m_ops(heterodyne):
     noise = res.expect[0][1:] - res.measurement[0][0]
     assert np.mean(noise) == pytest.approx(0., abs=std/50**0.5 * 4)
     assert np.std(noise) == pytest.approx(std, abs=std/50**0.5 * 4)
+
+
+def test_deprecation_warnings():
+    with pytest.warns(UserWarning, match=r'map_func'):
+        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], map_func=None)
+
+    with pytest.warns(UserWarning, match=r'progress_bar'):
+        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], progress_bar=None)
+
+    with pytest.warns(UserWarning, match=r'nsubsteps'):
+        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], nsubsteps=None)
+
+    with pytest.warns(UserWarning, match=r'map_func'):
+        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], map_func=None)
+
+    with pytest.warns(UserWarning, match=r'store_all_expect'):
+        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], store_all_expect=1)
+
+    with pytest.warns(UserWarning, match=r'store_measurement'):
+        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], store_measurement=1)
+
+    with pytest.raises(TypeError) as err:
+        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], m_ops=1)
+    assert '"m_ops" and "dW_factors"' in str(err.value)


### PR DESCRIPTION
**Description**
Add warning messages went passing input to solver that moved / were renamed in v5.
Hopefully this should help with the transition.

When the parameter affect the physical result, an error is raised instead of a warning.