### PR TITLE
Improve fidelity's docstring

### DIFF
--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -9,13 +9,10 @@ __all__ = ['fidelity', 'tracedist', 'bures_dist', 'bures_angle',
            'hellinger_dist', 'hilbert_dist', 'average_gate_fidelity',
            'process_fidelity', 'unitarity', 'dnorm']
 
-import warnings
-
 import numpy as np
 from scipy import linalg as la
 import scipy.sparse as sp
-from .superop_reps import (to_kraus, to_choi, _to_superpauli, to_super,
-                           kraus_to_choi)
+from .superop_reps import to_choi, _to_superpauli, to_super, kraus_to_choi
 from .superoperator import operator_to_vector, vector_to_operator
 from .operators import qeye, qeye_like
 from .states import ket2dm
@@ -31,7 +28,13 @@ except ImportError:
 def fidelity(A, B):
     """
     Calculates the fidelity (pseudo-metric) between two density matrices.
-    See: Nielsen & Chuang, "Quantum Computation and Quantum Information"
+
+    Notes
+    -----
+    Use the definition from Nielsen & Chuang, "Quantum Computation and Quantum
+    Information". For the fidelity defined in A. Gilchrist, N.K. Langford,
+    M.A. Nielsen, Phys. Rev. A 71, 062310 (2005), please use
+    :func:`process_fidelity` instead.
 
     Parameters
     ----------
@@ -196,7 +199,7 @@ def process_fidelity(oper, target=None):
         if isinstance(oper, list):  # oper is a list of Kraus operators
             return _process_fidelity_to_id([k * target.dag() for k in oper])
         elif oper.type == 'oper':
-            return _process_fidelity_to_id(oper*target.dag())
+            return _process_fidelity_to_id(oper * target.dag())
         elif oper.type == 'super':
             oper_super = to_super(oper)
             target_dag_super = to_super(target.dag())


### PR DESCRIPTION
**Description**
As seen in #2102, there are some confusion to the definition of fidelity.
`fidelity`, `process_fidelity` each implement a different version of fidelity from different papers.

`process_fidelity` has a note explaining the differences, but `fidelity` didn't.
In this PR, I add a note in `fidelity`, so that at least when looking at the documentation, which version used is clear.

I also fixed a few flake8 issues.