### PR TITLE
Fix `bloch.clear` breaking `point_color`

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -310,7 +310,7 @@ class Bloch:
         self.vector_alpha = []
         self.annotations = []
         self.vector_color = []
-        self.point_color = []
+        self.point_color = None
         self._lines = []
         self._arcs = []
 
@@ -803,7 +803,7 @@ class Bloch:
 
             if self._inner_point_color[k] is not None:
                 color = self._inner_point_color[k]
-            elif self.point_color not in [None, []]:
+            elif self.point_color is not None:
                 color = self.point_color
             elif self.point_style[k] in ['s', 'l']:
                 color = [self.point_default_color[

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -803,7 +803,7 @@ class Bloch:
 
             if self._inner_point_color[k] is not None:
                 color = self._inner_point_color[k]
-            elif self.point_color is not None:
+            elif self.point_color not in [None, []]:
                 color = self.point_color
             elif self.point_style[k] in ['s', 'l']:
                 color = [self.point_default_color[

--- a/qutip/tests/test_bloch.py
+++ b/qutip/tests/test_bloch.py
@@ -470,6 +470,23 @@ class TestBloch:
                    "size as the number of vectors. ")
         assert str(err.value) == err_msg
 
+    @check_pngs_equal
+    def test_clear(self, fig_test=None, fig_ref=None):
+        b = Bloch(fig=fig_test)
+        b.add_vectors([0, 1, 0])
+        b.add_points([1, 0, 0])
+        b.vector_color = ["g"]
+        b.point_color = ["g"]
+        b.clear()
+        b.add_vectors([0, 0, 1])
+        b.add_points([0, 0, -1])
+        b.make_sphere()
+
+        b2 = Bloch(fig=fig_ref)
+        b2.add_vectors([0, 0, 1])
+        b2.add_points([0, 0, -1])
+        b2.make_sphere()
+
 
 def test_repr_svg():
     pytest.importorskip("matplotlib")


### PR DESCRIPTION
**Description**
In #2308, the default for `point_color` was changed from `[]` to `None`, but `clear` still set it to an empty list.
This broke a notebook in qutip-tutorial: tutorials-v5/visualization/bloch-sphere-animation.


