### PR TITLE
Add inplace operators for Qobj

### DIFF
--- a/qutip/core/gates.py
+++ b/qutip/core/gates.py
@@ -778,7 +778,7 @@ def _powers(op, N):
     yield acc
 
     for _ in range(N - 1):
-        acc *= op
+        acc = acc * op
         yield acc
 
 

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -385,6 +385,12 @@ class Qobj:
         return self.__add__(other)
 
     @_require_equal_type
+    def __iadd__(self, other: Qobj | numbers.Number) -> Qobj:
+        self.data = (self + other).data
+        self._isherm = (self._isherm and other._isherm) or None
+        return self
+
+    @_require_equal_type
     def __sub__(self, other: Qobj | numbers.Number) -> Qobj:
         if other == 0:
             return self.copy()
@@ -395,6 +401,12 @@ class Qobj:
 
     def __rsub__(self, other: Qobj | numbers.Number) -> Qobj:
         return self.__neg__().__add__(other)
+
+    @_require_equal_type
+    def __isub__(self, other: Qobj | numbers.Number) -> Qobj:
+        self.data = (self - other).data
+        self._isherm = (self._isherm and other._isherm) or None
+        return self
 
     def __mul__(self, other: numbers.Number) -> Qobj:
         """
@@ -435,6 +447,16 @@ class Qobj:
         # we _shouldn't_ check that `other` is `Qobj`.
         return self.__mul__(other)
 
+    def __imul__(self, other: numbers.Number) -> Qobj:
+        if isinstance(other, Qobj):
+            self @= other
+        else:
+            out = self * other
+            self.data = out.data
+            self._isherm = out._isherm
+            self._isunitary = out._isunitary
+        return self
+
     def __matmul__(self, other: Qobj) -> Qobj:
         if not isinstance(other, Qobj):
             try:
@@ -452,8 +474,22 @@ class Qobj:
             copy=False
         )
 
+    def __imatmul__(self, other: Qobj) -> Qobj:
+        out = self @ other
+        self.data = out.data
+        self._dims = out._dims
+        self._isunitary = out._isunitary
+        return self
+
     def __truediv__(self, other: numbers.Number) -> Qobj:
         return self.__mul__(1 / other)
+
+    def __itruediv__(self, other: numbers.Number) -> Qobj:
+        out = self * (1 / other)
+        self.data = out.data
+        self._isherm = out._isherm
+        self._isunitary = out._isunitary
+        return self
 
     def __neg__(self) -> Qobj:
         return Qobj(_data.neg(self._data),

--- a/qutip/solver/nonmarkov/transfertensor.py
+++ b/qutip/solver/nonmarkov/transfertensor.py
@@ -166,7 +166,7 @@ def _generatetensors(dynmaps, threshold):
     for n in range(len(dynmaps)):
         T = dynmaps[n]
         for m in range(1, n):
-            T -= Tensors[n - m] @ dynmaps[m]
+            T = T - Tensors[n - m] @ dynmaps[m]
         Tensors.append(T)
         if n > 1:
             diff.append((Tensors[-1] - Tensors[-2]).norm())

--- a/qutip/solver/steadystate.py
+++ b/qutip/solver/steadystate.py
@@ -130,7 +130,7 @@ def steadystate(A, c_ops=[], *, method='direct', solver=None, **kwargs):
         A = liouvillian(A, c_ops)
     else:
         for op in c_ops:
-            A += lindblad_dissipator(op)
+            A = A + lindblad_dissipator(op)
 
     if "-" in method:
         # to support v4's "power-gmres" method
@@ -500,9 +500,9 @@ def pseudo_inverse(L, rhoss=None, w=None, method='splu', *, use_rcm=False,
     Q = _data.sub(I, P)
 
     if w in [None, 0.0]:
-        L += 1e-15j
+        L = L + 1e-15j
     else:
-        L += 1.0j * w
+        L = L + 1.0j * w
 
     use_rcm = use_rcm and isinstance(L.data, _data.CSR)
 

--- a/qutip/tests/core/test_qobj.py
+++ b/qutip/tests/core/test_qobj.py
@@ -1279,3 +1279,30 @@ def test_qobj_dtype(dtype):
 def test_dtype_in_info_string(dtype):
     obj = qutip.qeye(2, dtype=dtype)
     assert dtype.lower() in str(obj).lower()
+
+
+def test_inplace():
+    ops = [qutip.qeye(2)]
+    for op in ops:
+        op += 1
+    assert op.tr() == 4
+
+    ops = [qutip.qeye(2)]
+    for op in ops:
+        op -= 1
+    assert op.tr() == 0
+
+    ops = [qutip.qeye(2)]
+    for op in ops:
+        op *= 1
+    assert op.tr() == 2
+
+    ops = [qutip.qeye(2)]
+    for op in ops:
+        op /= 2
+    assert op.tr() == 1
+
+    ops = [qutip.qeye(2)]
+    for op in ops:
+        op @= qutip.destroy(2)
+    assert op.tr() == 0


### PR DESCRIPTION
**Description**
Add inplace operations `+=`, `-=`, `*=`, `@=`, `/=` for Qobj.
These operations could already be used as python fallback on normal operator.
But cases like:
```
for op in operators:
    op *= 2
```
in place operations are needed.

Added a tests and checked cases where in place operations were used on users input.