### PR TITLE
Improve dnorm efficiency in unitary case

### DIFF
--- a/doc/biblio.rst
+++ b/doc/biblio.rst
@@ -41,9 +41,8 @@ Bibliography
     open quantum systems*. :arxiv:`1111.6950`
 
 .. [AKN98]
-    D. Aharonov, A. Kitaev, and N. Nisan, *Quantum circuits with mixed states*, 
-    in Proceedings of the thirtieth annual ACM symposium on Theory of computing, 
-    20–30 (1998). :arxiv:`quant-ph/9806029`
+    D. Aharonov, A. Kitaev, and N. Nisan, *Quantum circuits with mixed states*, in Proceedings of the 
+    thirtieth annual ACM symposium on Theory of computing, 20-30 (1998). :arxiv:`quant-ph/9806029`
 
 .. [dAless08]
     D. d’Alessandro, *Introduction to Quantum Control and Dynamics*, (Chapman & Hall/CRC, 2008).

--- a/doc/biblio.rst
+++ b/doc/biblio.rst
@@ -40,6 +40,11 @@ Bibliography
     C. Wood, J. Biamonte, D. G. Cory, *Tensor networks and graphical calculus for
     open quantum systems*. :arxiv:`1111.6950`
 
+.. [AKN98]
+    D. Aharonov, A. Kitaev, and N. Nisan, *Quantum circuits with mixed states*, 
+    in Proceedings of the thirtieth annual ACM symposium on Theory of computing, 
+    20–30 (1998). :arxiv:`quant-ph/9806029`
+
 .. [dAless08]
     D. d’Alessandro, *Introduction to Quantum Control and Dynamics*, (Chapman & Hall/CRC, 2008).
 

--- a/doc/changes/2416.feature
+++ b/doc/changes/2416.feature
@@ -1,0 +1,2 @@
+Updated `qutip.core.metrics.dnorm` to have an efficient speedup when findind the difference of two unitaries. We use a result on page 19 of 
+D. Aharonov, A. Kitaev, and N. Nisan, (1998).

--- a/doc/changes/2416.feature
+++ b/doc/changes/2416.feature
@@ -1,2 +1,2 @@
-Updated `qutip.core.metrics.dnorm` to have an efficient speedup when finding the difference of two unitaries. We use a result on page 19 of 
+Updated `qutip.core.metrics.dnorm` to have an efficient speedup when finding the difference of two unitaries. We use a result on page 18 of 
 D. Aharonov, A. Kitaev, and N. Nisan, (1998).

--- a/doc/changes/2416.feature
+++ b/doc/changes/2416.feature
@@ -1,2 +1,2 @@
-Updated `qutip.core.metrics.dnorm` to have an efficient speedup when findind the difference of two unitaries. We use a result on page 19 of 
+Updated `qutip.core.metrics.dnorm` to have an efficient speedup when finding the difference of two unitaries. We use a result on page 19 of 
 D. Aharonov, A. Kitaev, and N. Nisan, (1998).

--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -505,9 +505,15 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
         eigs = U.eigenenergies()
         d = _find_poly_distance(eigs)
         return 2 * np.sqrt(1 - d**2)  # plug d into formula
+
     J = to_choi(A)
-    if B is not None:
+
+    if B is not None:  # If B is provided, calculate difference
         J -= to_choi(B)
+
+    if not force_solve and J.iscptp:
+        # diamond norm of a CPTP map is 1 (Prop 3.44 Watrous 2018)
+        return 1.0
 
     # Watrous 2012 also points out that the diamond norm of Lambda
     # is the same as the completely-bounded operator-norm (∞-norm)
@@ -522,9 +528,6 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
         # The 2-norm was not implemented for sparse matrices as of the time
         # of this writing. Thus, we must yet again go dense.
         return la.norm(op.full(), 2)
-    if not force_solve and J.iscptp:
-        # diamond norm of a CPTP map is 1 (Prop 3.44 Watrous 2018)
-        return 1.0
 
     # If we're still here, we need to actually solve the problem.
 

--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -489,17 +489,11 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
     # d between the origin and compelx hull of these. Plugging
     # this into 2√1-d² gives the diamond norm.
 
-    def check_unitary(op):
-        # Helper function to check not None and is unitary.
-        if op is None or not op.isoper:
-            return False
-        else:
-            return (op * op.dag() - qeye_like(op)).norm() < 1e-6
-
     if (
         not force_solve
-        and check_unitary(A)
-        and check_unitary(B)
+        and A.isunitary
+        and B is not None
+        and B.isunitary
     ):  # Special optimisation fo a difference of unitaries.
         U = A * B.dag()
         eigs = U.eigenenergies()

--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -441,7 +441,7 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
     The diamond norm SDP is solved by using `CVXPY <https://www.cvxpy.org/>`_.
 
     If B is provided and both A and B are unitaries, a special optimised
-    case of the diamond norm is used.
+    case of the diamond norm is used. See [AKN98]_.
 
     Parameters
     ----------

