### PR TITLE
Ensure tests can pass without ipython and matplotlib

### DIFF
--- a/doc/changes/2311.misc
+++ b/doc/changes/2311.misc
@@ -1,0 +1,1 @@
+Allow tests to run without matplotlib and ipython.

--- a/qutip/tests/test_animation.py
+++ b/qutip/tests/test_animation.py
@@ -1,9 +1,10 @@
 import pytest
 import qutip
 import numpy as np
-import matplotlib as mpl
-import matplotlib.pyplot as plt
 from scipy.special import sph_harm
+
+mpl = pytest.importorskip("matplotlib")
+plt = pytest.importorskip("matplotlib.pyplot")
 
 def test_result_state():
     H = qutip.rand_dm(2)

--- a/qutip/tests/test_ipynbtools.py
+++ b/qutip/tests/test_ipynbtools.py
@@ -1,6 +1,7 @@
-from qutip.ipynbtools import version_table
 import pytest
+pytest.importorskip("IPython")
 
+from qutip.ipynbtools import version_table
 
 @pytest.mark.parametrize('verbose', [False, True])
 def test_version_table(verbose):

--- a/qutip/tests/test_visualization.py
+++ b/qutip/tests/test_visualization.py
@@ -1,10 +1,10 @@
 import pytest
 import qutip
 import numpy as np
-import matplotlib as mpl
-import matplotlib.pyplot as plt
 from scipy.special import sph_harm
 
+mpl = pytest.importorskip("matplotlib")
+plt = pytest.importorskip("matplotlib.pyplot")
 
 def test_cyclic():
     qutip.settings.colorblind_safe = True


### PR DESCRIPTION
**Description**
Tests would fail to run if `matplotlib` or `ipython` were not installed.
This add `pytest.importskip` to skip instead or failing the the packages are missing.