### PR TITLE
Increase test reliability

### DIFF
--- a/qutip/tests/solver/test_floquet.py
+++ b/qutip/tests/solver/test_floquet.py
@@ -51,7 +51,7 @@ class TestFloquet:
         states = sesolve(H, psi0, tlist).states
         for t, state in zip(tlist, states):
             from_floquet = floquet_basis.from_floquet_basis(floquet_psi0, t)
-            assert state.overlap(from_floquet) == pytest.approx(1., abs=5e-5)
+            assert state.overlap(from_floquet) == pytest.approx(1., abs=8e-5)
 
     def testFloquetUnitary(self):
         N = 10

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -222,7 +222,7 @@ def test_rand_super(dimensions, dtype, superrep):
     """
     random_qobj = rand_super(dimensions, dtype=dtype, superrep=superrep)
     assert random_qobj.issuper
-    with CoreOptions(atol=1e-9):
+    with CoreOptions(atol=2e-9):
         assert random_qobj.iscptp
     assert random_qobj.superrep == superrep
     _assert_metadata(random_qobj, dimensions, dtype, super=True)


### PR DESCRIPTION
**Description**
Increase the tolerance of tests that could randomly fail.

`testFloquetBasis` would fail 1/2000 of the time. The error has a std of 1.2e-5 , but does not follow a gaussian distribution. Fat tails made 4 std not enough.

`test_rand_super` failed once recently in #2919 ( I reran the test). I can't reproduce the failure locally, but it is ran a few hundred of times in each actions, so even a small probability of failure will eventually happen.