### PR TITLE
Stochastic solvers small bugfix

### DIFF
--- a/qutip/solver/stochastic.py
+++ b/qutip/solver/stochastic.py
@@ -83,6 +83,11 @@ class StochasticTrajResult(Result):
         """
         if not self.options["store_measurement"]:
             return None
+        elif len(self.m_ops) == 0:
+            if self.heterodyne:
+                return np.empty(shape=(0, 2, len(self.times) - 1))
+            else:
+                return np.empty(shape=(0, len(self.times) - 1))
         elif self.options["store_measurement"] == "start":
             m_expect = np.array(self.m_expect)[:, :-1]
         elif self.options["store_measurement"] == "middle":

--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -15,6 +15,10 @@ def _make_system(N, system):
     gamma = 0.25
     a = destroy(N)
 
+    if system == "no sc_ops":
+        H = a.dag() * a
+        sc_ops = []
+
     if system == "simple":
         H = a.dag() * a
         sc_ops = [np.sqrt(gamma) * a]
@@ -39,7 +43,7 @@ def _make_system(N, system):
 
 
 @pytest.mark.parametrize("system", [
-    "simple", "2 c_ops", "H td", "complex", "c_ops td",
+    "no sc_ops", "simple", "2 c_ops", "H td", "complex", "c_ops td",
 ])
 @pytest.mark.parametrize("heterodyne", [True, False])
 def test_smesolve(heterodyne, system):
@@ -138,7 +142,7 @@ def test_smesolve_methods(method, heterodyne):
 
 
 @pytest.mark.parametrize("system", [
-    "simple", "2 c_ops", "H td", "complex", "c_ops td",
+    "no sc_ops", "simple", "2 c_ops", "H td", "complex", "c_ops td",
 ])
 @pytest.mark.parametrize("heterodyne", [True, False])
 def test_ssesolve(heterodyne, system):

--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -77,13 +77,15 @@ def test_smesolve(heterodyne, system):
         )
 
 
+@pytest.mark.parametrize("system", [
+    "no sc_ops", "simple"
+])
 @pytest.mark.parametrize("heterodyne", [True, False])
 @pytest.mark.parametrize("method", SMESolver.avail_integrators().keys())
-def test_smesolve_methods(method, heterodyne):
+def test_smesolve_methods(method, heterodyne, system):
     tol = 0.05
     N = 4
     ntraj = 20
-    system = "simple"
 
     H, sc_ops = _make_system(N, system)
     c_ops = [destroy(N)]
@@ -178,14 +180,16 @@ def test_ssesolve(heterodyne, system):
     assert res.dW is None
 
 
+@pytest.mark.parametrize("system", [
+    "no sc_ops", "simple"
+])
 @pytest.mark.parametrize("heterodyne", [True, False])
 @pytest.mark.parametrize("method", SSESolver.avail_integrators().keys())
-def test_ssesolve_method(method, heterodyne):
+def test_ssesolve_method(method, heterodyne, system):
     "Stochastic: smesolve: homodyne, time-dependent H"
     tol = 0.1
     N = 4
     ntraj = 20
-    system = "simple"
 
     H, sc_ops = _make_system(N, system)
     psi0 = coherent(N, 0.5)


### PR DESCRIPTION
When calling `ssesolve` or `smesolve` without any stochastic collapse operators but `store_measurement` set to True, there is an IndexError. This PR fixes the error and adds a test for this situation.

Example code:
```python
import qutip as qt
r = qt.ssesolve(qt.sigmaz(), qt.basis(2, 1), [0, 1, 2], options={'store_measurement': True}, ntraj=15)
```