### PR TITLE
Fix argument type in doctring of projection()

### DIFF
--- a/doc/changes/2363.doc
+++ b/doc/changes/2363.doc
@@ -1,0 +1,1 @@
+Add your info here

--- a/doc/changes/2363.doc
+++ b/doc/changes/2363.doc
@@ -1,1 +1,1 @@
-Add your info here
+Fix types in docstring of projection()

--- a/qutip/core/states.py
+++ b/qutip/core/states.py
@@ -571,7 +571,7 @@ def projection(dimensions, n, m, offset=None, *, dtype=None):
         Number of basis states in Hilbert space.  If a list, then the resultant
         object will be a tensor product over spaces with those dimensions.
 
-    n, m : float
+    n, m : int
         The number states in the projection.
 
     offset : int, default: 0


### PR DESCRIPTION
In projection(dim, m, n, ...), m,n are Fock state numbers, so must be integers.  Also matches the docstring of basis() which is used by projection().

