### PR TITLE
Monte-Carlo simulations with mixed initial states

### DIFF
--- a/doc/changes/2437.feature
+++ b/doc/changes/2437.feature
@@ -1,0 +1,1 @@
+Allow mixed initial conditions for mcsolve and nm_mcsolve.

--- a/doc/guide/dynamics/dynamics-monte.rst
+++ b/doc/guide/dynamics/dynamics-monte.rst
@@ -282,6 +282,77 @@ trajectories:
     plt.show()
 
 
+Mixed Initial states
+--------------------
+
+The Monte-Carlo solver can be used for mixed initial states. For example, if a
+qubit can initially be in the excited state :math:`|+\rangle` with probability
+:math:`p` or in the ground state :math:`|-\rangle` with probability
+:math:`(1-p)`, the initial state is described by the density matrix
+:math:`\rho_0 = p | + \rangle\langle + | + (1-p) | - \rangle\langle - |`.
+
+In QuTiP, this initial density matrix can be created as follows:
+
+.. code-block::
+
+    ground = qutip.basis(2, 0)
+    excited = qutip.basis(2, 1)
+    density_matrix = p * excited.proj() + (1 - p) * ground.proj()
+
+One can then pass this density matrix directly to ``mcsolve``, as in
+
+.. code-block::
+
+    mcsolve(H, density_matrix, ...)
+
+Alternatively, using the class interface, if ``solver`` is an
+:class:`.MCSolver` object, one can either call
+``solver.run(density_matrix, ...)`` or pass the list of initial states like
+
+.. code-block::
+
+    solver.run([(excited, p), (ground, 1-p)], ...)
+
+The number of trajectories can still be specified as a single number ``ntraj``.
+In that case, QuTiP will automatically decide how many trajectories to use for
+each of the initial states, guaranteeing that the total number of trajectories
+is exactly the specified number. When using the class interface and providing
+the initial state as a list, the `ntraj` parameter may also be a list
+specifying the number of trajectories to use for each state manually. In either
+case, the resulting :class:`McResult` will have attributes ``initial_states``
+and ``ntraj_per_initial_state`` listing the initial states and the
+corresponding numbers of trajectories that were actually used.
+
+Note that in general, the fraction of trajectories starting in a given initial
+state will (and can) not exactly match the probability :math:`p` of that state
+in the initial ensemble. In this case, QuTiP will automatically apply a
+correction to the averages, weighting for example the initial states with
+"too few" trajectories more strongly. Therefore, the initial state returned in
+the result object will always match the provided one up to numerical
+inaccuracies. Furthermore, the result returned by the `mcsolve` call above is
+equivalent to the following:
+
+.. code-block::
+
+    result1 = qutip.mcsolve(H, excited, ...)
+    result2 = qutip.mcsolve(H, ground, ...)
+    result1.merge(result2, p)
+
+However, the single ``mcsolve`` call allows for more parallelization (see
+below).
+
+The Monte-Carlo solver with a mixed initial state currently does not support
+specifying a target tolerance. Also, in case the simulation ends early due to
+timeout, it is not guaranteed that all initial states have been sampled. If
+not all initial states have been sampled, the resulting states will not be
+normalized, and the result should be discarded.
+
+Finally note that what we just discussed concerns the case of mixed initial
+states where the provided Hamiltonian is an operator. If it is a superoperator
+(i.e., a Liouvillian), ``mcsolve`` will generate trajectories of mixed states
+(see below) and the present discussion does not apply.
+
+
 Using the Improved Sampling Algorithm
 -------------------------------------
 

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -152,6 +152,8 @@ def mcsolve(
         Object storing all results from the simulation. Which results is saved
         depends on the presence of ``e_ops`` and the options used. ``collapse``
         and ``photocurrent`` is available to Monte Carlo simulation results.
+        If the initial condition is mixed, the result has additional attributes
+        ``initial_states`` and ``ntraj_per_initial_state``.
 
     Notes
     -----
@@ -628,9 +630,11 @@ class MCSolver(MultiTrajSolver):
 
         Returns
         -------
-        results : :class:`.MultiTrajResult`
+        results : :class:`.McResult`
             Results of the evolution. States and/or expect will be saved. You
-            can control the saved data in the options.
+            can control the saved data in the options. If the initial condition
+            is mixed, the result has additional attributes ``initial_states``
+            and ``ntraj_per_initial_state``.
 
         .. note:
             The simulation will end when the first end condition is reached
@@ -782,6 +786,10 @@ class MCSolver(MultiTrajSolver):
             progress_bar_kwargs=self.options["progress_kwargs"]
         )
         result.stats['run time'] = time() - start_time
+        result.initial_states = [self._restore_state(state, copy=False)
+                                 for state, _ in ics_info.state_list]
+        # add back +1 for the no-jump trajectories:
+        result.ntraj_per_initial_state = [(n+1) for n in ics_info.ntraj]
         return result
 
     def _get_integrator(self):

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -537,8 +537,7 @@ class MCSolver(MultiTrajSolver):
             # Our best option is to return a trajectory result containing only
             # zeroes. This also ensures # that the final multi-trajectory
             # result will contain the requested number of trajectories.
