### PR TITLE
Multi trajectory solver: minor internal changes

### DIFF
--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -478,25 +478,12 @@ class MCSolver(MultiTrajSolver):
         })
         return stats
 
-    def _initialize_run_one_traj(self, seed, state, tlist, e_ops,
-                                 no_jump=False, jump_prob_floor=0.0):
-        result = self._trajectory_resultclass(e_ops, self.options)
-        generator = self._get_generator(seed)
-        self._integrator.set_state(tlist[0], state, generator,
-                                   no_jump=no_jump,
-                                   jump_prob_floor=jump_prob_floor)
-        result.add(tlist[0], self._restore_state(state, copy=False))
-        return result
-
-    def _run_one_traj(self, seed, state, tlist, e_ops, no_jump=False,
-                      jump_prob_floor=0.0):
+    def _run_one_traj(self, seed, state, tlist, e_ops, **integrator_kwargs):
         """
         Run one trajectory and return the result.
         """
-        result = self._initialize_run_one_traj(seed, state, tlist, e_ops,
-                                               no_jump=no_jump,
-                                               jump_prob_floor=jump_prob_floor)
-        seed, result = self._integrate_one_traj(seed, tlist, result)
+        seed, result = super()._run_one_traj(seed, state, tlist, e_ops,
+                                             **integrator_kwargs)
         result.collapse = self._integrator.collapses
         return seed, result
 
