### PR TITLE
Fix heom steady state

### DIFF
--- a/doc/changes/2333.bugfix
+++ b/doc/changes/2333.bugfix
@@ -1,0 +1,1 @@
+Fixed two problems with the steady_state() solver in the HEOM method.

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -965,9 +965,10 @@ class HEOMSolver(Solver):
         else:
             L = L.tocsc()
             solution = spsolve(L, b_mat)
-
-        data = _data.Dense(solution[:n ** 2].reshape((n, n)))
-        data = _data.mul(_data.add(data, data.conj()), 0.5)
+ 
+        data = _data.Dense(solution[:n ** 2].reshape((n, n), order = 'F'))                
+        data = _data.mul(_data.add(data, data.adjoint()), 0.5)
+        
         steady_state = Qobj(data, dims=self._sys_dims)
 
         solution = solution.reshape((self._n_ados, n, n))

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -965,10 +965,9 @@ class HEOMSolver(Solver):
         else:
             L = L.tocsc()
             solution = spsolve(L, b_mat)
- 
-        data = _data.Dense(solution[:n ** 2].reshape((n, n), order = 'F'))                
+
+        data = _data.Dense(solution[:n ** 2].reshape((n, n), order='F'))
         data = _data.mul(_data.add(data, data.adjoint()), 0.5)
-        
         steady_state = Qobj(data, dims=self._sys_dims)
 
         solution = solution.reshape((self._n_ados, n, n))

--- a/qutip/tests/solver/heom/test_bofin_solvers.py
+++ b/qutip/tests/solver/heom/test_bofin_solvers.py
@@ -740,14 +740,14 @@ class TestHEOMSolver:
             assert rho_final == ado_state.extract(0)
         else:
             assert_raises_steady_state_time_dependent(hsolver)
-    
-    
+
     def test_steady_state_bosonic_bath(
         self, atol=1e-3
     ):
-        H_sys =  0.25 * sigmaz() + 0.5 * sigmay()
+        H_sys = 0.25 * sigmaz() + 0.5 * sigmay()
 
-        bath = DrudeLorentzBath(sigmaz(), lam=0.025, gamma=0.05, T=1/0.95, Nk=2)
+        bath = DrudeLorentzBath(sigmaz(), lam=0.025,
+                                gamma=0.05, T=1/0.95, Nk=2)
         options = {"nsteps": 15000, "store_states": True}
         hsolver = HEOMSolver(H_sys, bath, 5, options=options)
 
@@ -758,8 +758,6 @@ class TestHEOMSolver:
         rho_final, ado_state = hsolver.steady_state()
         fid = fidelity(rho_final, result.states[-1])
         np.testing.assert_allclose(fid, 1.0, atol=atol)
-        
-        
 
     @pytest.mark.parametrize(['terminator'], [
         pytest.param(True, id="terminator"),

--- a/qutip/tests/solver/heom/test_bofin_solvers.py
+++ b/qutip/tests/solver/heom/test_bofin_solvers.py
@@ -8,8 +8,8 @@ from numpy.linalg import eigvalsh
 from scipy.integrate import quad
 
 from qutip import (
-    basis, destroy, expect, liouvillian, qeye, sigmax, sigmaz,
-    tensor, Qobj, QobjEvo
+    basis, destroy, expect, liouvillian, qeye, sigmax, sigmaz, sigmay,
+    tensor, Qobj, QobjEvo, fidelity
 )
 from qutip.core import data as _data
 from qutip.solver.heom.bofin_baths import (
@@ -740,6 +740,26 @@ class TestHEOMSolver:
             assert rho_final == ado_state.extract(0)
         else:
             assert_raises_steady_state_time_dependent(hsolver)
+    
+    
+    def test_steady_state_bosonic_bath(
+        self, atol=1e-3
+    ):
+        H_sys =  0.25 * sigmaz() + 0.5 * sigmay()
+
+        bath = DrudeLorentzBath(sigmaz(), lam=0.025, gamma=0.05, T=1/0.95, Nk=2)
+        options = {"nsteps": 15000, "store_states": True}
+        hsolver = HEOMSolver(H_sys, bath, 5, options=options)
+
+        tlist = np.linspace(0, 500, 21)
+        rho0 = basis(2, 0) * basis(2, 0).dag()
+
+        result = hsolver.run(rho0, tlist)
+        rho_final, ado_state = hsolver.steady_state()
+        fid = fidelity(rho_final, result.states[-1])
+        np.testing.assert_allclose(fid, 1.0, atol=atol)
+        
+        
 
     @pytest.mark.parametrize(['terminator'], [
         pytest.param(True, id="terminator"),


### PR DESCRIPTION
**Description**
Two small bugs crept in in the conversion of the steady_state solver in the HEOM method to QuTiP v5.   Firstly, the system state was returned without Fortran ordering (so it was effectively returned transposed), and the line which was supposed to enforce hermiticity used a conj() instead of an adjoint() so it just deleted the imaginary parts of the off-diagonals instead.  

I think none of the notebooks or tests were sensitive to these two compounding issues, but it is fairly easy to make an example which is. This is also added as a rudimentary test, comparing output of the long-time dynamics to the steadystate. I didn't include any parameters to change in that test, but can do so if its useful.

As a comment, the steady-state solver could probably be written to be more like the standard steadystate solver. But maybe better that is done alongside an effort to make the heom solver more data-layer flexible.