### PR TITLE
Fixing rendering problem

### DIFF
--- a/doc/changes/2400.bugfix
+++ b/doc/changes/2400.bugfix
@@ -1,0 +1,3 @@
+Bug Fix in Process Matrix Rendering
+
+Resolved a rendering issue in the process matrix visualization. Previously, the code did not utilize matplotlib's built-in z-sorting mechanism. Experiments with various z-sort configurations (min, max, average) yielded inconsistent results across different charts. The solution was inspired by a Stack Overflow discussion (https://stackoverflow.com/questions/18602660/matplotlib-bar3d-clipping-problems). By adjusting the calculation of camera coordinates and incorporating minor modifications from the suggested approach, the rendering issue has been successfully addressed.

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -684,7 +684,9 @@ def sphview(ax):
     zlim = ax.get_zlim()
     # Compute  based on the plots xyz limits.
     r = 0.5 * np.sqrt(
-        (xlim[1] - xlim[0]) ** 2 + (ylim[1] - ylim[0]) ** 2 + (zlim[1] - zlim[0]) ** 2
+    (xlim[1] - xlim[0]) ** 2 +
+    (ylim[1] - ylim[0]) ** 2 +
+    (zlim[1] - zlim[0]) ** 2
     )
     theta, phi = np.radians((90 - ax.elev, ax.azim))
     return r, theta, phi
@@ -946,12 +948,24 @@ def matrix_histogram(
 
         # calculating z_order for each bar based on its position
         z_order = (
-            np.multiply([temp_xpos, temp_ypos, temp_zpos], camera).sum(0).flatten()
+            np.multiply(
+                [
+                    temp_xpos, temp_ypos, temp_zpos], camera
+                    ).sum(0).flatten()
         )
 
         for i, uxpos in enumerate(xpos):
             bars.append(
-                [uxpos, ypos[i], zpos[i], dx[i], dy[i], bar_M[i], colors[i], z_order[i]]
+                [
+                    uxpos,
+                    ypos[i],
+                    zpos[i],
+                    dx[i],
+                    dy[i],
+                    bar_M[i],
+                    colors[i],
+                    z_order[i]
+                ]
             )
 
         # Adding bars individually to the plot
@@ -971,7 +985,7 @@ def matrix_histogram(
             # sorting the bars based on our calculated z_order
             artist._sort_zpos = bar[7]
             artist_list.append([artist])
-        # The sorting issue was fixed by making minor change to the recommendations from
+        # The sorting issue was fixed by making minor change to
         # https://stackoverflow.com/questions/18602660/matplotlib-bar3d-clipping-problems
 
     if len(Ms) == 1:
@@ -1004,7 +1018,8 @@ def matrix_histogram(
 
     # color axis
     if colorbar:
-        cax, kw = mpl.colorbar.make_axes(ax, shrink=0.75, pad=options["cbar_pad"])
+        cax, kw = mpl.colorbar.make_axes(
+            ax, shrink=0.75, pad=options["cbar_pad"])
         cb = mpl.colorbar.ColorbarBase(cax, cmap=cmap, norm=norm)
 
         if color_style == "real":
@@ -1022,7 +1037,6 @@ def matrix_histogram(
                 )
 
     return fig, output
-
 
 
 def plot_energy_levels(H_list, h_labels=None, energy_levels=None, N=0, *,

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -902,7 +902,7 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
                           edgecolors=options['bars_edgecolor'],
                           linewidths=options['bars_lw'],
                           shade=options['shade'],
-                            zsort='max')
+                          zsort='max')
         artist_list.append([artist])
 
     if len(Ms) == 1:

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -858,7 +858,7 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
                 c_max = pi
             else:
                 c_min = min(color_M) if i == 0 else min(min(color_M), c_min)
-                c_max = min(color_M) if i == 0 else max(max(color_M), c_max)
+                c_max = max(color_M) if i == 0 else max(max(color_M), c_max)
 
             if c_min == c_max:
                 c_min -= 0.1
@@ -901,7 +901,8 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
         artist = ax.bar3d(xpos, ypos, zpos, dx, dy, bar_M, color=colors,
                           edgecolors=options['bars_edgecolor'],
                           linewidths=options['bars_lw'],
-                          shade=options['shade'])
+                          shade=options['shade'],
+                            zsort='max')
         artist_list.append([artist])
 
     if len(Ms) == 1:

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -669,7 +669,7 @@ def _get_matrix_components(option, M, argument):
 
 
 def sph2cart(r, theta, phi):
-    '''spherical to cartesian transformation.'''
+    """spherical to cartesian transformation."""
     x = r * np.sin(theta) * np.cos(phi)
     y = r * np.sin(theta) * np.sin(phi)
     z = r * np.cos(theta)
@@ -677,21 +677,34 @@ def sph2cart(r, theta, phi):
 
 
 def sphview(ax):
-    '''
-    returns the camera position for 3D axes in spherical coordinates.'''
+    """
+    returns the camera position for 3D axes in spherical coordinates."""
     xlim = ax.get_xlim()
     ylim = ax.get_ylim()
     zlim = ax.get_zlim()
-    # Compute  based on plot limits rather and x and y limits squared and summed
-    r = 0.5 * np.sqrt((xlim[1] - xlim[0])**2 + (ylim[1] - ylim[0])**2 + (zlim[1] - zlim[0])**2)
+    # Compute  based on the plots xyz limits.
+    r = 0.5 * np.sqrt(
+        (xlim[1] - xlim[0]) ** 2 + (ylim[1] - ylim[0]) ** 2 + (zlim[1] - zlim[0]) ** 2
+    )
     theta, phi = np.radians((90 - ax.elev, ax.azim))
     return r, theta, phi
 
 
-def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
-                     bar_style='real', color_limits=None, color_style='real',
-                     options=None, *, cmap=None, colorbar=True,
-                     fig=None, ax=None):
+def matrix_histogram(
+    M,
+    x_basis=None,
+    y_basis=None,
+    limits=None,
+    bar_style="real",
+    color_limits=None,
+    color_style="real",
+    options=None,
+    *,
+    cmap=None,
+    colorbar=True,
+    fig=None,
+    ax=None,
+):
     """
     Draw a histogram for the matrix M, with the given x and y labels and title.
 
@@ -809,10 +822,20 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
 
     """
 
