### PR TITLE
fix simdiag not returning orthonormal eigenvectors

### DIFF
--- a/doc/changes/2269.bugfix
+++ b/doc/changes/2269.bugfix
@@ -1,0 +1,1 @@
+Fixed simdiag not returning orthonormal eigenvectors.

--- a/qutip/simdiag.py
+++ b/qutip/simdiag.py
@@ -22,7 +22,7 @@ def _degen(tol, vecs, ops, i=0):
                               / (1 - np.abs(dot)**2)**0.5)
 
     subspace = vecs.conj().T @ ops[i].full() @ vecs
-    eigvals, eigvecs = la.eig(subspace)
+    eigvals, eigvecs = la.eigh(subspace)
 
     perm = np.argsort(eigvals)
     eigvals = eigvals[perm]

--- a/qutip/tests/test_simdiag.py
+++ b/qutip/tests/test_simdiag.py
@@ -73,6 +73,28 @@ def test_simdiag_degen_large():
                 atol=1e-13
             )
 
+def test_simdiag_orthonormal_eigenvectors():
+
+    # Special matrix that used to be problematic (see Issue #2268)
+    a = np.array([[1,  0, 1, -1, 0],
+                  [0,  4, 0,  0, 1],
+                  [1,  0, 4,  1, 0],
+                  [-1, 0, 1,  4, 0],
+                  [0,  1, 0,  0, 4]])
+
+    b = np.eye(5)
+
+    _, evecs = qutip.simdiag([qutip.Qobj(a), qutip.Qobj(b)])
+    evecs = np.array([evec.full() for evec in evecs]).squeeze()
+
+    # Check that eigenvectors form an othonormal basis
+    # (<=> matrix of eigenvectors is unitary)
+    np.testing.assert_allclose(
+        evecs@evecs.conj().T,
+        np.eye(len(evecs)),
+        atol=1e-13
+    )
+
 
 def test_simdiag_no_input():
     with pytest.raises(ValueError):

--- a/qutip/tests/test_simdiag.py
+++ b/qutip/tests/test_simdiag.py
@@ -82,9 +82,7 @@ def test_simdiag_orthonormal_eigenvectors():
                   [-1, 0, 1,  4, 0],
                   [0,  1, 0,  0, 4]])
 
-    b = np.eye(5)
-
-    _, evecs = qutip.simdiag([qutip.Qobj(a), qutip.Qobj(b)])
+    _, evecs = qutip.simdiag([qutip.Qobj(a), qutip.qeye(5)])
     evecs = np.array([evec.full() for evec in evecs]).squeeze()
 
     # Check that eigenvectors form an othonormal basis


### PR DESCRIPTION
**Description**
Use `scipy.linalg.eigh` instead of `scipy.linalg.eig` for `qutip.simdiag` in order to ensure returned eigenvectors are always orthonormal. Since `simdiag` requires operands to be commuting and hermitian, this change should be justified.

I did not add any new tests as this bug only occured in very rare circumstances. If desired, I could add the reproducing code from the related issue as a test case.

**Related issues or PRs**
Fixes issue #2268 
