### PR TITLE
Increase `test_nm_mcsolve.test_super_H` tolerance

### DIFF
--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -575,7 +575,7 @@ def test_super_H():
         qutip.liouvillian(H), state, times, ops_and_rates, e_ops, ntraj=ntraj,
         target_tol=0.1, options={'map': 'serial'},
     )
-    np.testing.assert_allclose(mc_expected.expect[0], mc.expect[0], atol=0.5)
+    np.testing.assert_allclose(mc_expected.expect[0], mc.expect[0], atol=0.65)
 
 
 def test_NonMarkovianMCSolver_run():


### PR DESCRIPTION
**Description**
`test_nm_mcsolve.test_super_H` [failed in master's test](https://github.com/qutip/qutip/actions/runs/8807804559/job/24175678290). 

Same issue as #2344. The tolerance is too tight and the test can fail randomly with a low probability.