-    default_opts = {'zticks': None, 'bars_spacing': 0.3,
-                    'bars_alpha': 1., 'bars_lw': 0.7, 'bars_edgecolor': 'k',
-                    'shade': True, 'azim': -60, 'elev': 30, 'stick': False,
-                    'cbar_pad': 0.04, 'cbar_to_z': False, 'threshold': None}
+    default_opts = {
+        "zticks": None,
+        "bars_spacing": 0.3,
+        "bars_alpha": 1.0,
+        "bars_lw": 0.7,
+        "bars_edgecolor": "k",
+        "shade": True,
+        "azim": -60,
+        "elev": 30,
+        "stick": False,
+        "cbar_pad": 0.04,
+        "cbar_to_z": False,
+        "threshold": None,
+    }
 
     # update default_opts from input options
     if options is None:
@@ -821,8 +844,10 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
     if isinstance(options, dict):
         # check if keys in options dict are valid
         if set(options) - set(default_opts):
-            raise ValueError("invalid key(s) found in options: "
-                             f"{', '.join(set(options) - set(default_opts))}")
+            raise ValueError(
+                "invalid key(s) found in options: "
+                f"{', '.join(set(options) - set(default_opts))}"
+            )
         else:
             # updating default options
             default_opts.update(options)
@@ -830,7 +855,7 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
     else:
         raise ValueError("options must be a dictionary")
 
-    fig, ax = _is_fig_and_ax(fig, ax, projection='3d')
+    fig, ax = _is_fig_and_ax(fig, ax, projection="3d")
 
     if not isinstance(M, list):
         Ms = [M]
@@ -848,10 +873,9 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
             # extract matrix data from Qobj
             M = M.full()
 
-        bar_M = _get_matrix_components(bar_style, M, 'bar_style')
+        bar_M = _get_matrix_components(bar_style, M, "bar_style")
 
-        if isinstance(limits, list) and \
-                len(limits) == 2:
+        if isinstance(limits, list) and len(limits) == 2:
             z_min = limits[0]
             z_max = limits[1]
         else:
@@ -862,14 +886,13 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
                 z_min -= 0.1
                 z_max += 0.1
 
-        color_M = _get_matrix_components(color_style, M, 'color_style')
+        color_M = _get_matrix_components(color_style, M, "color_style")
 
-        if isinstance(color_limits, list) and \
-                len(color_limits) == 2:
+        if isinstance(color_limits, list) and len(color_limits) == 2:
             c_min = color_limits[0]
             c_max = color_limits[1]
         else:
-            if color_style == 'phase':
+            if color_style == "phase":
                 c_min = -pi
                 c_max = pi
             else:
@@ -884,7 +907,7 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
 
     if cmap is None:
         # change later
