### PR TITLE
Ensure feedback work for all trajectories

### DIFF
--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -482,7 +482,6 @@ cdef class QobjEvo:
                     f"Desired feedback {key} is not available for the {solver}."
                 )
             new_args[key] = solvers_feeds[feed]
-        # self.arguments(new_args)
 
         if new_args:
             cache = []

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -482,7 +482,16 @@ cdef class QobjEvo:
                     f"Desired feedback {key} is not available for the {solver}."
                 )
             new_args[key] = solvers_feeds[feed]
-        self.arguments(**new_args)
+        # self.arguments(new_args)
+
+        if new_args:
+            cache = []
+            self.elements = [
+                element.replace_arguments(new_args, cache=cache)
+                for element in self.elements
+            ]
+
+
 
     def _update_feedback(QobjEvo self, QobjEvo other=None):
         """

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -490,8 +490,6 @@ cdef class QobjEvo:
                 for element in self.elements
             ]
 
-
-
     def _update_feedback(QobjEvo self, QobjEvo other=None):
         """
         Merge feedback from ``op`` into self.

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -476,14 +476,18 @@ def test_MCSolver_stepping():
 
 def _coeff_collapse(t, A):
     if t == 0:
+        # New trajectory, was collapse list reset?
         assert len(A) == 0
+    if t > 2.75:
+        # End of the trajectory, was collapse list was filled?
+        assert len(A) != 0
     return (len(A) < 3) * 1.0
+
 
 @pytest.mark.parametrize(["func", "kind"], [
     pytest.param(
         lambda t, A: A-4,
         lambda: qutip.MCSolver.ExpectFeedback(qutip.num(10)),
-        # 7.+0j,
         id="expect"
     ),
     pytest.param(
@@ -500,9 +504,9 @@ def test_feedback(func, kind):
     solver = qutip.MCSolver(
         H,
         c_ops=[qutip.QobjEvo([a, func], args={"A": kind()})],
-        options={"map": "serial"}
+        options={"map": "serial", "max_step": 0.2}
     )
     result = solver.run(
-        psi0,np.linspace(0, 3, 31), e_ops=[qutip.num(10)], ntraj=10
+        psi0, np.linspace(0, 3, 31), e_ops=[qutip.num(10)], ntraj=10
     )
     assert np.all(result.expect[0] > 4. - tol)

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -474,6 +474,11 @@ def test_MCSolver_stepping():
     assert state.isket
 
 
+def _coeff_collapse(t, A):
+    if t == 0:
+        assert len(A) == 0
+    return (len(A) < 3) * 1.0
+
 @pytest.mark.parametrize(["func", "kind"], [
     pytest.param(
         lambda t, A: A-4,
@@ -482,7 +487,7 @@ def test_MCSolver_stepping():
         id="expect"
     ),
     pytest.param(
-        lambda t, A: (len(A) < 3) * 1.0,
+        _coeff_collapse,
         lambda: qutip.MCSolver.CollapseFeedback(),
         id="collapse"
     ),


### PR DESCRIPTION
**Description**
Fix the bug in collapse feedback that made it work properly only for the first trajectories. (#2422)
Also added a check in the feedback test to ensure the collapse argument is reset for each trajectories.

