### PR TITLE
Faster `kraus_to_choi`

### DIFF
--- a/doc/changes/2284.misc
+++ b/doc/changes/2284.misc
@@ -1,0 +1,1 @@
+Rework `kraus_to_choi` making it faster

--- a/qutip/core/superop_reps.py
+++ b/qutip/core/superop_reps.py
@@ -138,7 +138,7 @@ def _choi_to_kraus(q_oper, tol=1e-9):
 # Individual conversions from Kraus operators are public because the output
 # list of Kraus operators is not itself a quantum object.
 
-def kraus_to_choi(kraus_ops: list[Qobj]) -> Qobj:
+def kraus_to_choi(kraus_ops):
     r"""
     Convert a list of Kraus operators into Choi representation of the channel.
 

--- a/qutip/core/superop_reps.py
+++ b/qutip/core/superop_reps.py
@@ -156,13 +156,13 @@ def kraus_to_choi(kraus_ops: list[Qobj]) -> Qobj:
         A quantum object representing the same map as ``kraus_ops``, such that
         ``choi.superrep == "choi"``.
     """
-    num_ops = len(kraus_ops)
+    len_op = np.prod(kraus_ops[0].shape)
     # If Kraus ops have dims [M, N] in qutip notation (act on [N, N] density matrix and produce [M, M] d.m.),
     # Choi matrix Hilbert space will be [[M, N], [M, N]] because Choi Hilbert space is (output space) x (input space).
     choi_dims = [kraus_ops[0].dims] * 2
     # transform a list of Qobj matrices list[sum_ij k_ij |i><j|]
     # into an array of array vectors sum_ij k_ij |i, j>> = sum_I k_I |I>>
-    kraus_vectors = np.reshape(np.asarray(kraus_ops), (num_ops, -1))
+    kraus_vectors = np.asarray([np.reshape(kraus_op.full(), len_op, "F") for kraus_op in kraus_ops])
     # sum_{I} |k_I|^2 |I>><<I|
     choi_array = np.tensordot(kraus_vectors, kraus_vectors.conj(), axes=([0], [0]))
     return Qobj(choi_array, choi_dims, superrep="choi", copy=False)


### PR DESCRIPTION
**Description**
Adaptation of PR #2283 to qutip 5: using `np.tensordot` instead of a triple loop.

Co-authored with [Rafael Haenel](https://github.com/rafaelha)