--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -500,7 +500,7 @@ def dnorm(A, B=None, solver="CVXOPT", verbose=False, force_solve=False,
         and A.isunitary
         and B is not None
         and B.isunitary
-    ):  # Special optimisation fo a difference of unitaries.
+    ):  # Special optimisation for a difference of unitaries.
         U = A * B.dag()
         eigs = U.eigenenergies()
         d = _find_poly_distance(eigs)

--- a/qutip/tests/core/test_metrics.py
+++ b/qutip/tests/core/test_metrics.py
@@ -454,6 +454,15 @@ class Test_dnorm:
         )
 
     @pytest.mark.repeat(3)
+    def test_unitary_case(self, dimension):
+        """Check that the diamond norm is one for unitary maps."""
+        A, B = rand_unitary(dimension), rand_unitary(dimension)
+        assert (
+            dnorm(A, B)
+            == pytest.approx(dnorm(A, B, force_solve=True), abs=1e-5)
+        )
+
+    @pytest.mark.repeat(3)
     def test_cptp(self, dimension, sparse):
         """Check that the diamond norm is one for CPTP maps."""
         A = rand_super_bcsz(dimension)

--- a/qutip/tests/core/test_metrics.py
+++ b/qutip/tests/core/test_metrics.py
@@ -439,21 +439,6 @@ class Test_dnorm:
         assert dnorm(A + B) <= dnorm(A) + dnorm(B) + 1e-7
 
     @pytest.mark.repeat(3)
-    @pytest.mark.parametrize("generator", [
-        pytest.param(rand_super_bcsz, id="super"),
-        pytest.param(rand_unitary, id="unitary"),
-    ])
-    def test_force_solve(self, dimension, generator):
-        """
-        Metrics: checks that special cases for dnorm agree with SDP solutions.
-        """
-        A, B = generator(dimension), generator(dimension)
-        assert (
-            dnorm(A, B, force_solve=False)
-            == pytest.approx(dnorm(A, B, force_solve=True), abs=1e-5)
-        )
-
-    @pytest.mark.repeat(3)
     def test_unitary_case(self, dimension):
         """Check that the diamond norm is one for unitary maps."""
         A, B = rand_unitary(dimension), rand_unitary(dimension)
@@ -463,7 +448,16 @@ class Test_dnorm:
         )
 
     @pytest.mark.repeat(3)
-    def test_cptp(self, dimension, sparse):
+    def test_cp_case(self, dimension):
+        """Check that the diamond norm is one for unitary maps."""
+        A = rand_super_bcsz(dimension, enforce_tp=False)
+        assert (
+            dnorm(A)
+            == pytest.approx(dnorm(A, force_solve=True), abs=1e-5)
+        )
+
+    @pytest.mark.repeat(3)
+    def test_cptp_case(self, dimension, sparse):
         """Check that the diamond norm is one for CPTP maps."""
         A = rand_super_bcsz(dimension)
         assert A.iscptp


### PR DESCRIPTION
## Preliminaries
The diamond norm [1] is a commonly used metric in quantum information theory for calculating the distance between two quantum channels. It has a number of useful properties making it the gold standard [2] in the field for several applications. In general, a complex semidefinite program is required to calculate the diamond norm. Although elegant, this approach is very inefficient. Unfortunately, no alternative method has been discovered for calculating the diamond norm in the general case of CPTP channels.

However, in the special case where we are trying to calculate the difference between two unitary channels, a very efficient implementation exists. This makes use of an unproved theorem on page 29 of [1]. I have proved this theorem and elaborated an efficient algorithm to calculate the diamond distance between two unitaries as part of my masters thesis. 

The current qutip implementation makes use of the semi-definite program formulation in [3] and only uses a simplified calculation on 2 qubit unitary differences.

The implementation of this novel approach is very simple - the hardest step involves diagonalising a unitary. Although time complexity is still exponential in the number of qubits, this implementation is far more efficient than the more general implementation. The Choi representation of the quantum channel isn't used and there is no need to solve a complicated semi-definite program (meaning I can do away with the `cvxpy` dependency).

## Empirical testing
Results of empirical testing on my machine are reported below

|                                 | 3 qubit | 4 qubit  |
|---------|---------|----------|
| current implementation           | 5.22 s  | 3min 21s |
| hyper-efficient implementation  | 924 µs  | 1.11 ms  |

## Proposition
Given the popularity of the circuit model and unitary-based quantum computation, I believe a very efficient implementation of the diamond distance for unitaries would be incredibly valuable for the research community. Given how simple the change is (current tests already cover the test case), I think it would be a simple and worthwhile addition to qutip.

## Citations

[1] D. Aharonov, A. Kitaev, and N. Nisan, “Quantum circuits with mixed states,” in Proceedings of the thirtieth annual ACM symposium on Theory of computing, pp. 20–30, 1998.
[2] A. Gilchrist, N. K. Langford, and M. A. Nielsen, “Distance measures to compare real and ideal quantum processes,” Physical Review A, vol. 71, no. 6, p. 062310, 2005
[3] J. Watrous, “Simpler semidefinite programs for completely bounded norms,” arXiv preprint arXiv:1207.5726, 2012.
