### PR TITLE
Parallelization fixes

### DIFF
--- a/doc/changes/2280.bugfix
+++ b/doc/changes/2280.bugfix
@@ -1,0 +1,1 @@
+Improved behavior of `parallel_map` and `loky_pmap` in the case of timeouts, errors or keyboard interrupts

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -87,8 +87,6 @@ def mcsolve(H, state, tlist, c_ops=(), e_ops=None, ntraj=500, *,
           | How to run the trajectories. "parallel" uses concurent module to
             run in parallel while "loky" use the module of the same name to do
             so.
-        - | job_timeout : int
-          | Maximum time to compute one trajectory.
         - | num_cpus : int
           | Number of cpus to use when running in parallel. ``None`` detect the
             number of available cpus.
@@ -416,7 +414,6 @@ class MCSolver(MultiTrajSolver):
         "keep_runs_results": False,
         "method": "adams",
         "map": "serial",
-        "job_timeout": None,
         "num_cpus": None,
         "bitgenerator": None,
         "mc_corr_eps": 1e-10,
@@ -602,9 +599,6 @@ class MCSolver(MultiTrajSolver):
             How to run the trajectories. "parallel" uses concurent module to
             run in parallel while "loky" use the module of the same name to do
             so.
-
-        job_timeout: None, int
-            Maximum time to compute one trajectory.
 
         num_cpus: None, int
             Number of cpus to use when running in parallel. ``None`` detect the

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -64,7 +64,6 @@ class MultiTrajSolver(Solver):
         "normalize_output": False,
         "method": "",
         "map": "serial",
-        "job_timeout": None,
         "num_cpus": None,
         "bitgenerator": None,
     }
