### PR TITLE
Ignore deprecation warnings from cython 0.29

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
             scipy-requirement: ">=1.5,<1.6"
             condaforge: 1
             oldcython: 1
+            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
 
           # No MKL runs.  MKL is now the default for conda installations, but
           # not necessarily for pip.
@@ -75,6 +76,7 @@ jobs:
             python-version: "3.10"
             condaforge: 1
             oldcython: 1
+            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
 
           # Python 3.11 and latest numpy
           # Use conda-forge to provide Python 3.11 and latest numpy

--- a/doc/changes/2288.bugfix
+++ b/doc/changes/2288.bugfix
@@ -1,0 +1,1 @@
+Ignore deprecation warnings from cython 0.29.X in tests.


### PR DESCRIPTION
**Description**
Cython 0.29 is raise a deprecation warning when used with the newest setuptools.

Ignore these warnings in tests.