### PR TITLE
add output type to qobj.eigenstate

### DIFF
--- a/doc/changes/2351.feature
+++ b/doc/changes/2351.feature
@@ -1,0 +1,1 @@
+Add output_type to qobj.eigenstate() to add return type as both operator as well as kets

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1539,12 +1539,14 @@ class Qobj:
                 phase = np.array([np.abs(ket[phase_fix, 0]) / ket[phase_fix, 0]
                                 if ket[phase_fix, 0] else 1
                                 for ket in ekets])
+
             return evals, ekets / norms * phase
         elif output_type == 'operator':
             ekets = Qobj(evecs)
             norm = ekets.norm()
+
             return evals, ekets/norm
-        
+ 
     def eigenenergies(self, sparse=False, sort='low',
                       eigvals=0, tol=0, maxiter=100000):
         """Eigenenergies of a quantum object.

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1541,11 +1541,17 @@ class Qobj:
                                 for ket in ekets])
 
             return evals, ekets / norms * phase
+        
         elif output_type == 'operator':
-            ekets = Qobj(evecs)
-            norm = ekets.norm()
-
-            return evals, ekets/norm
+            ekets = Qobj(evecs, dims=[new_dims[0], [evecs.shape[1]]])
+            norms = np.sqrt(np.sum(np.abs(ekets.data)**2, axis=0))
+            ekets = ekets / norms
+            if phase_fix is not None:
+                phases = np.array([np.abs(ekets[phase_fix, i]) / ekets[phase_fix, i]
+                                if ekets[phase_fix, i] else 1
+                                for i in range(evecs.shape[1])])
+                ekets = ekets * phases
+            return evals, ekets
  
     def eigenenergies(self, sparse=False, sort='low',
                       eigvals=0, tol=0, maxiter=100000):

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1540,20 +1540,11 @@ class Qobj:
                                 if ket[phase_fix, 0] else 1
                                 for ket in ekets])
             return evals, ekets / norms * phase
+        elif output_type == 'operator':
+            ekets = Qobj(evecs)
+            norm = ekets.norm()
+            return evals, ekets/norm
         
-        else:
-            evecs = np.empty((evecs.shape[1],), dtype=object)
-            evecs[:] = [Qobj(vec, dims=new_dims, copy=False)
-                        for vec in evecs]
-            norms = np.array([vec.norm() for vec in evecs])
-            if phase_fix is None:
-                phase = np.array([1] * len(evecs))
-            else:
-                phase = np.array([np.abs(ket[phase_fix, 0]) / ket[phase_fix, 0]
-                                if ket[phase_fix, 0] else 1
-                                for ket in evecs])
-            return evals, evecs / norms * phase
-
     def eigenenergies(self, sparse=False, sort='low',
                       eigvals=0, tol=0, maxiter=100000):
         """Eigenenergies of a quantum object.

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -579,7 +579,9 @@ def test_QobjEigenStates():
     kets = [qutip.basis(5, k) for k in range(5)]
     for k in range(5):
         assert c[k] == kets[k]
-
+    d, e = A.eigenstates(output_type='operator')
+    assert np.all(d == np.ones(5))
+    assert e == A/5
 
 def test_QobjExpm():
     "qutip.Qobj expm (dense)"


### PR DESCRIPTION

**Description**
Add output_type to qobj.eigenstate() to add return type as both operator as well as kets

**Related issues or PRs**
fix #2338 