### PR TITLE
Add dispatcher for sqrtm

### DIFF
--- a/qutip/core/data/expm.py
+++ b/qutip/core/data/expm.py
@@ -12,7 +12,7 @@ from .base import idxint_dtype
 
 __all__ = [
     'expm', 'expm_csr', 'expm_csr_dense', 'expm_dense', 'expm_dia',
-    'logm', 'logm_dense',
+    'logm', 'logm_dense', 'sqrtm', 'sqrtm_dense'
 ]
 
 
@@ -127,6 +127,27 @@ logm = _Dispatcher(
 logm.__doc__ = """Matrix logarithm `ln(A)` for a matrix `A`."""
 logm.add_specialisations([
     (Dense, Dense, logm_dense),
+], _defer=True)
+
+
+def sqrtm_dense(matrix) -> Dense:
+    if matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("can only compute logarithm square matrix")
+    return Dense(scipy.linalg.sqrtm(matrix.as_ndarray()), copy=False)
+
+
+sqrtm = _Dispatcher(
+    _inspect.Signature([
+        _inspect.Parameter('matrix', _inspect.Parameter.POSITIONAL_ONLY),
+    ]),
+    name='sqrtm',
+    module=__name__,
+    inputs=('matrix',),
+    out=True,
+)
+sqrtm.__doc__ = """Matrix square root `sqrt(A)` for a matrix `A`."""
+sqrtm.add_specialisations([
+    (Dense, Dense, sqrtm_dense),
 ], _defer=True)
 
 del _inspect, _Dispatcher

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -720,9 +720,9 @@ class Qobj:
         out = _data.trace(self._data)
         # This ensures that trace can return something that is not a number such
         # as a `tensorflow.Tensor` in qutip-tensorflow.
-        return out.real if (self.isherm
-                        and hasattr(out, "real")
-                        ) else out
+        if settings.core["auto_real_casting"] and self.isherm:
+            out = out.real
+        return out
 
     def purity(self) -> numbers.Number:
         """Calculate purity of a quantum object.
@@ -794,10 +794,9 @@ class Qobj:
         """
         # TODO: add a `diagonal` method to the data layer?
         out = _data.to(_data.CSR, self.data).as_scipy().diagonal()
-        if np.any(np.imag(out) > settings.core['atol']) or not self.isherm:
-            return out
-        else:
-            return np.real(out)
+        if settings.core["auto_real_casting"] and self.isherm:
+            out = np.real(out)
+        return out
 
     def expm(self, dtype: LayerType = _data.Dense) -> Qobj:
         """Matrix exponential of quantum operator.
@@ -896,23 +895,11 @@ class Qobj:
         """
         if self._dims[0] != self._dims[1]:
             raise TypeError('sqrt only valid on square matrices')
-        if isinstance(self.data, _data.CSR) and sparse:
-            evals, evecs = _data.eigs_csr(self.data,
-                                          isherm=self._isherm,
-                                          tol=tol, maxiter=maxiter)
-        elif isinstance(self.data, _data.CSR):
-            evals, evecs = _data.eigs(_data.to(_data.Dense, self.data),
-                                      isherm=self._isherm)
-        else:
-            evals, evecs = _data.eigs(self.data, isherm=self._isherm)
-
-        dV = _data.diag([np.sqrt(evals, dtype=complex)], 0)
-        if self.isherm:
-            spDv = _data.matmul(dV, evecs.conj().transpose())
-        else:
-            spDv = _data.matmul(dV, _data.inv(evecs))
-        return Qobj(_data.matmul(evecs, spDv),
+        if isinstance(self.data, _data.CSR):
+            self._data = _data.to(_data.Dense, self.data)
+        return Qobj(_data.sqrtm(self._data),
                     dims=self._dims,
+                    isherm=self._isherm,
                     copy=False)
 
     def cosm(self) -> Qobj:

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -937,6 +937,17 @@ class TestLogm(UnaryOpMixin):
     ]
 
 
+class TestSqrtm(UnaryOpMixin):
+    def op_numpy(self, matrix):
+        return scipy.linalg.sqrtm(matrix)
+
+    shapes = shapes_square()
+    bad_shapes = shapes_not_square()
+    specialisations = [
+        pytest.param(data.sqrtm_dense, Dense, Dense),
+    ]
+
+
 class TestTranspose(UnaryOpMixin):
     def op_numpy(self, matrix):
         return matrix.T


### PR DESCRIPTION
**Description**
Add dispatcher for `sqrtm` in `qobj.py`. This will help us to create a similar function in `jax` for `sqrtm` specifically.

This PR creates a dispatcher function for `sqrtm` that uses `scipy.linalg.sqrtm` to compute square root of a matrix
