### PR TITLE
Ensure progress bars don't break on too many update

### DIFF
--- a/qutip/tests/test_progressbar.py
+++ b/qutip/tests/test_progressbar.py
@@ -34,6 +34,30 @@ def test_progressbar(pbar):
     assert bar.total_time() > 0
 
 
+@pytest.mark.parametrize("pbar", bars)
+def test_progressbar_too_few_update(pbar):
+    N = 5
+    bar = progress_bars[pbar](N)
+    assert bar.total_time() < 0
+    for _ in range(N-2):
+        time.sleep(0.01)
+        bar.update()
+    bar.finished()
+    assert bar.total_time() > 0
+
+
+@pytest.mark.parametrize("pbar", bars)
+def test_progressbar_too_many_update(pbar):
+    N = 5
+    bar = progress_bars[pbar](N)
+    assert bar.total_time() < 0
+    for _ in range(N+2):
+        time.sleep(0.01)
+        bar.update()
+    bar.finished()
+    assert bar.total_time() > 0
+
+
 @pytest.mark.parametrize("pbar", bars[1:])
 def test_progressbar_has_print(pbar, capsys):
     N = 2

--- a/qutip/ui/progressbar.py
+++ b/qutip/ui/progressbar.py
@@ -44,7 +44,7 @@ class BaseProgressBar(object):
         return "%6.2fs" % (time.time() - self.t_start)
 
     def time_remaining_est(self, p):
-        if p > 0.0:
+        if 100 >= p > 0.0:
             t_r_est = (time.time() - self.t_start) * (100.0 - p) / p
         else:
             t_r_est = 0


### PR DESCRIPTION
**Description**
While trying to reproduce #1229. I found that the progress bar would raise an error (`OverflowError: date value out of range`) if `update` was called too often.
Now when the bar goes over 100% it says 0 sec remaining.