### PR TITLE
Fixed Dicke Entropy returns -Inf #1919

### DIFF
--- a/doc/changes/2466.bugfix
+++ b/doc/changes/2466.bugfix
@@ -1,4 +1,1 @@
-Fixed issue #1919
-Dicke density state matrix should only have positive eigenvalues, but rounding errors causes eigenvalues of 0 to instead be represented as a very small negative number.
-This causes dicke_trace_function to return -Inf, since scipy.special.entr returns -Inf for any values < 0.
-This issue was fixed by simply taking the absolute value of the eigenvalues in dicke_trace_function.
+Fixed rounding error in dicke_trace_function that resulted in negative eigenvalues.

--- a/doc/changes/2466.bugfix
+++ b/doc/changes/2466.bugfix
@@ -1,4 +1,4 @@
 Fixed issue #1919
-Dicke density state matrix should only have positive eigenvalues, but rounding errors causes eigenvalues of 0 to isntead be represented as a very small negative number.
+Dicke density state matrix should only have positive eigenvalues, but rounding errors causes eigenvalues of 0 to instead be represented as a very small negative number.
 This causes dicke_trace_function to return -Inf, since scipy.special.entr returns -Inf for any values < 0.
 This issue was fixed by simply taking the absolute value of the eigenvalues in dicke_trace_function.

--- a/doc/changes/2466.bugfix
+++ b/doc/changes/2466.bugfix
@@ -1,0 +1,4 @@
+Fixed issue #1919
+Dicke density state matrix should only have positive eigenvalues, but rounding errors causes eigenvalues of 0 to isntead be represented as a very small negative number.
+This causes dicke_trace_function to return -Inf, since scipy.special.entr returns -Inf for any values < 0.
+This issue was fixed by simply taking the absolute value of the eigenvalues in dicke_trace_function.

--- a/qutip/piqs/piqs.py
+++ b/qutip/piqs/piqs.py
@@ -268,7 +268,7 @@ def dicke_function_trace(f, rho):
         normalized_block = block / dj
         eigenvals_block = eigvalsh(normalized_block)
         for val in eigenvals_block:
-            eigenvals_degeneracy.append(val)
+            eigenvals_degeneracy.append(abs(val))
             deg.append(dj)
 
     eigenvalue = np.array(eigenvals_degeneracy)


### PR DESCRIPTION
**Description**
Dicke density state matrix should only have positive eigenvalues, but rounding errors causes eigenvalues of 0 to instead be represented as a very small negative number.
This causes `dicke_trace_function` to return -Inf, since `scipy.special.entr` returns -Inf for any values < 0.
This issue was fixed by simply taking the absolute value of the eigenvalues in dicke_trace_function, which we are allowed to do since the density state matrix should only have positive eigenvalues.

**Related issues or PRs**
fix #1919