### PR TITLE
Multi Trajectory solver bugfixes

### DIFF
--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -532,7 +532,7 @@ class MCSolver(MultiTrajSolver):
         Run one trajectory and return the result.
         """
         jump_prob_floor = integrator_kwargs.get('jump_prob_floor', 0)
-        if jump_prob_floor == 1:
+        if jump_prob_floor >= 1 - self.options["norm_tol"]:
             # The no-jump probability is one, but we are asked to generate
             # a trajectory with at least one jump.
             # This can happen when a user uses "improved sampling" with a dark
@@ -543,6 +543,7 @@ class MCSolver(MultiTrajSolver):
             zero = qzero_like(self._restore_state(state, copy=False))
             result = self._trajectory_resultclass(e_ops, self.options)
             result.collapse = []
+            result.add_relative_weight(0)
             for t in tlist:
                 result.add(t, zero)
             return seed, result

--- a/qutip/solver/multitrajresult.py
+++ b/qutip/solver/multitrajresult.py
@@ -337,13 +337,16 @@ class MultiTrajResult(_BaseResult):
             # We only include traj. without abs. weights in this calculation.
             # Since there are traj. with abs. weights., the weights don't add
             # up to one. We have to consider that as follows:
-            #   <(x - <x>)^2> / <1> = <x^2> / <1> - <x>^2 / <1>^2
+            # err = (std * <w>**2 / (N-1)) ** 0.5
+            # avg = <x * w>
+            # avg2 = <x**2 * w>
+            # std * <w>**2 = (<x**2> - <x>**2) * <w>**2
+            #              = avg2 * <w> - avg**2
             # and "<1>" is one minus the sum of all absolute weights
             one = one - self._total_abs_weight
 
-        std = avg2 - abs(avg)**2
-        target_ntraj = np.max(std / target**2) * one**2 + 1
-
+        std = avg2 * one - abs(avg)**2
+        target_ntraj = np.max(std / target**2) + 1
         self._estimated_ntraj = min(target_ntraj - self._num_rel_trajectories,
                                     self._target_ntraj - self.num_trajectories)
         if self._estimated_ntraj <= 0:
@@ -522,11 +525,29 @@ class MultiTrajResult(_BaseResult):
         """
         Last states of each trajectories averaged into a density matrix.
         """
-        if ((self._sum_abs and not self._sum_abs.sum_final_state) or
-                (self._sum_rel and not self._sum_rel.sum_final_state)):
-            if (average_states := self.average_states) is not None:
-                return average_states[-1]
-            return None
+        trajectory_states_available = (self.trajectories and
+                                       self.trajectories[0].final_state)
+        states = self.average_states
+        need_to_reduce_states = False
+        if self._sum_abs and not self._sum_abs.sum_final_state:
+            if not (trajectory_states_available or states):
+                return None
+            need_to_reduce_states = True
+
+        if self._sum_rel and not self._sum_rel.sum_final_state:
+            if not (trajectory_states_available or states):
+                return None
+            need_to_reduce_states = True
+
+        if need_to_reduce_states and states:
+            return states[-1]
+        elif need_to_reduce_states:
+            if self._sum_abs:
+                self._sum_abs._initialize_sum_finalstate(self.trajectories[0])
+            if self._sum_rel:
+                self._sum_rel._initialize_sum_finalstate(self.trajectories[0])
+            for trajectory in self.trajectories:
+                self._reduce_final_state(trajectory)
 
         if self._sum_abs and self._sum_rel:
             return (self._sum_abs.sum_final_state +
@@ -659,19 +680,42 @@ class MultiTrajResult(_BaseResult):
         new.times = self.times
         new.e_ops = self.e_ops
 
+        if bool(self.trajectories) != bool(other.trajectories):
+            # ensure the states are reduced.
+            if self.trajectories:
+                self.average_states
+                self.average_final_state
+            else:
+                other.average_states
+                other.average_final_state
+
         new.num_trajectories = self.num_trajectories + other.num_trajectories
         new._num_rel_trajectories = (self._num_rel_trajectories +
                                      other._num_rel_trajectories)
         new.seeds = self.seeds + other.seeds
 
-        p_equal = self.num_trajectories / new.num_trajectories
+        p_equal = self._num_rel_trajectories / new._num_rel_trajectories
         if p is None:
-            p = p_equal
+            p = self.num_trajectories / new.num_trajectories
 
         if self.trajectories and other.trajectories:
             new.trajectories = self._merge_trajectories(other, p, p_equal)
         else:
             new._weight_info = self._merge_weight_info(other, p, p_equal)
+            new.trajectories = []
+            new.options["keep_runs_results"] = False
+            new.runs_e_data = {}
+
+        self_states = self.options["store_states"]
+        self_fstate = self.options["store_final_state"]
+        other_states = other.options["store_states"]
+        other_fstate = other.options["store_final_state"]
+
+        new.options["store_states"] = self_states and other_states
+
+        new.options["store_final_state"] = (
+            (self_fstate or self_states) and (other_fstate or other_states)
+        )
 
         new._sum_abs = _TrajectorySum.merge(
             self._sum_abs, p, other._sum_abs, 1 - p)
@@ -682,7 +726,6 @@ class MultiTrajResult(_BaseResult):
         new._create_e_data()
 
         if self.runs_e_data and other.runs_e_data:
-            new.runs_e_data = {}
             for k in self._raw_ops:
                 new.runs_e_data[k] = self.runs_e_data[k] + other.runs_e_data[k]
 
@@ -802,6 +845,11 @@ class _TrajectorySum:
     def _initialize_sum_states(self, example_trajectory):
         self.sum_states = [
             qzero_like(_to_dm(state)) for state in example_trajectory.states]
+
+    def _initialize_sum_finalstate(self, example_trajectory):
+        self.sum_final_state = qzero_like(
+            _to_dm(example_trajectory.final_state)
+        )
 
     def reduce_states(self, trajectory):
         """
