### PR TITLE
Faster dm norm in solvers

### DIFF
--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -102,7 +102,10 @@ class Solver:
             state = Qobj(data, **self._state_metadata, copy=copy)
 
         if data.shape[1] == 1 and self._options['normalize_output']:
-            state = state * (1 / state.norm())
+            if state._isherm:
+                state = state * (1 / state.tr())
+            else:
+                state = state * (1 / state.norm())
 
         return state
 

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -206,7 +206,7 @@ class TestMESolveDecay:
     def test_mesolve_normalization(self, state_type):
         # non-hermitean H causes state to evolve non-unitarily
         H = qutip.Qobj([[1, -0.1j], [-0.1j, 1]])
-        H = qutip.sprepost(H, H) # ensure use of MeSolve
+        H = qutip.spre(H) + qutip.spost(H.dag()) # ensure use of MeSolve
         psi0 = qutip.basis(2, 0)
         options = {"normalize_output": True, "progress_bar": None}
 


### PR DESCRIPTION
**Description**
The trace norm was used to normalized dm in mesolve and other open solvers.
This is computed as `tr( sqrtm(op @ op.dag()) )` which is quite slow.
For density matrices, this is equivalent to the normal trace.
By using the trace, `mesolve` can be twice as fast.

**Related issues or PRs**
fix #2406

ps. While we check if the input is a dm to set the `isherm` flag, we don't check the liouvillian.
Since we accept any super-operator as Liouvillian, we could wrongly set the flag in some cases.
