### PR TITLE
Improve mcsolve's `test_super_H` test tolerance.

### DIFF
--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -411,7 +411,7 @@ def test_super_H(improved_sampling):
                  target_tol=0.1,
                  options={'map': 'serial',
                           "improved_sampling": improved_sampling})
-    np.testing.assert_allclose(mc_expected.expect[0], mc.expect[0], atol=0.5)
+    np.testing.assert_allclose(mc_expected.expect[0], mc.expect[0], atol=0.65)
 
 
 def test_MCSolver_run():


### PR DESCRIPTION
**Description**
`test_super_H` can randomly fail, as seen in https://github.com/qutip/qutip/actions/runs/8112849659/job/22174928821.

Trying it locally, it fail with a probability of `~1/500`.
Which is very close to what is expected with the tolerance used in the test.
I loosen the test `atol` for an expected rate of failure of about ~1/100000.
