### PR TITLE
Bug.warnings stochastic

### DIFF
--- a/doc/changes/2313.misc
+++ b/doc/changes/2313.misc
@@ -1,0 +1,1 @@
+Add too small step warnings in fixed dt SODE solver

--- a/qutip/solver/sode/rouchon.py
+++ b/qutip/solver/sode/rouchon.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 from qutip import unstack_columns, stack_columns
 from qutip.core import data as _data
 from ..stochastic import StochasticSolver
@@ -97,12 +98,16 @@ class RouchonSODE(SIntegrator):
 
     def integrate(self, t, copy=True):
         delta_t = (t - self.t)
+        dt = self.options["dt"]
         if delta_t < 0:
             raise ValueError("Stochastic integration need increasing times")
-        elif delta_t == 0:
-            return self.t, self.state, np.zeros()
+        elif delta_t < 0.5 * dt:
+            warnings.warn(
+                f"Step under minimum step ({dt}), skipped.",
+                RuntimeWarning
+            )
+            return self.t, self.state, np.zeros(len(self.sc_ops))
 
-        dt = self.options["dt"]
         N, extra = np.divmod(delta_t, dt)
         N = int(N)
         if extra > 0.5 * dt:

--- a/qutip/solver/sode/sode.py
+++ b/qutip/solver/sode/sode.py
@@ -146,7 +146,6 @@ class _Explicit_Simple_Integrator(SIntegrator):
             )
             return self.t, self.state, np.zeros(self.N_dw)
 
-
         N, extra = np.divmod(delta_t, dt)
         N = int(N)
         if extra > 0.5 * dt:

--- a/qutip/solver/sode/sode.py
+++ b/qutip/solver/sode/sode.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 from . import _sode
 from ..integrator.integrator import Integrator
 from ..stochastic import StochasticSolver, SMESolver
@@ -135,12 +136,17 @@ class _Explicit_Simple_Integrator(SIntegrator):
 
     def integrate(self, t, copy=True):
         delta_t = t - self.t
+        dt = self.options["dt"]
         if delta_t < 0:
-            raise ValueError("Stochastic integration time")
-        elif delta_t == 0:
+            raise ValueError("Integration time, can't be negative.")
+        elif delta_t < 0.5 * dt:
+            warnings.warn(
+                f"Step under minimum step ({dt}), skipped.",
+                RuntimeWarning
+            )
             return self.t, self.state, np.zeros(self.N_dw)
 
-        dt = self.options["dt"]
+
         N, extra = np.divmod(delta_t, dt)
         N = int(N)
         if extra > 0.5 * dt:

--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -348,23 +348,23 @@ def test_feedback():
 
 def test_deprecation_warnings():
     with pytest.warns(FutureWarning, match=r'map_func'):
-        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], map_func=None)
+        ssesolve(qeye(2), basis(2), [0, 0.01], [qeye(2)], map_func=None)
 
     with pytest.warns(FutureWarning, match=r'progress_bar'):
-        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], progress_bar=None)
+        ssesolve(qeye(2), basis(2), [0, 0.01], [qeye(2)], progress_bar=None)
 
     with pytest.warns(FutureWarning, match=r'nsubsteps'):
-        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], nsubsteps=None)
+        ssesolve(qeye(2), basis(2), [0, 0.01], [qeye(2)], nsubsteps=None)
 
     with pytest.warns(FutureWarning, match=r'map_func'):
-        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], map_func=None)
+        ssesolve(qeye(2), basis(2), [0, 0.01], [qeye(2)], map_func=None)
 
     with pytest.warns(FutureWarning, match=r'store_all_expect'):
-        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], store_all_expect=1)
+        ssesolve(qeye(2), basis(2), [0, 0.01], [qeye(2)], store_all_expect=1)
 
     with pytest.warns(FutureWarning, match=r'store_measurement'):
-        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], store_measurement=1)
+        ssesolve(qeye(2), basis(2), [0, 0.01], [qeye(2)], store_measurement=1)
 
     with pytest.raises(TypeError) as err:
-        ssesolve(qeye(2), basis(2), [0, 1e-5], [qeye(2)], m_ops=1)
+        ssesolve(qeye(2), basis(2), [0, 0.01], [qeye(2)], m_ops=1)
     assert '"m_ops" and "dW_factors"' in str(err.value)

--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -368,3 +368,7 @@ def test_deprecation_warnings():
     with pytest.raises(TypeError) as err:
         ssesolve(qeye(2), basis(2), [0, 0.01], [qeye(2)], m_ops=1)
     assert '"m_ops" and "dW_factors"' in str(err.value)
+
+def test_small_step_warnings():
+    with pytest.warns(RuntimeWarning, match=r'under minimum'):
+        ssesolve(qeye(2), basis(2), [0, 0.0000001], [qeye(2)])

--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -369,6 +369,11 @@ def test_deprecation_warnings():
         ssesolve(qeye(2), basis(2), [0, 0.01], [qeye(2)], m_ops=1)
     assert '"m_ops" and "dW_factors"' in str(err.value)
 
-def test_small_step_warnings():
+
+@pytest.mark.parametrize("method", ["euler", "rouchon"])
+def test_small_step_warnings(method):
     with pytest.warns(RuntimeWarning, match=r'under minimum'):
-        ssesolve(qeye(2), basis(2), [0, 0.0000001], [qeye(2)])
+        smesolve(
+            qeye(2), basis(2), [0, 0.0000001], [qeye(2)],
+            options={"method": method}
+        )


### PR DESCRIPTION
**Description**
Fix failing `test_stochastic.test_deprecation_warnings`.
It used to catch the first warnings, the one we tested for, and stop.
An update in pytest, made it continue to catch another warning (step rounded to 0) later and failing.

This PR fix the test to raise only the desired warnings.
It add a warnings for when the step in rounded to 0 and a test for that warning.