### PR TITLE
Update test matrix to include python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           # For the sdist we should be as conservative as possible with our
           # Python version.  This should be the lowest supported version.  This
           # means that no unsupported syntax can sneak through.
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Install pip build
         run: |
@@ -107,11 +107,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      # Set up wheels matrix.  This is CPython 3.8--3.10 for all OS targets.
-      CIBW_BUILD: "cp3{8,9,10,11}-*"
+      # Set up wheels matrix.  This is CPython 3.10--3.12 for all OS targets.
+      CIBW_BUILD: "cp3{10,11,12}-*"
       # Numpy and SciPy do not supply wheels for i686 or win32 for
       # Python 3.10+, so we skip those:
-      CIBW_SKIP: "*-musllinux* cp3{8,9,10,11}-manylinux_i686 cp3{8,9,10,11}-win32"
+      CIBW_SKIP: "*-musllinux* cp3{10,11,12}-manylinux_i686 cp3{10,11,12}-win32"
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
@@ -165,12 +165,12 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp38-cp38-manylinux*.whl
+          python -m pip install wheels/*-cp310-cp310-manylinux*.whl
           python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on
@@ -198,12 +198,12 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp38-cp38-manylinux*.whl
+          python -m pip install wheels/*-cp310-cp310-manylinux*.whl
           python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           # For the sdist we should be as conservative as possible with our
           # Python version.  This should be the lowest supported version.  This
           # means that no unsupported syntax can sneak through.
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Install pip build
         run: |
@@ -107,8 +107,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      # Set up wheels matrix.  This is CPython 3.10--3.12 for all OS targets.
-      CIBW_BUILD: "cp3{10,11,12}-*"
+      # Set up wheels matrix.  This is CPython 3.9--3.12 for all OS targets.
+      CIBW_BUILD: "cp3{9,10,11,12}-*"
       # Numpy and SciPy do not supply wheels for i686 or win32 for
       # Python 3.10+, so we skip those:
       CIBW_SKIP: "*-musllinux* cp3{10,11,12}-manylinux_i686 cp3{10,11,12}-win32"
@@ -121,7 +121,7 @@ jobs:
         name: Install Python
         with:
           # This is about the build environment, not the released wheel version.
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install cibuildwheel
         run: |
@@ -165,12 +165,12 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp310-cp310-manylinux*.whl
+          python -m pip install wheels/*-cp39-cp39-manylinux*.whl
           python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on
@@ -198,12 +198,12 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp310-cp310-manylinux*.whl
+          python -m pip install wheels/*-cp39-cp39-manylinux*.whl
           python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,29 +43,30 @@ jobs:
           - case-name: Old setup
             os: ubuntu-latest
             python-version: "3.9"
-            numpy-requirement: ">=1.22,<1.23"
             scipy-requirement: ">=1.8,<1.9"
+            numpy-requirement: ">=1.22,<1.23"
             condaforge: 1
             oldcython: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
 
-          # Python 3.10, no cython, oldist dependencies
-          - case-name: no cython
+          # Python 3.10, no mkl, scipy 1.9, numpy 1.23
+          # Scipy 1.10 did not support cython 3.0 yet.
+          - case-name: no mkl
             os: ubuntu-latest
             python-version: "3.10"
             scipy-requirement: ">=1.9,<1.10"
             numpy-requirement: ">=1.23,<1.24"
             condaforge: 1
-            nocython: 1
+            oldcython: 1
+            nomkl: 1
 
-          # Python 3.10, no mkl
+          # Python 3.10, no cython, scipy 1.10, numpy 1.24
           - case-name: no mkl
             os: ubuntu-latest
             python-version: "3.10"
             scipy-requirement: ">=1.10,<1.11"
             numpy-requirement: ">=1.24,<1.25"
-            condaforge: 1
-            nomkl: 1
+            nocython: 1
 
           # Mac
           # Mac has issues with MKL since september 2022.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,8 @@ jobs:
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
 
           # Python 3.10, no mkl, scipy 1.9, numpy 1.23
-          # Scipy 1.10 did not support cython 3.0 yet.
+          # Scipy 1.9 did not support cython 3.0 yet.
+          # cython#17234
           - case-name: no mkl
             os: ubuntu-latest
             python-version: "3.10"
@@ -59,9 +60,10 @@ jobs:
             condaforge: 1
             oldcython: 1
             nomkl: 1
+            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
 
           # Python 3.10, no cython, scipy 1.10, numpy 1.24
-          - case-name: no mkl
+          - case-name: no cython
             os: ubuntu-latest
             python-version: "3.10"
             scipy-requirement: ">=1.10,<1.11"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,47 +36,43 @@ jobs:
         # the lack of a variable is _always_ false-y, and the defaults lack all
         # the special cases.
         include:
+          # Python 3.10, Scipy 1.8, numpy 1.23
+          # Oldest version we have to support according to SPEC 0
+          # https://scientific-python.org/specs/spec-0000/
+          - case-name: Old setup
+            os: ubuntu-latest
+            python-version: "3.10"
+            numpy-requirement: ">=1.23,<1.24"
+            scipy-requirement: ">=1.8,<1.9"
+            condaforge: 1
+            oldcython: 1
+            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
+
+          # Python 3.10, no mkl, no cython
+          - case-name: Python 3.10, no mkl
+            os: ubuntu-latest
+            python-version: "3.10"
+            condaforge: 1
+            nomkl: 1
+            nocython: 1
+
           # Mac
           # Mac has issues with MKL since september 2022.
           - case-name: macos
             os: macos-latest
-            python-version: "3.10"
+            python-version: "3.11"
             condaforge: 1
             nomkl: 1
 
-          # Scipy 1.5
-          - case-name: old SciPy
-            os: ubuntu-latest
-            python-version: "3.8"
-            numpy-requirement: ">=1.20,<1.21"
-            scipy-requirement: ">=1.5,<1.6"
-            condaforge: 1
-            oldcython: 1
-            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
-
-          # No MKL runs.  MKL is now the default for conda installations, but
-          # not necessarily for pip.
-          - case-name: no MKL
-            os: ubuntu-latest
-            python-version: "3.9"
-            numpy-requirement: ">=1.20,<1.21"
-            nomkl: 1
-
-          # Builds without Cython at runtime.  This is a core feature;
-          # everything should be able to run this.
-          - case-name: no Cython
-            os: ubuntu-latest
-            python-version: "3.8"
-            nocython: 1
-
-          # Python 3.10 and numpy 1.22
-          # Use conda-forge to provide numpy 1.22
-          - case-name: Python 3.10
-            os: ubuntu-latest
-            python-version: "3.10"
-            condaforge: 1
-            oldcython: 1
-            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
+          # Windows. Once all tests pass without special options needed, this
+          # can be moved to the main os list in the test matrix. All the tests
+          # that fail currently seem to do so because mcsolve uses
+          # multiprocessing under the hood. Windows does not support fork()
+          # well, which makes transfering objects to the child processes
+          # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
+          - case-name: Windows
+            os: windows-latest
+            python-version: "3.11"
 
           # Python 3.11 and latest numpy
           # Use conda-forge to provide Python 3.11 and latest numpy
@@ -91,15 +87,13 @@ jobs:
             conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
             pytest-extra-options: "-W ignore::DeprecationWarning:Cython.Tempita"
 
-          # Windows. Once all tests pass without special options needed, this
-          # can be moved to the main os list in the test matrix. All the tests
-          # that fail currently seem to do so because mcsolve uses
-          # multiprocessing under the hood. Windows does not support fork()
-          # well, which makes transfering objects to the child processes
-          # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
-          - case-name: Windows Latest
-            os: windows-latest
-            python-version: "3.10"
+          # Python 3.12 and latest numpy
+          # Use conda-forge to provide Python 3.11 and latest numpy
+          - case-name: Python 3.12
+            os: ubuntu-latest
+            python-version: "3.12"
+            condaforge: 1
+
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,34 +27,45 @@ jobs:
         os: [ubuntu-latest]
         # Test other versions of Python in special cases to avoid exploding the
         # matrix size; make sure to test all supported versions in some form.
-        python-version: ["3.9"]
+        python-version: ["3.11"]
         case-name: [defaults]
-        numpy-requirement: [">=1.20,<1.21"]
+        numpy-requirement: [">=1.22,<1.27"]
+        scipy-requirement: [">=1.8,<1.12"]
         coverage-requirement: ["==6.5"]
         # Extra special cases.  In these, the new variable defined should always
         # be a truth-y value (hence 'nomkl: 1' rather than 'mkl: 0'), because
         # the lack of a variable is _always_ false-y, and the defaults lack all
         # the special cases.
         include:
-          # Python 3.10, Scipy 1.8, numpy 1.23
-          # Oldest version we have to support according to SPEC 0
+          # Python 3.9, Scipy 1.7, numpy 1.22
+          # On more version than suggested by SPEC 0
           # https://scientific-python.org/specs/spec-0000/
           - case-name: Old setup
             os: ubuntu-latest
-            python-version: "3.10"
-            numpy-requirement: ">=1.23,<1.24"
+            python-version: "3.9"
+            numpy-requirement: ">=1.22,<1.23"
             scipy-requirement: ">=1.8,<1.9"
             condaforge: 1
             oldcython: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
 
-          # Python 3.10, no mkl, no cython
+          # Python 3.10, no cython, oldist dependencies
+          - case-name: Python 3.10, no cython
+            os: ubuntu-latest
+            python-version: "3.10"
+            scipy-requirement: ">=1.9,<1.10"
+            numpy-requirement: ">=1.23,<1.24"
+            condaforge: 1
+            nocython: 1
+
+          # Python 3.10, no mkl
           - case-name: Python 3.10, no mkl
             os: ubuntu-latest
             python-version: "3.10"
+            scipy-requirement: ">=1.10,<1.11"
+            numpy-requirement: ">=1.24,<1.25"
             condaforge: 1
             nomkl: 1
-            nocython: 1
 
           # Mac
           # Mac has issues with MKL since september 2022.
@@ -74,7 +85,7 @@ jobs:
             os: windows-latest
             python-version: "3.11"
 
-          # Python 3.11 and latest numpy
+          # Python 3.11 and recent numpy
           # Use conda-forge to provide Python 3.11 and latest numpy
           # Ignore deprecation of the cgi module in Python 3.11 that is
           # still imported by Cython.Tempita. This was addressed in
@@ -84,8 +95,10 @@ jobs:
             os: ubuntu-latest
             python-version: "3.11"
             condaforge: 1
+            numpy-requirement: ">=1.25,<1.26"
+            scipy-requirement: ">=1.11,<1.12"
             conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
-            pytest-extra-options: "-W ignore::DeprecationWarning:Cython.Tempita"
+            # pytest-extra-options: "-W ignore::DeprecationWarning:Cython.Tempita"
 
           # Python 3.12 and latest numpy
           # Use conda-forge to provide Python 3.11 and latest numpy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,8 @@ jobs:
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.11"]
         case-name: [defaults]
-        numpy-requirement: [">=1.22,<1.27"]
-        scipy-requirement: [">=1.8,<1.12"]
+        numpy-requirement: [">=1.22"]
+        scipy-requirement: [">=1.8"]
         coverage-requirement: ["==6.5"]
         # Extra special cases.  In these, the new variable defined should always
         # be a truth-y value (hence 'nomkl: 1' rather than 'mkl: 0'), because
@@ -40,6 +40,7 @@ jobs:
           # Python 3.9, Scipy 1.7, numpy 1.22
           # On more version than suggested by SPEC 0
           # https://scientific-python.org/specs/spec-0000/
+          # There are deprecation warnings when using cython 0.29.X
           - case-name: Old setup
             os: ubuntu-latest
             python-version: "3.9"
@@ -70,6 +71,30 @@ jobs:
             numpy-requirement: ">=1.24,<1.25"
             nocython: 1
 
+          # Python 3.11 and recent numpy
+          # Use conda-forge to provide Python 3.11 and latest numpy
+          # Ignore deprecation of the cgi module in Python 3.11 that is
+          # still imported by Cython.Tempita. This was addressed in
+          # https://github.com/cython/cython/pull/5128 but not backported
+          # to any currently released version.
+          - case-name: Python 3.11
+            os: ubuntu-latest
+            python-version: "3.11"
+            condaforge: 1
+            scipy-requirement: ">=1.11,<1.12"
+            numpy-requirement: ">=1.25,<1.26"
+            conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
+
+          # Python 3.12 and latest numpy
+          # Use conda-forge to provide Python 3.11 and latest numpy
+          - case-name: Python 3.12
+            os: ubuntu-latest
+            python-version: "3.12"
+            scipy-requirement: ">=1.12,<1.13"
+            numpy-requirement: ">=1.26,<1.27"
+            condaforge: 1
+            pytest-extra-options: "-W ignore:datetime:DeprecationWarning"
+
           # Mac
           # Mac has issues with MKL since september 2022.
           - case-name: macos
@@ -87,29 +112,6 @@ jobs:
           - case-name: Windows
             os: windows-latest
             python-version: "3.11"
-
-          # Python 3.11 and recent numpy
-          # Use conda-forge to provide Python 3.11 and latest numpy
-          # Ignore deprecation of the cgi module in Python 3.11 that is
-          # still imported by Cython.Tempita. This was addressed in
-          # https://github.com/cython/cython/pull/5128 but not backported
-          # to any currently released version.
-          - case-name: Python 3.11
-            os: ubuntu-latest
-            python-version: "3.11"
-            condaforge: 1
-            numpy-requirement: ">=1.25,<1.26"
-            scipy-requirement: ">=1.11,<1.12"
-            conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
-
-          # Python 3.12 and latest numpy
-          # Use conda-forge to provide Python 3.11 and latest numpy
-          - case-name: Python 3.12
-            os: ubuntu-latest
-            python-version: "3.12"
-            condaforge: 1
-            pytest-extra-options: "-W ignore:datetime:DeprecationWarning"
-
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
 
           # Python 3.10, no cython, oldist dependencies
-          - case-name: Python 3.10, no cython
+          - case-name: no cython
             os: ubuntu-latest
             python-version: "3.10"
             scipy-requirement: ">=1.9,<1.10"
@@ -59,7 +59,7 @@ jobs:
             nocython: 1
 
           # Python 3.10, no mkl
-          - case-name: Python 3.10, no mkl
+          - case-name: no mkl
             os: ubuntu-latest
             python-version: "3.10"
             scipy-requirement: ">=1.10,<1.11"
@@ -98,7 +98,6 @@ jobs:
             numpy-requirement: ">=1.25,<1.26"
             scipy-requirement: ">=1.11,<1.12"
             conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
-            # pytest-extra-options: "-W ignore::DeprecationWarning:Cython.Tempita"
 
           # Python 3.12 and latest numpy
           # Use conda-forge to provide Python 3.11 and latest numpy
@@ -106,6 +105,7 @@ jobs:
             os: ubuntu-latest
             python-version: "3.12"
             condaforge: 1
+            pytest-extra-options: "-W ignore:datetime:DeprecationWarning"
 
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     # See https://numpy.org/doc/stable/user/depending_on_numpy.html for
     # the recommended way to build against numpy's C API:
     "oldest-supported-numpy",
-    "scipy>=1.0",
+    "scipy>=1.8",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -17,12 +17,6 @@ manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 # Change in future version to "build"
 build-frontend = "pip"
-
-[[tool.cibuildwheel.overrides]]
-# NumPy and SciPy support manylinux2010 on CPython 3.6 and 3.7
-select = "cp3{6,7}-*"
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
 
 [tool.towncrier]
 directory = "doc/changes"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython>=0.29.20
-numpy>=1.16.6
-scipy>=1.5
+numpy>=1.22
+scipy>=1.8
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,12 @@ packages = find:
 include_package_data = True
 zip_safe = False
 install_requires =
-    numpy>=1.16.6
-    scipy>=1.0
+    numpy>=1.22,<1.26
+    scipy>=1.8,<1.12
     packaging
 setup_requires =
-    numpy>=1.13.3
-    scipy>=1.0
+    numpy>=1.22
+    scipy>=1.8
     cython>=0.29.20; python_version>='3.10'
     cython>=0.29.20,<3.0.3; python_version<='3.9'
     packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,11 +31,11 @@ packages = find:
 include_package_data = True
 zip_safe = False
 install_requires =
-    numpy>=1.22,<1.26
+    numpy>=1.22
     scipy>=1.8,<1.12
     packaging
 setup_requires =
-    numpy>=1.22
+    numpy>=1.19
     scipy>=1.8
     cython>=0.29.20; python_version>='3.10'
     cython>=0.29.20,<3.0.3; python_version<='3.9'


### PR DESCRIPTION
**Description**
Updated the test matrix, removing test using older version of python, scipy and numpy to add new versions.
Matrix include all python versions from 3.9 to 3.12, all scipy from 1.8 to 1.12, all numpy from 1.22 to 1.26.
I keep test with no cython, cython 0.X and 3.X. With and without mkl and all 3 os.

Added python 3.12 to the list of build wheels, but removed 3.8.

Increase minimum version of scipy and numpy in requirement to match those we actually tests.