-        if color_style == 'phase':
+        if color_style == "phase":
             cmap = _cyclic_cmap()
         else:
             cmap = _sequential_cmap()
@@ -898,77 +921,82 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
         if isinstance(M, Qobj):
             M = M.full()
 
-        bar_M = _get_matrix_components(bar_style, M, 'bar_style')
-        color_M = _get_matrix_components(color_style, M, 'color_style')
+        bar_M = _get_matrix_components(bar_style, M, "bar_style")
+        color_M = _get_matrix_components(color_style, M, "color_style")
 
         n = np.size(M)
         xpos, ypos = np.meshgrid(range(M.shape[0]), range(M.shape[1]))
         xpos = xpos.T.flatten() + 0.5
         ypos = ypos.T.flatten() + 0.5
         zpos = np.zeros(n)
-        dx = dy = (1 - options['bars_spacing']) * np.ones(n)
+        dx = dy = (1 - options["bars_spacing"]) * np.ones(n)
         colors = cmap(norm(color_M))
 
-        colors[:, 3] = options['bars_alpha']
+        colors[:, 3] = options["bars_alpha"]
 
-        if options['threshold'] is not None:
-            colors[:, 3] *= 1 * (bar_M >= options['threshold'])
+        if options["threshold"] is not None:
+            colors[:, 3] *= 1 * (bar_M >= options["threshold"])
 
-            idx, = np.where(bar_M < options['threshold'])
+            (idx,) = np.where(bar_M < options["threshold"])
             bar_M[idx] = 0
-        
+
         temp_xpos = xpos.reshape(M.shape)
         temp_ypos = ypos.reshape(M.shape)
         temp_zpos = zpos.reshape(M.shape)
 
         # calculating z_order for each bar based on its position
-        z_order = np.multiply(
-            [temp_xpos, temp_ypos, temp_zpos],camera
-            ).sum(0).flatten()
+        z_order = (
+            np.multiply([temp_xpos, temp_ypos, temp_zpos], camera).sum(0).flatten()
+        )
 
         for i, uxpos in enumerate(xpos):
-            bars.append([
-                uxpos, ypos[i], zpos[i], dx[i], dy[i], bar_M[i], colors[i],z_order[i]
-                ])
+            bars.append(
+                [uxpos, ypos[i], zpos[i], dx[i], dy[i], bar_M[i], colors[i], z_order[i]]
+            )
 
         # Adding bars individually to the plot
         for bar in bars:
-            artist = ax.bar3d(bar[0], bar[1], bar[2], bar[3], bar[4], bar[5],
-                                color=bar[6],
-                                edgecolors=options['bars_edgecolor'],
-                                linewidths=options['bars_lw'],
-                                shade=options['shade'])
+            artist = ax.bar3d(
+                bar[0],
+                bar[1],
+                bar[2],
+                bar[3],
+                bar[4],
+                bar[5],
+                color=bar[6],
+                edgecolors=options["bars_edgecolor"],
+                linewidths=options["bars_lw"],
+                shade=options["shade"],
+            )
             # sorting the bars based on our calculated z_order
             artist._sort_zpos = bar[7]
             artist_list.append([artist])
         # The sorting issue was fixed by making minor change to the recommendations from
         # https://stackoverflow.com/questions/18602660/matplotlib-bar3d-clipping-problems
 
-
     if len(Ms) == 1:
         output = ax
     else:
-        output = animation.ArtistAnimation(fig, artist_list, interval=50,
-                                           blit=True, repeat_delay=1000)
+        output = animation.ArtistAnimation(
+            fig, artist_list, interval=50, blit=True, repeat_delay=1000
+        )
 
     # remove vertical lines on xz and yz plane
-    ax.yaxis._axinfo["grid"]['linewidth'] = 0
-    ax.xaxis._axinfo["grid"]['linewidth'] = 0
+    ax.yaxis._axinfo["grid"]["linewidth"] = 0
+    ax.xaxis._axinfo["grid"]["linewidth"] = 0
 
     # x axis
-    _update_xaxis(options['bars_spacing'], M, ax, x_basis)
+    _update_xaxis(options["bars_spacing"], M, ax, x_basis)
 
     # y axis
-    _update_yaxis(options['bars_spacing'], M, ax, y_basis)
+    _update_yaxis(options["bars_spacing"], M, ax, y_basis)
 
     # z axis
-    _update_zaxis(ax, z_min, z_max, options['zticks'])
+    _update_zaxis(ax, z_min, z_max, options["zticks"])
 
     # stick to xz and yz plane
