### PR TITLE
fix two bugs in floquet steadystate

### DIFF
--- a/doc/changes/2393.bugfix
+++ b/doc/changes/2393.bugfix
@@ -1,0 +1,1 @@
+Fix two bugs in steadystate floquet solver, and adjust tests to be sensitive to this issue.

--- a/qutip/solver/steadystate.py
+++ b/qutip/solver/steadystate.py
@@ -356,9 +356,10 @@ def steadystate_floquet(H_0, c_ops, Op_t, w_d=1.0, n_it=3, sparse=False,
         - "mkl_spsolve"
           sparse solver by mkl.
 
-        Extensions to qutip, such as qutip-tensorflow, may provide their own solvers.
-        When ``H_0`` and ``c_ops`` use these data backends, see their documentation
-        for the names and details of additional solvers they may provide.
+        Extensions to qutip, such as qutip-tensorflow, may provide their own
+        solvers. When ``H_0`` and ``c_ops`` use these data backends, see their
+        documentation for the names and details of additional solvers they may
+        provide.
 
     **kwargs:
         Extra options to pass to the linear system solver. See the
@@ -387,7 +388,6 @@ def steadystate_floquet(H_0, c_ops, Op_t, w_d=1.0, n_it=3, sparse=False,
     Id = qeye_like(L_0)
     S = qzero_like(L_0)
     T = qzero_like(L_0)
-
 
     if isinstance(H_0.data, _data.CSR) and not sparse:
         L_0 = L_0.to("Dense")

--- a/qutip/solver/steadystate.py
+++ b/qutip/solver/steadystate.py
@@ -373,18 +373,21 @@ def steadystate_floquet(H_0, c_ops, Op_t, w_d=1.0, n_it=3, sparse=False,
     Notes
     -----
     See: Sze Meng Tan,
-    https://copilot.caltech.edu/documents/16743/qousersguide.pdf,
-    Section (10.16)
+    https://painterlab.caltech.edu/wp-content/uploads/2019/06/qe_quantum_optics_toolbox.pdf,
+    Section (16)
 
     """
 
     L_0 = liouvillian(H_0, c_ops)
-    L_m = L_p = 0.5 * liouvillian(Op_t)
+    L_m = 0.5 * liouvillian(Op_t)
+    L_p = 0.5 * liouvillian(Op_t)
     # L_p and L_m correspond to the positive and negative
     # frequency terms respectively.
     # They are independent in the model, so we keep both names.
     Id = qeye_like(L_0)
-    S = T = qzero_like(L_0)
+    S = qzero_like(L_0)
+    T = qzero_like(L_0)
+
 
     if isinstance(H_0.data, _data.CSR) and not sparse:
         L_0 = L_0.to("Dense")
@@ -395,7 +398,7 @@ def steadystate_floquet(H_0, c_ops, Op_t, w_d=1.0, n_it=3, sparse=False,
     for n_i in np.arange(n_it, 0, -1):
         L = L_0 - 1j * n_i * w_d * Id + L_m @ S
         S.data = - _data.solve(L.data, L_p.data, solver, kwargs)
-        L = L_0 - 1j * n_i * w_d * Id + L_p @ T
+        L = L_0 + 1j * n_i * w_d * Id + L_p @ T
         T.data = - _data.solve(L.data, L_m.data, solver, kwargs)
 
     M_subs = L_0 + L_m @ S + L_p @ T

--- a/qutip/tests/solver/test_steadystate.py
+++ b/qutip/tests/solver/test_steadystate.py
@@ -194,39 +194,40 @@ def test_steadystate_floquet(sparse):
     Test the steadystate solution for a periodically
     driven system.
     """
-    N_c = 20
-
-    a = qutip.destroy(N_c)
-    a_d = a.dag()
-    X_c = a + a_d
+    sz = qutip.sigmaz()
+    sx = qutip.sigmax()
 
     w_c = 1
-
-    A_l = 0.001
+    A_l = 0.5
     w_l = w_c
     gam = 0.01
 
-    H = w_c * a_d * a
+    H = w_c * sz
 
-    H_t = [H, [X_c, lambda t, args: args["A_l"] * np.cos(args["w_l"] * t)]]
+    H_t = [H, [sx, lambda t, args: args["A_l"] * np.cos(args["w_l"] * t)]]
 
-    psi0 = qutip.fock(N_c, 0)
+    psi0 = qutip.basis(2, 0)
 
     args = {"A_l": A_l, "w_l": w_l}
 
     c_ops = []
-    c_ops.append(np.sqrt(gam) * a)
+    c_ops.append(np.sqrt(gam) * qutip.destroy(2).dag())
 
     t_l = np.linspace(0, 20 / gam, 2000)
 
     expect_me = qutip.mesolve(H_t, psi0, t_l,
-                        c_ops, [a_d * a], args=args).expect[0]
+                              c_ops, [sz], args=args).expect[0]
 
     rho_ss = qutip.steadystate_floquet(H, c_ops,
-                                       A_l * X_c, w_l, n_it=3, sparse=sparse)
-    expect_ss = qutip.expect(a_d * a, rho_ss)
+                                       A_l * sx, w_l, n_it=3, sparse=sparse)
+    expect_ss = qutip.expect(sz, rho_ss)
 
-    np.testing.assert_allclose(expect_me[-20:], expect_ss, atol=1e-3)
+    dt = (20 / gam) / len(t_l)
+    one_period = int(1/(w_l/(2*np.pi)) / dt)
+
+    average_ex = sum(expect_me[-one_period:]) / float(one_period)
+
+    np.testing.assert_allclose(average_ex, expect_ss, atol=1e-2)
     assert rho_ss.tr() == pytest.approx(1, abs=1e-15)
 
 

--- a/qutip/tests/solver/test_steadystate.py
+++ b/qutip/tests/solver/test_steadystate.py
@@ -202,7 +202,7 @@ def test_steadystate_floquet(sparse):
     w_l = w_c
     gam = 0.01
 
-    H = w_c * sz
+    H = 0.5 * w_c * sz
 
     H_t = [H, [sx, lambda t, args: args["A_l"] * np.cos(args["w_l"] * t)]]
 
@@ -212,8 +212,8 @@ def test_steadystate_floquet(sparse):
 
     c_ops = []
     c_ops.append(np.sqrt(gam) * qutip.destroy(2).dag())
-
-    t_l = np.linspace(0, 20 / gam, 2000)
+    T_max = 20 * 2 * np.pi / gam
+    t_l = np.linspace(0, T_max, 20000)
 
     expect_me = qutip.mesolve(H_t, psi0, t_l,
                               c_ops, [sz], args=args).expect[0]
@@ -222,7 +222,7 @@ def test_steadystate_floquet(sparse):
                                        A_l * sx, w_l, n_it=3, sparse=sparse)
     expect_ss = qutip.expect(sz, rho_ss)
 
