### PR TITLE
Faster Qobj matmul (less overhead from dimensions)

### DIFF
--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -908,12 +908,12 @@ cdef class QobjEvo:
     @property
     def isoper(self):
         """Indicates if the system represents an operator."""
-        return self._dims.type == "oper"
+        return self._dims.type in ['oper', 'scalar']
 
     @property
     def issuper(self):
         """Indicates if the system represents a superoperator."""
-        return self._dims.issuper
+        return self._dims.type == 'super'
 
     @property
     def dims(self):
@@ -926,6 +926,26 @@ cdef class QobjEvo:
     @property
     def superrep(self):
         return self._dims.superrep
+
+    @property
+    def isbra(self):
+        """Indicates if the system represents a bra state."""
+        return self._dims.type in ['bra', 'scalar']
+
+    @property
+    def isket(self):
+        """Indicates if the system represents a ket state."""
+        return self._dims.type in ['ket', 'scalar']
+
+    @property
+    def isoperket(self):
+        """Indicates if the system represents a operator-ket state."""
+        return self._dims.type == 'operator-ket'
+
+    @property
+    def isoperbra(self):
+        """Indicates if the system represents a operator-bra state."""
+        return self._dims.type == 'operator-bra'
 
     ###########################################################################
     # operation methods                                                       #

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -783,6 +783,25 @@ class Dimensions(metaclass=MetaDims):
             )
         return NotImplemented
 
+    def __ne__(self, other):
+        if isinstance(other, Dimensions):
+            return not (
+                self is other
+                or (
+                    self.to_ == other.to_
+                    and self.from_ == other.from_
+                )
+            )
+        return NotImplemented
+
+    def __matmul__(self, other):
+        if self.from_ != other.to_:
+            raise TypeError(f"incompatible dimensions {self} and {other}")
+        args = other.from_, self.to_
+        if args in Dimensions._stored_dims:
+            return Dimensions._stored_dims[args]
+        return Dimensions(*args)
+
     def __hash__(self):
         return hash((self.to_, self.from_))
 

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1728,7 +1728,9 @@ class Qobj:
         return self._isunitary
 
     @property
-    def shape(self): return self._data.shape
+    def shape(self):
+        """Return the shape of the Qobj data."""
+        return self._data.shape
 
     @property
     def isoper(self):

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -91,10 +91,7 @@ def _require_equal_type(method):
             return method(self, other)
         if other == 0:
             return method(self, other)
-        if (
-            self._dims.issquare
-            and isinstance(other, numbers.Number)
-        ):
+        if self._dims.issquare and isinstance(other, numbers.Number):
             scale = complex(other)
             other = Qobj(_data.identity(self.shape[0], scale,
                                         dtype=type(self.data)),
@@ -102,14 +99,9 @@ def _require_equal_type(method):
                          isherm=(scale.imag == 0),
                          isunitary=(abs(abs(scale)-1) < settings.core['atol']),
                          copy=False)
-        else:
-            try:
-                # This allow `Qobj + array` if the shape is good.
-                # Do we really want that?
-                other = Qobj(other, dims=self._dims)
-            except TypeError:
-                return NotImplemented
-        return method(self, other)
+            return method(self, other)
+        return NotImplemented
+
     return out
 
 
@@ -392,8 +384,7 @@ class Qobj:
     def __add__(self, other):
         if other == 0:
             return self.copy()
