### PR TITLE
Add parallelization support for `verN` integrators

### DIFF
--- a/doc/changes/2454.bugfix
+++ b/doc/changes/2454.bugfix
@@ -1,0 +1,1 @@
+Add parallelizing support for `vernN` methods with `mcsolve`.

--- a/qutip/solver/integrator/explicit_rk.pyx
+++ b/qutip/solver/integrator/explicit_rk.pyx
@@ -199,6 +199,15 @@ cdef class Explicit_RungeKutta:
         self.b_factor_np = np.empty(self.rk_extra_step, dtype=np.float64)
         self.b_factor = self.b_factor_np
 
+    def __reduce__(self):
+        """
+        Helper for pickle to serialize the object
+        """
+        return (self.__class__, (
+            self.qevo, self.rtol, self.atol, self.max_numsteps, self.first_step,
+            self.min_step, self.max_step, self.interpolate, self.method
+        ))
+
     cpdef void set_initial_value(self, Data y0, double t) except *:
         """
         Set the initial state and time of the integration.

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -182,6 +182,7 @@ def test_pickling_vern_methods(integrator):
     import pickle
     pickled = pickle.dumps(inter, -1)
     recreated = pickle.loads(pickled)
+    recreated.set_state(0, qutip.basis(1,0).data)
 
     for t in np.linspace(0,1,6):
         expected = pytest.approx(np.exp(t/2), abs=1e-5)

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -166,3 +166,25 @@ def test_concurent_usage(integrator):
         assert inter1.integrate(t)[1].to_array()[0, 0] == expected1
         expected2 = pytest.approx(np.exp(-t/2), abs=1e-5)
         assert inter2.integrate(t)[1].to_array()[0, 0] == expected2
+
+@pytest.mark.parametrize('integrator',
+    [IntegratorVern7, IntegratorVern9],
+    ids=["vern7", 'vern9']
+)
+def test_pickling_vern_methods(integrator):
+    """Test whether VernN methods can be pickled and hence used in multiprocessing"""
+    opt = {'atol':1e-10, 'rtol':1e-7}
+
+    sys = qutip.QobjEvo(0.5*qutip.qeye(1))
+    inter = integrator(sys, opt)
+    inter.set_state(0, qutip.basis(1,0).data)
+
+    import pickle
+    pickled = pickle.dumps(inter, -1)
+    recreated = pickle.loads(pickled)
+
+    for t in np.linspace(0,1,6):
+        expected = pytest.approx(np.exp(t/2), abs=1e-5)
+        result1 = inter.integrate(t)[1].to_array()[0, 0]
+        result2 = recreated.integrate(t)[1].to_array()[0, 0]
+        assert result1 == result2 == expected


### PR DESCRIPTION
**Description**
Multiprocessing for `vernN` methods was failing because `Explicit_RungeKutta` objects were unpicklable. This PR adds a helper method `__reduce__` in that class to help with pickling. 

**Related issues or PRs**
fix #2450