### PR TITLE
Update requirement to include numpy 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,31 +29,35 @@ jobs:
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.11"]
         case-name: [defaults]
-        numpy-requirement: [">=1.22"]
-        scipy-requirement: [">=1.8"]
+        numpy-build: [""]  # On conda, the prerelease is tagged as 2.0
+        numpy-requirement: [""]
+        scipy-requirement: [">=1.9"]
         coverage-requirement: ["==6.5"]
+        # pypi: 1  # numpy 2 not yet available on conda
         # Extra special cases.  In these, the new variable defined should always
         # be a truth-y value (hence 'nomkl: 1' rather than 'mkl: 0'), because
         # the lack of a variable is _always_ false-y, and the defaults lack all
         # the special cases.
         include:
           # Test with the version 2 of numpy comming soon.
-          - case-name: numpy2
+          - case-name: python 3.12
             os: ubuntu-latest
             python-version: "3.12"
-            scipy-requirement: ""
-            numpy-requirement: "==2.0.0rc2"
+            numpy-build: ">=2.0.0rc2"
             pypi: 1
 
           # Binaries compiled with numpy 2 should be compatible when using
           # numpy 1.X at runtime.
-          - case-name: numpy2_to_1
+          - case-name: build numpy 1.22
             os: ubuntu-latest
             python-version: "3.10"
             scipy-requirement: ""
-            numpy-requirement: "==2.0.0rc2"
-            roll_back_numpy: 1
-            pypi: 1  # numpy 2 not yet available on conda
+            numpy-requirement: ">=1.22.0,<1.23.0"
+            numpy-build: ">=1.22.0,<1.23.0"
+            semidefinite: 1
+            oldcython: 1
+            pypi: 1
+            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
           # Python 3.10, no mkl, scipy 1.9, numpy 1.23
           # Scipy 1.9 did not support cython 3.0 yet.
@@ -63,33 +67,11 @@ jobs:
             python-version: "3.10"
             scipy-requirement: ">=1.9,<1.10"
             numpy-requirement: ">=1.23,<1.24"
+            semidefinite: 1
             condaforge: 1
             oldcython: 1
             nomkl: 1
-            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning"
-
-          # Python 3.10, no cython, scipy 1.10, numpy 1.24
-          - case-name: no cython
-            os: ubuntu-latest
-            python-version: "3.10"
-            scipy-requirement: ">=1.10,<1.11"
-            numpy-requirement: ">=1.24,<1.25"
-            oldcython: 1
-            nocython: 1
-
-          # Python 3.11 and recent numpy
-          # Use conda-forge to provide Python 3.11 and latest numpy
-          # Ignore deprecation of the cgi module in Python 3.11 that is
-          # still imported by Cython.Tempita. This was addressed in
-          # https://github.com/cython/cython/pull/5128 but not backported
-          # to any currently released version.
-          - case-name: Python 3.11
-            os: ubuntu-latest
-            python-version: "3.11"
-            condaforge: 1
-            scipy-requirement: ">=1.11,<1.12"
-            numpy-requirement: ">=1.25,<1.26"
-            conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
+            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
           # Python 3.12 and latest numpy
           # Use conda-forge to provide Python 3.11 and latest numpy
@@ -99,7 +81,6 @@ jobs:
             scipy-requirement: ">=1.12,<1.13"
             numpy-requirement: ">=1.26,<1.27"
             condaforge: 1
-            pytest-extra-options: "-W ignore:datetime:DeprecationWarning"
             # Install mpi4py to test mpi_pmap
             # Should be enough to include this in one of the runs
             includempi: 1
@@ -110,19 +91,32 @@ jobs:
             # setup-miniconda not compatible with macos-latest presently.
             # https://github.com/conda-incubator/setup-miniconda/issues/344
             os: macos-12
-            python-version: "3.11"
+            python-version: "3.12"
             condaforge: 1
             nomkl: 1
 
-          # Windows. Once all tests pass without special options needed, this
-          # can be moved to the main os list in the test matrix. All the tests
-          # that fail currently seem to do so because mcsolve uses
-          # multiprocessing under the hood. Windows does not support fork()
-          # well, which makes transfering objects to the child processes
-          # error prone. See, e.g., https://github.com/qutip/qutip/issues/1202
+          - case-name: macos - numpy 1.25
+            os: macos-12
+            python-version: "3.11"
+            scipy-requirement: ">=1.11,<1.12"
+            numpy-requirement: ">=1.25,<1.26"
+            # conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
+            condaforge: 1
+            nomkl: 1
+
           - case-name: Windows
             os: windows-latest
             python-version: "3.11"
