### PR TITLE
Set requirements to refuse scipy 1.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.9"]
         case-name: [defaults]
-        numpy-requirement: [">=1.20,<1.21"]
+        numpy-requirement: [">=1.20"]
         coverage-requirement: ["==6.5"]
         # Extra special cases.  In these, the new variable defined should always
         # be a truth-y value (hence 'nomkl: 1' rather than 'mkl: 0'), because
@@ -68,6 +68,7 @@ jobs:
             python-version: "3.9"
             numpy-requirement: ">=1.20,<1.21"
             openmp: 1
+            oldmatplotlib: 1  # Recent matplotlib don't work with numpy 1.20
 
           # Builds without Cython at runtime.  This is a core feature;
           # everything should be able to run this.
@@ -143,13 +144,23 @@ jobs:
         # In the run, first we handle any special cases.  We do this in bash
         # rather than in the GitHub Actions file directly, because bash gives us
         # a proper programming language to use.
+        # We install without build isolation so qutip is compiled with the
+        # version of cython, scipy, numpy in the test matrix, not a temporary
+        # version use in the installation virtual environment.
         run: |
-          QUTIP_TARGET="tests,graphics,ipython"
-          if [[ -z "${{ matrix.nocython }}" ]]; then
-            QUTIP_TARGET="$QUTIP_TARGET,runtime_compilation"
+          # Install the extra requirement
+          python -m pip install pytest>=5.2 pytest-rerunfailures  # tests
+          python -m pip install matplotlib  # graphics
+          python -m pip install ipython  # ipython
+          python -m pip install "coverage${{ matrix.coverage-requirement }}" chardet
+          python -m pip install pytest-cov coveralls pytest-fail-slow
+          python -m pip install cython==0.29.36
+
+          if [[ "${{ matrix.oldmatplotlib }}" ]]; then
+            python -m pip install matplotlib==3.5.3
           fi
           if [[ -z "${{ matrix.nocvxopt }}" ]]; then
-            QUTIP_TARGET="$QUTIP_TARGET,semidefinite"
+            python -m pip install cvxpy>=1.0 cvxopt  # semidefinite
           fi
           export CI_QUTIP_WITH_OPENMP=${{ matrix.openmp }}
           if [[ -z "${{ matrix.nomkl }}" ]]; then
@@ -164,9 +175,11 @@ jobs:
           if [[ -n "${{ matrix.conda-extra-pkgs }}" ]]; then
             conda install "${{ matrix.conda-extra-pkgs }}"
           fi
-          python -m pip install -e .[$QUTIP_TARGET]
-          python -m pip install "coverage${{ matrix.coverage-requirement }}"
-          python -m pip install pytest-cov coveralls pytest-fail-slow
+
+          python -m pip install -e . -v --no-build-isolation
+          if [[ "${{ matrix.nocython }}" ]]; then
+            python -m pip uninstall cython -y
+          fi
 
       - name: Package information
         run: |

--- a/doc/changes/2383.misc
+++ b/doc/changes/2383.misc
@@ -1,0 +1,1 @@
+Exclude scipy 1.13 from in the requirements

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ include_package_data = True
 zip_safe = False
 install_requires =
     numpy>=1.16.6
-    scipy>=1.0
+    scipy>=1.0,<1.13.0
     packaging
 setup_requires =
     numpy>=1.13.3


### PR DESCRIPTION
**Description**
Scipy 1.13 change the way sparse operations are done.
Some changes to scipy fix most issues, but I get some segfault with the sparse eigen solver and I am unable to run all tests.
1.13 work with v5 so I changed the requirements to exclude that version in v4.7.