@@ -146,7 +145,6 @@ class MultiTrajSolver(Solver):
         map_func = _get_map[self.options['map']]
         map_kw = {
             'timeout': timeout,
-            'job_timeout': self.options['job_timeout'],
             'num_cpus': self.options['num_cpus'],
         }
         state0 = self._prepare_state(state)

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -108,8 +108,6 @@ def nm_mcsolve(H, state, tlist, ops_and_rates=(), e_ops=None, ntraj=500, *,
           | How to run the trajectories. "parallel" uses concurent module to
             run in parallel while "loky" use the module of the same name to do
             so.
-        - | job_timeout : int
-          | Maximum time to compute one trajectory.
         - | num_cpus : int
           | Number of cpus to use when running in parallel. ``None`` detect the
             number of available cpus.
@@ -558,9 +556,6 @@ class NonMarkovianMCSolver(MCSolver):
             How to run the trajectories. "parallel" uses concurent module to
             run in parallel while "loky" use the module of the same name to do
             so.
-
-        job_timeout: None, int
-            Maximum time to compute one trajectory.
 
         num_cpus: None, int
             Number of cpus to use when running in parallel. ``None`` detect the

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -203,11 +203,11 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
         if not future.cancelled():
             try:
                 result = future.result()
+                remaining_ntraj = result_func(future._i, result)
+                if remaining_ntraj is not None and remaining_ntraj <= 0:
+                    finished.append(True)
             except Exception as e:
                 errors[future._i] = e
-        remaining_ntraj = result_func(future._i, result)
-        if remaining_ntraj is not None and remaining_ntraj <= 0:
-            finished.append(True)
         progress_bar.update()
 
     if sys.version_info >= (3, 7):

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -25,7 +25,6 @@ else:
 
 
 default_map_kw = {
-    'job_timeout': threading.TIMEOUT_MAX,
     'timeout': threading.TIMEOUT_MAX,
     'num_cpus': available_cpu_count(),
     'fail_fast': True,
@@ -165,7 +164,6 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
     map_kw: dict, optional
         Dictionary containing entry for:
         - timeout: float, Maximum time (sec) for the whole map.
-        - job_timeout: float, Maximum time (sec) for each job in the map.
         - num_cpus: int, Number of jobs to run at once.
         - fail_fast: bool, Abort at the first error.
 

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -199,25 +199,21 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
 
     def _done_callback(future):
         if not future.cancelled():
-            try:
+            ex = future.exception()
+            if isinstance(ex, KeyboardInterrupt):
+                # When a keyboard interrupt happens, it is raised in the main
+                # thread and in all worker threads. At this point in the code,
+                # the worker threads have already returned and the main thread
+                # is only waiting for the ProcessPoolExecutor to shutdown
+                # before exiting. We therefore return immediately.
+                return
+            if isinstance(ex, Exception):
+                errors[future._i] = ex
+            else:
                 result = future.result()
                 remaining_ntraj = result_func(future._i, result)
                 if remaining_ntraj is not None and remaining_ntraj <= 0:
                     finished.append(True)
-            except Exception as e:
-                errors[future._i] = e
-            except KeyboardInterrupt:
-                # When a keyboard interrupt happens, it is raised in the main
-                # thread and in all worker threads. The worker threads have
-                # already returned and the main thread is only waiting for the
-                # ProcessPoolExecutor to shutdown before exiting. If the call
-                # to `future.result()` in this callback function raises the
-                # KeyboardInterrupt again, it makes the system enter a kind of
-                # deadlock state, where the user has to press CTRL+C a second
-                # time to actually end the program. For that reason, we
-                # silently ignore the KeyboardInterrupt here, avoiding the
-                # deadlock and allowing the main thread to exit.
-                pass
         progress_bar.update()
 
     if sys.version_info >= (3, 7):

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -184,7 +184,6 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
         task_kwargs = {}
     map_kw = _read_map_kw(map_kw)
     end_time = map_kw['timeout'] + time.time()
-    job_time = map_kw['job_timeout']
 
     progress_bar = progress_bars[progress_bar](
         len(values), **progress_bar_kwargs
@@ -194,10 +193,11 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
     finished = []
     if reduce_func is not None:
         results = None
-        result_func = lambda i, value: reduce_func(value)
+        def result_func(_, value):
+            return reduce_func(value)
     else:
         results = [None] * len(values)
-        result_func = lambda i, value: results.__setitem__(i, value)
+        result_func = results.__setitem__
 
     def _done_callback(future):
         if not future.cancelled():

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -311,8 +311,8 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
         The optional additional keyword arguments to the ``task`` function.
     reduce_func : func, optional
         If provided, it will be called with the output of each task instead of
-        storing them in a list. Note that the order in which results are
-        passed to ``reduce_func`` is not defined. It should return None or a
+        storing them in a list. Note that the results are passed to
+        ``reduce_func`` in the original order. It should return None or a
         number. When returning a number, it represents the estimation of the
         number of tasks left. On a return <= 0, the map will end early.
     progress_bar : str, optional

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -322,7 +322,6 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
     map_kw: dict, optional
         Dictionary containing entry for:
         - timeout: float, Maximum time (sec) for the whole map.
-        - job_timeout: float, Maximum time (sec) for each job in the map.
         - num_cpus: int, Number of jobs to run at once.
         - fail_fast: bool, Abort at the first error.
 
@@ -341,7 +340,6 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
         task_kwargs = {}
     map_kw = _read_map_kw(map_kw)
     end_time = map_kw['timeout'] + time.time()
-    job_time = map_kw['job_timeout']
 
     progress_bar = progress_bars[progress_bar](
         len(values), **progress_bar_kwargs
@@ -363,7 +361,7 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
                for value in values]
 
         for n, job in enumerate(jobs):
-            remaining_time = min(end_time - time.time(), job_time)
+            remaining_time = max(end_time - time.time(), 0)
             try:
                 result = job.result(remaining_time)
             except Exception as err:

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -472,7 +472,7 @@ def _solver_deprecation(kwargs, options, solver="me"):
     if "map_kwargs" in kwargs and solver in ["mc", "stoc"]:
         warnings.warn(
             '"map_kwargs" are now included in options:\n'
-            'Use `options={"num_cpus": N, "job_timeout": Nsec}`',
+            'Use `options={"num_cpus": N}`',
             FutureWarning
         )
         del kwargs["map_kwargs"]

--- a/qutip/solver/stochastic.py
+++ b/qutip/solver/stochastic.py
@@ -337,8 +337,6 @@ def smesolve(
           | How to run the trajectories. "parallel" uses concurent module to
             run in parallel while "loky" use the module of the same name to do
             so.
-        - | job_timeout : NoneType, int
-          | Maximum time to compute one trajectory.
         - | num_cpus : NoneType, int
           | Number of cpus to use when running in parallel. ``None`` detect the
             number of available cpus.
@@ -459,8 +457,6 @@ def ssesolve(
             How to run the trajectories. "parallel" uses concurent module to
             run in parallel while "loky" use the module of the same name to do
             so.
-        - | job_timeout : NoneType, int
-          | Maximum time to compute one trajectory.
         - | num_cpus : NoneType, int
           | Number of cpus to use when running in parallel. ``None`` detect the
             number of available cpus.
@@ -507,7 +503,6 @@ class StochasticSolver(MultiTrajSolver):
         "normalize_output": False,
         "method": "taylor1.5",
         "map": "serial",
-        "job_timeout": None,
         "num_cpus": None,
         "bitgenerator": None,
     }
@@ -684,9 +679,6 @@ class StochasticSolver(MultiTrajSolver):
             run in parallel while "loky" use the module of the same name to do
             so.
 
-        job_timeout: None, int, default: None
-            Maximum time to compute one trajectory.
-
         num_cpus: None, int, default: None
             Number of cpus to use when running in parallel. ``None`` detect the
             number of available cpus.
@@ -796,7 +788,6 @@ class SMESolver(StochasticSolver):
         "normalize_output": False,
         "method": "platen",
         "map": "serial",
-        "job_timeout": None,
         "num_cpus": None,
         "bitgenerator": None,
     }
@@ -840,7 +831,6 @@ class SSESolver(StochasticSolver):
         "normalize_output": False,
         "method": "platen",
         "map": "serial",
-        "job_timeout": None,
         "num_cpus": None,
         "bitgenerator": None,
     }

--- a/qutip/tests/solver/test_parallel.py
+++ b/qutip/tests/solver/test_parallel.py
@@ -34,7 +34,6 @@ def test_map(map, num_cpus):
     args = (1, 2, 3)
     kwargs = {'d': 4, 'e': 5, 'f': 6}
     map_kw = {
-        'job_timeout': threading.TIMEOUT_MAX,
         'timeout': threading.TIMEOUT_MAX,
         'num_cpus': num_cpus,
     }
@@ -60,7 +59,6 @@ def test_map_accumulator(map, num_cpus):
     args = (1, 2, 3)
     kwargs = {'d': 4, 'e': 5, 'f': 6}
     map_kw = {
-        'job_timeout': threading.TIMEOUT_MAX,
         'timeout': threading.TIMEOUT_MAX,
         'num_cpus': num_cpus,
     }


### PR DESCRIPTION
**Background**

Since I am planning to add an mpi_parallel_map to the parallel module, I had a detailed look at the current implementations of parallel_map and loky_pmap. In the case of timeouts, errors or interrupts, I found surprising behavior. I will first summarize the current behavior in these situations, and then the behavior if my changes are included. It seems difficult to write better unit tests for such timing-sensitive behavior, but I have tested in detail on both Linux (WSL) and Windows.

**Current behavior**

&nbsp; | `parallel_map` | `loky_pmap`
---|---|---
Timeout | Finishes currently running tasks, <br> then returns results of all finished tasks. | If `fail_fast`, behaves similarly to `parallel_map`. <br> Otherwise, completes all tasks but only returns <br> results of those that were started before the timeout.
CTRL+C | First CTRL+C interrupts all tasks, but program <br> enters deadlock requiring second CTRL+C | Interrupts currently running tasks, but then still <br> executes the rest before raising `KeyboardInterrupt`.
Task raises <br> exception | `fail_fast`: finishes running tasks, <br> then raises exception. <br> `!fail_fast`: raises `MapExceptions` at the end. | `fail_fast`: finishes all tasks, then raises exception. <br> `!fail_fast`: raises `MapExceptions` at the end.
Job timeout | Ignored | Always completes all tasks anyway, see below

**New behavior**

&nbsp; | `parallel_map` | `loky_pmap`
---|---|---
Timeout | Finishes currently running tasks, <br> then returns results of all finished tasks. | Aborts currently running tasks, <br> then returns results of all finished tasks.
CTRL+C | First CTRL+C raises `KeyboardInterrupt` | First CTRL+C raises `KeyboardInterrupt`
Task raises <br> exception | `fail_fast`: finishes running tasks, <br> then raises exception. <br> `!fail_fast`: raises `MapExceptions` at the end. | `fail_fast`: finishes tasks earlier in the list, then <br> aborts remaining ones and raises exception. <br> `!fail_fast`: raises `MapExceptions` at the end.
Job timeout | Removed from documentation | Removed from documentation

**Job timeout**

Currently, the job timeout parameter is ignored by parallel_map. In loky_pmap, it is not the maximum allowed time for one job, but the maximum time between two job finishes (possibly in different processes). If this time is exceeded, all tasks will still be executed until the end; only the results of the tasks that finished too slowly will be discarded. I do not think that this was the intention of the job timeout parameter?

Unfortunately, both `ProcessPoolExecutor` (which parallel_map is based on) and its loky version do not support timeouts for single tasks, nor do they support aborting single tasks manually. (The loky one supports killing *all* worker processes at once.) If we wanted to have a job timeout parameter, we would need to either use non-public API to obtain references to the worker processes and interrupt them manually, or to completely rewrite parallel_map and base it on e.g. `multiprocessing.pool.Pool`.

Maybe better to just remove the job_timeout parameter? If you agree with that, I will then also remove it from the available options for `MultiTrajSolver` and all its subclasses.