+
+          - case-name: Windows - No cython
+            os: windows-latest
+            python-version: "3.10"
+            scipy-requirement: ">=1.10,<1.11"
+            numpy-requirement: ">=1.24,<1.25"
+            semidefinite: 1
+            oldcython: 1
+            nocython: 1
+            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
     steps:
       - uses: actions/checkout@v4
@@ -140,25 +134,29 @@ jobs:
         # version of cython, scipy, numpy in the test matrix, not a temporary
         # version use in the installation virtual environment.
         run: |
+          conda config --add channels conda-forge/label/numpy_rc
           # Install the extra requirement
           python -m pip install pytest>=5.2 pytest-rerunfailures  # tests
           python -m pip install matplotlib>=1.2.1  # graphics
-          python -m pip install cvxpy>=1.0 cvxopt  # semidefinite
           python -m pip install ipython  # ipython
           python -m pip install loky tqdm  # extras
           python -m pip install "coverage${{ matrix.coverage-requirement }}" chardet
           python -m pip install pytest-cov coveralls pytest-fail-slow
 
           if [[ "${{ matrix.pypi }}" ]]; then
-            pip install "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
+            pip install "numpy${{ matrix.numpy-build }}"
+            pip install "scipy${{ matrix.scipy-requirement }}"
           elif [[ -z "${{ matrix.nomkl }}" ]]; then
-            conda install blas=*=mkl "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
+            conda install blas=*=mkl "numpy${{ matrix.numpy-build }}" "scipy${{ matrix.scipy-requirement }}"
           elif [[ "${{ matrix.os }}" =~ ^windows.*$ ]]; then
             # Conda doesn't supply forced nomkl builds on Windows, so we rely on
             # pip not automatically linking to MKL.
-            pip install "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
+            pip install "numpy${{ matrix.numpy-build }}" "scipy${{ matrix.scipy-requirement }}"
           else
-            conda install nomkl "numpy${{ matrix.numpy-requirement }}" "scipy${{ matrix.scipy-requirement }}"
+            conda install nomkl "numpy${{ matrix.numpy-build }}" "scipy${{ matrix.scipy-requirement }}"
+          fi
+          if [[ -n "${{ matrix.semidefinite }}" ]]; then
+            python -m pip install cvxpy>=1.0 cvxopt
           fi
           if [[ -n "${{ matrix.conda-extra-pkgs }}" ]]; then
             conda install "${{ matrix.conda-extra-pkgs }}"
@@ -168,7 +166,7 @@ jobs:
             conda install "openmpi<5" mpi4py
           fi
           if [[ "${{ matrix.oldcython }}" ]]; then
-            python -m pip install cython==0.29.36 filelock
+            python -m pip install cython==0.29.36 filelock matplotlib==3.5
           else
             python -m pip install cython filelock
           fi
@@ -179,11 +177,15 @@ jobs:
             python -m pip uninstall cython -y
           fi
 
-          if [[ "${{ matrix.roll_back_numpy }}" ]]; then
-            # Binary compiled with numpy 2.X should be compatible with numpy 1.X
-            python -m pip install "numpy<1.24"
+          if [[ "${{ matrix.pypi }}" ]]; then
+            python -m pip install "numpy${{ matrix.numpy-requirement }}" --pre
+          elif [[ -z "${{ matrix.nomkl }}" ]]; then
+            conda install "numpy${{ matrix.numpy-requirement }}"
+          elif [[ "${{ matrix.os }}" =~ ^windows.*$ ]]; then
+            python -m pip install "numpy${{ matrix.numpy-requirement }}" --pre
+          else
+            conda install nomkl "numpy${{ matrix.numpy-requirement }}"
           fi
-
 
 
       - name: Package information

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.11"]
         case-name: [defaults]
+        # Version 2 not yet available on conda's default channel
+        condaforge: [1]
         numpy-build: [""]
         numpy-requirement: [""]
         scipy-requirement: [">=1.9"]
@@ -38,51 +40,49 @@ jobs:
         # the lack of a variable is _always_ false-y, and the defaults lack all
         # the special cases.
         include:
-          # Test with the version 2 of numpy comming soon.
-          - case-name: python 3.12
+          - case-name: p312 numpy 2
             os: ubuntu-latest
             python-version: "3.12"
             numpy-build: ">=2.0.0"
