### PR TITLE
Fix bug in steadystate where permutation was inversed

### DIFF
--- a/doc/changes/2443.bugfix
+++ b/doc/changes/2443.bugfix
@@ -1,0 +1,1 @@
+Fix steadystate permutation being reversed.

--- a/qutip/solver/steadystate.py
+++ b/qutip/solver/steadystate.py
@@ -12,14 +12,16 @@ __all__ = ["steadystate", "steadystate_floquet", "pseudo_inverse"]
 
 
 def _permute_wbm(L, b):
-    perm = scipy.sparse.csgraph.maximum_bipartite_matching(L.as_scipy())
+    perm = np.argsort(
+        scipy.sparse.csgraph.maximum_bipartite_matching(L.as_scipy())
+    )
     L = _data.permute.indices(L, perm, None)
     b = _data.permute.indices(b, perm, None)
     return L, b
 
 
 def _permute_rcm(L, b):
-    perm = scipy.sparse.csgraph.reverse_cuthill_mckee(L.as_scipy())
+    perm = np.argsort(scipy.sparse.csgraph.reverse_cuthill_mckee(L.as_scipy()))
     L = _data.permute.indices(L, perm, perm)
     b = _data.permute.indices(b, perm, None)
     return L, b, perm


### PR DESCRIPTION
**Description**
The permutation function used in v5 is reversed from v4, (it does `out[perm] = in`). This was not taken into account when updating the steadystates permutations functions.
Fixed and added tests.

**Related issues or PRs**
fix #2443