### PR TITLE
Fix LaTeX display of Qobj state in Jupyter cell outputs

### DIFF
--- a/doc/changes/2172.bugfix
+++ b/doc/changes/2172.bugfix
@@ -1,0 +1,1 @@
+Fix LaTeX display of Qobj state in Jupyter cell outputs

--- a/doc/changes/2172.bugfix
+++ b/doc/changes/2172.bugfix
@@ -1,1 +1,0 @@
-Fix LaTeX display of Qobj state in Jupyter cell outputs

--- a/doc/changes/2272.bugfix
+++ b/doc/changes/2272.bugfix
@@ -1,0 +1,1 @@
+Fix LaTeX display of Qobj state in Jupyter cell outputs

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -603,10 +603,10 @@ class Qobj:
             cols.append(None)
             cols += list(range(n_cols - half_length, n_cols))
         # Make the data array.
-        data = r'\begin{equation*}\left(\begin{array}{*{11}c}'
+        data = r'$$\left(\begin{array}{cc}'
         data += r"\\".join(_latex_row(row, cols, self.data.to_array())
                            for row in rows)
-        data += r'\end{array}\right)\end{equation*}'
+        data += r'\end{array}\right)$$'
         return self._str_header() + data
 
     def __and__(self, other):


### PR DESCRIPTION
**Description**
When a `Qobj` is present in the output of a Jupyter cell, e.g. when running:
```python
import qutip as qt
qt.fock(2, 0)
```
the output, which contains LaTeX code, is displayed in Markdown. The aim of this PR is to display the LaTeX output correctly. Replacing the `equation` environment in the LaTeX code with `$$...$$` and changing the `array` environment alignment from `*{11}c` to `cc` causes the vectors and matrices to display in the expected mathematical typeface. A test has not yet been provided, because the change was to a stored raw string; if a test is needed then the presence of this syntax in the string could be detected.

**Related issues or PRs**
Fixes #2172