### PR TITLE
Faster steadystate, mainly for Dia

### DIFF
--- a/qutip/core/data/solve.py
+++ b/qutip/core/data/solve.py
@@ -75,6 +75,9 @@ def solve_csr_dense(matrix: Union[CSR, Dia], target: Dense, method=None,
         raise ValueError("mkl is not available")
     elif method == "mkl_spsolve":
         solver = mkl_spsolve
+        # mkl does not support dia.
+        if isinstance(matrix, Dia):
+            matrix = _data.to("CSR", matrix)
     else:
         raise ValueError(f"Unknown sparse solver {method}.")
 

--- a/qutip/solver/steadystate.py
+++ b/qutip/solver/steadystate.py
@@ -220,14 +220,14 @@ def _steadystate_direct(A, weight, **kw):
         if isinstance(L, _data.CSR):
             L, b = _permute_wbm(L, b)
         else:
-            warn("Only CSR matrice can be permuted.", RuntimeWarning)
+            warn("Only CSR matrices can be permuted.", RuntimeWarning)
     use_rcm = False
     if kw.pop("use_rcm", False):
         if isinstance(L, _data.CSR):
             L, b, perm = _permute_rcm(L, b)
             use_rcm = True
         else:
-            warn("Only CSR matrice can be permuted.", RuntimeWarning)
+            warn("Only CSR matrices can be permuted.", RuntimeWarning)
     if kw.pop("use_precond", False):
         if isinstance(L, (_data.CSR, _data.Dia)):
             kw["M"] = _compute_precond(L, kw)
@@ -276,14 +276,14 @@ def _steadystate_power(A, **kw):
         if isinstance(L, _data.CSR):
             L, y = _permute_wbm(L, y)
         else:
-            warn("Only CSR matrice can be permuted.", RuntimeWarning)
+            warn("Only CSR matrices can be permuted.", RuntimeWarning)
     use_rcm = False
     if kw.pop("use_rcm", False):
         if isinstance(L, _data.CSR):
             L, y, perm = _permute_rcm(L, y)
             use_rcm = True
         else:
-            warn("Only CSR matrice can be permuted.", RuntimeWarning)
+            warn("Only CSR matrices can be permuted.", RuntimeWarning)
     if kw.pop("use_precond", False):
         if isinstance(L, (_data.CSR, _data.Dia)):
             kw["M"] = _compute_precond(L, kw)

--- a/qutip/tests/solver/test_steadystate.py
+++ b/qutip/tests/solver/test_steadystate.py
@@ -29,10 +29,12 @@ import warnings
     pytest.param('iterative-bicgstab', {'atol': 1e-12, "tol": 1e-10},
                  id="iterative-bicgstab"),
 ])
-def test_qubit(method, kwargs):
+@pytest.mark.parametrize("dtype", ["dense", "dia", "csr"])
+@pytest.mark.filterwarnings("ignore:Only CSR matrices:RuntimeWarning")
+def test_qubit(method, kwargs, dtype):
     # thermal steadystate of a qubit: compare numerics with analytical formula
-    sz = qutip.sigmaz()
-    sm = qutip.destroy(2)
+    sz = qutip.sigmaz().to(dtype)
+    sm = qutip.destroy(2, dtype=dtype)
 
     H = 0.5 * 2 * np.pi * sz
     gamma1 = 0.05


### PR DESCRIPTION
**Description**

Speed up `steadystate`, mainly for the `direct` method with the `dia` method, but some of the optimization affect most calls.

- liouvillian(H) + lindblad_dissipator(c_ops) is slower that liouvillian(H, c_ops) by about 2x.
-  Dia are bad with vectors, the `kron(bra, ket)` in `_steadystate_direct` alone was ~90% of the compute time. Using `CSR` instead is much faster.
- Dia to CSR conversion are about made 100x faster.

Overall, the timing for `Dia` is about 20x faster and 10% faster for `CSR`