### PR TITLE
Improve `test_m_ops` and `test_spin_q_function_normalized` stability

### DIFF
--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -312,10 +312,13 @@ def test_m_ops(heterodyne):
     solver.dW_factors = [1.] * len(m_ops)
     # With dW_factors=0, measurements are computed as expectation values.
     res = solver.run(psi0, times, e_ops=m_ops)
-    std = 1/times[1]**0.5
-    noise = res.expect[0][1:] - res.measurement[0][0]
-    assert np.mean(noise) == pytest.approx(0., abs=std/50**0.5 * 4)
-    assert np.std(noise) == pytest.approx(std, abs=std/50**0.5 * 4)
+    std = 1 / times[1]**0.5
+    if heterodyne:
+        noise = res.expect[0][1:] - res.measurement[0][0][0]
+    else:
+        noise = res.expect[0][1:] - res.measurement[0][0]
+    assert np.mean(noise) == pytest.approx(0., abs=std / 50**0.5 * 5)
+    assert np.std(noise) == pytest.approx(std, abs=std / 50**0.5 * 5)
 
 
 def test_feedback():

--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -635,7 +635,7 @@ def test_spin_q_function_normalized(spin, pure):
     Q, THETA, _ = qutip.spin_q_function(rho, theta, phi)
 
     norm = d / (4 * np.pi) * np.trapz(np.trapz(Q * np.sin(THETA), theta), phi)
-    assert_almost_equal(norm, 1, decimal=4)
+    assert_allclose(norm, 1, atol=2e-4)
 
 
 @pytest.mark.parametrize(["spin"], [


### PR DESCRIPTION
**Description**
Fix 2 other tests failing randomly with low probability:
- `test_spin_q_function_normalized`
- `test_m_ops`

`test_m_ops` had a mistake: `measurement`'s shape is not the same for homodyne and heterodyne.