+            numpy-requirement: ">=2.0.0"
             pypi: 1
 
-          # Binaries compiled with numpy 2 should be compatible when using
-          # numpy 1.X at runtime.
-          - case-name: build numpy 1.22
+          - case-name: p310 numpy 1.22
             os: ubuntu-latest
             python-version: "3.10"
-            scipy-requirement: ""
-            numpy-requirement: ">=1.22.0,<1.23.0"
             numpy-build: ">=1.22.0,<1.23.0"
+            numpy-requirement: ">=1.22.0,<1.23.0"
+            scipy-requirement: ">=1.10,<1.11"
             semidefinite: 1
             oldcython: 1
             pypi: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
+          # Python 3.12 and latest numpy
+          # Use conda-forge to provide Python 3.11 and latest numpy
+          - case-name: p312, numpy fallback
+            os: ubuntu-latest
+            python-version: "3.12"
+            numpy-requirement: ">=1.26,<1.27"
+            scipy-requirement: ">=1.11,<1.12"
+            condaforge: 1
+            # Install mpi4py to test mpi_pmap
+            # Should be enough to include this in one of the runs
+            includempi: 1
+
           # Python 3.10, no mkl, scipy 1.9, numpy 1.23
           # Scipy 1.9 did not support cython 3.0 yet.
           # cython#17234
-          - case-name: no mkl
+          - case-name: p310 no mkl
             os: ubuntu-latest
             python-version: "3.10"
-            scipy-requirement: ">=1.9,<1.10"
             numpy-requirement: ">=1.23,<1.24"
+            scipy-requirement: ">=1.9,<1.10"
             semidefinite: 1
             condaforge: 1
             oldcython: 1
             nomkl: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
-
-          # Python 3.12 and latest numpy
-          # Use conda-forge to provide Python 3.11 and latest numpy
-          - case-name: Python 3.12
-            os: ubuntu-latest
-            python-version: "3.12"
-            scipy-requirement: ">=1.12,<1.13"
-            numpy-requirement: ">=1.26,<1.27"
-            condaforge: 1
-            # Install mpi4py to test mpi_pmap
-            # Should be enough to include this in one of the runs
-            includempi: 1
 
           # Mac
           # Mac has issues with MKL since september 2022.
@@ -91,30 +91,35 @@ jobs:
             # https://github.com/conda-incubator/setup-miniconda/issues/344
             os: macos-12
             python-version: "3.12"
+            numpy-build: ">=2.0.0"
+            numpy-requirement: ">=2.0.0"
             condaforge: 1
             nomkl: 1
 
-          - case-name: macos - numpy 1.25
+          - case-name: macos - numpy fallback
             os: macos-12
             python-version: "3.11"
-            scipy-requirement: ">=1.11,<1.12"
+            numpy-build: ">=2.0.0"
             numpy-requirement: ">=1.25,<1.26"
-            # conda-extra-pkgs: "suitesparse"  # for compiling cvxopt
             condaforge: 1
             nomkl: 1
 
           - case-name: Windows
             os: windows-latest
             python-version: "3.11"
+            numpy-build: ">=2.0.0"
+            numpy-requirement: ">=2.0.0"
+            pypi: 1
 
-          - case-name: Windows - No cython
+          - case-name: Windows - numpy fallback
             os: windows-latest
             python-version: "3.10"
-            scipy-requirement: ">=1.10,<1.11"
+            numpy-build: ">=2.0.0"
             numpy-requirement: ">=1.24,<1.25"
             semidefinite: 1
             oldcython: 1
             nocython: 1
+            condaforge: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
     steps:
@@ -176,11 +181,11 @@ jobs:
           fi
 
           if [[ "${{ matrix.pypi }}" ]]; then
-            python -m pip install "numpy${{ matrix.numpy-requirement }}" --pre
+            python -m pip install "numpy${{ matrix.numpy-requirement }}"
           elif [[ -z "${{ matrix.nomkl }}" ]]; then
             conda install "numpy${{ matrix.numpy-requirement }}"
           elif [[ "${{ matrix.os }}" =~ ^windows.*$ ]]; then
-            python -m pip install "numpy${{ matrix.numpy-requirement }}" --pre
+            python -m pip install "numpy${{ matrix.numpy-requirement }}"
           else
             conda install nomkl "numpy${{ matrix.numpy-requirement }}"
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,11 +29,10 @@ jobs:
         # matrix size; make sure to test all supported versions in some form.
         python-version: ["3.11"]
         case-name: [defaults]
