### PR TITLE
Remove pin on scipy 1.12

### DIFF
--- a/doc/changes/2354.misc
+++ b/doc/changes/2354.misc
@@ -1,0 +1,1 @@
+Allow scipy 1.12 to be used with qutip.

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ include_package_data = True
 zip_safe = False
 install_requires =
     numpy>=1.22
-    scipy>=1.8,<1.12
+    scipy>=1.8
     packaging
 setup_requires =
     numpy>=1.19


### PR DESCRIPTION
**Description**

We allow scipy version 1.12 (released about 2 months ago) to be used with qutip. Scipy 1.12 is already tested in the build matrix https://github.com/qutip/qutip/blob/master/.github/workflows/tests.yml#L93