-            state_qobj = self._restore_state(state, copy=True)
-            zero = qzero_like(state_qobj)
+            zero = qzero_like(self._restore_state(state, copy=True))
             result = self._trajectory_resultclass(e_ops, self.options)
             result.collapse = []
             for t in tlist:
@@ -906,7 +905,6 @@ class MCSolver(MultiTrajSolver):
         if raw_data:
             return _DataFeedback(default, open=open)
         return _QobjFeedback(default, open=open)
-
 
 
 class _unpack_arguments:

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -298,7 +298,7 @@ class MultiTrajSolver(Solver):
             result.add_relative_weight(weight)
         return seed, result
 
-    def run_mixed(
+    def _run_mixed(
         self,
         initial_conditions: list[tuple[Qobj, float]],
         tlist: ArrayLike,
@@ -310,12 +310,8 @@ class MultiTrajSolver(Solver):
         seeds: int | SeedSequence | list[int | SeedSequence] = None,
     ) -> MultiTrajResult:
         """
-        Do the evolution of the Quantum system with a mixed initial state.
-
-        The evolution is done as directed by ``rhs``. For each time in
-        ``tlist``, stores the state and/or expectation values in a
-        :class:`.MultiTrajResult`. The evolution method and stored results are
-        determined by ``options``.
+        Subclasses can use this method to allow simulations with a mixed
+        initial state. The following parameters differ from the `run` method:
 
         Parameters
         ----------
@@ -326,12 +322,6 @@ class MultiTrajSolver(Solver):
             describing the fraction of the ensemble in that state. The sum of
             all weights is assumed to be one.
 
-        tlist : list of double
-            Time for which to save the results (state and/or expect) of the
-            evolution. The first element of the list is the initial time of the
-            evolution. Time in the list must be in increasing order, but does
-            not need to be uniformly distributed.
-
         ntraj : {int, list of int}
             Number of trajectories to add. If a single number is provided, this
             will be the total number of trajectories, which are distributed
@@ -339,29 +329,6 @@ class MultiTrajSolver(Solver):
             a list of numbers with the same number of entries as in
             `initial_conditions`, specifying the number of trajectories for
             each initial state explicitly.
-
-        args : dict, optional
-            Change the ``args`` of the rhs for the evolution.
-
-        e_ops : list
-            list of Qobj or QobjEvo to compute the expectation values.
-            Alternatively, function[s] with the signature f(t, state) -> expect
-            can be used.
-
-        timeout : float, optional
-            Maximum time in seconds for the trajectories to run. Once this time
-            is reached, the simulation will end even if the number
-            of trajectories is less than ``ntraj``. In this case, the results
-            returned by this function will generally be invalid.
-
-        seeds : {int, SeedSequence, list}, optional
-            Seed or list of seeds for each trajectories.
-
-        Returns
-        -------
-        results : :class:`.MultiTrajResult`
-            Results of the evolution. States and/or expect will be saved. You
-            can control the saved data in the options.
 
         .. note:
             The simulation will end when the first end condition is reached

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -469,7 +469,7 @@ class _InitialConditions:
         Calculate a list ntraj from the given total number, under contraints
         explained above. Algorithm based on https://stackoverflow.com/a/792490
         """
-        # First we through out zero-weight states
+        # First we throw out zero-weight states
         filtered_states = [(index, weight)
                            for index, (_, weight) in enumerate(state_list)
                            if weight > 0]
@@ -542,6 +542,6 @@ class _InitialConditions:
         """
         state_index = self.get_state_index(id)
         state, target_weight = self.state_list[state_index]
-        state_frequency = self._ntraj[state_index] / self.ntraj_total
+        state_frequency = self.ntraj[state_index] / self.ntraj_total
         correction_weight = target_weight / state_frequency
         return state, correction_weight

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -283,7 +283,7 @@ class MultiTrajSolver(Solver):
         self,
         initial_conditions: list[tuple[Qobj, float]],
         tlist: ArrayLike,
-        ntraj: int | list[int] = None,
+        ntraj: int | list[int],
         *,
         args: dict[str, Any] = None,
         e_ops: dict[Any, Qobj | QobjEvo | Callable[[float, Qobj], Any]] = None,

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -257,14 +257,6 @@ class MultiTrajSolver(Solver):
         result.stats['run time'] = time() - start_time
         return result
 
-    def _run_one_traj(self, seed, state, tlist, e_ops, **integrator_kwargs):
-        """
-        Run one trajectory and return the result.
-        """
-        result = self._initialize_run_one_traj(seed, state, tlist, e_ops,
-                                               **integrator_kwargs)
-        return self._integrate_one_traj(seed, tlist, result)
-
     def _initialize_run_one_traj(self, seed, state, tlist, e_ops,
                                  **integrator_kwargs):
         result = self._trajectory_resultclass(e_ops, self.options)
@@ -276,6 +268,14 @@ class MultiTrajSolver(Solver):
                                    **integrator_kwargs)
         result.add(tlist[0], self._restore_state(state, copy=False))
         return result
+
+    def _run_one_traj(self, seed, state, tlist, e_ops, **integrator_kwargs):
+        """
+        Run one trajectory and return the result.
+        """
+        result = self._initialize_run_one_traj(seed, state, tlist, e_ops,
+                                               **integrator_kwargs)
+        return self._integrate_one_traj(seed, tlist, result)
 
     def _integrate_one_traj(self, seed, tlist, result):
         for t, state in self._integrator.run(tlist):
@@ -422,7 +422,6 @@ class MultiTrajSolver(Solver):
         else:
             generator = np.random.default_rng(seed)
         return generator
-
 
 
 class _InitialConditions:

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -44,7 +44,7 @@ def nm_mcsolve(H, state, tlist, ops_and_rates=(), e_ops=None, ntraj=500, *,
         operators are to be treated deterministically.
 
     state : :class:`.Qobj`
-        Initial state vector.
+        Initial state vector or density matrix.
 
     tlist : array_like
         Times at which results are recorded.

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -553,7 +553,7 @@ class NonMarkovianMCSolver(MCSolver):
         self._martingale.reset()
 
         return result
-    
+
     def run_mixed(self, initial_conditions, tlist, ntraj, *,
                   args=None, **kwargs):
         # update `args` dictionary before precomputing martingale

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -185,13 +185,8 @@ def nm_mcsolve(H, state, tlist, ops_and_rates=(), e_ops=None, ntraj=500, *,
     ]
 
     nmmc = NonMarkovianMCSolver(H, ops_and_rates, options=options)
-
-    if state.isket:
-        result = nmmc.run(state, tlist=tlist, ntraj=ntraj, e_ops=e_ops,
-                          seeds=seeds, target_tol=target_tol, timeout=timeout)
-    else:
-        result = nmmc.run_mixed(state, tlist=tlist, ntraj=ntraj, e_ops=e_ops,
-                                timeout=timeout, seeds=seeds)
+    result = nmmc.run(state, tlist=tlist, ntraj=ntraj, e_ops=e_ops,
+                      seeds=seeds, target_tol=target_tol, timeout=timeout)
     return result
 
 
@@ -550,17 +545,6 @@ class NonMarkovianMCSolver(MCSolver):
 
         self._martingale.initialize(tlist[0], cache=tlist)
         result = super().run(state, tlist, ntraj, **kwargs)
-        self._martingale.reset()
-
-        return result
-
-    def run_mixed(self, initial_conditions, tlist, ntraj, *,
-                  args=None, **kwargs):
-        # update `args` dictionary before precomputing martingale
-        self._argument(args)
-
-        self._martingale.initialize(tlist[0], cache=tlist)
-        result = super().run_mixed(initial_conditions, tlist, ntraj, **kwargs)
         self._martingale.reset()
 
         return result

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -163,7 +163,9 @@ def nm_mcsolve(H, state, tlist, ops_and_rates=(), e_ops=None, ntraj=500, *,
         ``trace`` (and ``runs_trace`` if ``store_final_state`` is set). Note
         that the states on the individual trajectories are not normalized. This
         field contains the average of their trace, which will converge to one
-        in the limit of sufficiently many trajectories.
+        in the limit of sufficiently many trajectories. If the initial
+        condition is mixed, the result has additional attributes
+        ``initial_states`` and ``ntraj_per_initial_state``.
     """
     H = QobjEvo(H, args=args, tlist=tlist)
 

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -594,6 +594,17 @@ def test_mixed_averaging(improved_sampling, initial_state, ntraj):
     assert result.states[0] == reference
     assert result.num_trajectories == np.sum(ntraj)
 
+    assert hasattr(result, 'initial_states')
+    assert isinstance(result.initial_states, list)
+    assert all(isinstance(st, qutip.Qobj) for st in result.initial_states)
+    assert hasattr(result, 'ntraj_per_initial_state')
+    assert isinstance(result.ntraj_per_initial_state, list)
+    assert len(result.ntraj_per_initial_state) == len(result.initial_states)
+    if isinstance(ntraj, list):
+        assert result.ntraj_per_initial_state == ntraj
+    else:
+        assert sum(result.ntraj_per_initial_state) == ntraj
+
 
 @pytest.mark.parametrize("improved_sampling", [True, False])
 @pytest.mark.parametrize("p", [0, 0.25, 0.5])
@@ -630,3 +641,10 @@ def test_mixed_equals_merged(improved_sampling, p):
     assert merged_result.num_trajectories == sum(ntraj)
     for state1, state2 in zip(mixed_result.states, merged_result.states):
         assert state1 == state2
+
+    assert hasattr(mixed_result, 'initial_states')
+    assert isinstance(mixed_result.initial_states, list)
+    assert mixed_result.initial_states == [initial_state1, initial_state2]
+    assert hasattr(mixed_result, 'ntraj_per_initial_state')
+    assert isinstance(mixed_result.ntraj_per_initial_state, list)
+    assert mixed_result.ntraj_per_initial_state == ntraj

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -584,7 +584,7 @@ def test_mixed_averaging(improved_sampling, initial_state, ntraj):
 
     solver = qutip.MCSolver(
         H, [L], options={'improved_sampling': improved_sampling})
-    result = solver.run_mixed(initial_state, tlist, ntraj)
+    result = solver.run(initial_state, tlist, ntraj)
 
     if isinstance(initial_state, qutip.Qobj):
         reference = initial_state

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -604,7 +604,7 @@ def test_mixed_equals_merged(improved_sampling, p):
     initial_state2 = (qutip.basis(2, 1) + qutip.basis(2, 0)).unit()
     H = qutip.sigmax()
     L = qutip.sigmam()
-    tlist = [0, 1, 2]
+    tlist = np.linspace(0, 2, 20)
     ntraj = [3, 9]
 
     solver = qutip.MCSolver(

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -740,7 +740,7 @@ def test_mixed_equals_merged(improved_sampling, p):
     L = qutip.sigmam()
     def rate_function(t):
         return -1 + t
-    tlist = [0, 1, 2]
+    tlist = np.linspace(0, 2, 20)
     ntraj = [3, 9]
 
     solver = qutip.NonMarkovianMCSolver(

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -728,6 +728,17 @@ def test_mixed_averaging(improved_sampling, initial_state, ntraj):
     assert result.states[0] == reference
     assert result.num_trajectories == np.sum(ntraj)
 
+    assert hasattr(result, 'initial_states')
+    assert isinstance(result.initial_states, list)
+    assert all(isinstance(st, qutip.Qobj) for st in result.initial_states)
+    assert hasattr(result, 'ntraj_per_initial_state')
+    assert isinstance(result.ntraj_per_initial_state, list)
+    assert len(result.ntraj_per_initial_state) == len(result.initial_states)
+    if isinstance(ntraj, list):
+        assert result.ntraj_per_initial_state == ntraj
+    else:
+        assert sum(result.ntraj_per_initial_state) == ntraj
+
 
 @pytest.mark.parametrize("improved_sampling", [True, False])
 @pytest.mark.parametrize("p", [0, 0.25, 0.5])
@@ -767,3 +778,10 @@ def test_mixed_equals_merged(improved_sampling, p):
     assert merged_result.num_trajectories == sum(ntraj)
     for state1, state2 in zip(mixed_result.states, merged_result.states):
         assert state1 == state2
+
+    assert hasattr(mixed_result, 'initial_states')
+    assert isinstance(mixed_result.initial_states, list)
+    assert mixed_result.initial_states == [initial_state1, initial_state2]
+    assert hasattr(mixed_result, 'ntraj_per_initial_state')
+    assert isinstance(mixed_result.ntraj_per_initial_state, list)
+    assert mixed_result.ntraj_per_initial_state == ntraj

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -7,14 +7,20 @@ import qutip
 from qutip.solver.nm_mcsolve import nm_mcsolve, NonMarkovianMCSolver
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("improved_sampling", [True, False])
-def test_agreement_with_mesolve_for_negative_rates(improved_sampling):
+@pytest.mark.parametrize("mixed_initial_state", [True, False])
+def test_agreement_with_mesolve_for_negative_rates(
+        improved_sampling, mixed_initial_state):
     """
     A rough test that nm_mcsolve agress with mesolve in the
     presence of negative rates.
     """
     times = np.linspace(0, 0.25, 51)
-    psi0 = qutip.basis(2, 1)
+    if mixed_initial_state:
+        state0 = qutip.maximally_mixed_dm(2)
+    else:
+        state0 = qutip.basis(2, 1)
     a0 = qutip.destroy(2)
     H = a0.dag() * a0
     e_ops = [
@@ -38,7 +44,7 @@ def test_agreement_with_mesolve_for_negative_rates(improved_sampling):
         [a0, gamma2],
     ]
     mc_result = nm_mcsolve(
-        H, psi0, times, ops_and_rates,
+        H, state0, times, ops_and_rates,
         args=args, e_ops=e_ops, ntraj=1000 if improved_sampling else 2000,
         options={"rtol": 1e-8, "improved_sampling": improved_sampling},
         seeds=0,
@@ -50,7 +56,7 @@ def test_agreement_with_mesolve_for_negative_rates(improved_sampling):
         [qutip.lindblad_dissipator(a0, a0), gamma2],
     ]
     me_result = qutip.mesolve(
-        H, psi0, times, d_ops,
+        H, state0, times, d_ops,
         args=args, e_ops=e_ops,
     )
 
@@ -154,10 +160,11 @@ class StatesAndExpectOutputCase:
     """
     size = 10
     h = qutip.num(size)
-    state = qutip.basis(size, size-1)
+    pure_state = qutip.basis(size, size-1)
+    mixed_state = qutip.maximally_mixed_dm(size)
     times = np.linspace(0, 1, 101)
     e_ops = [qutip.num(size)]
-    ntraj = 2000
+    ntraj = 500
 
     def _assert_states(self, result, expected, tol):
         assert hasattr(result, 'states')
@@ -176,16 +183,17 @@ class StatesAndExpectOutputCase:
 
     @pytest.mark.parametrize("improved_sampling", [True, False])
     def test_states_and_expect(
-        self, hamiltonian, args, ops_and_rates, expected, tol,
-        improved_sampling
+        self, hamiltonian, state, args, ops_and_rates,
+        expected, tol, improved_sampling
     ):
         options = {"store_states": True, "map": "serial",
                    "improved_sampling": improved_sampling}
         result = nm_mcsolve(
-            hamiltonian, self.state, self.times, args=args,
+            hamiltonian, state, self.times, args=args,
             ops_and_rates=ops_and_rates,
             e_ops=self.e_ops, ntraj=self.ntraj, options=options,
-            target_tol=0.05,
+            # target_tol not supported for mixed initial state
+            target_tol=(0.05 if state.isket else None)
         )
         self._assert_expect(result, expected, tol)
         self._assert_states(result, expected, tol)
@@ -199,10 +207,6 @@ class TestNoCollapse(StatesAndExpectOutputCase):
 
     def pytest_generate_tests(self, metafunc):
         tol = 1e-8
-        expect = (
-            qutip.expect(self.e_ops[0], self.state)
-            * np.ones_like(self.times)
-        )
         hamiltonian_types = [
             (self.h, "Qobj"),
             ([self.h], "list"),
@@ -212,12 +216,22 @@ class TestNoCollapse(StatesAndExpectOutputCase):
             (callable_qobj(self.h), "callable"),
         ]
         cases = [
-            pytest.param(hamiltonian, {}, [], [expect], tol, id=id)
+            pytest.param(hamiltonian, {}, [], tol, id=id)
             for hamiltonian, id in hamiltonian_types
         ]
         metafunc.parametrize([
-            'hamiltonian', 'args', 'ops_and_rates', 'expected', 'tol',
+            'hamiltonian', 'args', 'ops_and_rates', 'tol',
         ], cases)
+
+        initial_state_types = [
+            (self.pure_state, "pure"),
+            (self.mixed_state, "mixed"),
+        ]
+        expect = [qutip.expect(self.e_ops[0], state) * np.ones_like(self.times)
+                  for state, _ in initial_state_types]
+        cases = [pytest.param(state, [exp], id=id)
+                 for (state, id), exp in zip(initial_state_types, expect)]
+        metafunc.parametrize(['state', 'expected'], cases)
 
     # Previously the "states_only" and "expect_only" tests were mixed in to
     # every other test case.  We move them out into the simplest set so that
@@ -226,23 +240,23 @@ class TestNoCollapse(StatesAndExpectOutputCase):
     # test cases, this is just testing the single-output behaviour.
 
     @pytest.mark.parametrize("improved_sampling", [True, False])
-    def test_states_only(self, hamiltonian, args, ops_and_rates, expected, tol,
-                         improved_sampling):
+    def test_states_only(self, hamiltonian, state, args, ops_and_rates,
+                         expected, tol, improved_sampling):
         options = {"store_states": True, "map": "serial",
                    "improved_sampling": improved_sampling}
         result = nm_mcsolve(
-            hamiltonian, self.state, self.times, args=args,
+            hamiltonian, state, self.times, args=args,
             ops_and_rates=ops_and_rates,
             e_ops=[], ntraj=self.ntraj, options=options,
         )
         self._assert_states(result, expected, tol)
 
     @pytest.mark.parametrize("improved_sampling", [True, False])
-    def test_expect_only(self, hamiltonian, args, ops_and_rates, expected, tol,
-                         improved_sampling):
+    def test_expect_only(self, hamiltonian, state, args, ops_and_rates,
+                         expected, tol, improved_sampling):
         options = {'map': 'serial', "improved_sampling": improved_sampling}
         result = nm_mcsolve(
-            hamiltonian, self.state, self.times, args=args,
+            hamiltonian, state, self.times, args=args,
             ops_and_rates=ops_and_rates,
             e_ops=self.e_ops, ntraj=self.ntraj, options=options,
         )
@@ -258,10 +272,6 @@ class TestConstantCollapse(StatesAndExpectOutputCase):
     def pytest_generate_tests(self, metafunc):
         tol = 0.25
         rate = 0.2
-        expect = (
-            qutip.expect(self.e_ops[0], self.state)
-            * np.exp(-rate * self.times)
-        )
         op = qutip.destroy(self.size)
         op_and_rate_types = [
             ([op, rate], {}, "constant"),
@@ -270,12 +280,23 @@ class TestConstantCollapse(StatesAndExpectOutputCase):
             ([op, lambda t, w: rate], {"w": 1.0}, "function_with_args"),
         ]
         cases = [
-            pytest.param(self.h, args, [op_and_rate], [expect], tol, id=id)
+            pytest.param(self.h, args, [op_and_rate], tol, id=id)
             for op_and_rate, args, id in op_and_rate_types
         ]
         metafunc.parametrize([
-            'hamiltonian', 'args', 'ops_and_rates', 'expected', 'tol',
+            'hamiltonian', 'args', 'ops_and_rates', 'tol',
         ], cases)
+
+        initial_state_types = [
+            (self.pure_state, "pure"),
+            (self.mixed_state, "mixed"),
+        ]
+        expect = [(qutip.expect(self.e_ops[0], state)
+                   * np.exp(-rate * self.times))
+                  for state, _ in initial_state_types]
+        cases = [pytest.param(state, [exp], id=id)
+                 for (state, id), exp in zip(initial_state_types, expect)]
+        metafunc.parametrize(['state', 'expected'], cases)
 
 
 class TestTimeDependentCollapse(StatesAndExpectOutputCase):
@@ -287,10 +308,6 @@ class TestTimeDependentCollapse(StatesAndExpectOutputCase):
     def pytest_generate_tests(self, metafunc):
         tol = 0.25
         coupling = 0.2
-        expect = (
-            qutip.expect(self.e_ops[0], self.state)
-            * np.exp(-coupling * (1 - np.exp(-self.times)))
-        )
         op = qutip.destroy(self.size)
         rate_args = {'constant': coupling, 'rate': 0.5}
         rate_string = 'sqrt({} * exp(-t))'.format(coupling)
@@ -299,12 +316,23 @@ class TestTimeDependentCollapse(StatesAndExpectOutputCase):
             ([op, _return_decay], rate_args, "function"),
         ]
         cases = [
-            pytest.param(self.h, args, [op_and_rate], [expect], tol, id=id)
+            pytest.param(self.h, args, [op_and_rate], tol, id=id)
             for op_and_rate, args, id in op_and_rate_types
         ]
         metafunc.parametrize([
-            'hamiltonian', 'args', 'ops_and_rates', 'expected', 'tol',
+            'hamiltonian', 'args', 'ops_and_rates', 'tol',
         ], cases)
+
+        initial_state_types = [
+            (self.pure_state, "pure"),
+            (self.mixed_state, "mixed"),
+        ]
+        expect = [(qutip.expect(self.e_ops[0], state)
+                   * np.exp(-coupling * (1 - np.exp(-self.times))))
+                  for state, _ in initial_state_types]
+        cases = [pytest.param(state, [exp], id=id)
+                 for (state, id), exp in zip(initial_state_types, expect)]
+        metafunc.parametrize(['state', 'expected'], cases)
 
 
 def test_stored_collapse_operators_and_times():
@@ -332,16 +360,21 @@ def test_stored_collapse_operators_and_times():
 
 @pytest.mark.parametrize("improved_sampling", [True, False])
 @pytest.mark.parametrize("keep_runs_results", [True, False])
-def test_states_outputs(keep_runs_results, improved_sampling):
+@pytest.mark.parametrize("mixed_initial_state", [True, False])
+def test_states_outputs(keep_runs_results, improved_sampling,
+                        mixed_initial_state):
     # We're just testing the output value, so it's important whether certain
     # things are complex or real, but not what the magnitudes of constants are.
     focks = 5
-    ntraj = 5
-    a = qutip.tensor(qutip.destroy(focks), qutip.qeye(2))
-    sm = qutip.tensor(qutip.qeye(focks), qutip.sigmam())
+    ntraj = 13
+    a = qutip.destroy(focks) & qutip.qeye(2)
+    sm = qutip.qeye(focks) & qutip.sigmam()
     H = 1j*a.dag()*sm + a
     H = H + H.dag()
-    state = qutip.basis([focks, 2], [0, 1])
+    if mixed_initial_state:
+        state = qutip.maximally_mixed_dm(focks) & qutip.fock_dm(2, 1)
+    else:
+        state = qutip.basis([focks, 2], [0, 1])
     times = np.linspace(0, 10, 21)
     ops_and_rates = [
         (a, 1.0),
@@ -361,6 +394,10 @@ def test_states_outputs(keep_runs_results, improved_sampling):
     assert isinstance(data.average_states[0], qutip.Qobj)
     assert data.average_states[0].norm() == pytest.approx(1.)
     assert data.average_states[0].isoper
+    if state.isket:
+        assert data.average_states[0] == qutip.ket2dm(state)
+    else:
+        assert data.average_states[0] == state
 
     assert isinstance(data.average_final_state, qutip.Qobj)
     assert data.average_final_state.norm() == pytest.approx(1.)
@@ -378,9 +415,10 @@ def test_states_outputs(keep_runs_results, improved_sampling):
         assert data.runs_final_states[0].norm() == pytest.approx(1.)
         assert data.runs_final_states[0].isket
 
-    assert isinstance(data.steady_state(), qutip.Qobj)
-    assert data.steady_state().norm() == pytest.approx(1.)
-    assert data.steady_state().isoper
+    steady_state = data.steady_state()
+    assert isinstance(steady_state, qutip.Qobj)
+    assert steady_state.norm() == pytest.approx(1.)
+    assert steady_state.isoper
 
     np.testing.assert_allclose(times, data.times)
     assert data.num_trajectories == ntraj
@@ -393,16 +431,21 @@ def test_states_outputs(keep_runs_results, improved_sampling):
 
 @pytest.mark.parametrize("improved_sampling", [True, False])
 @pytest.mark.parametrize("keep_runs_results", [True, False])
-def test_expectation_outputs(keep_runs_results, improved_sampling):
+@pytest.mark.parametrize("mixed_initial_state", [True, False])
+def test_expectation_outputs(keep_runs_results, improved_sampling,
+                             mixed_initial_state):
     # We're just testing the output value, so it's important whether certain
     # things are complex or real, but not what the magnitudes of constants are.
     focks = 5
-    ntraj = 5
-    a = qutip.tensor(qutip.destroy(focks), qutip.qeye(2))
-    sm = qutip.tensor(qutip.qeye(focks), qutip.sigmam())
+    ntraj = 13
+    a = qutip.destroy(focks) & qutip.qeye(2)
+    sm = qutip.qeye(focks) & qutip.sigmam()
     H = 1j*a.dag()*sm + a
     H = H + H.dag()
-    state = qutip.basis([focks, 2], [0, 1])
+    if mixed_initial_state:
+        state = qutip.maximally_mixed_dm(focks) & qutip.fock_dm(2, 1)
+    else:
+        state = qutip.basis([focks, 2], [0, 1])
     times = np.linspace(0, 10, 5)
     ops_and_rates = [
         (a, 1.0),
@@ -529,12 +572,16 @@ class TestSeeds:
 
 
 @pytest.mark.parametrize("improved_sampling", [True, False])
-def test_timeout(improved_sampling):
+@pytest.mark.parametrize("mixed_initial_state", [True, False])
+def test_timeout(improved_sampling, mixed_initial_state):
     size = 10
     ntraj = 1000
     a = qutip.destroy(size)
     H = qutip.num(size)
-    state = qutip.basis(size, size-1)
+    if mixed_initial_state:
+        state = qutip.maximally_mixed_dm(size)
+    else:
+        state = qutip.basis(size, size-1)
     times = np.linspace(0, 1.0, 100)
     coupling = 0.5
     n_th = 0.05
@@ -551,12 +598,16 @@ def test_timeout(improved_sampling):
 
 
 @pytest.mark.parametrize("improved_sampling", [True, False])
-def test_super_H(improved_sampling):
+@pytest.mark.parametrize("mixed_initial_state", [True, False])
+def test_super_H(improved_sampling, mixed_initial_state):
     size = 10
-    ntraj = 1000
+    ntraj = 250
     a = qutip.destroy(size)
     H = qutip.num(size)
-    state = qutip.basis(size, size-1)
+    if mixed_initial_state:
+        state = qutip.maximally_mixed_dm(size)
+    else:
+        state = qutip.basis(size, size-1)
     times = np.linspace(0, 1.0, 100)
     # Arbitrary coupling and bath temperature.
     coupling = 0.5
@@ -567,13 +618,13 @@ def test_super_H(improved_sampling):
     e_ops = [qutip.num(size)]
     mc_expected = nm_mcsolve(
         H, state, times, ops_and_rates, e_ops, ntraj=ntraj,
-        target_tol=0.1, options={'map': 'serial',
-                                 "improved_sampling": improved_sampling},
+        target_tol=(0.1 if state.isket else None),
+        options={'map': 'serial', "improved_sampling": improved_sampling},
     )
     mc = nm_mcsolve(
         qutip.liouvillian(H), state, times, ops_and_rates, e_ops, ntraj=ntraj,
-        target_tol=0.1, options={'map': 'serial',
-                                 "improved_sampling": improved_sampling})
+        target_tol=(0.1 if state.isket else None),
+        options={'map': 'serial', "improved_sampling": improved_sampling})
     np.testing.assert_allclose(mc_expected.expect[0], mc.expect[0], atol=0.65)
 
 
@@ -644,3 +695,35 @@ def test_dynamic_arguments():
         H, state, times, ops_and_rates, ntraj=25, args={"collapse": []},
     )
     assert all(len(collapses) <= 1 for collapses in mc.col_which)
+
+
+@pytest.mark.parametrize(["initial_state", "ntraj"], [
+    pytest.param(qutip.maximally_mixed_dm(2), 5, id="dm"),
+    pytest.param([(qutip.basis(2, 0), 0.3), (qutip.basis(2, 1), 0.7)],
+                 5, id="statelist"),
+    pytest.param([(qutip.basis(2, 0), 0.3), (qutip.basis(2, 1), 0.7)],
+                 [4, 2], id="ntraj-spec"),
+    pytest.param([(qutip.basis(2, 0), 0.3),
+                  ((qutip.basis(2, 0) + qutip.basis(2, 1)).unit(), 0.7)],
+                 [4, 2], id="non-orthogonals"),
+])
+@pytest.mark.parametrize("improved_sampling", [True, False])
+def test_mixed_averaging(improved_sampling, initial_state, ntraj):
+    # we will only check that the initial state of the result equals the
+    # intended initial state exactly
+    H = qutip.sigmax()
+    tlist = [0, 1]
+    L = qutip.sigmam()
+    rate = -1
+
+    solver = qutip.NonMarkovianMCSolver(
+        H, [(L, rate)], options={'improved_sampling': improved_sampling})
+    result = solver.run_mixed(initial_state, tlist, ntraj)
+
+    if isinstance(initial_state, qutip.Qobj):
+        reference = initial_state
+    else:
+        reference = sum(p * psi.proj() for psi, p in initial_state)
+
+    assert result.states[0] == reference
+    assert result.num_trajectories == np.sum(ntraj)

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -727,3 +727,43 @@ def test_mixed_averaging(improved_sampling, initial_state, ntraj):
 
     assert result.states[0] == reference
     assert result.num_trajectories == np.sum(ntraj)
+
+
+@pytest.mark.parametrize("improved_sampling", [True, False])
+@pytest.mark.parametrize("p", [0, 0.25, 0.5])
+def test_mixed_equals_merged(improved_sampling, p):
+    # Running mcsolve with mixed ICs should be the same as running mcsolve
+    # multiple times and merging the results afterwards
+    initial_state1 = qutip.basis(2, 1)
+    initial_state2 = (qutip.basis(2, 1) + qutip.basis(2, 0)).unit()
+    H = qutip.sigmax()
+    L = qutip.sigmam()
+    def rate_function(t):
+        return -1 + t
+    tlist = [0, 1, 2]
+    ntraj = [3, 9]
+
+    solver = qutip.NonMarkovianMCSolver(
+        H, [(L, rate_function)],
+        options={'improved_sampling': improved_sampling})
+    mixed_result = solver.run(
+        [(initial_state1, p), (initial_state2, 1 - p)], tlist, ntraj)
+
+    # Reuse seeds, then results should be identical
+    seeds = mixed_result.seeds
+    if improved_sampling:
+        # For improved sampling, first two seeds are no-jump trajectories
+        seeds1 = seeds[0:1] + seeds[2:(ntraj[0]+1)]
+        seeds2 = seeds[1:2] + seeds[(ntraj[0]+1):]
+    else:
+        seeds1 = seeds[:ntraj[0]]
+        seeds2 = seeds[ntraj[0]:]
+
+    pure_result1 = solver.run(initial_state1, tlist, ntraj[0], seeds=seeds1)
+    pure_result2 = solver.run(initial_state2, tlist, ntraj[1], seeds=seeds2)
+    merged_result = pure_result1.merge(pure_result2, p)
+
+    assert mixed_result.num_trajectories == sum(ntraj)
+    assert merged_result.num_trajectories == sum(ntraj)
+    for state1, state2 in zip(mixed_result.states, merged_result.states):
+        assert state1 == state2

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -718,7 +718,7 @@ def test_mixed_averaging(improved_sampling, initial_state, ntraj):
 
     solver = qutip.NonMarkovianMCSolver(
         H, [(L, rate)], options={'improved_sampling': improved_sampling})
-    result = solver.run_mixed(initial_state, tlist, ntraj)
+    result = solver.run(initial_state, tlist, ntraj)
 
     if isinstance(initial_state, qutip.Qobj):
         reference = initial_state


### PR DESCRIPTION
**Description**
Enables use of `mcsolve` and `nm_mcsolve` with mixed initial conditions.

Added functions `run_mixed` to the MCSolver and NonMarkovianMCSolver classes. Instead of an initial pure state, these functions take either a density matrix or a list of `(psi_i, p_i)` where `psi_i` are pure initial states and `p_i` are the weights for the average over the initial states. In the latter case, the `ntraj` parameter can be a list specifying the number of trajectories to be used for each initial state. The trajectories automatically obtain correction weights if the fraction of trajectories starting in `psi_i` does not match `p_i`.

The functions `mcsolve` and `nm_mcsolve` take either a pure state or a density matrix as the initial state, and call either `run` or `run_mixed` of the solver, respectively.

The stochastic solvers also inherit the `run_mixed` functions, but I don't know if there is any use case for that.

The most complicated issue here was the combination of a mixed initial state with "improved sampling". In this case, run_mixed first runs the no-jump trajectories for all initial states (potentially using `parallel_map` etc) and then runs all other trajectories (using `parallel_map` again, this means that there are two progress bars...)

**Todo**
- [X] Please add tests to cover your changes if applicable.
- [x] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-tutorials). Feel free to ask if you are not sure.
- [x] Include the changelog in a file named: `doc/changes/<PR number>.<type>`