### PR TITLE
PPoly and Bspline accept real coeff + tested

### DIFF
--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -517,7 +517,7 @@ cdef class InterCoefficient(Coefficient):
 
     @classmethod
     def from_PPoly(cls, ppoly, **_):
-        return cls.restore(ppoly.x, ppoly.c)
+        return cls.restore(ppoly.x, np.array(ppoly.c, complex, copy=False))
 
     @classmethod
     def from_Bspline(cls, spline, **_):
@@ -528,7 +528,7 @@ cdef class InterCoefficient(Coefficient):
         poly = np.concatenate([
             spline(tlist, i) / fact[i]
             for i in range(spline.k, -1, -1)
-        ]).reshape((spline.k+1, -1))
+        ]).reshape((spline.k+1, -1)).astype(complex, copy=False)
         return cls.restore(tlist, poly)
 
     cpdef Coefficient copy(self):

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -381,9 +381,13 @@ def test_CoeffArray(order):
         assert derrs[i] == pytest.approx(0.0,  abs=0.0001)
 
 
-def test_CoeffFromScipy():
+@pytest.mark.parametrize('imag', [True, False])
+def test_CoeffFromScipyPPoly(imag):
     tlist = np.linspace(0, 1.01, 101)
-    y = np.exp((-1 + 1j) * tlist)
+    if imag:
+        y = np.exp(-1j * tlist)
+    else:
+        y = np.exp(-1 * tlist)
 
     coeff = coefficient(y, tlist=tlist, order=3)
     from_scipy = coefficient(interp.CubicSpline(tlist, y))
@@ -396,6 +400,24 @@ def test_CoeffFromScipy():
     coeff = coefficient(y, tlist=tlist, order=3, boundary_conditions="natural")
     from_scipy = coefficient(interp.make_interp_spline(tlist, y, k=3, bc_type="natural"))
     _assert_eq_over_interval(coeff, from_scipy, rtol=1e-8, inside=True)
+
+
+@pytest.mark.parametrize('imag', [True, False])
+def test_CoeffFromScipyBSpline(imag):
+    tlist = np.linspace(-0.1, 1.1, 121)
+    if imag:
+        y = np.exp(-1j * tlist)
+    else:
+        y = np.exp(-1 * tlist)
+
+    spline = interp.BSpline(tlist, y, 2)
+
+    def func(t):
+        return complex(spline(t))
+
+    coverted = coefficient(spline)
+    raw_scipy = coefficient(func)
+    _assert_eq_over_interval(coverted, raw_scipy, rtol=1e-8, inside=True)
 
 
 @pytest.mark.parametrize('map_func', [


### PR DESCRIPTION
**Description**
`qutip.coefficient` accept scipy's CubicSpline input, but only work for complex `y` array:
```
x = np.linspace(0, 1, 11)
y = np.exp(-1j*x)
H = qutip.QobjEvo([H0, scipy.interpolate.CubicSpline(x, y)])
```
worked, but 
```
x = np.linspace(0, 1, 11)
y = np.sin(x)
H = qutip.QobjEvo([H0, scipy.interpolate.CubicSpline(x, y)])
```
did not. 
This add support for CubicSpline built using real array. 
Also add a test for both real and imag arrays + using both PPoly (parent class of CubicSpline) and Bspline (another spline class of scipy.)

bug reported in: https://groups.google.com/g/qutip/c/MS0r6YNFkd8/m/0_cPnqheAQAJ