### PR TITLE
Fix broken links for the doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 You are most welcome to contribute to QuTiP development by forking this repository and sending pull requests, or filing bug reports at the [issues page](https://github.com/qutip/qutip/issues).
 You can also help out with users' questions, or discuss proposed changes in the [QuTiP discussion group](https://groups.google.com/g/qutip).
-All code contributions are acknowledged in the [contributors](https://qutip.org/docs/latest/contributors.html) section in the documentation.
+All code contributions are acknowledged in the [contributors](https://qutip.readthedocs.io/en/stable/contributors.html) section in the documentation.
 
-For more information, including technical advice, please see the ["contributing to QuTiP development" section of the documentation](https://qutip.org/docs/latest/development/contributing.html).
+For more information, including technical advice, please see the ["contributing to QuTiP development" section of the documentation](https://qutip.readthedocs.io/en/stable/development/contributing.html).

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ pip install qutip
 
 to get the minimal installation.
 You can instead use the target `qutip[full]` to install QuTiP with all its optional dependencies.
-For more details, including instructions on how to build from source, see [the detailed installation guide in the documentation](https://qutip.org/docs/latest/installation.html).
+For more details, including instructions on how to build from source, see [the detailed installation guide in the documentation](https://qutip.readthedocs.io/en/stable/installation.html).
 
 All back releases are also available for download in the [releases section of this repository](https://github.com/qutip/qutip/releases), where you can also find per-version changelogs.
-For the most complete set of release notes and changelogs for historic versions, see the [changelog](https://qutip.org/docs/latest/changelog.html) section in the documentation.
+For the most complete set of release notes and changelogs for historic versions, see the [changelog](https://qutip.readthedocs.io/en/stable/changelog.html) section in the documentation.
 
 
 The pre-release of QuTiP 5.0 is available on PyPI and can be installed using pip:
@@ -107,9 +107,9 @@ Contribute
 
 You are most welcome to contribute to QuTiP development by forking this repository and sending pull requests, or filing bug reports at the [issues page](https://github.com/qutip/qutip/issues).
 You can also help out with users' questions, or discuss proposed changes in the [QuTiP discussion group](https://groups.google.com/g/qutip).
-All code contributions are acknowledged in the [contributors](https://qutip.org/docs/latest/contributors.html) section in the documentation.
+All code contributions are acknowledged in the [contributors](https://qutip.readthedocs.io/en/stable/contributors.html) section in the documentation.
 
-For more information, including technical advice, please see the ["contributing to QuTiP development" section of the documentation](https://qutip.org/docs/latest/development/contributing.html).
+For more information, including technical advice, please see the ["contributing to QuTiP development" section of the documentation](https://qutip.readthedocs.io/en/stable/development/contributing.html).
 
 
 Citing QuTiP

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ license = BSD 3-Clause License
 license_files = LICENSE.txt
 project_urls =
     Bug Tracker = https://github.com/qutip/qutip/issues
-    Documentation = https://qutip.org/docs/latest/
+    Documentation = https://qutip.readthedocs.io/en/stable/
     Source Code = https://github.com/qutip/qutip
 classifiers =
     Development Status :: 2 - Pre-Alpha


### PR DESCRIPTION
A few links to the documentation are broken because we moved to readthedoc.