### PR TITLE
Fix macos version in runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,9 @@ jobs:
           # Mac
           # Mac has issues with MKL since september 2022.
           - case-name: macos
-            os: macos-latest
+            # setup-miniconda not compatible with macos-latest yet.
+            # https://github.com/conda-incubator/setup-miniconda/issues/344
+            os: macos-13
             python-version: "3.11"
             condaforge: 1
             nomkl: 1
@@ -119,7 +121,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,9 +102,9 @@ jobs:
           # Mac
           # Mac has issues with MKL since september 2022.
           - case-name: macos
-            # setup-miniconda not compatible with macos-latest yet.
+            # setup-miniconda not compatible with macos-latest presently.
             # https://github.com/conda-incubator/setup-miniconda/issues/344
-            os: macos-13
+            os: macos-12
             python-version: "3.11"
             condaforge: 1
             nomkl: 1


### PR DESCRIPTION
**Description**
A new version of mac in github runners is not compatible with [setup-miniconda](https://github.com/conda-incubator/setup-miniconda/issues/344).
Until they fix it, to run on mac, we need to fix the mac version.