@@ -1124,9 +1172,9 @@ class NmmcResult(McResult):
     def merge(self, other, p=None):
         new = super().merge(other, p)
 
-        p_eq = self.num_trajectories / new.num_trajectories
+        p_eq = self._num_rel_trajectories / new._num_rel_trajectories
         if p is None:
-            p = p_eq
+            p = self.num_trajectories / new.num_trajectories
 
         new._sum_trace_abs = (
             self._merge_weight(p, p_eq, True) * self._sum_trace_abs +

--- a/qutip/solver/multitrajresult.py
+++ b/qutip/solver/multitrajresult.py
@@ -341,8 +341,8 @@ class MultiTrajResult(_BaseResult):
             # and "<1>" is one minus the sum of all absolute weights
             one = one - self._total_abs_weight
 
-        target_ntraj = np.max((avg2 / one - (abs(avg) ** 2) / (one ** 2)) /
-                              target**2 + 1)
+        std = avg2 - abs(avg)**2
+        target_ntraj = np.max(std / target**2) * one**2 + 1
 
         self._estimated_ntraj = min(target_ntraj - self._num_rel_trajectories,
                                     self._target_ntraj - self.num_trajectories)
@@ -635,8 +635,7 @@ class MultiTrajResult(_BaseResult):
 
         where p is a parameter between 0 and 1. Its default value is
         :math:`p_{\textrm{def}} = N / (N + N')`, N and N' being the number of
-        trajectories in the two result objects. (In the case of weighted
-        trajectories, only trajectories without absolute weights are counted.)
+        trajectories in the two result objects.
 
         Parameters
         ----------
@@ -665,7 +664,7 @@ class MultiTrajResult(_BaseResult):
                                      other._num_rel_trajectories)
         new.seeds = self.seeds + other.seeds
 
-        p_equal = self._num_rel_trajectories / new._num_rel_trajectories
+        p_equal = self.num_trajectories / new.num_trajectories
         if p is None:
             p = p_equal
 
@@ -1125,7 +1124,7 @@ class NmmcResult(McResult):
     def merge(self, other, p=None):
         new = super().merge(other, p)
 
-        p_eq = self._num_rel_trajectories / new._num_rel_trajectories
+        p_eq = self.num_trajectories / new.num_trajectories
         if p is None:
             p = p_eq
 

--- a/qutip/solver/multitrajresult.py
+++ b/qutip/solver/multitrajresult.py
@@ -342,7 +342,7 @@ class MultiTrajResult(_BaseResult):
             # avg2 = <x**2 * w>
             # std * <w>**2 = (<x**2> - <x>**2) * <w>**2
             #              = avg2 * <w> - avg**2
-            # and "<1>" is one minus the sum of all absolute weights
+            # and "<w>" is one minus the sum of all absolute weights
             one = one - self._total_abs_weight
 
         std = avg2 * one - abs(avg)**2
@@ -830,8 +830,8 @@ class _TrajectorySum:
         else:
             self.sum_states = None
 
-        if (fstate := example_trajectory.final_state) and store_final_state:
-            self.sum_final_state = qzero_like(_to_dm(fstate))
+        if example_trajectory.final_state and store_final_state:
+            self._initialize_sum_finalstate(example_trajectory)
         else:
             self.sum_final_state = None
 

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -604,6 +604,7 @@ def test_mixed_averaging(improved_sampling, initial_state, ntraj):
         assert result.ntraj_per_initial_state == ntraj
     else:
         assert sum(result.ntraj_per_initial_state) == ntraj
+    assert sum(result.runs_weights) == pytest.approx(1.)
 
 
 @pytest.mark.parametrize("improved_sampling", [True, False])
@@ -648,3 +649,5 @@ def test_mixed_equals_merged(improved_sampling, p):
     assert hasattr(mixed_result, 'ntraj_per_initial_state')
     assert isinstance(mixed_result.ntraj_per_initial_state, list)
     assert mixed_result.ntraj_per_initial_state == ntraj
+    assert sum(mixed_result.runs_weights) == pytest.approx(1.)
+    assert sum(merged_result.runs_weights) == pytest.approx(1.)


### PR DESCRIPTION
**Description**
Fix issues with multi- trajectory results:
- When one result had trajectories and the other did not, but both stored the states, the merged result had no states.
- When merging 2 results with default ratio, that ratio would depend on whether the `improved_sampling` options was used. 
- When the no-jump probability was 1, the total weight as measured by sum(res.runs_weight) would not be one.
- A no-jump probability over 1 by numerical error would break the evolution.
- Fix weight application in the `_target_tolerance_end`. (At `abs_weight == 1`, the error should be 0).
- `average_final_state` not being computed properly when runs were stored.

This PR is a part of #2455. (1/4?)
The absolute weighted trajectories are still mixed with the other. (#2455 fixed the issues by not counting the no-jump evolution are a trajectory.)

Tests need #2457 to pass.