### PR TITLE
Use CSR as the default for expand_operator

### DIFF
--- a/doc/changes/2280.bugfix
+++ b/doc/changes/2280.bugfix
@@ -1,0 +1,1 @@
+Use CSR as the default for expand_operator

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -437,9 +437,9 @@ def expand_operator(oper, dims, targets, dtype=None):
     targets : int or list of int
         The indices of subspace that are acted on.
     dtype : str, optional
-        Data type of the output :class:`.Qobj`. By default it uses the data type
-        specified in settings. If no data type is specified in settings
-        it uses the ``CSR`` data type.
+        Data type of the output :class:`.Qobj`. By default it uses the data
+        type specified in settings. If no data type is specified
+        in settings it uses the ``CSR`` data type.
 
     Returns
     -------

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -17,6 +17,7 @@ from .dimensions import (
     dims_idxs_to_tensor_idxs
 )
 from . import data as _data
+from . import settings
 
 
 class _reverse_partial_tensor:
@@ -435,6 +436,8 @@ def expand_operator(oper, dims, targets):
         E.g ``[2, 3, 2, 3, 4]``.
     targets : int or list of int
         The indices of subspace that are acted on.
+    dtype : str, optional
+        Data type of the output `Qobj`.
 
     Returns
     -------
@@ -442,6 +445,8 @@ def expand_operator(oper, dims, targets):
         The expanded operator acting on a system with desired dimension.
     """
     from .operators import identity
+    dtype = dtype or settings.core["default_dtype"] or _data.CSR
+    oper = oper.to(dtype)
     N = len(dims)
     targets = _targets_to_list(targets, oper=oper, N=N)
     _check_oper_dims(oper, dims=dims, targets=targets)

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -17,7 +17,7 @@ from .dimensions import (
     dims_idxs_to_tensor_idxs
 )
 from . import data as _data
-from . import settings
+from .. import settings
 
 
 class _reverse_partial_tensor:

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -414,7 +414,7 @@ def _targets_to_list(targets, oper=None, N=None):
     return targets
 
 
-def expand_operator(oper, dims, targets):
+def expand_operator(oper, dims, targets, dtype=None):
     """
     Expand an operator to one that acts on a system with desired dimensions.
     e.g.

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -437,12 +437,14 @@ def expand_operator(oper, dims, targets, dtype=None):
     targets : int or list of int
         The indices of subspace that are acted on.
     dtype : str, optional
-        Data type of the output `Qobj`.
+        Data type of the output :class:`.Qobj`. By default it uses the data type
+        specified in settings. If no data type is specified in settings
+        it uses the ``CSR`` data type.
 
     Returns
     -------
     expanded_oper : :class:`.Qobj`
-        The expanded operator acting on a system with desired dimension.
+        The expanded operator acting on a system with the desired dimension.
     """
     from .operators import identity
     dtype = dtype or settings.core["default_dtype"] or _data.CSR

--- a/qutip/tests/core/test_tensor.py
+++ b/qutip/tests/core/test_tensor.py
@@ -257,8 +257,11 @@ class Test_expand_operator:
             np.testing.assert_allclose(test.full(), expected.full())
 
     def test_dtype(self):
-        expanded_qobj = expand_operator(qutip.gates.cnot(), dims=[2, 2, 2]).data
+        expanded_qobj = expand_operator(
+            qutip.gates.cnot(), dims=[2, 2, 2], targets=[0, 1]
+        ).data
         assert isinstance(expanded_qobj, qutip.data.CSR)
         expanded_qobj = expand_operator(
-            qutip.gates.cnot(), dims=[2, 2, 2], dtype="dense").data
+            qutip.gates.cnot(), dims=[2, 2, 2], targets=[0, 1], dtype="dense"
+        ).data
         assert isinstance(expanded_qobj, qutip.data.Dense)

--- a/qutip/tests/core/test_tensor.py
+++ b/qutip/tests/core/test_tensor.py
@@ -255,3 +255,10 @@ class Test_expand_operator:
             test = expand_operator(base_test, dims=dimensions, targets=targets)
             assert test.dims == expected.dims
             np.testing.assert_allclose(test.full(), expected.full())
+
+    def test_dtype(self):
+        expanded_qobj = expand_operator(qutip.gates.cnot(), dims=[2, 2, 2]).data
+        assert isinstance(expanded_qobj, qutip.data.CSR)
+        expanded_qobj = expand_operator(
+            qutip.gates.cnot(), dims=[2, 2, 2], dtype="dense").data
+        assert isinstance(expanded_qobj, qutip.data.Dense)


### PR DESCRIPTION
**Description**
Use CSR as the default for expand_operator because the output is usually sparse.