-        numpy-build: [""]  # On conda, the prerelease is tagged as 2.0
+        numpy-build: [""]
         numpy-requirement: [""]
         scipy-requirement: [">=1.9"]
         coverage-requirement: ["==6.5"]
-        # pypi: 1  # numpy 2 not yet available on conda
         # Extra special cases.  In these, the new variable defined should always
         # be a truth-y value (hence 'nomkl: 1' rather than 'mkl: 0'), because
         # the lack of a variable is _always_ false-y, and the defaults lack all
@@ -43,7 +42,7 @@ jobs:
           - case-name: python 3.12
             os: ubuntu-latest
             python-version: "3.12"
-            numpy-build: ">=2.0.0rc2"
+            numpy-build: ">=2.0.0"
             pypi: 1
 
           # Binaries compiled with numpy 2 should be compatible when using
@@ -134,7 +133,6 @@ jobs:
         # version of cython, scipy, numpy in the test matrix, not a temporary
         # version use in the installation virtual environment.
         run: |
-          conda config --add channels conda-forge/label/numpy_rc
           # Install the extra requirement
           python -m pip install pytest>=5.2 pytest-rerunfailures  # tests
           python -m pip install matplotlib>=1.2.1  # graphics

--- a/doc/changes/2457.misc
+++ b/doc/changes/2457.misc
@@ -1,0 +1,1 @@
+Add numpy 2 support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ requires = [
     "cython>=0.29.20,<3.0.0; python_version<='3.9'",
     # See https://numpy.org/doc/stable/user/depending_on_numpy.html for
     # the recommended way to build against numpy's C API:
-    "oldest-supported-numpy",
-    "scipy>=1.8",
+    "numpy>=2.0.0rc2",
+    "scipy>=1.9",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "cython>=0.29.20,<3.0.0; python_version<='3.9'",
     # See https://numpy.org/doc/stable/user/depending_on_numpy.html for
     # the recommended way to build against numpy's C API:
-    "numpy>=2.0.0rc2",
+    "numpy>=2.0.0",
     "scipy>=1.9",
 ]
 build-backend = "setuptools.build_meta"

--- a/qutip/core/data/expm.py
+++ b/qutip/core/data/expm.py
@@ -133,7 +133,7 @@ logm.add_specialisations([
 def sqrtm_dense(matrix) -> Dense:
     if matrix.shape[0] != matrix.shape[1]:
         raise ValueError("can only compute logarithm square matrix")
-    return Dense(scipy.linalg.sqrtm(matrix.as_ndarray()), copy=False)
+    return Dense(scipy.linalg.sqrtm(matrix.as_ndarray()))
 
 
 sqrtm = _Dispatcher(

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,24 +32,22 @@ include_package_data = True
 zip_safe = False
 python_requires = >=3.10
 install_requires =
-    numpy>=1.22,<2.0.0
-    scipy>=1.8
+    numpy>=1.22
+    scipy>=1.9
     packaging
 setup_requires =
-    numpy>=1.19,<2.0.0
-    scipy>=1.8
+    numpy>=2.0.0rc2
+    scipy>=1.9
     cython>=0.29.20; python_version>='3.10'
-    cython>=0.29.20,<3.0.0; python_version<='3.9'
     packaging
 
 [options.packages.find]
 include = qutip*
 
 [options.extras_require]
-graphics = matplotlib>=1.2.1
+graphics = matplotlib>=3.5
 runtime_compilation =
     cython>=0.29.20; python_version>='3.10'
-    cython>=0.29.20,<3.0.0; python_version<='3.9'
     filelock
     setuptools
 semidefinite =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     scipy>=1.9
     packaging
 setup_requires =
-    numpy>=2.0.0rc2
+    numpy>=2.0.0
     scipy>=1.9
     cython>=0.29.20; python_version>='3.10'
     packaging


### PR DESCRIPTION
Last week we added numpy 2 support but did not update the requirements in `setup.cfg`.

This update dependency to build using numpy 2 instead of oldest-supported-numpy.
I also increased the minimum requirements for matplotlib and scipy to version tested.

I added more test using numpy 2, only one tests build and run using numpy 1.X.
I added more windows / mac tests. Using these os for testing numpy versions and no cython.
`cvxopt` (`dnorm`) does not run with numpy 2 yet, so it's only tested with older numpy version.

Fix sqrtm needing copy. This mean that the test intended to run with numpy 2 previouly did not...
