### PR TITLE
Small doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ QuTiP: Quantum Toolbox in Python
 [S. Cross](https://github.com/hodgestar),
 [A. Galicia](https://github.com/AGaliciaMartinez),
 [P. Menczel](https://github.com/pmenczel),
+[P. Hopf](https://github.com/flowerthrower/),
 [P. D. Nation](https://github.com/nonhermitian),
 and [J. R. Johansson](https://github.com/jrjohansson)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ QuTiP: Quantum Toolbox in Python
 [J. Lishman](https://github.com/jakelishman),
 [S. Cross](https://github.com/hodgestar),
 [A. Galicia](https://github.com/AGaliciaMartinez),
+[P. Menczel](https://github.com/pmenczel),
 [P. D. Nation](https://github.com/nonhermitian),
 and [J. R. Johansson](https://github.com/jrjohansson)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,10 +62,12 @@ author = ', '.join([
     'B. Li',
     'J. Lishman',
     'S. Cross',
+    'A. Galicia',
+    'P. Menczel',
     'and E. Giguère'
 ])
 
-copyright = '2011 to 2021 inclusive, QuTiP developers and contributors'
+copyright = '2011 to 2024 inclusive, QuTiP developers and contributors'
 
 
 def _check_source_folder_and_imported_qutip_match():

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,6 +64,7 @@ author = ', '.join([
     'S. Cross',
     'A. Galicia',
     'P. Menczel',
+    'P. Hopf',
     'and E. Giguère'
 ])
 

--- a/doc/frontmatter.rst
+++ b/doc/frontmatter.rst
@@ -40,6 +40,10 @@ This document contains a user guide and automatically generated API documentatio
 
 :Author: Simon Cross
 
+:Author: Asier Galicia
+
+:Author: Paul Menczel
+
 :release: |release|
 
 :copyright:

--- a/doc/frontmatter.rst
+++ b/doc/frontmatter.rst
@@ -44,6 +44,8 @@ This document contains a user guide and automatically generated API documentatio
 
 :Author: Paul Menczel
 
+:Author: Patrick Hopf
+
 :release: |release|
 
 :copyright:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,6 +6,12 @@
 QuTiP: Quantum Toolbox in Python
 ================================
 
+
+This documentation contains a user guide and automatically generated API documentation for QuTiP.
+For more information see the `QuTiP project web page <https://qutip.org/>`_.
+Here, you can also find a collection of `tutorials for QuTiP <https://qutip.org/qutip-tutorials/>`_.
+
+
 .. toctree::
    :maxdepth: 3
 

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -25,7 +25,8 @@ def about():
     print(
         "Current admin team: Alexander Pitchford, "
         "Nathan Shammah, Shahnawaz Ahmed, Neill Lambert, Eric Giguère, "
-        "Boxi Li, Jake Lishman, Simon Cross and Asier Galicia."
+        "Boxi Li, Jake Lishman, Simon Cross, Asier Galicia, Paul Menczel, "
+        "and Patrick Hopf."
     )
     print(
         "Board members: Daniel Burgarth, Robert Johansson, Anton F. Kockum, "


### PR DESCRIPTION
A user was confused because they were on the readthedocs website, thought that was the main qutip website, and couldn't find the tutorial notebooks. I added a link to the main qutip website and the tutorials section to the landing page of the readthedocs.

I also used the opportunity to update the list of admins in several places to match the admin team as listed on the qutip website. Meaning, mostly, I added @AGaliciaMartinez , myself, and @flowerthrower . Let me know in case that isn't okay and I will undo it.