### PR TITLE
Add dtype to QobjEvo and use it in `qeye_like`

### DIFF
--- a/doc/changes/2325.misc
+++ b/doc/changes/2325.misc
@@ -1,0 +1,1 @@
+Add `dtype` to `Qobj` and `QobjEvo`

--- a/qutip/core/cy/_element.pyx
+++ b/qutip/core/cy/_element.pyx
@@ -267,6 +267,10 @@ cdef class _BaseElement:
             return new.qobj(t) * new.coeff(t)
         return self.qobj(t) * self.coeff(t)
 
+    @property
+    def dtype(self):
+        return None
+
 
 cdef class _ConstantElement(_BaseElement):
     """
@@ -312,6 +316,10 @@ cdef class _ConstantElement(_BaseElement):
 
     def __call__(self, t, args=None):
         return self._qobj
+
+    @property
+    def dtype(self):
+        return type(self._data)
 
 
 cdef class _EvoElement(_BaseElement):
@@ -369,6 +377,10 @@ cdef class _EvoElement(_BaseElement):
             self._qobj,
             self._coefficient.replace_arguments(args)
         )
+
+    @property
+    def dtype(self):
+        return type(self._data)
 
 
 cdef class _FuncElement(_BaseElement):

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -947,6 +947,21 @@ cdef class QobjEvo:
         """Indicates if the system represents a operator-bra state."""
         return self._dims.type == 'operator-bra'
 
+    @property
+    def dtype(self):
+        """
+        Type of the data layers of the QobjEvo.
+        When different data layers are used, we return the type of the sum of
+        the parts.
+        """
+        part_types = [part.dtype for part in self.elements]
+        if (
+            part_types[0] is not None
+            and all(part == part_types[0] for part in part_types)
+        ):
+            return part_types[0]
+        return self(0).dtype
+
     ###########################################################################
     # operation methods                                                       #
     ###########################################################################

--- a/qutip/core/data/constant.py
+++ b/qutip/core/data/constant.py
@@ -96,7 +96,7 @@ def identity_like_data(data, /):
     Create an identity matrix of the same type and shape.
     """
     if not data.shape[0] == data.shape[1]:
-        raise ValueError("Can't create and identity like a non square matrix.")
+        raise ValueError("Can't create an identity matrix like a non square matrix.")
     return identity[type(data)](data.shape[0])
 
 
@@ -105,7 +105,7 @@ def identity_like_dense(data, /):
     Create an identity matrix of the same type and shape.
     """
     if not data.shape[0] == data.shape[1]:
-        raise ValueError("Can't create and identity like a non square matrix.")
+        raise ValueError("Can't create an identity matrix like a non square matrix.")
     return dense.identity(data.shape[0], fortran=data.fortran)
 
 

--- a/qutip/core/data/constant.py
+++ b/qutip/core/data/constant.py
@@ -96,7 +96,9 @@ def identity_like_data(data, /):
     Create an identity matrix of the same type and shape.
     """
     if not data.shape[0] == data.shape[1]:
-        raise ValueError("Can't create an identity matrix like a non square matrix.")
+        raise ValueError(
+            "Can't create an identity matrix like a non square matrix."
+        )
     return identity[type(data)](data.shape[0])
 
 
@@ -105,7 +107,9 @@ def identity_like_dense(data, /):
     Create an identity matrix of the same type and shape.
     """
     if not data.shape[0] == data.shape[1]:
-        raise ValueError("Can't create an identity matrix like a non square matrix.")
+        raise ValueError(
+            "Can't create an identity matrix like a non square matrix."
+        )
     return dense.identity(data.shape[0], fortran=data.fortran)
 
 

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -766,7 +766,9 @@ def qeye_like(qobj):
 
     """
     if qobj.shape[0] != qobj.shape[1]:
-        raise ValueError(f"Cannot build a {qobj.shape} identity matrix.")
+        raise ValueError(
+            "Can't create an identity matrix like a non square matrix."
+        )
     return Qobj(
         _data.identity[qobj.dtype](qobj.shape[0]), dims=qobj._dims,
         isherm=True, isunitary=False, copy=False

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -771,7 +771,7 @@ def qeye_like(qobj):
         )
     return Qobj(
         _data.identity[qobj.dtype](qobj.shape[0]), dims=qobj._dims,
-        isherm=True, isunitary=False, copy=False
+        isherm=True, isunitary=True, copy=False
     )
 
 

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -691,11 +691,9 @@ def qzero_like(qobj):
         Zero operator Qobj.
 
     """
-    from .cy.qobjevo import QobjEvo
-    if isinstance(qobj, QobjEvo):
-        qobj = qobj(0)
+
     return Qobj(
-        _data.zeros_like(qobj.data), dims=qobj._dims,
+        _data.zeros[qobj.dtype](*qobj.shape), dims=qobj._dims,
         isherm=True, isunitary=False, copy=False
     )
 
@@ -767,12 +765,11 @@ def qeye_like(qobj):
         Identity operator Qobj.
 
     """