-        new_data = _data.add(self._data, other._data)
-        return Qobj(new_data,
+        return Qobj(_data.add(self._data, other._data),
                     dims=self._dims,
                     isherm=(self._isherm and other._isherm) or None,
                     copy=False)

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1726,12 +1726,35 @@ class Qobj:
     @property
     def shape(self): return self._data.shape
 
-    isbra = property(isbra)
-    isket = property(isket)
-    isoper = property(isoper)
-    issuper = property(issuper)
-    isoperbra = property(isoperbra)
-    isoperket = property(isoperket)
+    @property
+    def isoper(self):
+        """Indicates if the Qobj represents an operator."""
+        return self._dims.type in ['oper', 'scalar']
+
+    @property
+    def isbra(self):
+        """Indicates if the Qobj represents a bra state."""
+        return self._dims.type in ['bra', 'scalar']
+
+    @property
+    def isket(self):
+        """Indicates if the Qobj represents a ket state."""
+        return self._dims.type in ['ket', 'scalar']
+
+    @property
+    def issuper(self):
+        """Indicates if the Qobj represents a superoperator."""
+        return self._dims.type == 'super'
+
+    @property
+    def isoperket(self):
+        """Indicates if the Qobj represents a operator-ket state."""
+        return self._dims.type == 'operator-ket'
+
+    @property
+    def isoperbra(self):
+        """Indicates if the Qobj represents a operator-bra state."""
+        return self._dims.type == 'operator-bra'
 
 
 def ptrace(Q, sel):

--- a/qutip/tests/core/test_dimensions.py
+++ b/qutip/tests/core/test_dimensions.py
@@ -162,3 +162,30 @@ class TestCollapseDims:
 def test_bad_dims(dims_list):
     with pytest.raises(ValueError):
         Dimensions([dims_list, [1]])
+
+
+@pytest.mark.parametrize("space_l", [[1], [2], [2, 3]])
+@pytest.mark.parametrize("space_m", [[1], [2], [2, 3]])
+@pytest.mark.parametrize("space_r", [[1], [2], [2, 3]])
+def test_dims_matmul(space_l, space_m, space_r):
+    dims_l = Dimensions([space_l, space_m])
+    dims_r = Dimensions([space_m, space_r])
+    assert dims_l @ dims_r == Dimensions([space_l, space_r])
+
+
+def test_dims_matmul_bad():
+    dims_l = Dimensions([[1], [3]])
+    dims_r = Dimensions([[2], [2]])
+    with pytest.raises(TypeError):
+        dims_l @ dims_r
+
+
+def test_dims_comparison():
+    assert Dimensions([[1], [2]]) == Dimensions([[1], [2]])
+    assert not Dimensions([[1], [2]]) != Dimensions([[1], [2]])
+    assert Dimensions([[1], [2]]) != Dimensions([[2], [1]])
+    assert not Dimensions([[1], [2]]) == Dimensions([[2], [1]])
+    assert Dimensions([[1], [2]])[1] == Dimensions([[1], [2]])[1]
+    assert Dimensions([[1], [2]])[0] != Dimensions([[1], [2]])[1]
+    assert not Dimensions([[1], [2]])[1] != Dimensions([[1], [2]])[1]
+    assert not Dimensions([[1], [2]])[0] != Dimensions([[1], [2]])[0]


### PR DESCRIPTION
**Description**
Looking at the [historical benchmarks](https://qutip.org/qutip-benchmark/ops/matmul.html), Qobj operations got slower last November, which correspond to when we merged the dimensions PR. This PR is to improve those graph. Usually, when a lot of matrix operations are done, we use the data layer object directly. So the overhead of the Qobj should not be that critical.

Adding QobjEvo support to `isbra`, `isket`, etc, slowed them down quite a lot. The import of QobjEvo in the function can easily be slower than the matrix operation. (0.7us for the import which is the same as a 32x32 CSR@ket product.) This is the biggest culprit in the jump in the matmul benchmark graph. I added properties for each `is_type_` to Qobj and QobjEvo.

The `Qobj` and `QobjEvo`'s `issuper` where not the same. `QobjEvo` would return `True` for oper-ket, not just super operator, while `Qobj.issuper` would be `True` only for super operator. `QobjEvo` now match `Qobj`.

I also changed the check to tell if `Qobj.__matmul__` return a number or Qobj. It is now done looking at the output dimensions. Now that type cannot be overwritten, it is the same check. (Before a `[[1], [1]]` could be a bra, ket, oper, etc., now it's a scalar which return True to isbra, isket and isoper.)

For `Qobj.__add__` I could speed it up by doing the Qobj check first. But the extra overhead of `Qobj.__init__` is still there. That said, the graph don't look as bad as the matmul ones and it's probably enough.






