### PR TITLE
Mpi support

### DIFF
--- a/doc/apidoc/functions.rst
+++ b/doc/apidoc/functions.rst
@@ -297,7 +297,7 @@ Parallelization
 ---------------
 
 .. automodule:: qutip.solver.parallel
-    :members: parallel_map, serial_map, loky_pmap
+    :members: parallel_map, serial_map, loky_pmap, mpi_pmap
 
 
 .. _functions-ipython:

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -144,7 +144,9 @@ class MultiTrajSolver(Solver):
         result.add_end_condition(ntraj, target_tol)
 
         map_func = _get_map[self.options['map']]
-        map_kw = self.options['mpi_options'] if map_func == mpi_pmap else {}
+        map_kw = {}
+        if map_func == mpi_pmap:
+            map_kw.update(self.options['mpi_options'])
         map_kw.update({
             'timeout': timeout,
             'num_cpus': self.options['num_cpus'],

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -1,5 +1,5 @@
 from .result import Result, MultiTrajResult
-from .parallel import _get_map
+from .parallel import _get_map, mpi_pmap
 from time import time
 from .solver_base import Solver
 from ..core import QobjEvo
@@ -64,6 +64,7 @@ class MultiTrajSolver(Solver):
         "normalize_output": False,
         "method": "",
         "map": "serial",
+        "mpi_options": {},
         "num_cpus": None,
         "bitgenerator": None,
     }
@@ -143,10 +144,11 @@ class MultiTrajSolver(Solver):
         result.add_end_condition(ntraj, target_tol)
 
         map_func = _get_map[self.options['map']]
-        map_kw = {
+        map_kw = self.options['mpi_options'] if map_func == mpi_pmap else {}
+        map_kw.update({
             'timeout': timeout,
             'num_cpus': self.options['num_cpus'],
-        }
+        })
         state0 = self._prepare_state(state)
         stats['preparation time'] += time() - start_time
         return stats, seeds, result, map_func, map_kw, state0

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -83,8 +83,6 @@ def nm_mcsolve(H, state, tlist, ops_and_rates=(), e_ops=None, ntraj=500, *,
           | Whether or not to store the state vectors or density matrices.
             On `None` the states will be saved if no expectation operators are
             given.
-        - | normalize_output : bool
-          | Normalize output state to hide ODE numerical errors.
         - | progress_bar : str {'text', 'enhanced', 'tqdm', ''}
           | How to present the solver progress.
             'tqdm' uses the python module of the same name and raise an error
@@ -99,18 +97,26 @@ def nm_mcsolve(H, state, tlist, ops_and_rates=(), e_ops=None, ntraj=500, *,
           | Maximum number of (internally defined) steps allowed in one ``tlist``
             step.
         - | max_step : float
-          | Maximum lenght of one internal step. When using pulses, it should be
+          | Maximum length of one internal step. When using pulses, it should be
             less than half the width of the thinnest pulse.
         - | keep_runs_results : bool, [False]
           | Whether to store results from all trajectories or just store the
             averages.
-        - | map : str {"serial", "parallel", "loky"}
-          | How to run the trajectories. "parallel" uses concurent module to
-            run in parallel while "loky" use the module of the same name to do
-            so.
+        - | map : str {"serial", "parallel", "loky", "mpi"}
+          | How to run the trajectories. "parallel" uses the multiprocessing
+            module to run in parallel while "loky" and "mpi" use the "loky" and
+            "mpi4py" modules to do so.
+        - | mpi_options : dict
+          | Only applies if map is "mpi". This dictionary will be passed as
+            keyword arguments to the `mpi4py.futures.MPIPoolExecutor`
+            constructor. Note that the `max_workers` argument is provided
+            separately through the `num_cpus` option.
         - | num_cpus : int
           | Number of cpus to use when running in parallel. ``None`` detect the
             number of available cpus.
+        - | bitgenerator : {None, "MT19937", "PCG64", "PCG64DXSM", ...}
+            Which of numpy.random's bitgenerator to use. With `None`, your
+            numpy version's default is used.
         - | norm_t_tol, norm_tol, norm_steps : float, float, int
           | Parameters used to find the collapse location. ``norm_t_tol`` and
             ``norm_tol`` are the tolerance in time and norm respectively.
@@ -119,9 +125,6 @@ def nm_mcsolve(H, state, tlist, ops_and_rates=(), e_ops=None, ntraj=500, *,
         - | mc_corr_eps : float
           | Small number used to detect non-physical collapse caused by
             numerical imprecision.
-        - | improved_sampling : Bool
-          | Whether to use the improved sampling algorithm from Abdelhafez et
-            al. PRA (2019)
         - | completeness_rtol, completeness_atol : float, float
           | Parameters used in determining whether the given Lindblad operators
             satisfy a certain completeness relation. If they do not, an
@@ -132,6 +135,9 @@ def nm_mcsolve(H, state, tlist, ops_and_rates=(), e_ops=None, ntraj=500, *,
             integration of the martingale.
 
         Note that the 'improved_sampling' option is not currently supported.
+        Additional options may be available depending on the selected
+        differential equation integration method, see
+        `Integrator <./classes.html#classes-ode>`_.
 
     seeds : int, SeedSequence, list, optional
         Seed for the random number generator. It can be a single seed used to
@@ -538,24 +544,30 @@ class NonMarkovianMCSolver(MCSolver):
 
         progress_bar: str {'text', 'enhanced', 'tqdm', ''}, default: "text"
             How to present the solver progress.
-            'tqdm' uses the python module of the same name and raise an error
-            if not installed. Empty string or False will disable the bar.
+            'tqdm' uses the python module of the same name and raise an error if
+            not installed. Empty string or False will disable the bar.
 
         progress_kwargs: dict, default: {"chunk_size":10}
             Arguments to pass to the progress_bar. Qutip's bars use
             ``chunk_size``.
 
         keep_runs_results: bool, default: False
-          Whether to store results from all trajectories or just store the
-          averages.
+            Whether to store results from all trajectories or just store the
+            averages.
 
         method: str, default: "adams"
-            Which ODE integrator methods are supported.
+            Which differential equation integration method to use.
 
-        map: str {"serial", "parallel", "loky"}, default: "serial"
-            How to run the trajectories. "parallel" uses concurent module to
-            run in parallel while "loky" use the module of the same name to do
-            so.
+        map: str {"serial", "parallel", "loky", "mpi"}, default: "serial"
+            How to run the trajectories. "parallel" uses the multiprocessing
+            module to run in parallel while "loky" and "mpi" use the "loky" and
+            "mpi4py" modules to do so.
+
+        mpi_options: dict, default: {}
+            Only applies if map is "mpi". This dictionary will be passed as
+            keyword arguments to the `mpi4py.futures.MPIPoolExecutor`
+            constructor. Note that the `max_workers` argument is provided
+            separately through the `num_cpus` option.
 
         num_cpus: None, int
             Number of cpus to use when running in parallel. ``None`` detect the

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -188,7 +188,7 @@ def _generic_pmap(task, values, task_args, task_kwargs,
             if isinstance(ex, Exception):
                 errors[future._i] = ex
             else:
-                result = future.result()
+                result = extract_result(future._i, future)
                 remaining_ntraj = result_func(future._i, result)
                 if remaining_ntraj is not None and remaining_ntraj <= 0:
                     finished.append(True)

--- a/qutip/solver/parallel.py
+++ b/qutip/solver/parallel.py
@@ -272,7 +272,7 @@ def parallel_map(task, values, task_args=None, task_kwargs=None,
                  progress_bar=None, progress_bar_kwargs={}):
     """
     Parallel execution of a mapping of ``values`` to the function ``task``.
-    This is functionally equivalent to:
+    This is functionally equivalent to::
 
         result = [task(value, *task_args, **task_kwargs) for value in values]
 
@@ -346,7 +346,7 @@ def loky_pmap(task, values, task_args=None, task_kwargs=None,
               progress_bar=None, progress_bar_kwargs={}):
     """
     Parallel execution of a mapping of ``values`` to the function ``task``.
-    This is functionally equivalent to:
+    This is functionally equivalent to::
 
         result = [task(value, *task_args, **task_kwargs) for value in values]
 
@@ -421,7 +421,7 @@ def mpi_pmap(task, values, task_args=None, task_kwargs=None,
              progress_bar=None, progress_bar_kwargs={}):
     """
     Parallel execution of a mapping of ``values`` to the function ``task``.
-    This is functionally equivalent to:
+    This is functionally equivalent to::
 
         result = [task(value, *task_args, **task_kwargs) for value in values]
 

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -829,6 +829,7 @@ class MultiTrajResult(_BaseResult):
             raise ValueError("Shared `times` are is required to merge results")
         new = self.__class__(self._raw_ops, self.options,
                              solver=self.solver, stats=self.stats)
+        new.e_ops = self.e_ops
         if self.trajectories and other.trajectories:
             new.trajectories = self.trajectories + other.trajectories
         new.num_trajectories = self.num_trajectories + other.num_trajectories
@@ -836,7 +837,8 @@ class MultiTrajResult(_BaseResult):
         new.seeds = self.seeds + other.seeds
 
         if self._sum_states is not None and other._sum_states is not None:
-            new._sum_states = self._sum_states + other._sum_states
+            new._sum_states = [state1 + state2 for state1, state2
+                               in zip(self._sum_states, other._sum_states)]
 
         if (
             self._sum_final_states is not None

--- a/qutip/solver/stochastic.py
+++ b/qutip/solver/stochastic.py
@@ -1,11 +1,10 @@
 __all__ = ["smesolve", "SMESolver", "ssesolve", "SSESolver"]
 
-from .sode.ssystem import *
+from .sode.ssystem import StochasticOpenSystem, StochasticClosedSystem
 from .result import MultiTrajResult, Result, ExpectOp
 from .multitraj import MultiTrajSolver
-from .. import Qobj, QobjEvo, liouvillian, lindblad_dissipator
+from .. import Qobj, QobjEvo
 import numpy as np
-from collections.abc import Iterable
 from functools import partial
 from .solver_base import _solver_deprecation
 from ._feedback import _QobjFeedback, _DataFeedback, _WeinerFeedback

--- a/qutip/tests/solver/test_parallel.py
+++ b/qutip/tests/solver/test_parallel.py
@@ -4,7 +4,7 @@ import pytest
 import threading
 
 from qutip.solver.parallel import (
-    parallel_map, serial_map, loky_pmap, MapExceptions
+    parallel_map, serial_map, loky_pmap, mpi_pmap, MapExceptions
 )
 
 
@@ -22,6 +22,7 @@ def _func2(x, a, b, c, d=0, e=0, f=0):
 @pytest.mark.parametrize('map', [
     pytest.param(parallel_map, id='parallel_map'),
     pytest.param(loky_pmap, id='loky_pmap'),
+    pytest.param(mpi_pmap, id='mpi_pmap'),
     pytest.param(serial_map, id='serial_map'),
 ])
 @pytest.mark.parametrize('num_cpus',
@@ -29,7 +30,9 @@ def _func2(x, a, b, c, d=0, e=0, f=0):
                          ids=['1', '2'])
 def test_map(map, num_cpus):
     if map is loky_pmap:
-        loky = pytest.importorskip("loky")
+        pytest.importorskip("loky")
+    if map is mpi_pmap:
+        pytest.importorskip("mpi4py")
 
     args = (1, 2, 3)
     kwargs = {'d': 4, 'e': 5, 'f': 6}
@@ -48,6 +51,7 @@ def test_map(map, num_cpus):
 @pytest.mark.parametrize('map', [
     pytest.param(parallel_map, id='parallel_map'),
     pytest.param(loky_pmap, id='loky_pmap'),
+    pytest.param(mpi_pmap, id='mpi_pmap'),
     pytest.param(serial_map, id='serial_map'),
 ])
 @pytest.mark.parametrize('num_cpus',
@@ -55,7 +59,10 @@ def test_map(map, num_cpus):
                          ids=['1', '2'])
 def test_map_accumulator(map, num_cpus):
     if map is loky_pmap:
-        loky = pytest.importorskip("loky")
+        pytest.importorskip("loky")
+    if map is mpi_pmap:
+        pytest.importorskip("mpi4py")
+
     args = (1, 2, 3)
     kwargs = {'d': 4, 'e': 5, 'f': 6}
     map_kw = {
@@ -84,11 +91,14 @@ def func(i):
 @pytest.mark.parametrize('map', [
     pytest.param(parallel_map, id='parallel_map'),
     pytest.param(loky_pmap, id='loky_pmap'),
+    pytest.param(mpi_pmap, id='mpi_pmap'),
     pytest.param(serial_map, id='serial_map'),
 ])
 def test_map_pass_error(map):
     if map is loky_pmap:
-        loky = pytest.importorskip("loky")
+        pytest.importorskip("loky")
+    if map is mpi_pmap:
+        pytest.importorskip("mpi4py")
 
     with pytest.raises(CustomException) as err:
         map(func, range(10))
@@ -98,11 +108,14 @@ def test_map_pass_error(map):
 @pytest.mark.parametrize('map', [
     pytest.param(parallel_map, id='parallel_map'),
     pytest.param(loky_pmap, id='loky_pmap'),
+    pytest.param(mpi_pmap, id='mpi_pmap'),
     pytest.param(serial_map, id='serial_map'),
 ])
 def test_map_store_error(map):
     if map is loky_pmap:
-        loky = pytest.importorskip("loky")
+        pytest.importorskip("loky")
+    if map is mpi_pmap:
+        pytest.importorskip("mpi4py")
 
     with pytest.raises(MapExceptions) as err:
         map(func, range(10), map_kw={"fail_fast": False})
@@ -122,11 +135,14 @@ def test_map_store_error(map):
 @pytest.mark.parametrize('map', [
     pytest.param(parallel_map, id='parallel_map'),
     pytest.param(loky_pmap, id='loky_pmap'),
+    pytest.param(mpi_pmap, id='mpi_pmap'),
     pytest.param(serial_map, id='serial_map'),
 ])
 def test_map_early_end(map):
     if map is loky_pmap:
-        loky = pytest.importorskip("loky")
+        pytest.importorskip("loky")
+    if map is mpi_pmap:
+        pytest.importorskip("mpi4py")
 
     results = []
 


### PR DESCRIPTION
**Summary**
This change adds `mpi_pmap` to qutip.parallel. It is an analogue of `parallel_map` that can run parallel computations on multiple CPUs (e.g., multiple supercomputer nodes) at the same time by using the MPI (message passing interface) API. We make use of the mpi4py module and its MPIPoolExecutor class. That is, parallel_map and mpi_pmap are basically the same, except that the `multiprocessing.ProcessPoolExecutor` gets replaced by the `mpi4py.MPIPoolExecutor`, and we allow users to provide arbitrary keyword arguments to be passed on to the MPIPoolExecutor.

**Detailed list of changes**
* Added `mpi_pmap`. Extracted the common functionality of parallel_map, loky_pmap and mpi_pmap into a `_generic_pmap` function. The behavior of parallel_map and loky_pmap should be unchanged (except for a tiny change in loky_pmap regarding the order in which reduce_func is called).
* Added a section showcasing QuTiP's MPI capabilities in the tutorial notebook "Non-Markovian Monte Carlo Solver", see PR [[TODO]] in qutip-tutorials.
* Added `mpi_options` to the options of MultiTrajSolver and all its subclasses. This option only takes effect if the 'map' option is set to 'mpi', in which case the mpi_options are added to the map_kwargs.
* For MultiTrajSolver, all its subclasses and corresponding XXsolve functions, I double-checked that the descriptions of the options in the docstrings correspond to the `solver_options`. That is, I did not touch the solver options except for adding 'mpi_options', but I edited the docstrings in some places in order to reflect the actually available solver options.
* While creating the new section in the tutorial notebook, I noticed some bugs in MultiTrajResult#__add__ and fixed them.
* Added tests. Tests are skipped if the mpi4py module is not available (like with loky_pmap and the loky module).

**Todo**
Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](http://qutip.org/docs/latest/development/contributing.html#changelog-generation) for more information).

**Related issues or PRs**
Continuing work started in [2280](https://github.com/qutip/qutip/pull/2280)