### PR TITLE
Update actions tools versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -90,7 +90,7 @@ jobs:
           zip "$zipfile" -r "$stem"
           rm -r "$stem"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: |
@@ -115,7 +115,7 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -137,7 +137,7 @@ jobs:
           if [[ ! -z "$OVERRIDE_VERSION" ]]; then echo "$OVERRIDE_VERSION" > VERSION; fi
           python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Download build artifacts to local runner
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -193,7 +193,7 @@ jobs:
 
     steps:
       - name: Download build artifacts to local runner
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - uses: actions/setup-python@v4
         name: Install Python

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -43,7 +43,7 @@ jobs:
           #   -T : display a full traceback if a Python exception occurs
 
       - name: Upload built PDF files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qutip_pdf_docs
           path: doc/_build/latex/*
@@ -59,7 +59,7 @@ jobs:
           #   -T : display a full traceback if a Python exception occurs
 
       - name: Upload built HTML files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qutip_html_docs
           path: doc/_build/html/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,7 +107,7 @@ jobs:
             python-version: "3.11"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
@@ -228,7 +228,7 @@ jobs:
     name: Verify Towncrier entry added
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
**Description**
We have warnings for actions using deprecated node.js version, such as:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/download-artifact@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
Updating the tools from v3 to v4 should fix the issue.