### PR TITLE
Update to fix scipy1.12 deprecation warnings

### DIFF
--- a/qutip/cy/stochastic.pyx
+++ b/qutip/cy/stochastic.pyx
@@ -19,7 +19,7 @@ import scipy
 from packaging.version import parse as _parse_version
 
 
-NEW_SCIPY = _parse_version(scipy.__version__) >= _parse_version("1.12")
+SCIPY_GT_1_12 = _parse_version(scipy.__version__) >= _parse_version("1.12")
 
 
 cdef int ZERO=0
@@ -1238,7 +1238,7 @@ cdef class SSESolver(StochasticSolver):
             self.imp = LinearOperator( (self.l_vec,self.l_vec),
                                       matvec=self.implicit_op, dtype=complex)
             self.imp_options = {"tol": sso.tol, "atol": 1e-12}
-            if NEW_SCIPY:
+            if SCIPY_GT_1_12:
                 self.imp_options["rtol"] = self.imp_options.pop("tol")
 
     def implicit_op(self, vec):
@@ -1648,7 +1648,7 @@ cdef class SMESolver(StochasticSolver):
             self.tol = sso.tol
             self.imp = sso.imp
             self.imp_options = {"tol": sso.tol, "atol": 1e-12}
-            if NEW_SCIPY:
+            if SCIPY_GT_1_12:
                 self.imp_options["rtol"] = self.imp_options.pop("tol")
 
     cdef void _normalize_inplace(self, complex[::1] vec):

--- a/qutip/steadystate.py
+++ b/qutip/steadystate.py
@@ -53,6 +53,20 @@ def _eat_kwargs(function, names):
     return out
 
 
+def _rename_kwargs(function, names_pairs):
+    """
+    Return a wrapped version of `function` that rename any keyword
+    arguments from the first value of the pair, to the second.
+    """
+    @functools.wraps(function)
+    def out(*args, **kwargs):
+        for old, new in names_pairs:
+            if old in kwargs:
+                kwargs[new] = kwargs.pop(old)
+        return function(*args, **kwargs)
+    return out
+
+
 # From SciPy 1.4 onwards we need to pass the `callback_type='legacy'` argument
 # to gmres to maintain the same behaviour we used to have.  Since this should
 # be the default behaviour, we use that in the main code and just "eat" the
@@ -67,6 +81,14 @@ if _parse_version(scipy.__version__) < _parse_version("1.1"):
     bicgstab = _eat_kwargs(bicgstab, ['atol'])
 elif _parse_version(scipy.__version__) < _parse_version("1.4"):
     gmres = _eat_kwargs(gmres, ['callback_type'])
+
+
+# From SciPy 1.12, the `tol` keyword argument to iterative solvers was renamed
+# to `rtol`.
+if _parse_version(scipy.__version__) >= _parse_version("1.12"):
+    gmres = _rename_kwargs(gmres, [('tol', 'rtol')])
+    lgmres = _rename_kwargs(lgmres, [('tol', 'rtol')])
+    bicgstab = _rename_kwargs(bicgstab, [('tol', 'rtol')])
 
 
 def _empty_info_dict():


### PR DESCRIPTION
**Description**
Scipy 1.12 changed parameter `tol` to `rtol` in sparse solver, with a deprecation warnings.
We already filter parameters for these function in steadystate, so I added another layer.
Also fixed it in stochastic implicit methods.