-    _stick_to_planes(options['stick'],
-                     options['azim'], ax, M,
-                     options['bars_spacing'])
-    
+    _stick_to_planes(options["stick"], options["azim"], ax, M, options["bars_spacing"])
+
     # removing margins
     _remove_margins(ax.xaxis)
     _remove_margins(ax.yaxis)
@@ -976,24 +1004,25 @@ def matrix_histogram(M, x_basis=None, y_basis=None, limits=None,
 
     # color axis
     if colorbar:
-        cax, kw = mpl.colorbar.make_axes(ax, shrink=.75,
-                                         pad=options['cbar_pad'])
+        cax, kw = mpl.colorbar.make_axes(ax, shrink=0.75, pad=options["cbar_pad"])
         cb = mpl.colorbar.ColorbarBase(cax, cmap=cmap, norm=norm)
 
-        if color_style == 'real':
-            cb.set_label('real')
-        elif color_style == 'img':
-            cb.set_label('imaginary')
-        elif color_style == 'abs':
-            cb.set_label('absolute')
+        if color_style == "real":
+            cb.set_label("real")
+        elif color_style == "img":
+            cb.set_label("imaginary")
+        elif color_style == "abs":
+            cb.set_label("absolute")
         else:
-            cb.set_label('arg')
+            cb.set_label("arg")
             if color_limits is None:
                 cb.set_ticks([-pi, -pi / 2, 0, pi / 2, pi])
                 cb.set_ticklabels(
-                    (r'$-\pi$', r'$-\pi/2$', r'$0$', r'$\pi/2$', r'$\pi$'))
+                    (r"$-\pi$", r"$-\pi/2$", r"$0$", r"$\pi/2$", r"$\pi$")
+                )
 
     return fig, output
+
 
 
 def plot_energy_levels(H_list, h_labels=None, energy_levels=None, N=0, *,

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -684,9 +684,9 @@ def sphview(ax):
     zlim = ax.get_zlim()
     # Compute  based on the plots xyz limits.
     r = 0.5 * np.sqrt(
-    (xlim[1] - xlim[0]) ** 2 +
-    (ylim[1] - ylim[0]) ** 2 +
-    (zlim[1] - zlim[0]) ** 2
+        (xlim[1] - xlim[0]) ** 2 +
+        (ylim[1] - ylim[0]) ** 2 +
+        (zlim[1] - zlim[0]) ** 2
     )
     theta, phi = np.radians((90 - ax.elev, ax.azim))
     return r, theta, phi

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -691,6 +691,7 @@ def sphview(ax):
     theta, phi = np.radians((90 - ax.elev, ax.azim))
     return r, theta, phi
 
+
 def get_camera_position(ax):
     """
     returns the camera position for 3D axes in cartesian coordinates
@@ -698,6 +699,7 @@ def get_camera_position(ax):
     """
     r, theta, phi = sphview(ax)
     return np.array(sph2cart(r, theta, phi), ndmin=3).T
+
 
 def matrix_histogram(
     M,
@@ -980,7 +982,6 @@ def matrix_histogram(
             # Setting the z-order for rendering
             artist._sort_zpos = z_order[i]
             artist_list.append([artist])
-
 
     if len(Ms) == 1:
         output = ax

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -1007,9 +1007,9 @@ def matrix_histogram(
     _stick_to_planes(options["stick"], options["azim"], ax, M, options["bars_spacing"])
 
     # removing margins
-    # _remove_margins(ax.xaxis)
-    # _remove_margins(ax.yaxis)
-    # _remove_margins(ax.zaxis)
+    _remove_margins(ax.xaxis)
+    _remove_margins(ax.yaxis)
+    _remove_margins(ax.zaxis)
 
     # color axis
     if colorbar:


### PR DESCRIPTION
**Checklist**

- [x] Please read [Contributing to QuTiP Development](http://qutip.org/docs/latest/development/contributing.html)
- [x] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
- [ ] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-tutorials). Feel free to ask if you are not sure.
- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](http://qutip.org/docs/latest/development/contributing.html#changelog-generation) for more information).

Delete this checklist after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.

**Description**
Fixes the rendering problem, upon going over matplotlib docs and discussions around [similar issues](https://github.com/matplotlib/matplotlib/issues/13728), I discovered that zsort was not set in when calling the ax.bar3d , I have set the sort to max which fixes the bars being rendered incorrectly. @BoxiLi  The PR is up for review , it should fix the rendering issue 

**Related issues or PRs**
fixes #2400 


