### PR TITLE
Makes measurement support degenerate states

### DIFF
--- a/doc/changes/2342.misc
+++ b/doc/changes/2342.misc
@@ -1,0 +1,1 @@
+Allow measurement functions to support degenerate operators.

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -50,7 +50,7 @@ from .entropy import *
 from .partial_transpose import *
 from .continuous_variables import *
 from .distributions import *
-
+from . import measurement
 
 # utilities
 from .utilities import *

--- a/qutip/measurement.py
+++ b/qutip/measurement.py
@@ -13,7 +13,7 @@ __all__ = [
 
 import numpy as np
 
-from . import Qobj, expect, identity, tensor
+from . import Qobj, expect, identity, tensor, settings
 
 
 def _verify_input(op, state):
@@ -36,7 +36,7 @@ def _verify_input(op, state):
         raise ValueError("state must be a ket or a density matrix")
 
 
-def _measurement_statistics_povm_ket(state, ops):
+def _measurement_statistics_povm_ket(state, ops, tol=None):
     r"""
     Returns measurement statistics (resultant states and probabilities)
     for a measurements specified by a set of positive operator valued
@@ -51,6 +51,9 @@ def _measurement_statistics_povm_ket(state, ops):
       List of measurement operators :math:`M_i` (specifying a POVM such that
       :math:`E_i = M_i^\dagger M_i`).
 
+    tol : float, optional
+        Smallest value for the probabilities. Smaller probabilities will be
+        rounded to ``0``.
 
     Returns
     -------
@@ -65,19 +68,23 @@ def _measurement_statistics_povm_ket(state, ops):
     """
     probabilities = []
     collapsed_states = []
+    if tol is None:
+        tol = settings.core["atol"]
 
     for i, op in enumerate(ops):
-        p = np.absolute((state.dag() * op.dag() * op * state))
-        probabilities.append(p)
-        if p != 0:
-            collapsed_states.append((op * state) / np.sqrt(p))
+        psi = op * state
+        p = np.absolute(psi.overlap(psi))
+        if p >= tol:
+            collapsed_states.append(psi / np.sqrt(p))
+            probabilities.append(p)
         else:
             collapsed_states.append(None)
+            probabilities.append(0.)
 
     return collapsed_states, probabilities
 
 
-def _measurement_statistics_povm_dm(density_mat, ops):
+def _measurement_statistics_povm_dm(density_mat, ops, tol=None):
     r"""
     Returns measurement statistics (resultant states and probabilities)
     for a measurements specified by a set of positive operator valued
@@ -92,6 +99,10 @@ def _measurement_statistics_povm_dm(density_mat, ops):
         List of measurement operators :math:`M_i` (specifying a POVM s.t.
         :mathm:`E_i = M_i^\dagger M_i`)
 
+    tol : float, optional
+        Smallest value for the probabilities. Smaller probabilities will be
+        rounded to ``0``.
+
     Returns
     -------
     collapsed_states : list of :class:`.Qobj`
@@ -105,20 +116,24 @@ def _measurement_statistics_povm_dm(density_mat, ops):
     """
     probabilities = []
     collapsed_states = []
+    if tol is None:
+        tol = settings.core["atol"]
 
     for i, op in enumerate(ops):
         st = op * density_mat * op.dag()
         p = st.tr()
-        probabilities.append(p)
-        if p != 0:
+        if p >= tol:
             collapsed_states.append(st/p)
+            probabilities.append(p)
         else:
             collapsed_states.append(None)
+            probabilities.append(0.)
+
 
     return collapsed_states, probabilities
 
 
-def measurement_statistics_povm(state, ops):
+def measurement_statistics_povm(state, ops, tol=None):
     r"""
     Returns measurement statistics (resultant states and probabilities) for a
     measurement specified by a set of positive operator valued measurements on
@@ -136,6 +151,10 @@ def measurement_statistics_povm(state, ops):
         2. projection operators if ops correspond to
            projectors (s.t. :math:`E_i = M_i^\dagger = M_i`)
         3. kets (transformed to projectors)
+
+    tol : float, optional
+        Smallest value for the probabilities. Smaller probabilities will be
+        rounded to ``0``. Default is qutip's core settings' ``atol``.
 
     Returns
     -------
@@ -160,12 +179,12 @@ def measurement_statistics_povm(state, ops):
         raise ValueError("measurement operators must sum to identity")
 
     if state.isket:
-        return _measurement_statistics_povm_ket(state, ops)
+        return _measurement_statistics_povm_ket(state, ops, tol)
     else:
-        return _measurement_statistics_povm_dm(state, ops)
+        return _measurement_statistics_povm_dm(state, ops, tol)
 
 
-def measurement_statistics_observable(state, op):
+def measurement_statistics_observable(state, op, tol=None):
     """
     Return the measurement eigenvalues, eigenstates (or projectors) and
     measurement probabilities for the given state and measurement operator.
@@ -178,33 +197,57 @@ def measurement_statistics_observable(state, op):
     op : :class:`.Qobj`
         The measurement operator.
 
+    tol : float, optional
+        Smallest value for the probabilities.
+        Default is qutip's core settings' ``atol``.
+
     Returns
     -------
     eigenvalues: list of float
         The list of eigenvalues of the measurement operator.
 
-    eigenstates_or_projectors: list of :class:`.Qobj`
-        If the state was a ket, return the eigenstates of the measurement
-        operator. Otherwise return the projectors onto the eigenstates.
+    projectors: list of :class:`.Qobj`
+        Return the projectors onto the eigenstates.
 
     probabilities: list of float
         The probability of measuring the state as being in the corresponding
         eigenstate (and the measurement result being the corresponding
         eigenvalue).
     """
+    probabilities = []
+    values = []
+    projectors = []
     _verify_input(op, state)
+    if tol is None:
+        tol = settings.core["atol"]
 
     eigenvalues, eigenstates = op.eigenstates()
-    if state.isket:
-        probabilities = [abs(e.overlap(state))**2 for e in eigenstates]
-        return eigenvalues, eigenstates, probabilities
-    else:
-        projectors = [e.proj() for e in eigenstates]
-        probabilities = [expect(v, state) for v in projectors]
-        return eigenvalues, projectors, probabilities
+    # Detect groups of eigenvalues within atol of each other.
+    # A group will be [True] + [False] * N
+    groups = np.append(True, np.diff(eigenvalues) >= tol)
+
+    present_group = []
+    for i in range(len(eigenvalues)-1, -1, -1):
+        present_group.append(i)
+        if not groups[i]:
+            continue
+
+        projector = 0
+        for j in present_group:
+            projector += eigenstates[j].proj()
+        probability = expect(projector, state)
+
+        if probability >= tol:
+            probabilities.append(probability)
+            values.append(np.mean(eigenvalues[present_group]))
+            projectors.append(projector)
+
+        present_group = []
+
+    return values[::-1], projectors[::-1], probabilities[::-1]
 
 
-def measure_observable(state, op):
+def measure_observable(state, op, tol=None):
     """
     Perform a measurement specified by an operator on the given state.
 
@@ -220,6 +263,10 @@ def measure_observable(state, op):
 
     op : :class:`.Qobj`
         The measurement operator.
+
+    tol : float, optional
+        Smallest value for the probabilities.
+        Default is qutip's core settings' ``atol``.
 
     Returns
     -------
@@ -269,19 +316,17 @@ def measure_observable(state, op):
     The measurement result is the same, but the new state is returned as a
     density matrix.
     """
-    eigenvalues, eigenstates_or_projectors, probabilities = (
-        measurement_statistics_observable(state, op))
-    i = np.random.choice(range(len(eigenvalues)), p=probabilities)
+    eigenvalues, projectors, probabilities = (
+        measurement_statistics_observable(state, op, tol))
+    i = np.random.choice(len(eigenvalues), p=probabilities)
     if state.isket:
-        eigenstates = eigenstates_or_projectors
-        state = eigenstates[i]
+        state = (projectors[i] * state) / probabilities[i]**0.5
     else:
-        projectors = eigenstates_or_projectors
         state = (projectors[i] * state * projectors[i]) / probabilities[i]
     return eigenvalues[i], state
 
 
-def measure_povm(state, ops):
+def measure_povm(state, ops, tol=None):
     r"""
     Perform a measurement specified by list of POVMs.
 
@@ -303,6 +348,10 @@ def measure_povm(state, ops):
            :math:`E_i = M_i^\dagger = M_i`)
         3. kets (transformed to projectors)
 
