### PR TITLE
Make sure result objects don't store references to corresponding solver objects

### DIFF
--- a/doc/changes/2262.bugfix
+++ b/doc/changes/2262.bugfix
@@ -1,0 +1,1 @@
+Fixed result objects storing a reference to the solver through options._feedback.

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -79,7 +79,10 @@ class _BaseResult:
         self._state_processors = []
         self._state_processors_require_copy = False
 
-        self.options = options
+        # do not store a reference to the solver
+        options_copy = options.copy()
+        options_copy._feedback = None
+        self.options = options_copy
 
     def _e_ops_to_dict(self, e_ops):
         """ Convert the supplied e_ops to a dictionary of Eop instances. """

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -1,6 +1,6 @@
 """ Class for solve function results"""
 import numpy as np
-from ..core import Qobj, QobjEvo, expect, isket, ket2dm, qzero, qzero_like
+from ..core import Qobj, QobjEvo, expect, isket, ket2dm, qzero_like
 
 __all__ = ["Result", "MultiTrajResult", "McResult", "NmmcResult",
            "McTrajectoryResult", "McResultImprovedSampling"]
@@ -79,9 +79,10 @@ class _BaseResult:
         self._state_processors = []
         self._state_processors_require_copy = False
 
-        # do not store a reference to the solver
+        # make sure not to store a reference to the solver
         options_copy = options.copy()
-        options_copy._feedback = None
+        if hasattr(options_copy, '_feedback'):
+            options_copy._feedback = None
         self.options = options_copy
 
     def _e_ops_to_dict(self, e_ops):


### PR DESCRIPTION
**Description**
Currently, result objects store a reference to the solver object that created them. I think this is an accident. The options field of a solver is an instance of `_SolverOptions` (see [here](https://github.com/qutip/qutip/blob/454b61529d7bf3c37f74c17925a749fcb046c364/qutip/solver/solver_base.py#L312)), which gets stored in the result [here](https://github.com/qutip/qutip/blob/454b61529d7bf3c37f74c17925a749fcb046c364/qutip/solver/solver_base.py#L147). `_SolverOptions` has a `_feedback` field which is assigned an instance method of the solver and thus keeps a reference to the solver.

I noticed this issue when I called `qsave` on a result object and the resulting file was ~100 MB instead of the expected ~100 KB. Setting `result.options._feedback = None` before calling `qsave` reduced the file size by a factor ~2000. But also without pickling, I think that this is a memory leak where solver objects can't be garbage collected.

The fix I am submitting here makes results create a copy of the options passed to it, setting `_feedback` to `None` if it exists. I considered converting `_SolverOptions` objects to plain `dict`s in the result class, but that would discard a little bit of information. (Note however that in many places, the `options` passed to the results are plain `dict`s anyway, [for example](https://github.com/qutip/qutip/blob/454b61529d7bf3c37f74c17925a749fcb046c364/qutip/tests/solver/test_results.py#L30).) I also considered making `_feedback` a weak reference, but that would make pickling more complicated.

I am not sure what tests to add about this, if any.