### PR TITLE
Update sphinx-rtd-theme to fix search.

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,7 +34,7 @@ six==1.16.0
 snowballstemmer==2.2.0
 Sphinx==6.1.3
 sphinx-gallery==0.12.2
-sphinx-rtd-theme==1.2.0
+sphinx-rtd-theme==1.2.1
 sphinxcontrib-applehelp==1.0.3
 sphinxcontrib-bibtex==2.5.0
 sphinxcontrib-devhelp==1.0.2

--- a/doc/rtd-environment.yml
+++ b/doc/rtd-environment.yml
@@ -38,7 +38,7 @@ dependencies:
 - snowballstemmer==2.2.0
 - Sphinx==6.1.3
 - sphinx-gallery==0.12.2
-- sphinx-rtd-theme==1.2.0
+- sphinx-rtd-theme==1.2.1
 - sphinxcontrib-applehelp==1.0.4
 - sphinxcontrib-bibtex==2.5.0
 - sphinxcontrib-devhelp==1.0.2


### PR DESCRIPTION
**Description**

@ajgpitch noticed that search is not working on our ReadTheDocs site. Some digging revealed that this was broken in sphinx-rtd-theme before 1.2.1 (https://github.com/readthedocs/sphinx_rtd_theme/pull/1448/). This PR updates the documentation builds to use version 1.2.1.

We'll need to merge this change to all release branches for search to work correctly on those builds.

**Related issues or PRs**
- https://github.com/readthedocs/sphinx_rtd_theme/pull/1448/