### PR TITLE
fix end condition on mcsolve when using target tolerance

### DIFF
--- a/doc/changes/2382.bugfix
+++ b/doc/changes/2382.bugfix
@@ -1,0 +1,1 @@
+Ensure that end_condition of mcsolve result doesn't say target tolerance reached when it hasn't 

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -657,7 +657,10 @@ class MultiTrajResult(_BaseResult):
 
         self._estimated_ntraj = min(target_ntraj, self._target_ntraj)
         if (self._estimated_ntraj - self.num_trajectories) <= 0:
-            self.stats["end_condition"] = "target tolerance reached"
+            if (self._estimated_ntraj - self._target_ntraj) < 0:
+                self.stats["end_condition"] = "target tolerance reached"
+            else:
+                self.stats["end_condition"] = "ntraj reached"
         return self._estimated_ntraj - self.num_trajectories
 
     def _post_init(self):

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -391,6 +391,28 @@ def test_timeout(improved_sampling):
                   timeout=1e-6)
     assert res.stats['end_condition'] == 'timeout'
 
+@pytest.mark.parametrize("improved_sampling", [True, False])
+def test_target_tol(improved_sampling):
+    size = 10
+    ntraj = 100
+    a = qutip.destroy(size)
+    H = qutip.num(size)
+    state = qutip.basis(size, size-1)
+    times = np.linspace(0, 1.0, 100)
+    coupling = 0.5
+    n_th = 0.05
+    c_ops = np.sqrt(coupling * (n_th + 1)) * a
+    e_ops = [qutip.num(size)]
+
+    options = {'map': 'serial', "improved_sampling": improved_sampling}
+
+    res = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj, options=options,
+                  target_tol = 0.5)
+    assert res.stats['end_condition'] == 'target tolerance reached'
+
+    res = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj, options=options,
+                  target_tol = 1e-6)
+    assert res.stats['end_condition'] == 'ntraj reached'
 
 @pytest.mark.parametrize("improved_sampling", [True, False])
 def test_super_H(improved_sampling):


### PR DESCRIPTION
**Description**
Previously, if you specified a target tolerance when using `mcsolve`, the result's `end_condition` would show "target tolerance reached" regardless of whether this was true. I added a line to check this and set `end_condition` to "ntraj reached" when appropriate. 
