### PR TITLE
Ignore deprecation warnings from pxyimport in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
             python-version: "3.10"
             condaforge: 1
             nocvxopt: 1
-            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper -W ignore:Absolute:DeprecationWarning"
+            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper -W ignore:Absolute:DeprecationWarning -W ignore:dep_util:DeprecationWarning"
 
           # Python 3.11 and latest numpy
           # Use conda-forge to provide Python 3.11 and latest numpy
@@ -110,7 +110,7 @@ jobs:
             python-version: "3.11"
             condaforge: 1
             conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
-            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper -W ignore:Absolute:DeprecationWarning -W ignore::DeprecationWarning:Cython.Tempita"
+            pytest-extra-options: "-W ignore::ImportWarning -W ignore::DeprecationWarning:cvxpy.interface.scipy_wrapper -W ignore:Absolute:DeprecationWarning -W ignore::DeprecationWarning:Cython.Tempita -W ignore:dep_util:DeprecationWarning"
 
           # Windows. Once all tests pass without special options needed, this
           # can be moved to the main os list in the test matrix. All the tests

--- a/doc/changes/2287.bugfix
+++ b/doc/changes/2287.bugfix
@@ -1,0 +1,1 @@
+Ignore DeprecationWarning from pyximport


### PR DESCRIPTION
**Description**
Over the holidays a new versions of cython and setuptools came out resulting in pyximport raising a deprecation warning.

For v4.7, I just set it to ignore the warning in tests.