### PR TITLE
Tidy up formatting of type aliases in docs

### DIFF
--- a/doc/changes/2436.doc
+++ b/doc/changes/2436.doc
@@ -1,0 +1,1 @@
+Tidy up formatting of type aliases in the api documentation

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -359,6 +359,15 @@ texinfo_documents = [
 
 autodoc_member_order = 'alphabetical'
 
+# Makes the following types appear as their alias in the apidoc
+# instead of expanding the alias
+autodoc_type_aliases = {
+    'CoefficientLike': 'CoefficientLike',
+    'ElementType': 'ElementType',
+    'QobjEvoLike': 'QobjEvoLike',
+    'LayerType': 'LayerType'
+}
+
 ## EXTLINKS CONFIGURATION ######################################################
 
 extlinks = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -365,7 +365,8 @@ autodoc_type_aliases = {
     'CoefficientLike': 'CoefficientLike',
     'ElementType': 'ElementType',
     'QobjEvoLike': 'QobjEvoLike',
-    'LayerType': 'LayerType'
+    'LayerType': 'LayerType',
+    'ArrayLike': 'ArrayLike'
 }
 
 ## EXTLINKS CONFIGURATION ######################################################

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -1,3 +1,6 @@
+from __future__ import annotations  # Required for Sphinx to follow
+                                    # autodoc_type_aliases
+
 import numpy as np
 from numpy.typing import ArrayLike
 import scipy

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -1,5 +1,5 @@
-from __future__ import annotations  # Required for Sphinx to follow
-                                    # autodoc_type_aliases
+# Required for Sphinx to follow autodoc_type_aliases
+from __future__ import annotations
 
 import numpy as np
 from numpy.typing import ArrayLike

--- a/qutip/core/cy/qobjevo.pyi
+++ b/qutip/core/cy/qobjevo.pyi
@@ -1,5 +1,5 @@
-from __future__ import annotations  # Required for Sphinx to follow
-                                    # autodoc_type_aliases
+# Required for Sphinx to follow autodoc_type_aliases
+from __future__ import annotations
 
 from qutip.typing import LayerType, ElementType, QobjEvoLike
 from qutip.core.qobj import Qobj

--- a/qutip/core/cy/qobjevo.pyi
+++ b/qutip/core/cy/qobjevo.pyi
@@ -1,3 +1,6 @@
+from __future__ import annotations  # Required for Sphinx to follow
+                                    # autodoc_type_aliases
+
 from qutip.typing import LayerType, ElementType, QobjEvoLike
 from qutip.core.qobj import Qobj
 from qutip.core.data import Data

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -646,7 +646,7 @@ class Qobj:
 
     def norm(
         self,
-        norm: Litteral["l2", "max", "fro", "tr", "one"] = None,
+        norm: Literal["l2", "max", "fro", "tr", "one"] = None,
         kwargs: dict[str, Any] = None
     ) -> numbers.Number:
         """
@@ -991,7 +991,7 @@ class Qobj:
     def unit(
         self,
         inplace: bool = False,
-        norm: Litteral["l2", "max", "fro", "tr", "one"] = None,
+        norm: Literal["l2", "max", "fro", "tr", "one"] = None,
         kwargs: dict[str, Any] = None
     ) -> Qobj:
         """

--- a/qutip/solver/krylovsolve.py
+++ b/qutip/solver/krylovsolve.py
@@ -1,3 +1,6 @@
+# Required for Sphinx to follow autodoc_type_aliases
+from __future__ import annotations
+
 __all__ = ['krylovsolve']
 
 from .. import QobjEvo, Qobj

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -1,3 +1,6 @@
+from __future__ import annotations  # Required for Sphinx to follow
+                                    # autodoc_type_aliases
+
 __all__ = ['mcsolve', "MCSolver"]
 
 import numpy as np

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -1,5 +1,5 @@
-from __future__ import annotations  # Required for Sphinx to follow
-                                    # autodoc_type_aliases
+# Required for Sphinx to follow autodoc_type_aliases
+from __future__ import annotations
 
 __all__ = ['mcsolve', "MCSolver"]
 

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -3,8 +3,8 @@ This module provides solvers for the Lindblad master equation and von Neumann
 equation.
 """
 
-from __future__ import annotations  # Required for Sphinx to follow
-                                    # autodoc_type_aliases
+# Required for Sphinx to follow autodoc_type_aliases
+from __future__ import annotations
 
 __all__ = ['mesolve', 'MESolver']
 

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -3,15 +3,16 @@ This module provides solvers for the Lindblad master equation and von Neumann
 equation.
 """
 
+from __future__ import annotations  # Required for Sphinx to follow
+                                    # autodoc_type_aliases
+
 __all__ = ['mesolve', 'MESolver']
 
-import numpy as np
 from numpy.typing import ArrayLike
 from typing import Any, Callable
 from time import time
-from .. import (Qobj, QobjEvo, isket, liouvillian, ket2dm, lindblad_dissipator)
+from .. import (Qobj, QobjEvo, liouvillian, lindblad_dissipator)
 from ..typing import QobjEvoLike
-from ..core import stack_columns, unstack_columns
 from ..core import data as _data
 from .solver_base import Solver, _solver_deprecation
 from .sesolve import sesolve, SESolver

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -1,3 +1,6 @@
+# Required for Sphinx to follow autodoc_type_aliases
+from __future__ import annotations
+
 from .result import TrajectoryResult
 from .multitrajresult import MultiTrajResult
 from .parallel import _get_map

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -1,5 +1,5 @@
-from __future__ import annotations  # Required for Sphinx to follow
-                                    # autodoc_type_aliases
+# Required for Sphinx to follow autodoc_type_aliases
+from __future__ import annotations
 
 __all__ = ['Propagator', 'propagator', 'propagator_steadystate']
 

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -1,3 +1,6 @@
+from __future__ import annotations  # Required for Sphinx to follow
+                                    # autodoc_type_aliases
+
 __all__ = ['Propagator', 'propagator', 'propagator_steadystate']
 
 import numbers

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -1,10 +1,12 @@
 """ Class for solve function results"""
 
+# Required for Sphinx to follow autodoc_type_aliases
+from __future__ import annotations
+
 from typing import TypedDict, Any, Callable
 import numpy as np
 from numpy.typing import ArrayLike
-from numbers import Number
-from ..core import Qobj, QobjEvo, expect, isket, ket2dm, qzero_like
+from ..core import Qobj, QobjEvo, expect
 
 __all__ = [
     "Result",

--- a/qutip/solver/sesolve.py
+++ b/qutip/solver/sesolve.py
@@ -2,8 +2,8 @@
 This module provides solvers for the unitary Schrodinger equation.
 """
 
-from __future__ import annotations  # Required for Sphinx to follow
-                                    # autodoc_type_aliases
+# Required for Sphinx to follow autodoc_type_aliases
+from __future__ import annotations
 
 __all__ = ['sesolve', 'SESolver']
 

--- a/qutip/solver/sesolve.py
+++ b/qutip/solver/sesolve.py
@@ -2,9 +2,11 @@
 This module provides solvers for the unitary Schrodinger equation.
 """
 
+from __future__ import annotations  # Required for Sphinx to follow
+                                    # autodoc_type_aliases
+
 __all__ = ['sesolve', 'SESolver']
 
-import numpy as np
 from numpy.typing import ArrayLike
 from time import time
 from typing import Any, Callable

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -1,3 +1,6 @@
+# Required for Sphinx to follow autodoc_type_aliases
+from __future__ import annotations
+
 __all__ = ['Solver']
 
 from numpy.typing import ArrayLike

--- a/qutip/typing.py
+++ b/qutip/typing.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union, Any, Callable, Protocol
+from typing import Sequence, Union, Any, Protocol
 from numbers import Number, Real
 import numpy as np
 import scipy.interpolate


### PR DESCRIPTION
Following the workaround in [this stackoverflow answer](https://stackoverflow.com/a/67483317), added `autodoc_type_aliases` to the config of sphinx and added `from __future__ import annotations` where necessary. Makes it so that the docs say
```
H: QobjEvoLike
```
instead of
```
H: Qobj | QobjEvo | ~qutip.typing.QEvoProtocol | tuple['Qobj', typing.Union[ForwardRef('Coefficient'), str, qutip.typing.CoeffProtocol, numpy.ndarray, scipy.interpolate._interpolate.PPoly, scipy.interpolate._bsplines.BSpline, typing.Any]] | ~typing.Sequence[~qutip.typing.QEvoProtocol | Qobj | tuple['Qobj', typing.Union[ForwardRef('Coefficient'), str, qutip.typing.CoeffProtocol, numpy.ndarray, scipy.interpolate._interpolate.PPoly, scipy.interpolate._bsplines.BSpline, typing.Any]]]
```

(Also cleaned up imports in files I touched, and fixed a typo in Qobj type annotations.)