+    tol : float, optional
+        Smallest value for the probabilities.
+        Default is qutip's core settings' ``atol``.
+
     Returns
     -------
     index : float
@@ -311,13 +360,14 @@ def measure_povm(state, ops):
     state : :class:`.Qobj`
         The new state (a ket if a ket was given, otherwise a density matrix).
     """
-    collapsed_states, probabilities = measurement_statistics_povm(state, ops)
-    index = np.random.choice(range(len(collapsed_states)), p=probabilities)
+    collapsed_states, probabilities = (
+        measurement_statistics_povm(state, ops, tol))
+    index = np.random.choice(len(collapsed_states), p=probabilities)
     state = collapsed_states[index]
     return index, state
 
 
-def measurement_statistics(state, ops):
+def measurement_statistics(state, ops, tol=None):
     r"""
     A dispatch method that provides measurement statistics handling both
     observable style measurements and projector style measurements(POVMs and
@@ -342,14 +392,18 @@ def measurement_statistics(state, ops):
           2. projection operators if ops correspond to projectors (s.t.
              :math:`E_i = M_i^\dagger = M_i`)
           3. kets (transformed to projectors)
+
+    tol : float, optional
+        Smallest value for the probabilities.
+        Default is qutip's core settings' ``atol``.
     """
     if isinstance(ops, list):
-        return measurement_statistics_povm(state, ops)
+        return measurement_statistics_povm(state, ops, tol)
     else:
-        return measurement_statistics_observable(state, ops)
+        return measurement_statistics_observable(state, ops, tol)
 
 
-def measure(state, ops):
+def measure(state, ops, tol=None):
     r"""
     A dispatch method that provides measurement results handling both
     observable style measurements and projector style measurements (POVMs and
@@ -374,8 +428,12 @@ def measure(state, ops):
           2. projection operators if ops correspond to projectors (s.t.
              :math:`E_i = M_i^\dagger = M_i`)
           3. kets (transformed to projectors)
+
+    tol : float, optional
+        Smallest value for the probabilities.
+        Default is qutip's core settings' ``atol``.
     """
     if isinstance(ops, list):
-        return measure_povm(state, ops)
+        return measure_povm(state, ops, tol)
     else:
-        return measure_observable(state, ops)
+        return measure_observable(state, ops, tol)

--- a/qutip/measurement.py
+++ b/qutip/measurement.py
@@ -223,11 +223,11 @@ def measurement_statistics_observable(state, op, tol=None):
 
     eigenvalues, eigenstates = op.eigenstates()
     # Detect groups of eigenvalues within atol of each other.
-    # A group will be [True] + [False] * N
-    groups = np.append(True, np.diff(eigenvalues) >= tol)
+    # A group will be [False] * N + [True]
+    groups = np.append(np.diff(eigenvalues) >= tol, True)
 
     present_group = []
-    for i in range(len(eigenvalues)-1, -1, -1):
+    for i in range(len(eigenvalues)):
         present_group.append(i)
         if not groups[i]:
             continue
@@ -244,7 +244,7 @@ def measurement_statistics_observable(state, op, tol=None):
 
         present_group = []
 
-    return values[::-1], projectors[::-1], probabilities[::-1]
+    return values, projectors, probabilities
 
 
 def measure_observable(state, op, tol=None):


### PR DESCRIPTION
**Description**
Measurement functions did not take into account degenerate states of the operator. (#1800, #2054)
Also the returned probabilities could be negative. (#2265)

I added a tolerance to these function for the minimal probability. Smaller / negative probabilities are rounded to `0`.
I also changed `measurement_statistics_observable` to support degenerate operators: It always return the projectors, with projectors and probabilities of degenerate sub-systems summed. It also only return the (eigenvalues, projector, probability) set for cases where the probability is greater than `tol`.

**Related issues or PRs**
fix #1800, #2054, #2029, #2265