### PR TITLE
Add `rtol` to `Qobj.__eq__`

### DIFF
--- a/doc/changes/2425.misc
+++ b/doc/changes/2425.misc
@@ -1,0 +1,1 @@
+Qobj.__eq__ uses core's settings rtol.

--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -527,6 +527,10 @@ cpdef CSR multiply_csr(CSR left, CSR right):
             + " and "
             + str(right.shape)
         )
+
+    left = left.sort_indices()
+    right = right.sort_indices()
+
     cdef idxint col_left, left_nnz = csr.nnz(left)
     cdef idxint col_right, right_nnz = csr.nnz(right)
     cdef idxint ptr_left, ptr_right, ptr_left_max, ptr_right_max

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -510,8 +510,8 @@ class Qobj:
             return True
         if not isinstance(other, Qobj) or self._dims != other._dims:
             return False
-        return _data.iszero(_data.sub(self._data, other._data),
-                            tol=settings.core['atol'])
+        # isequal uses both atol and rtol from settings.core
+        return _data.isequal(self._data, other._data)
 
     def __pow__(self, n, m=None):  # calculates powers of Qobj
         if (

--- a/qutip/tests/core/data/conftest.py
+++ b/qutip/tests/core/data/conftest.py
@@ -67,7 +67,7 @@ def random_scipy_csr(shape, density, sorted_):
     cols = np.random.choice(np.arange(shape[1]), nnz)
     sci = scipy.sparse.coo_matrix((data, (rows, cols)), shape=shape).tocsr()
     if not sorted_:
-        shuffle_indices_scipy_csr(sci)
+        sci = shuffle_indices_scipy_csr(sci)
     return sci
 
 

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -442,6 +442,15 @@ def test_QobjEquals():
     q2 = qutip.Qobj(-data)
     assert q1 != q2
 
+    # data's entry are of order 1,
+    with qutip.CoreOptions(atol=10):
+        assert q1 == q2
+        assert q1 != q2 * 100
+
+    with qutip.CoreOptions(rtol=10):
+        assert q1 == q2
+        assert q1 == q2 * 100
+
 
 def test_QobjGetItem():
     "qutip.Qobj getitem"


### PR DESCRIPTION
**Description**
As proposed in  #2420,  changed `Qobj.__eq__` to use both `rtol` and `atol`.
The a new low level function is needed to support `rtol`.

Also I found that our test did not properly shuffled CSR matrices indices in mathematics tests. There was a bug we missed in `multiply_csr`...

**Related issues or PRs**
fix #2420