-    dt = (20 / gam) / len(t_l)
+    dt = T_max / len(t_l)
     one_period = int(1/(w_l/(2*np.pi)) / dt)
 
     average_ex = sum(expect_me[-one_period:]) / float(one_period)


### PR DESCRIPTION
Two small bugs appeared in floquet steadystate in v5, this is a quick patch.

**Description**
Two bugs:

1) Small minus sign error in one of the terms (comparing to v4.7 and what is written in the old toolbox guide).

2) Some kind of data copying confusion with the S and T operators when updating their data contents with the results.  Just initiating these two separately seems to fix it.

other minor fix: updated the link to the toolbox guide

Some other minor niggles that I didn't fix:
- some of the optional solver methods dont work (seem not to support square right hand sides in '_data.solve()'.  I didn't dig much on fixing these though

- the 'splu' method fails for a couple of reasons. I can get it to work by removing the choice of warnings as errors in 'solve.py' (which make it fail in other instances as well i suppose, like with normal steadystate()), making sure the solver option is not passed to steadystate(), and making sure that S and T are always converted back to CSR() after being updated in the iterative bit (in `steadystate_floquet()' they get returned as dense from _data.solve).  I did not include those changes here though as the docstrings dont actually indicate support for splu anyway, so perhaps not needed.

I am marking this as draft at the moment as I also want to update the test to be sensitive to these bugs (its a bit too coarse at the moment), and double check that the results from this solver are now correct.

**Related issues or PRs**
fix #2386