### PR TITLE
Fixed Qobj string representation

### DIFF
--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -533,7 +533,7 @@ class Qobj:
             "Quantum object: dims=" + str(self.dims),
             "shape=" + str(self._data.shape),
             "type=" + repr(self.type),
-            "dtype=" + str(type(self.type)),
+            "dtype=" + self.dtype.__name__,
         ])
         if self.type in ('oper', 'super'):
             out += ", isherm=" + str(self.isherm)

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -1264,7 +1264,13 @@ def test_data_as():
     assert "dia_matrix" in str(err.value)
 
 
-@pytest.mark.parametrize('dtype', ["CSR", "Dense"])
+@pytest.mark.parametrize('dtype', ["CSR", "Dense", "Dia"])
 def test_qobj_dtype(dtype):
     obj = qutip.qeye(2, dtype=dtype)
     assert obj.dtype == qutip.data.to.parse(dtype)
+
+
+@pytest.mark.parametrize('dtype', ["CSR", "Dense", "Dia"])
+def test_dtype_in_info_string(dtype):
+    obj = qutip.qeye(2, dtype=dtype)
+    assert dtype.lower() in str(obj).lower()


### PR DESCRIPTION
Currently, the output of printing a `Qobj` always contains `dtype=<class 'str'>`. This fixes it to `dtype=CSR`, `dtype=Dense`, etc.

**Related issues or PRs**
Previous PR: https://github.com/qutip/qutip/pull/2352