### PR TITLE
Remove mpi from full and update versions

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -10,9 +10,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: 'openmpi'
 
       - uses: actions/setup-python@v4
         name: Install Python

--- a/doc/rtd-environment.yml
+++ b/doc/rtd-environment.yml
@@ -8,7 +8,7 @@ dependencies:
 - certifi==2022.12.7
 - chardet==4.0.0
 - cycler==0.10.0
-- Cython==0.29.33
+- Cython==3.0.8
 - decorator==5.1.1
 - docutils==0.18.1
 - idna==3.4
@@ -19,7 +19,7 @@ dependencies:
 - kiwisolver==1.4.4
 - MarkupSafe==2.1.2
 - matplotlib==3.7.1
-- numpy==1.24.2
+- numpy==1.25.2
 - numpydoc==1.5.0
 - packaging==23.0
 - parso==0.8.3
@@ -33,7 +33,7 @@ dependencies:
 - python-dateutil==2.8.2
 - pytz==2023.3
 - requests==2.28.2
-- scipy==1.10.1
+- scipy==1.11.4
 - six==1.16.0
 - snowballstemmer==2.2.0
 - Sphinx==6.1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,4 +72,3 @@ full =
     %(tests)s
     %(ipython)s
     %(extras)s
-    %(mpi)s


### PR DESCRIPTION
**Description**
Removed `mpi4py` from `full`. 
It is hard to install locally (for the users) and in readthedocs, where it is not actually used (#2317).

I am not sure what it is the best practice for this. `full` should normally include every optional dependency, but mpi4py is too specialized and not useful for most users. If it makes qutip harder to install since `pip install qutip[full]` would fail for most, maybe it's better to leave it out.

Also updated some versions.