### PR TITLE
Add the possibility to customize point colors as in V4

### DIFF
--- a/doc/changes/1974.bugfix
+++ b/doc/changes/1974.bugfix
@@ -1,0 +1,1 @@
+Add the possibility to customize point colors as in V4 and fix point plot behavior for 'l' style

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -794,7 +794,6 @@ class Bloch:
             dist = np.linalg.norm(points, axis=0)
             if not np.allclose(dist, dist[0], rtol=1e-12):
                 indperm = np.argsort(dist)
-                points = points[:, indperm]
             else:
                 indperm = np.arange(num_points)
 
@@ -817,9 +816,9 @@ class Bloch:
                 color = list(color)
 
             if self.point_style[k] in ['s', 'm']:
-                self.axes.scatter(np.real(points[1]),
-                                  -np.real(points[0]),
-                                  np.real(points[2]),
+                self.axes.scatter(np.real(points[1][indperm]),
+                                  -np.real(points[0][indperm]),
+                                  np.real(points[2][indperm]),
                                   s=s,
                                   marker=marker,
                                   color=color,

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -169,8 +169,10 @@ class Bloch:
         # ---point options---
         # List of colors for Bloch point markers, default = ['b','g','r','y']
         self.point_default_color = ['b', 'r', 'g', '#CC6600']
+        # Old variable used in V4 to customise the color of the points
+        self.point_color = None
         # List that stores the display colors for each set of points
-        self.point_color = []
+        self.inner_point_color = []
         # Size of point markers, default = 25
         self.point_size = [25, 32, 35, 45]
         # Shape of point markers, default = ['o','^','d','s']
@@ -360,7 +362,7 @@ class Bloch:
         self.point_style.append(meth)
         self.points.append(points)
         self.point_alpha.append(alpha)
-        self.point_color.append(colors)
+        self.inner_point_color.append(colors)
 
     def add_states(self, state, kind='vector', colors=None, alpha=1.0):
         """Add a state vector Qobj to Bloch sphere.
@@ -799,12 +801,15 @@ class Bloch:
             s = self.point_size[np.mod(k, len(self.point_size))]
             marker = self.point_marker[np.mod(k, len(self.point_marker))]
             style = self.point_style[k]
-            if self.point_color[k] is not None:
-                color = self.point_color[k]
+
+            if self.inner_point_color[k] is not None:
+                color = self.inner_point_color[k]
+            elif self.point_color is not None:
+                color = self.point_color
             elif self.point_style[k] in ['s', 'l']:
-                color = self.point_default_color[
+                color = [self.point_default_color[
                     k % len(self.point_default_color)
-                ]
+                ]]
             elif self.point_style[k] == 'm':
                 length = np.ceil(num_points/len(self.point_default_color))
                 color = np.tile(self.point_default_color, length.astype(int))
@@ -824,6 +829,7 @@ class Bloch:
                                   )
 
             elif self.point_style[k] == 'l':
+                color = color[k % len(color)]
                 self.axes.plot(np.real(points[1]),
                                -np.real(points[0]),
                                np.real(points[2]),

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -172,7 +172,7 @@ class Bloch:
         # Old variable used in V4 to customise the color of the points
         self.point_color = None
         # List that stores the display colors for each set of points
-        self.inner_point_color = []
+        self._inner_point_color = []
         # Size of point markers, default = 25
         self.point_size = [25, 32, 35, 45]
         # Shape of point markers, default = ['o','^','d','s']
@@ -362,7 +362,7 @@ class Bloch:
         self.point_style.append(meth)
         self.points.append(points)
         self.point_alpha.append(alpha)
-        self.inner_point_color.append(colors)
+        self._inner_point_color.append(colors)
 
     def add_states(self, state, kind='vector', colors=None, alpha=1.0):
         """Add a state vector Qobj to Bloch sphere.
@@ -801,8 +801,8 @@ class Bloch:
             marker = self.point_marker[np.mod(k, len(self.point_marker))]
             style = self.point_style[k]
 
-            if self.inner_point_color[k] is not None:
-                color = self.inner_point_color[k]
+            if self._inner_point_color[k] is not None:
+                color = self._inner_point_color[k]
             elif self.point_color is not None:
                 color = self.point_color
             elif self.point_style[k] in ['s', 'l']:


### PR DESCRIPTION
**Description**
Allow V5 to accept customization of point colors as it did in V4. To keep the changes implemented in V5, I have created a new variable to store the colors that are applied to the points (_inner_point_color_), so in total we now have three variables:

_inner_point_color_: Defined as an argument in the _add_points_ function, this variable takes precedence over the others.
_point_color_: This variable stores a list of colors, reminiscent of V4, and is utilized when _inner_point_color_ is not specified.
_point_default_color_: A list of colors that serves as the default when neither of the other variables is defined

**Related issues or PRs**
fix #1974 