### PR TITLE
Syncronize setup.cfg and pyproject.toml requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "packaging",
     "wheel",
     "cython>=0.29.20; python_version>='3.10'",
-    "cython>=0.29.20,<3.0.3; python_version<='3.9'",
+    "cython>=0.29.20,<3.0.0; python_version<='3.9'",
     # See https://numpy.org/doc/stable/user/depending_on_numpy.html for
     # the recommended way to build against numpy's C API:
     "oldest-supported-numpy",


### PR DESCRIPTION
**Description**
In #2413 I updated `setup.cfg` but forgot `pyproject.toml`.