### PR TITLE
Update the readme note for v5 and add setuptools requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,6 @@ and [J. R. Johansson](https://github.com/jrjohansson)
 [![PyPi Downloads](https://img.shields.io/pypi/dm/qutip?label=downloads%20%7C%20pip&logo=PyPI)](https://pypi.org/project/qutip)
 [![Conda-Forge Downloads](https://img.shields.io/conda/dn/conda-forge/qutip?label=downloads%20%7C%20conda&logo=Conda-Forge)](https://anaconda.org/conda-forge/qutip)
 
-> **Note**
->
-> The master branch now contains the alpha version of QuTiP 5. This is major
-> revision that breaks compatibility in many small ways withh QuTiP 4.7.
->
-> If you need to track QuTiP 4.7 changes or submit pull requests for 4.7,
-> please use the `qutip-4.7.X` branch.
->
-> If you need to track QuTiP 5 changes or submit  pull request for 5,
-> please use the `master` branch (and not the `dev.major` branch).
->
-> The change to master happened on 16 January 2023 in commit @fccec5d.
-
 QuTiP is open-source software for simulating the dynamics of closed and open quantum systems.
 It uses the excellent Numpy, Scipy, and Cython packages as numerical backends, and graphical output is provided by Matplotlib.
 QuTiP aims to provide user-friendly and efficient numerical simulations of a wide variety of quantum mechanical problems, including those with Hamiltonians and/or collapse operators with arbitrary time-dependence, commonly found in a wide range of physics applications.

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -11,8 +11,8 @@ import importlib
 import warnings
 import numbers
 from collections import defaultdict
-from setuptools import setup, Extension
 try:
+    from setuptools import setup, Extension
     from Cython.Build import cythonize
     import filelock
 except ImportError:

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ runtime_compilation =
     cython>=0.29.20; python_version>='3.10'
     cython>=0.29.20,<3.0.3; python_version<='3.9'
     filelock
+    setuptools
 semidefinite =
     cvxpy>=1.0
     cvxopt


### PR DESCRIPTION
**Description**
- setuptools is used for cython coefficient compilation, but was not in the requirements.
- The readme still had a note saying that v5 was in alpha, now that it is released, it should be removed.