-    from .cy.qobjevo import QobjEvo
-    if isinstance(qobj, QobjEvo):
-        qobj = qobj(0)
+    if qobj.shape[0] != qobj.shape[1]:
+        raise ValueError(f"Cannot build a {qobj.shape} identity matrix.")
     return Qobj(
-        _data.identity_like(qobj.data), dims=qobj._dims,
-        isherm=True, isunitary=True, copy=False
+        _data.identity[qobj.dtype](qobj.shape[0]), dims=qobj._dims,
+        isherm=True, isunitary=False, copy=False
     )
 
 

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -330,6 +330,10 @@ class Qobj:
     def data(self):
         return self._data
 
+    @property
+    def dtype(self):
+        return type(self._data)
+
     @data.setter
     def data(self, data):
         if not isinstance(data, _data.Data):

--- a/qutip/tests/core/test_operators.py
+++ b/qutip/tests/core/test_operators.py
@@ -328,6 +328,13 @@ def test_qeye_like(dims, superrep, dtype):
     assert new.dtype is qutip.data.to.parse(dtype)
 
 
+def test_qeye_like_error():
+    with pytest.raises(ValueError) as err:
+        qutip.qeye_like(qutip.basis(3))
+
+    assert "non square matrix" in str(err.value)
+
+
 @pytest.mark.parametrize(["dims", "superrep"], [
     pytest.param([2], None, id="simple"),
     pytest.param([2, 3], None, id="tensor"),

--- a/qutip/tests/core/test_operators.py
+++ b/qutip/tests/core/test_operators.py
@@ -320,10 +320,12 @@ def test_qeye_like(dims, superrep, dtype):
     expected = qutip.qeye(dims, dtype=dtype)
     expected.superrep = superrep
     assert new == expected
+    assert new.dtype is qutip.data.to.parse(dtype)
 
     opevo = qutip.QobjEvo(op)
     new = qutip.qeye_like(op)
     assert new == expected
+    assert new.dtype is qutip.data.to.parse(dtype)
 
 
 @pytest.mark.parametrize(["dims", "superrep"], [
@@ -340,10 +342,12 @@ def test_qzero_like(dims, superrep, dtype):
     expected = qutip.qzero(dims, dtype=dtype)
     expected.superrep = superrep
     assert new == expected
+    assert new.dtype is qutip.data.to.parse(dtype)
 
     opevo = qutip.QobjEvo(op)
     new = qutip.qzero_like(op)
     assert new == expected
+    assert new.dtype is qutip.data.to.parse(dtype)
 
 
 @pytest.mark.parametrize('n_sites', [2, 3, 4, 5])

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -1262,3 +1262,9 @@ def test_data_as():
     with pytest.raises(ValueError) as err:
         qobj.data_as("ndarray")
     assert "dia_matrix" in str(err.value)
+
+
+@pytest.mark.parametrize('dtype', ["CSR", "Dense"])
+def test_qobj_dtype(dtype):
+    obj = qutip.qeye(2, dtype=dtype)
+    assert obj.dtype == qutip.data.to.parse(dtype)

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -6,6 +6,7 @@ from qutip import (
     rand_herm, rand_ket, liouvillian, basis, spre, spost, to_choi, expect,
     rand_ket, rand_dm, operator_to_vector, SESolver, MESolver
 )
+import qutip.core.data as _data
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -623,3 +624,18 @@ def test_feedback_super():
     checker.state = rand_dm(4)
     checker.state.dims = [[[2],[2]], [[2],[2]]]
     qevo.matmul_data(0, checker.state.data)
+
+
+@pytest.mark.parametrize('dtype', ["CSR", "Dense"])
+def test_qobjevo_dtype(dtype):
+    obj = QobjEvo([qeye(2, dtype=dtype), [num(2, dtype=dtype), lambda t: t]])
+    assert obj.dtype == _data.to.parse(dtype)
+
+    obj = QobjEvo(lambda t: qeye(2, dtype=dtype))
+    assert obj.dtype == _data.to.parse(dtype)
+
+
+def test_qobjevo_mixed():
+    obj = QobjEvo([qeye(2, dtype="CSR"), [num(2, dtype="Dense"), lambda t: t]])
+    # We test that the output dtype is a know type: accepted by `to.parse`.
+    _data.to.parse(obj.dtype)


### PR DESCRIPTION
**Description**
`qzero_like` used on `QobjEvo` would call it (it needed `qevo(0).data`), which is both slow and could break `jax.jit`.
I added `Qobj.dtype` and `QobjEvo.dtype` to be used instead of accessing the data directly.
For `QobjEvo`, the `dtype` property still call the object when the type is unclear (mixed or function based), but it should be faster otherwise.
Tested that the example in qutip/qutip-jax#33 works.