### PR TITLE
Bloch `add_states` color argument dim bug

### DIFF
--- a/doc/changes/2445.bugfix
+++ b/doc/changes/2445.bugfix
@@ -1,0 +1,2 @@
+Fix a dimension problem for the argument color of Bloch.add_states
+Add Bloch.add_arc and Bloch.add_line in the guide on Bloch class

--- a/doc/changes/2445.bugfix
+++ b/doc/changes/2445.bugfix
@@ -1,2 +1,3 @@
 Fix a dimension problem for the argument color of Bloch.add_states
+Clean-up of the code in  Bloch.add_state
 Add Bloch.add_arc and Bloch.add_line in the guide on Bloch class

--- a/doc/guide/guide-bloch.rst
+++ b/doc/guide/guide-bloch.rst
@@ -29,7 +29,7 @@ Before getting into the details of these objects, we can simply plot the blank B
 .. plot::
     :context:
 
-    b.make_sphere()
+    b.render()
 
 In addition to the ``show`` command, see the API documentation for :class:`~qutip.bloch.Bloch` for a full list of other available functions.
 As an example, we can add a single data point:
@@ -107,6 +107,15 @@ a similar method works for adding vectors:
     b.clear()
     vec = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     b.add_vectors(vec)
+    b.render()
+
+You can also add lines and arcs:
+
+.. plot::
+    :context: close-figs
+
+    b.add_line(x, y)
+    b.add_arc(y, z)
     b.render()
 
 Adding multiple points to the Bloch sphere works slightly differently than adding multiple states or vectors.  For example, lets add a set of 20 points around the equator (after calling `clear()`):
@@ -332,7 +341,7 @@ The code to directly generate an mp4 movie of the Qubit decay is as follows ::
       sphere.clear()
       sphere.add_vectors([np.sin(theta), 0, np.cos(theta)], ["r"])
       sphere.add_points([sx[:i+1], sy[:i+1], sz[:i+1]])
-      sphere.make_sphere()
+      sphere.render()
       return ax
 
    ani = animation.FuncAnimation(fig, animate, np.arange(len(sx)), blit=False, repeat=False)

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -1,6 +1,7 @@
 __all__ = ['Bloch']
 
 import os
+from typing import Literal
 
 import numpy as np
 from numpy import (outer, cos, sin, ones)
@@ -314,7 +315,8 @@ class Bloch:
         self._lines = []
         self._arcs = []
 
-    def add_points(self, points, meth='s', colors=None, alpha=1.0):
+    def add_points(self, points, meth: Literal['s', 'm', 'l'] = 's',
+                   colors=None, alpha=1.0):
         """Add a list of data points to bloch sphere.
 
         Parameters
@@ -364,13 +366,14 @@ class Bloch:
         self.point_alpha.append(alpha)
         self._inner_point_color.append(colors)
 
-    def add_states(self, state, kind='vector', colors=None, alpha=1.0):
+    def add_states(self, state, kind: Literal['vector', 'point'] = 'vector',
+                   colors=None, alpha=1.0):
         """Add a state vector Qobj to Bloch sphere.
 
         Parameters
         ----------
-        state : :obj:`.Qobj`
-            Input state vector.
+        state : :obj:`.Qobj` or array_like
+            Input state vector or list.
 
         kind : {'vector', 'point'}
             Type of object to plot.
@@ -381,10 +384,27 @@ class Bloch:
         alpha : float, default=1.
             Transparency value for the vectors. Values between 0 and 1.
         """
-        if isinstance(state, Qobj):
-            state = [state]
-        if not isinstance(colors, (list, np.ndarray)) and colors is not None:
-            colors = [colors]
+        state = np.asarray(state)
+
+        if state.ndim == 0:
+            state = state[np.newaxis]
+
+        if state.ndim != 1:
+            raise ValueError("The included states are not valid. "
+                             "State should be a Qobj or a list of Qobj.")
+
+        if colors is not None:
+            colors = np.asarray(colors)
+
+            if colors.ndim == 0:
+                colors = colors[np.newaxis]
+
+            if colors.shape != state.shape:
+                raise ValueError("The included colors are not valid. "
+                                 "colors must be equivalent to a 1D array "
+                                 "with the same size as the number of states.")
+        else:
+            colors = np.array([None] * state.size)
 
         for k, st in enumerate(state):
             vec = [expect(sigmax(), st),
@@ -392,15 +412,9 @@ class Bloch:
                    expect(sigmaz(), st)]
 
             if kind == 'vector':
-                if colors is not None:
-                    self.add_vectors(vec, colors=[colors[k]], alpha=alpha)
-                else:
-                    self.add_vectors(vec)
+                self.add_vectors(vec, colors=[colors[k]], alpha=alpha)
             elif kind == 'point':
-                if colors is not None:
-                    self.add_points(vec, colors=[colors[k]], alpha=alpha)
-                else:
-                    self.add_points(vec)
+                self.add_points(vec, colors=[colors[k]], alpha=alpha)
 
     def add_vectors(self, vectors, colors=None, alpha=1.0):
         """Add a list of vectors to Bloch sphere.

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -393,12 +393,12 @@ class Bloch:
 
             if kind == 'vector':
                 if colors is not None:
-                    self.add_vectors(vec, colors=colors[k], alpha=alpha)
+                    self.add_vectors(vec, colors=[colors[k]], alpha=alpha)
                 else:
                     self.add_vectors(vec)
             elif kind == 'point':
                 if colors is not None:
-                    self.add_points(vec, colors=colors[k], alpha=alpha)
+                    self.add_points(vec, colors=[colors[k]], alpha=alpha)
                 else:
                     self.add_points(vec)
 


### PR DESCRIPTION
**Description**
- Fix a dimension problem for the argument `color` of `Bloch.add_states`
  ```python
  import qutip as qt
  bloch.add_states([qt.basis(2,0), qt.basis(2,1)], colors=["crimson", "gold"]) # fails whereas it should work
  bloch.add_states([qt.basis(2,0), qt.basis(2,1)], colors=[["crimson"], ["gold"]]) # what works
  ```
- Clean-up of the code in `Bloch.add_states` as asked in #1913 
- Add `Bloch.add_arc` and `Bloch.add_line` in the guide on Bloch class