@@ -538,7 +525,8 @@ class MCSolver(MultiTrajSolver):
         start_time = time()
         map_func(
             self._run_one_traj, seeds[1:],
-            (state0, tlist, e_ops, False, no_jump_prob),
+            task_args=(state0, tlist, e_ops),
+            task_kwargs={'no_jump': False, 'jump_prob_floor': no_jump_prob},
             reduce_func=result.add, map_kw=map_kw,
             progress_bar=self.options["progress_bar"],
             progress_bar_kwargs=self.options["progress_kwargs"]

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -180,17 +180,17 @@ class _MCRHS(_MultiTrajRHS):
         self.n_ops = n_ops
 
     def __call__(self):
-        return self.rhs
+        return self.H
 
     def arguments(self, args):
-        self.rhs.arguments(args)
+        self.H.arguments(args)
         for c_op in self.c_ops:
             c_op.arguments(args)
         for n_op in self.n_ops:
             n_op.arguments(args)
 
     def _register_feedback(self, key, val):
-        self.rhs._register_feedback({key: val}, solver="McSolver")
+        self.H._register_feedback({key: val}, solver="McSolver")
         for c_op in self.c_ops:
             c_op._register_feedback({key: val}, solver="McSolver")
         for n_op in self.n_ops:

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -174,23 +174,21 @@ class _MCRHS(_MultiTrajRHS):
 
     def __init__(self, H, c_ops, n_ops):
         self.rhs = H
-
-        self.H = H
         self.c_ops = c_ops
         self.n_ops = n_ops
 
     def __call__(self):
-        return self.H
+        return self.rhs
 
     def arguments(self, args):
-        self.H.arguments(args)
+        self.rhs.arguments(args)
         for c_op in self.c_ops:
             c_op.arguments(args)
         for n_op in self.n_ops:
             n_op.arguments(args)
 
     def _register_feedback(self, key, val):
-        self.H._register_feedback({key: val}, solver="McSolver")
+        self.rhs._register_feedback({key: val}, solver="McSolver")
         for c_op in self.c_ops:
             c_op._register_feedback({key: val}, solver="McSolver")
         for n_op in self.n_ops:
@@ -367,6 +365,10 @@ class MCIntegrator:
     def arguments(self, args):
         if args:
             self._integrator.arguments(args)
+            for c_op in self._c_ops:
+                c_op.arguments(args)
+            for n_op in self._n_ops:
+                n_op.arguments(args)
 
     @property
     def integrator_options(self):

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -181,13 +181,6 @@ class _MCSystem(_MTSystem):
     def __call__(self):
         return self.rhs
 
-    def __getattr__(self, attr):
-        if attr == "rhs":
-            raise AttributeError
-        if hasattr(self.rhs, attr):
-            return getattr(self.rhs, attr)
-        raise AttributeError
-
     def arguments(self, args):
         self.rhs.arguments(args)
         for c_op in self.c_ops:
@@ -539,9 +532,9 @@ class MCSolver(MultiTrajSolver):
             integrator = method
         else:
             raise ValueError("Integrator method not supported.")
-        integrator_instance = integrator(self.system(), self.options)
+        integrator_instance = integrator(self.rhs(), self.options)
         mc_integrator = self._mc_integrator_class(
-            integrator_instance, self.system, self.options
+            integrator_instance, self.rhs, self.options
         )
         self._init_integrator_time = time() - _time_start
         return mc_integrator

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -459,6 +459,8 @@ class MCSolver(MultiTrajSolver):
         """
         Retore the Qobj state from its data.
         """
+        # Duplicated from the Solver class, but removed the check for the
+        # normalize_output option, since MCSolver doesn't have that option.
         if self._state_metadata['dims'] == self.rhs._dims[1]:
             state = Qobj(unstack_columns(data),
                          **self._state_metadata, copy=False)

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -489,13 +489,9 @@ class MCSolver(MultiTrajSolver):
 
     def run(self, state, tlist, ntraj=1, *,
             args=None, e_ops=(), timeout=None, target_tol=None, seeds=None):
-        """
-        Do the evolution of the Quantum system.
-        See the overridden method for further details. The modification
-        here is to sample the no-jump trajectory first. Then, the no-jump
-        probability is used as a lower-bound for random numbers in future
-        monte carlo runs
-        """
+        # Overridden to sample the no-jump trajectory first. Then, the no-jump
+        # probability is used as a lower-bound for random numbers in future
+        # monte carlo runs
         if not self.options.get("improved_sampling", False):
             return super().run(state, tlist, ntraj=ntraj, args=args,
                                e_ops=e_ops, timeout=timeout,

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -373,10 +373,6 @@ class MCIntegrator:
     def arguments(self, args):
         if args:
             self._integrator.arguments(args)
-            for c_op in self._c_ops:
-                c_op.arguments(args)
-            for n_op in self._n_ops:
-                n_op.arguments(args)
 
     @property
     def integrator_options(self):

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -8,7 +8,7 @@ import numpy as np
 __all__ = ["MultiTrajSolver"]
 
 
-class _MTSystem:
+class _MultiTrajRHS:
     """
     Container for the operators of the solver.
     """
@@ -70,8 +70,8 @@ class MultiTrajSolver(Solver):
 
     def __init__(self, rhs, *, options=None):
         if isinstance(rhs, QobjEvo):
-            self.rhs = _MTSystem(rhs)
-        elif isinstance(rhs, _MTSystem):
+            self.rhs = _MultiTrajRHS(rhs)
+        elif isinstance(rhs, _MultiTrajRHS):
             self.rhs = rhs
         else:
             raise TypeError("The system should be a QobjEvo")

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -233,18 +233,21 @@ class MultiTrajSolver(Solver):
         result.stats['run time'] = time() - start_time
         return result
 
-    def _initialize_run_one_traj(self, seed, state, tlist, e_ops):
+    def _initialize_run_one_traj(self, seed, state, tlist, e_ops,
+                                 **integrator_kwargs):
         result = self._trajectory_resultclass(e_ops, self.options)
         generator = self._get_generator(seed)
-        self._integrator.set_state(tlist[0], state, generator)
+        self._integrator.set_state(tlist[0], state, generator,
+                                   **integrator_kwargs)
         result.add(tlist[0], self._restore_state(state, copy=False))
         return result
 
-    def _run_one_traj(self, seed, state, tlist, e_ops):
+    def _run_one_traj(self, seed, state, tlist, e_ops, **integrator_kwargs):
         """
         Run one trajectory and return the result.
         """
-        result = self._initialize_run_one_traj(seed, state, tlist, e_ops)
+        result = self._initialize_run_one_traj(seed, state, tlist, e_ops,
+                                               **integrator_kwargs)
         return self._integrate_one_traj(seed, tlist, result)
 
     def _integrate_one_traj(self, seed, tlist, result):

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -278,6 +278,7 @@ class MultiTrajSolver(Solver):
         """Update the args, for the `rhs` and `c_ops` and other operators."""
         if args:
             self.system.arguments(args)
+            self._integrator.arguments(args)
 
     def _get_generator(self, seed):
         """

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -248,8 +248,7 @@ class MultiTrajSolver(Solver):
         return self._integrate_one_traj(seed, tlist, result)
 
     def _integrate_one_traj(self, seed, tlist, result):
-        for t in tlist[1:]:
-            t, state = self._integrator.integrate(t, copy=False)
+        for t, state in self._integrator.run(tlist):
             result.add(t, self._restore_state(state, copy=False))
         return seed, result
 

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -15,9 +15,6 @@ class _MTSystem:
     def __init__(self, rhs):
         self.rhs = rhs
 
-    def __call__(self):
-        return self.rhs
-
     def arguments(self, args):
         self.rhs.arguments(args)
 
@@ -25,6 +22,8 @@ class _MTSystem:
         pass
 
     def __getattr__(self, attr):
+        if attr == "rhs":
+            raise AttributeError
         if hasattr(self.rhs, attr):
             return getattr(self.rhs, attr)
         raise AttributeError
@@ -71,12 +70,11 @@ class MultiTrajSolver(Solver):
 
     def __init__(self, rhs, *, options=None):
         if isinstance(rhs, QobjEvo):
-            self.system = _MTSystem(rhs)
+            self.rhs = _MTSystem(rhs)
         elif isinstance(rhs, _MTSystem):
-            self.system = rhs
+            self.rhs = rhs
         else:
             raise TypeError("The system should be a QobjEvo")
-        self.rhs = self.system()
         self.options = options
         self.seed_sequence = np.random.SeedSequence()
         self._integrator = self._get_integrator()
@@ -280,7 +278,7 @@ class MultiTrajSolver(Solver):
     def _argument(self, args):
         """Update the args, for the `rhs` and `c_ops` and other operators."""
         if args:
-            self.system.arguments(args)
+            self.rhs.arguments(args)
             self._integrator.arguments(args)
 
     def _get_generator(self, seed):

--- a/qutip/solver/stochastic.py
+++ b/qutip/solver/stochastic.py
@@ -2,7 +2,7 @@ __all__ = ["smesolve", "SMESolver", "ssesolve", "SSESolver"]
 
 from .sode.ssystem import StochasticOpenSystem, StochasticClosedSystem
 from .result import MultiTrajResult, Result, ExpectOp
-from .multitraj import MultiTrajSolver
+from .multitraj import _MTSystem, MultiTrajSolver
 from .. import Qobj, QobjEvo
 from ..core.dimensions import Dimensions
 import numpy as np
@@ -26,7 +26,7 @@ class StochasticTrajResult(Result):
             self.m_ops.append(ExpectOp(op, f, self.m_expect[-1].append))
             self.add_processor(self.m_ops[-1]._store)
 
-    def add(self, t, state, noise):
+    def add(self, t, state, noise=None):
         super().add(t, state)
         if noise is not None and self.options["store_measurement"]:
             for i, dW in enumerate(noise):
@@ -166,7 +166,7 @@ class StochasticResult(MultiTrajResult):
         return self._trajectories_attr("wiener_process")
 
 
-class _StochasticRHS:
+class _StochasticRHS(_MTSystem):
     """
     In between object to store the stochastic system.
 
@@ -181,7 +181,7 @@ class _StochasticRHS:
     def __init__(self, issuper, H, sc_ops, c_ops, heterodyne):
 
         if not isinstance(H, (Qobj, QobjEvo)) or not H.isoper:
-            raise TypeError("The Hamiltonian must be am operator")
+            raise TypeError("The Hamiltonian must be an operator")
         self.H = QobjEvo(H)
 
         if isinstance(sc_ops, (Qobj, QobjEvo)):
@@ -500,8 +500,8 @@ class StochasticSolver(MultiTrajSolver):
     name = "StochasticSolver"
     _resultclass = StochasticResult
     _avail_integrators = {}
-    system = None
     _open = None
+
     solver_options = {
         "progress_bar": "text",
         "progress_kwargs": {"chunk_size": 10},
@@ -517,20 +517,22 @@ class StochasticSolver(MultiTrajSolver):
         "store_measurement": False,
     }
 
+    def _trajectory_resultclass(self, e_ops, options):
+        return StochasticTrajResult(
+            e_ops,
+            options,
+            m_ops=self.m_ops,
+            dw_factor=self.dW_factors,
+            heterodyne=self.heterodyne,
+        )
+
     def __init__(self, H, sc_ops, heterodyne, *, c_ops=(), options=None):
-        self.options = options
         self._heterodyne = heterodyne
         if self.name == "ssesolve" and c_ops:
             raise ValueError("c_ops are not supported by ssesolve.")
 
         rhs = _StochasticRHS(self._open, H, sc_ops, c_ops, heterodyne)
-        self.rhs = rhs
-        self.system = rhs
-        self.options = options
-        self.seed_sequence = np.random.SeedSequence()
-        self._integrator = self._get_integrator()
-        self._state_metadata = {}
-        self.stats = self._initialize_stats()
+        super().__init__(rhs, options=options)
 
         if heterodyne:
             self._m_ops = []
@@ -619,25 +621,9 @@ class StochasticSolver(MultiTrajSolver):
                 )
         self._dW_factors = new_dW_factors
 
-    def _run_one_traj(self, seed, state, tlist, e_ops):
-        """
-        Run one trajectory and return the result.
-        """
-        result = StochasticTrajResult(
-            e_ops,
-            self.options,
-            m_ops=self.m_ops,
-            dw_factor=self.dW_factors,
-            heterodyne=self.heterodyne,
-        )
-        generator = self._get_generator(seed)
-        self._integrator.set_state(tlist[0], state, generator)
-        state_t = self._restore_state(state, copy=False)
-        result.add(tlist[0], state_t, None)
-        for t in tlist[1:]:
-            t, state, noise = self._integrator.integrate(t, copy=False)
-            state_t = self._restore_state(state, copy=False)
-            result.add(t, state_t, noise)
+    def _integrate_one_traj(self, seed, tlist, result):
+        for t, state, noise in self._integrator.run(tlist):
+            result.add(t, self._restore_state(state, copy=False), noise)
         return seed, result
 
     @classmethod

--- a/qutip/solver/stochastic.py
+++ b/qutip/solver/stochastic.py
@@ -2,7 +2,7 @@ __all__ = ["smesolve", "SMESolver", "ssesolve", "SSESolver"]
 
 from .sode.ssystem import StochasticOpenSystem, StochasticClosedSystem
 from .result import MultiTrajResult, Result, ExpectOp
-from .multitraj import _MTSystem, MultiTrajSolver
+from .multitraj import _MultiTrajRHS, MultiTrajSolver
 from .. import Qobj, QobjEvo
 from ..core.dimensions import Dimensions
 import numpy as np
@@ -166,7 +166,7 @@ class StochasticResult(MultiTrajResult):
         return self._trajectories_attr("wiener_process")
 
 
-class _StochasticRHS(_MTSystem):
+class _StochasticRHS(_MultiTrajRHS):
     """
     In between object to store the stochastic system.
 


### PR DESCRIPTION
A few proposed changes to internals of the MultiTrajSolver and its subclasses. The changes are (a) to increase consistency between the monte carlo solvers and the stochastic solvers, (b) to reduce repeating code from MultiTrajSolver in the subclasses, (c) to fix some documentation.

* Renamed `_MTSystem` and `_MCSystem` into `_MultiTrajRHS` and `_MCRHS` to make them analogous to `_StochasticRHS`. Removed distinction between `.system` and `.rhs` which seemed unnecessary and confusing to me (please tell me if I'm wrong).
* Made `_integrate_one_traj` use the integrator's run method (which doesn't do anything special currently, but I imagine that it could potentially be implemented more efficiently than repeated calls to integrate). Made subclasses use `_run_one_traj`, `_integrate_one_traj` etc of the parent class where possible, instead of duplicating logic.
* The docstring of MCSolver.run was not documenting its parameters, instead referring to the docstring of MultiTrajSolver.run, but MultiTrajSolver is not included in the docs.