### PR TITLE
Types.creators

### DIFF
--- a/doc/changes/2473.misc
+++ b/doc/changes/2473.misc
@@ -1,0 +1,1 @@
+Add type hints for Qobj creation functions.

--- a/qutip/core/gates.py
+++ b/qutip/core/gates.py
@@ -169,7 +169,7 @@ def ct_gate(*, dtype: LayerType = None) -> Qobj:
     )
 
 
-def rx(phi, *, dtype: LayerType = None) -> Qobj:
+def rx(phi: float, *, dtype: LayerType = None) -> Qobj:
     """Single-qubit rotation for operator sigmax with angle phi.
 
     Parameters

--- a/qutip/core/gates.py
+++ b/qutip/core/gates.py
@@ -819,7 +819,7 @@ def qubit_clifford_group(*, dtype: LayerType = None) -> list[Qobj]:
 
     X = sigmax()
     S = phasegate(np.pi / 2)
-    E = H @ (S**3) @ w**3
+    E = H @ (S**3) * w**3
 
     # partial(reduce, mul) returns a function that takes products
     # of its argument, by analogy to sum. Note that by analogy,

--- a/qutip/core/gates.py
+++ b/qutip/core/gates.py
@@ -8,6 +8,7 @@ from . import Qobj, qeye, sigmax, fock_dm, qdiags, qeye_like
 from .dimensions import Dimensions
 from .. import settings
 from . import data as _data
+from ..typing import LayerType
 
 
 __all__ = [
@@ -46,7 +47,7 @@ _DIMS_2_QB = Dimensions([[2, 2], [2, 2]])
 _DIMS_3_QB = Dimensions([[2, 2, 2], [2, 2, 2]])
 
 
-def cy_gate(*, dtype=None):
+def cy_gate(*, dtype: LayerType = None) -> Qobj:
     """Controlled Y gate.
 
     Parameters
@@ -69,7 +70,7 @@ def cy_gate(*, dtype=None):
     ).to(dtype)
 
 
-def cz_gate(*, dtype=None):
+def cz_gate(*, dtype: LayerType = None) -> Qobj:
     """Controlled Z gate.
 
     Parameters
@@ -87,7 +88,7 @@ def cz_gate(*, dtype=None):
     return qdiags([1, 1, 1, -1], dims=_DIMS_2_QB, dtype=dtype)
 
 
-def s_gate(*, dtype=None):
+def s_gate(*, dtype: LayerType = None) -> Qobj:
     """Single-qubit rotation also called Phase gate or the Z90 gate.
 
     Parameters
@@ -107,7 +108,7 @@ def s_gate(*, dtype=None):
     return qdiags([1, 1j], dtype=dtype)
 
 
-def cs_gate(*, dtype=None):
+def cs_gate(*, dtype: LayerType = None) -> Qobj:
     """Controlled S gate.
 
     Parameters
@@ -126,7 +127,7 @@ def cs_gate(*, dtype=None):
     return qdiags([1, 1, 1, 1j], dims=_DIMS_2_QB, dtype=dtype)
 
 
-def t_gate(*, dtype=None):
+def t_gate(*, dtype: LayerType = None) -> Qobj:
     """Single-qubit rotation related to the S gate by the relationship S=T*T.
 
     Parameters
@@ -145,7 +146,7 @@ def t_gate(*, dtype=None):
     return qdiags([1, np.exp(1j * np.pi / 4)], dtype=dtype)
 
 
-def ct_gate(*, dtype=None):
+def ct_gate(*, dtype: LayerType = None) -> Qobj:
     """Controlled T gate.
 
     Parameters
@@ -168,7 +169,7 @@ def ct_gate(*, dtype=None):
     )
 
 
-def rx(phi, *, dtype=None):
+def rx(phi, *, dtype: LayerType = None) -> Qobj:
     """Single-qubit rotation for operator sigmax with angle phi.
 
     Parameters
@@ -197,7 +198,7 @@ def rx(phi, *, dtype=None):
     ).to(dtype)
 
 
-def ry(phi, *, dtype=None):
+def ry(phi, *, dtype: LayerType = None) -> Qobj:
     """Single-qubit rotation for operator sigmay with angle phi.
 
     Parameters
@@ -226,7 +227,7 @@ def ry(phi, *, dtype=None):
     ).to(dtype)
 
 
-def rz(phi, *, dtype=None):
+def rz(phi, *, dtype: LayerType = None) -> Qobj:
     """Single-qubit rotation for operator sigmaz with angle phi.
 
     Parameters
@@ -248,7 +249,7 @@ def rz(phi, *, dtype=None):
     return qdiags([np.exp(-1j * phi / 2), np.exp(1j * phi / 2)], dtype=dtype)
 
 
-def sqrtnot(*, dtype=None):
+def sqrtnot(*, dtype: LayerType = None) -> Qobj:
     """Single-qubit square root NOT gate.
 
     Parameters
@@ -271,7 +272,7 @@ def sqrtnot(*, dtype=None):
     ).to(dtype)
 
 
-def snot(*, dtype=None):
+def snot(*, dtype: LayerType = None) -> Qobj:
     """Quantum object representing the SNOT (Hadamard) gate.
 
     Parameters
@@ -294,7 +295,7 @@ def snot(*, dtype=None):
     ).to(dtype)
 
 
-def phasegate(theta, *, dtype=None):
+def phasegate(theta: float, *, dtype: LayerType = None) -> Qobj:
     """
     Returns quantum object representing the phase shift gate.
 
@@ -316,7 +317,7 @@ def phasegate(theta, *, dtype=None):
     return qdiags([1, np.exp(1.0j * theta)], dtype=dtype)
 
 
-def qrot(theta, phi, *, dtype=None):
+def qrot(theta: float, phi: float, *, dtype: LayerType = None) -> Qobj:
     """
     Single qubit rotation driving by Rabi oscillation with 0 detune.
 
@@ -352,7 +353,7 @@ def qrot(theta, phi, *, dtype=None):
 #
 
 
-def cphase(theta, *, dtype=None):
+def cphase(theta: float, *, dtype: LayerType = None) -> Qobj:
     """
     Returns quantum object representing the controlled phase shift gate.
 
@@ -375,7 +376,7 @@ def cphase(theta, *, dtype=None):
     )
 
 
-def cnot(*, dtype=None):
+def cnot(*, dtype: LayerType = None) -> Qobj:
     """
     Quantum object representing the CNOT gate.
 
@@ -400,7 +401,7 @@ def cnot(*, dtype=None):
     ).to(dtype)
 
 
-def csign(*, dtype=None):
+def csign(*, dtype: LayerType = None) -> Qobj:
     """
     Quantum object representing the CSIGN gate.
 
@@ -419,7 +420,7 @@ def csign(*, dtype=None):
     return cz_gate(dtype=dtype)
 
 
-def berkeley(*, dtype=None):
+def berkeley(*, dtype: LayerType = None) -> Qobj:
     """
     Quantum object representing the Berkeley gate.
 
@@ -449,7 +450,7 @@ def berkeley(*, dtype=None):
     ).to(dtype)
 
 
-def swapalpha(alpha, *, dtype=None):
+def swapalpha(alpha: float, *, dtype: LayerType = None) -> Qobj:
     """
     Quantum object representing the SWAPalpha gate.
 
@@ -482,7 +483,7 @@ def swapalpha(alpha, *, dtype=None):
     ).to(dtype)
 
 
-def swap(*, dtype=None):
+def swap(*, dtype: LayerType = None) -> Qobj:
     """Quantum object representing the SWAP gate.
 
     Parameters
@@ -506,7 +507,7 @@ def swap(*, dtype=None):
     ).to(dtype)
 
 
-def iswap(*, dtype=None):
+def iswap(*, dtype: LayerType = None) -> Qobj:
     """Quantum object representing the iSWAP gate.
 
     Parameters
@@ -529,7 +530,7 @@ def iswap(*, dtype=None):
     ).to(dtype)
 
 
-def sqrtswap(*, dtype=None):
+def sqrtswap(*, dtype: LayerType = None) -> Qobj:
     """Quantum object representing the square root SWAP gate.
 
     Parameters
@@ -560,7 +561,7 @@ def sqrtswap(*, dtype=None):
     ).to(dtype)
 
 
-def sqrtiswap(*, dtype=None):
+def sqrtiswap(*, dtype: LayerType = None) -> Qobj:
     """Quantum object representing the square root iSWAP gate.
 
     Parameters
@@ -590,7 +591,7 @@ def sqrtiswap(*, dtype=None):
     ).to(dtype)
 
 
-def molmer_sorensen(theta, *, dtype=None):
+def molmer_sorensen(theta: float, *, dtype: LayerType = None) -> Qobj:
     """
     Quantum object of a Mølmer–Sørensen gate.
 
@@ -598,8 +599,6 @@ def molmer_sorensen(theta, *, dtype=None):
     ----------
     theta: float
         The duration of the interaction pulse.
-    N: int
-        Number of qubits in the system.
     target: int
         The indices of the target qubits.
     dtype : str or type, [keyword only] [optional]
@@ -630,7 +629,7 @@ def molmer_sorensen(theta, *, dtype=None):
 #
 
 
-def fredkin(*, dtype=None):
+def fredkin(*, dtype: LayerType = None) -> Qobj:
     """Quantum object representing the Fredkin gate.
 
     Parameters
@@ -663,7 +662,7 @@ def fredkin(*, dtype=None):
     ).to(dtype)
 
 
-def toffoli(*, dtype=None):
+def toffoli(*, dtype: LayerType = None) -> Qobj:
     """Quantum object representing the Toffoli gate.
 
     Parameters
@@ -701,7 +700,7 @@ def toffoli(*, dtype=None):
 #
 
 
-def globalphase(theta, N=1, *, dtype=None):
+def globalphase(theta: float, N: int = 1, *, dtype: LayerType = None) -> Qobj:
     """
     Returns quantum object representing the global phase shift gate.
 
@@ -709,6 +708,9 @@ def globalphase(theta, N=1, *, dtype=None):
     ----------
     theta : float
         Phase rotation angle.
+
+    N : int:
+        Number of qubits
 
     dtype : str or type, [keyword only] [optional]
         Storage representation. Any data-layer known to `qutip.data.to` is
@@ -741,11 +743,14 @@ def _hamming_distance(x):
     return tot
 
 
-def hadamard_transform(N=1, *, dtype=None):
+def hadamard_transform(N: int = 1, *, dtype: LayerType = None) -> Qobj:
     """Quantum object representing the N-qubit Hadamard gate.
 
     Parameters
     ----------
+    N : int:
+        Number of qubits
+
     dtype : str or type, [keyword only] [optional]
         Storage representation. Any data-layer known to `qutip.data.to` is
         accepted.
@@ -782,7 +787,7 @@ def _powers(op, N):
         yield acc
 
 
-def qubit_clifford_group(*, dtype=None):
+def qubit_clifford_group(*, dtype: LayerType = None) -> list[Qobj]:
     """
     Generates the Clifford group on a single qubit,
     using the presentation of the group given by Ross and Selinger
@@ -814,7 +819,7 @@ def qubit_clifford_group(*, dtype=None):
 
     X = sigmax()
     S = phasegate(np.pi / 2)
-    E = H * (S**3) * w**3
+    E = H @ (S**3) @ w**3
 
     # partial(reduce, mul) returns a function that takes products
     # of its argument, by analogy to sum. Note that by analogy,

--- a/qutip/core/gates.py
+++ b/qutip/core/gates.py
@@ -198,7 +198,7 @@ def rx(phi: float, *, dtype: LayerType = None) -> Qobj:
     ).to(dtype)
 
 
-def ry(phi, *, dtype: LayerType = None) -> Qobj:
+def ry(phi: float, *, dtype: LayerType = None) -> Qobj:
     """Single-qubit rotation for operator sigmay with angle phi.
 
     Parameters
@@ -227,7 +227,7 @@ def ry(phi, *, dtype: LayerType = None) -> Qobj:
     ).to(dtype)
 
 
-def rz(phi, *, dtype: LayerType = None) -> Qobj:
+def rz(phi: float, *, dtype: LayerType = None) -> Qobj:
     """Single-qubit rotation for operator sigmaz with angle phi.
 
     Parameters

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -13,23 +13,30 @@ __all__ = [
 ]
 
 import numpy as np
+from typing import Literal
 from . import data as _data
 from .qobj import Qobj
 from .dimensions import Space
 from .. import settings
+from ..typing import DimensionLike, SpaceLike, LayerType
 
-
-def qdiags(diagonals, offsets=None, dims=None, shape=None, *,
-           dtype=None):
+def qdiags(
+    diagonals: np.typing.ArrayLike | list[np.typing.ArrayLike],
+    offsets: int | list[int] = None,
+    dims: DimensionLike = None,
+    shape: tuple[int, int] = None,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """
     Constructs an operator from an array of diagonals.
 
     Parameters
     ----------
-    diagonals : sequence of array_like
+    diagonals : array_like or sequence of array_like
         Array of elements to place along the selected diagonals.
 
-    offsets : sequence of ints, optional
+    offsets : int or sequence of ints, optional
         Sequence for diagonals to be set:
             - k=0 main diagonal
             - k>0 kth upper diagonal
@@ -78,7 +85,12 @@ shape = [4, 4], type = oper, isherm = False
     )
 
 
-def jmat(j, which=None, *, dtype=None):
+def jmat(
+    j: float,
+    which: Literal["x", "y", "z", "+", "-"] = None,
+    *,
+    dtype: LayerType = None
+) -> Qobj | tuple[Qobj]:
     """Higher-order spin operators:
 
     Parameters
@@ -177,7 +189,7 @@ def _jz(j, *, dtype=None):
 #
 # Spin j operators:
 #
-def spin_Jx(j, *, dtype=None):
+def spin_Jx(j: float, *, dtype: LayerType = None) -> Qobj:
     """Spin-j x operator
 
     Parameters
@@ -198,7 +210,7 @@ def spin_Jx(j, *, dtype=None):
     return jmat(j, 'x', dtype=dtype)
 
 
-def spin_Jy(j, *, dtype=None):
+def spin_Jy(j: float, *, dtype: LayerType = None) -> Qobj:
     """Spin-j y operator
 
     Parameters
@@ -219,7 +231,7 @@ def spin_Jy(j, *, dtype=None):
     return jmat(j, 'y', dtype=dtype)
 
 
-def spin_Jz(j, *, dtype=None):
+def spin_Jz(j: float, *, dtype: LayerType = None) -> Qobj:
     """Spin-j z operator
 
     Parameters
@@ -240,7 +252,7 @@ def spin_Jz(j, *, dtype=None):
     return jmat(j, 'z', dtype=dtype)
 
 
-def spin_Jm(j, *, dtype=None):
+def spin_Jm(j: float, *, dtype: LayerType = None) -> Qobj:
     """Spin-j annihilation operator
 
     Parameters
@@ -261,7 +273,7 @@ def spin_Jm(j, *, dtype=None):
     return jmat(j, '-', dtype=dtype)
 
 
-def spin_Jp(j, *, dtype=None):
+def spin_Jp(j: float, *, dtype: LayerType = None) -> Qobj:
     """Spin-j creation operator
 
     Parameters
@@ -282,7 +294,7 @@ def spin_Jp(j, *, dtype=None):
     return jmat(j, '+', dtype=dtype)
 
 
-def spin_J_set(j, *, dtype=None):
+def spin_J_set(j: float, *, dtype: LayerType = None) -> tuple[Qobj]:
     """Set of spin-j operators (x, y, z)
 
     Parameters
@@ -296,7 +308,7 @@ def spin_J_set(j, *, dtype=None):
 
     Returns
     -------
-    list : list of Qobj
+    list : tuple of Qobj
         list of ``qobj`` representating of the spin operator.
 
     """
@@ -318,7 +330,7 @@ _SIGMAZ = 2 * jmat(0.5, 'z')
 _SIGMAZ._isunitary = True
 
 
-def sigmap(*, dtype=None):
+def sigmap(*, dtype: LayerType = None) -> Qobj:
     """Creation operator for Pauli spins.
 
     Parameters
@@ -341,7 +353,7 @@ shape = [2, 2], type = oper, isHerm = False
     return _SIGMAP.to(dtype, True)
 
 
-def sigmam(*, dtype=None):
+def sigmam(*, dtype: LayerType = None) -> Qobj:
     """Annihilation operator for Pauli spins.
 
     Parameters
@@ -364,7 +376,7 @@ shape = [2, 2], type = oper, isHerm = False
     return _SIGMAM.to(dtype, True)
 
 
-def sigmax(*, dtype=None):
+def sigmax(*, dtype: LayerType = None) -> Qobj:
     """Pauli spin 1/2 sigma-x operator
 
     Parameters
@@ -387,7 +399,7 @@ shape = [2, 2], type = oper, isHerm = False
     return _SIGMAX.to(dtype, True)
 
 
-def sigmay(*, dtype=None):
+def sigmay(*, dtype: LayerType = None) -> Qobj:
     """Pauli spin 1/2 sigma-y operator.
 
     Parameters
@@ -410,7 +422,7 @@ shape = [2, 2], type = oper, isHerm = True
     return _SIGMAY.to(dtype, True)
 
 
-def sigmaz(*, dtype=None):
+def sigmaz(*, dtype: LayerType = None) -> Qobj:
     """Pauli spin 1/2 sigma-z operator.
 
     Parameters
@@ -433,7 +445,7 @@ shape = [2, 2], type = oper, isHerm = True
     return _SIGMAZ.to(dtype, True)
 
 
-def destroy(N, offset=0, *, dtype=None):
+def destroy(N: int, offset: int = 0, *, dtype: LayerType = None) -> Qobj:
     """
     Destruction (lowering) operator.
 
@@ -472,7 +484,7 @@ def destroy(N, offset=0, *, dtype=None):
     return qdiags(data, 1, dtype=dtype)
 
 
-def create(N, offset=0, *, dtype=None):
+def create(N: int, offset: int = 0, *, dtype: LayerType = None) -> Qobj:
     """
     Creation (raising) operator.
 
@@ -511,7 +523,7 @@ def create(N, offset=0, *, dtype=None):
     return qdiags(data, -1, dtype=dtype)
 
 
-def fdestroy(n_sites, site, dtype=None):
+def fdestroy(n_sites: int, site, dtype: LayerType = None) -> Qobj:
     """
     Fermionic destruction operator.
     We use the Jordan-Wigner transformation,
@@ -529,7 +541,7 @@ def fdestroy(n_sites, site, dtype=None):
     n_sites : int
         Number of sites in Fock space.
 
-    site : int, default: 0
+    site : int
         The site in Fock space to add a fermion to.
         Corresponds to j in the above JW transform.
 
@@ -556,7 +568,7 @@ def fdestroy(n_sites, site, dtype=None):
     return _f_op(n_sites, site, 'destruction', dtype=dtype)
 
 
-def fcreate(n_sites, site, dtype=None):
+def fcreate(n_sites: int, site, dtype: LayerType = None) -> Qobj:
     """
     Fermionic creation operator.
     We use the Jordan-Wigner transformation,
@@ -602,7 +614,7 @@ def fcreate(n_sites, site, dtype=None):
     return _f_op(n_sites, site, 'creation', dtype=dtype)
 
 
-def _f_op(n_sites, site, action, dtype=None):
+def _f_op(n_sites, site, action, dtype: LayerType = None,):
     """ Makes fermionic creation and destruction operators.
     We use the Jordan-Wigner transformation,
     making use of the Jordan-Wigner ZZ..Z strings,
@@ -669,7 +681,12 @@ def _f_op(n_sites, site, action, dtype=None):
     return out
 
 
-def qzero(dimensions, dims_right=None, *, dtype=None):
+def qzero(
+    dimensions: SpaceLike,
+    dims_right: SpaceLike = None,
+    *,
+    dtype: LayerType = None
+) -> Qobj:
     """
     Zero operator.
 
@@ -710,7 +727,7 @@ def qzero(dimensions, dims_right=None, *, dtype=None):
                 isherm=True, isunitary=False, copy=False)
 
 
-def qzero_like(qobj):
+def qzero_like(qobj: Qobj) -> Qobj:
     """
     Zero operator of the same dims and type as the reference.
 
@@ -732,7 +749,7 @@ def qzero_like(qobj):
     )
 
 
-def qeye(dimensions, *, dtype=None):
+def qeye(dimensions: SpaceLike, *, dtype: LayerType = None) -> Qobj:
     """
     Identity operator.
 
@@ -782,7 +799,7 @@ isherm = True
 identity = qeye
 
 
-def qeye_like(qobj):
+def qeye_like(qobj: Qobj) -> Qobj:
     """
     Identity operator with the same dims and type as the reference quantum
     object.
@@ -808,7 +825,7 @@ def qeye_like(qobj):
     )
 
 
-def position(N, offset=0, *, dtype=None):
+def position(N: int, offset: int = 0, *, dtype: LayerType = None) -> Qobj:
     """
     Position operator :math:`x = 1 / sqrt(2) * (a + a.dag())`
 
@@ -838,7 +855,7 @@ def position(N, offset=0, *, dtype=None):
     return position.to(dtype)
 
 
-def momentum(N, offset=0, *, dtype=None):
+def momentum(N: int, offset: int = 0, *, dtype: LayerType = None) -> Qobj:
     """
     Momentum operator p=-1j/sqrt(2)*(a-a.dag())
 
@@ -868,7 +885,7 @@ def momentum(N, offset=0, *, dtype=None):
     return momentum.to(dtype)
 
 
-def num(N, offset=0, *, dtype=None):
+def num(N: int, offset: int = 0, *, dtype: LayerType = None) -> Qobj:
     """
     Quantum object for number operator.
 
@@ -905,7 +922,13 @@ def num(N, offset=0, *, dtype=None):
     return qdiags(data, 0, dtype=dtype)
 
 
-def squeeze(N, z, offset=0, *, dtype=None):
+def squeeze(
+    N: int,
+    z: float,
+    offset: int = 0,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """Single-mode squeezing operator.
 
     Parameters
@@ -950,7 +973,7 @@ shape = [4, 4], type = oper, isHerm = False
     return out
 
 
-def squeezing(a1, a2, z):
+def squeezing(a1: Qobj, a2: Qobj, z: float) -> Qobj:
     """Generalized squeezing operator.
 
     .. math::
@@ -979,7 +1002,13 @@ def squeezing(a1, a2, z):
     return b.expm()
 
 
-def displace(N, alpha, offset=0, *, dtype=None):
+def displace(
+    N: int,
+    alpha: float,
+    offset: int = 0,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """Single-mode displacement operator.
 
     Parameters
@@ -1023,7 +1052,11 @@ shape = [4, 4], type = oper, isHerm = False
     return out
 
 
-def commutator(A, B, kind="normal"):
+def commutator(
+    A: Qobj,
+    B: Qobj,
+    kind: Literal["normal", "anti"] = "normal"
+) -> Qobj:
     """
     Return the commutator of kind `kind` (normal, anti) of the
     two operators A and B.
@@ -1046,7 +1079,7 @@ def commutator(A, B, kind="normal"):
         raise TypeError("Unknown commutator kind '%s'" % kind)
 
 
-def qutrit_ops(*, dtype=None):
+def qutrit_ops(*, dtype: LayerType = None) -> list[Qobj]:
     """
     Operators for a three level system (qutrit).
 
@@ -1065,19 +1098,22 @@ def qutrit_ops(*, dtype=None):
     from .states import qutrit_basis
 
     dtype = dtype or settings.core["default_dtype"] or _data.CSR
-    out = np.empty((6,), dtype=object)
+    out = []
     basis = qutrit_basis(dtype=dtype)
     for i in range(3):
-        out[i] = basis[i] @ basis[i].dag()
-        out[i].isherm = True
-        out[i]._isunitary = False
-        out[i+3] = basis[i] @ basis[(i+1)%3].dag()
-        out[i+3].isherm = False
-        out[i+3]._isunitary = False
+        op = basis[i] @ basis[i].dag()
+        op.isherm = True
+        op._isunitary = False
+        out.append(op)
+    for i in range(3):
+        op = basis[i] @ basis[(i+1)%3].dag()
+        op.isherm = False
+        op._isunitary = False
+        out.append(op)
     return out
 
 
-def phase(N, phi0=0, *, dtype=None):
+def phase(N: int, phi0: float = 0, *, dtype: LayerType = None) -> Qobj:
     """
     Single-mode Pegg-Barnett phase operator.
 
@@ -1118,7 +1154,13 @@ def phase(N, phi0=0, *, dtype=None):
     ).to(dtype)
 
 
-def charge(Nmax, Nmin=None, frac=1, *, dtype=None):
+def charge(
+    Nmax: int,
+    Nmin: int = None,
+    frac: float = 1,
+    *,
+    dtype: LayerType = None
+) -> Qobj:
     """
     Generate the diagonal charge operator over charge states
     from Nmin to Nmax.
@@ -1157,7 +1199,7 @@ def charge(Nmax, Nmin=None, frac=1, *, dtype=None):
     return out
 
 
-def tunneling(N, m=1, *, dtype=None):
+def tunneling(N: int, m: int = 1, *, dtype: LayerType = None) -> Qobj:
     r"""
     Tunneling operator with elements of the form
     :math:`\\sum |N><N+m| + |N+m><N|`.
@@ -1186,7 +1228,7 @@ def tunneling(N, m=1, *, dtype=None):
     return T
 
 
-def qft(dimensions, *, dtype=None):
+def qft(dimensions: SpaceLike, *, dtype: LayerType = None) -> Qobj:
     """
     Quantum Fourier Transform operator.
 
@@ -1197,7 +1239,7 @@ def qft(dimensions, *, dtype=None):
         ints, then the dimension is the product over this list, but the
         ``dims`` property of the new Qobj are set to this list.
 
-    dtype : str or type, [keyword only] [optional]
+    dtype : type or str, optional
         Storage representation. Any data-layer known to ``qutip.data.to`` is
         accepted.
 
@@ -1219,7 +1261,7 @@ def qft(dimensions, *, dtype=None):
     return Qobj(data, isherm=False, isunitary=True, dims=dims).to(dtype)
 
 
-def swap(N, M, *, dtype=None):
+def swap(N: int, M: int, *, dtype: LayerType = None) -> Qobj:
     """
     Operator that exchanges the order of tensored spaces:
 

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -14,7 +14,7 @@ import scipy.sparse
 from .. import __version__
 from ..settings import settings
 from . import data as _data
-from qutip.typing import LayerType
+from qutip.typing import LayerType, DimensionLike
 from .dimensions import (
     enumerate_flat, collapse_dims_super, flatten, unflatten, Dimensions
 )
@@ -269,7 +269,7 @@ class Qobj:
     def __init__(
         self,
         arg: ArrayLike | Any = None,
-        dims: list[list[int]] | list[list[list[int]]] | Dimensions = None,
+        dims: DimensionLike = None,
         copy: bool = True,
         superrep: str = None,
         isherm: bool = None,

--- a/qutip/core/states.py
+++ b/qutip/core/states.py
@@ -9,10 +9,10 @@ __all__ = ['basis', 'qutrit_basis', 'coherent', 'coherent_dm', 'fock_dm',
 import itertools
 import numbers
 import warnings
-
+from collections.abc import Iterator
+from typing import Literal
 import numpy as np
 import scipy.sparse as sp
-import itertools
 
 from . import data as _data
 from .qobj import Qobj
@@ -20,6 +20,7 @@ from .operators import jmat, displace, qdiags
 from .tensor import tensor
 from .dimensions import Space
 from .. import settings
+from ..typing import SpaceLike, LayerType
 
 
 def _promote_to_zero_list(arg, length):
@@ -60,7 +61,13 @@ def _to_space(dimensions):
         return Space([dimensions])
 
 
-def basis(dimensions, n=None, offset=None, *, dtype=None):
+def basis(
+    dimensions: SpaceLike,
+    n: int | list[int] = None,
+    offset: int | list[int] = None,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """Generates the vector representation of a Fock state.
 
     Parameters
@@ -162,7 +169,7 @@ def basis(dimensions, n=None, offset=None, *, dtype=None):
                 copy=False)
 
 
-def qutrit_basis(*, dtype=None):
+def qutrit_basis(*, dtype: LayerType = None) -> list[Qobj]:
     """Basis states for a three level system (qutrit)
 
     dtype : type or str, optional
@@ -176,8 +183,7 @@ def qutrit_basis(*, dtype=None):
 
     """
     dtype = dtype or settings.core["default_dtype"] or _data.Dense
-    out = np.empty((3,), dtype=object)
-    out[:] = [
+    out = [
         basis(3, 0, dtype=dtype),
         basis(3, 1, dtype=dtype),
         basis(3, 2, dtype=dtype),
@@ -188,7 +194,14 @@ def qutrit_basis(*, dtype=None):
 _COHERENT_METHODS = ('operator', 'analytic')
 
 
-def coherent(N, alpha, offset=0, method=None, *, dtype=None):
+def coherent(
+    N: int,
+    alpha: float,
+    offset: int = 0,
+    method: str = None,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """Generates a coherent state with eigenvalue alpha.
 
     Constructed using displacement operator on vacuum state.
@@ -255,7 +268,7 @@ def coherent(N, alpha, offset=0, method=None, *, dtype=None):
                 "The method 'operator' does not support offset != 0. Please"
                 " select another method or set the offset to zero."
             )
-        return (displace(N, alpha, dtype=dtype) * basis(N, 0)).to(dtype)
+        return (displace(N, alpha, dtype=dtype) @ basis(N, 0)).to(dtype)
 
     elif method == "analytic":
         sqrtn = np.sqrt(np.arange(offset, offset+N, dtype=complex))
@@ -273,7 +286,14 @@ def coherent(N, alpha, offset=0, method=None, *, dtype=None):
     )
 
 
-def coherent_dm(N, alpha, offset=0, method='operator', *, dtype=None):
+def coherent_dm(
+    N: int,
+    alpha: float,
+    offset: int = 0,
+    method: str = None,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """Density matrix representation of a coherent state.
 
     Constructed via outer product of :func:`coherent`
@@ -332,7 +352,13 @@ shape = [3, 3], type = oper, isHerm = True
     ).proj().to(dtype)
 
 
-def fock_dm(dimensions, n=None, offset=None, *, dtype=None):
+def fock_dm(
+    dimensions: int | list[int] | Space,
+    n: int | list[int] = None,
+    offset: int | list[int] = None,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """Density matrix representation of a Fock state
 
     Constructed via outer product of :func:`basis`.
@@ -377,7 +403,13 @@ shape = [3, 3], type = oper, isHerm = True
     return basis(dimensions, n, offset=offset, dtype=dtype).proj().to(dtype)
 
 
-def fock(dimensions, n=None, offset=None, *, dtype=None):
+def fock(
+    dimensions: SpaceLike,
+    n: int | list[int] = None,
+    offset: int | list[int] = None,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """Bosonic Fock (number) state.
 
     Same as :func:`basis`.
@@ -420,7 +452,13 @@ def fock(dimensions, n=None, offset=None, *, dtype=None):
     return basis(dimensions, n, offset=offset, dtype=dtype)
 
 
-def thermal_dm(N, n, method='operator', *, dtype=None):
+def thermal_dm(
+    N: int,
+    n: float,
+    method: str = 'operator',
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """Density matrix for a thermal state of n particles
 
     Parameters
@@ -499,7 +537,11 @@ shape = [5, 5], type = oper, isHerm = True
         return out
 
 
-def maximally_mixed_dm(dimensions, *, dtype=None):
+def maximally_mixed_dm(
+    dimensions: SpaceLike,
+    *,
+    dtype: LayerType = None
+) -> Qobj:
     """
     Returns the maximally mixed density matrix for a Hilbert space of
     dimension N.
@@ -528,7 +570,7 @@ def maximally_mixed_dm(dimensions, *, dtype=None):
                 isherm=True, isunitary=(N == 1), copy=False)
 
 
-def ket2dm(Q):
+def ket2dm(Q: Qobj) -> Qobj:
     """
     Takes input ket or bra vector and returns density matrix formed by outer
     product.  This is completely identical to calling ``Q.proj()``.
@@ -560,7 +602,14 @@ shape = [3, 3], type = oper, isHerm = True
     raise TypeError("Input is not a ket or bra vector.")
 
 
-def projection(dimensions, n, m, offset=None, *, dtype=None):
+def projection(
+    dimensions: int | list[int],
+    n: int | list[int],
+    m: int | list[int],
+    offset: int | list[int] = None,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     r"""
     The projection operator that projects state :math:`\lvert m\rangle` on
     state :math:`\lvert n\rangle`.
@@ -594,7 +643,7 @@ def projection(dimensions, n, m, offset=None, *, dtype=None):
     ).to(dtype)
 
 
-def qstate(string, *, dtype=None):
+def qstate(string: str, *, dtype: LayerType = None) -> Qobj:
     r"""Creates a tensor product for a set of qubits in either
     the 'up' :math:`\lvert0\rangle` or 'down' :math:`\lvert1\rangle` state.
 
@@ -652,14 +701,19 @@ _qubit_dict = {
 }
 
 
-def _character_to_qudit(x):
+def _character_to_qudit(x: int | str) -> int:
     """
     Converts a character representing a one-particle state into int.
     """
     return _qubit_dict[x] if x in _qubit_dict else int(x)
 
 
-def ket(seq, dim=2, *, dtype=None):
+def ket(
+    seq: list[int | str] | str,
+    dim: int | list[int] = 2,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """
     Produces a multiparticle ket state for a list or string,
     where each element stands for state of the respective particle.
@@ -743,7 +797,12 @@ def ket(seq, dim=2, *, dtype=None):
     return basis(dim, ns, dtype=dtype)
 
 
-def bra(seq, dim=2, *, dtype=None):
+def bra(
+    seq: list[int | str] | str,
+    dim: int | list[int] = 2,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """
     Produces a multiparticle bra state for a list or string,
     where each element stands for state of the respective particle.
@@ -801,7 +860,10 @@ def bra(seq, dim=2, *, dtype=None):
     return ket(seq, dim=dim, dtype=dtype).dag()
 
 
-def state_number_enumerate(dims, excitations=None):
+def state_number_enumerate(
+    dims: list[int],
+    excitations: int = None
+) -> Iterator[tuple]:
     """
     An iterator that enumerates all the state number tuples (quantum numbers of
     the form (n1, n2, n3, ...)) for a system with dimensions given by dims.
@@ -817,7 +879,7 @@ def state_number_enumerate(dims, excitations=None):
 
     Parameters
     ----------
-    dims : list or array
+    dims : list
         The quantum state dimensions array, as it would appear in a Qobj.
 
     excitations : integer, optional
@@ -859,7 +921,10 @@ def state_number_enumerate(dims, excitations=None):
             state = state[:idx] + (state[idx]+1, 0) + state[idx+2:]
 
 
-def state_number_index(dims, state):
+def state_number_index(
+    dims: list[int],
+    state: list[int],
+) -> int:
     """
     Return the index of a quantum state corresponding to state,
     given a system with dimensions given by dims.
@@ -871,7 +936,7 @@ def state_number_index(dims, state):
 
     Parameters
     ----------
-    dims : list or array
+    dims : list
         The quantum state dimensions array, as it would appear in a Qobj.
 
     state : list
@@ -887,7 +952,10 @@ def state_number_index(dims, state):
     return np.ravel_multi_index(state, dims)
 
 
-def state_index_number(dims, index):
+def state_index_number(
+    dims: list[int],
+    index: int,
+) -> tuple:
     """
     Return a quantum number representation given a state index, for a system
     of composite structure defined by dims.
@@ -915,7 +983,12 @@ def state_index_number(dims, index):
     return np.unravel_index(index, dims)
 
 
-def state_number_qobj(dims, state, *, dtype=None):
+def state_number_qobj(
+    dims: SpaceLike,
+    state: int | list[int] = None,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """
     Return a Qobj representation of a quantum state specified by the state
     array `state`.
@@ -961,7 +1034,13 @@ shape = [8, 1], type = ket
     return basis(dims, state, dtype=dtype)
 
 
-def phase_basis(N, m, phi0=0, *, dtype=None):
+def phase_basis(
+    N: int,
+    m: int,
+    phi0: float = 0,
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     """
     Basis vector for the mth phase of the Pegg-Barnett phase operator.
 
@@ -999,7 +1078,7 @@ def phase_basis(N, m, phi0=0, *, dtype=None):
     return Qobj(data, dims=[[N], [1]], copy=False).to(dtype)
 
 
-def zero_ket(dimensions, *, dtype=None):
+def zero_ket(dimensions: SpaceLike, *, dtype: LayerType = None) -> Qobj:
     """
     Creates the zero ket vector with shape Nx1 and dimensions `dims`.
 
@@ -1026,7 +1105,13 @@ def zero_ket(dimensions, *, dtype=None):
                 dims=[dimensions, dimensions.scalar_like()], copy=False)
 
 
-def spin_state(j, m, type='ket', *, dtype=None):
+def spin_state(
+    j: float,
+    m: float,
+    type: Literal["ket", "bra", "dm"] = "ket",
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     r"""Generates the spin state :math:`\lvert j, m\rangle`, i.e. the
     eigenstate of the spin-j Sz operator with eigenvalue m.
 
@@ -1035,7 +1120,7 @@ def spin_state(j, m, type='ket', *, dtype=None):
     j : float
         The spin of the state ().
 
-    m : int
+    m : float
         Eigenvalue of the spin-j Sz operator.
 
     type : string {'ket', 'bra', 'dm'}, default: 'ket'
@@ -1063,7 +1148,14 @@ def spin_state(j, m, type='ket', *, dtype=None):
         raise ValueError(f"Invalid value keyword argument type='{type}'")
 
 
-def spin_coherent(j, theta, phi, type='ket', *, dtype=None):
+def spin_coherent(
+    j: float,
+    theta: float,
+    phi: float,
+    type: Literal["ket", "bra", "dm"] = "ket",
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     r"""Generate the coherent spin state :math:`\lvert \theta, \phi\rangle`.
 
     Parameters
@@ -1112,7 +1204,11 @@ _BELL_STATES = {
     '11': np.sqrt(0.5) * (basis([2, 2], [0, 1]) - basis([2, 2], [1, 0])),
 }
 
-def bell_state(state='00', *, dtype=None):
+def bell_state(
+    state: Literal["00", "01", "10", "11"] = "00",
+    *,
+    dtype: LayerType = None,
+) -> Qobj:
     r"""
     Returns the selected Bell state:
 
@@ -1148,7 +1244,7 @@ def bell_state(state='00', *, dtype=None):
     return _BELL_STATES[state].copy().to(dtype)
 
 
-def singlet_state(*, dtype=None):
+def singlet_state(*, dtype: LayerType = None) -> Qobj:
     r"""
     Returns the two particle singlet-state:
 
@@ -1173,7 +1269,7 @@ def singlet_state(*, dtype=None):
     return bell_state('11').to(dtype)
 
 
-def triplet_states(*, dtype=None):
+def triplet_states(*, dtype: LayerType = None) -> list[Qobj]:
     r"""
     Returns a list of the two particle triplet-states:
 
@@ -1207,7 +1303,7 @@ def triplet_states(*, dtype=None):
     ]
 
 
-def w_state(N_qubit, *, dtype=None):
+def w_state(N_qubit: int, *, dtype: LayerType = None) -> Qobj:
     """
     Returns the N-qubit W-state:
         ``[ |100..0> + |010..0> + |001..0> + ... |000..1> ] / sqrt(n)``
@@ -1236,7 +1332,7 @@ def w_state(N_qubit, *, dtype=None):
     return (np.sqrt(1 / N_qubit) * state).to(dtype)
 
 
-def ghz_state(N_qubit, *, dtype=None):
+def ghz_state(N_qubit: int, *, dtype: LayerType = None) -> Qobj:
     """
     Returns the N-qubit GHZ-state:
         ``[ |00...00> + |11...11> ] / sqrt(2)``

--- a/qutip/core/states.py
+++ b/qutip/core/states.py
@@ -455,7 +455,7 @@ def fock(
 def thermal_dm(
     N: int,
     n: float,
-    method: str = 'operator',
+    method: Literal['operator', 'analytic'] = 'operator',
     *,
     dtype: LayerType = None,
 ) -> Qobj:

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -19,12 +19,14 @@ import numpy as np
 from numpy.random import Generator, SeedSequence, default_rng
 import scipy.linalg
 import scipy.sparse as sp
+from typing import Literal, Sequence
 
 from . import (Qobj, create, destroy, jmat, basis,
                to_super, to_choi, to_chi, to_kraus, to_stinespring)
 from .core import data as _data
-from .core.dimensions import flatten, Dimensions
+from .core.dimensions import flatten, Dimensions, Space
 from . import settings
+from .typing import SpaceLike, LayerType
 
 
 _RAND = default_rng()
@@ -52,8 +54,10 @@ def _implicit_tensor_dimensions(dimensions, superoper=False):
     dimensions : list
         Dimension list in the form required by ``Qobj`` creation.
     """
+    if isinstance(dimensions, Space):
+        pass
     if not isinstance(dimensions, list):
-        dimensions = [dimensions]
+        dimensions = Space(dimensions)
     flat = flatten(dimensions)
     if not all(isinstance(x, numbers.Integral) and x >= 0 for x in flat):
         raise ValueError("All dimensions must be integers >= 0")
@@ -210,8 +214,15 @@ def _merge_shuffle_blocks(blocks, generator):
     return _data.create(matrix, copy=False)
 
 
-def rand_herm(dimensions, density=0.30, distribution="fill", *,
-              eigenvalues=(), seed=None, dtype=None):
+def rand_herm(
+    dimensions: SpaceLike,
+    density: float = 0.30,
+    distribution: Literal["fill", "pos_def", "eigen"] = "fill",
+    *,
+    eigenvalues: Sequence[float] = (),
+    seed: int | SeedSequence | Generator = None,
+    dtype: LayerType = None,
+):
     """Creates a random sparse Hermitian quantum object.
 
     Parameters
@@ -335,8 +346,14 @@ def _rand_herm_dense(N, density, pos_def, generator):
     return _data.create(M)
 
 
-def rand_unitary(dimensions, density=1, distribution="haar", *,
-                 seed=None, dtype=None):
+def rand_unitary(
+    dimensions: SpaceLike,
+    density: float = 1,
+    distribution: Literal["haar", "exp"] = "haar",
+    *,
+    seed: int | SeedSequence | Generator = None,
+    dtype: LayerType = None,
+):
     r"""Creates a random sparse unitary quantum object.
 
     Parameters
@@ -438,8 +455,14 @@ def _rand_unitary_haar(N, generator):
     return Q * Lambda
 
 
-def rand_ket(dimensions, density=1, distribution="haar", *,
-             seed=None, dtype=None):
+def rand_ket(
+    dimensions: SpaceLike,
+    density: float = 1,
+    distribution: Literal["haar", "fill"] = "haar",
+    *,
+    seed: int | SeedSequence | Generator = None,
+    dtype: LayerType = None,
+):
     """Creates a random ket vector.
 
     Parameters
@@ -501,9 +524,17 @@ def rand_ket(dimensions, density=1, distribution="haar", *,
     return ket.to(dtype)
 
 
-def rand_dm(dimensions, density=0.75, distribution="ginibre", *,
-            eigenvalues=(), rank=None, seed=None,
-            dtype=None):
+def rand_dm(
+    dimensions: SpaceLike,
+    density: float = 0.75,
+    distribution: Literal["ginibre", "hs", "pure", "eigen", "uniform"] \
+                  = "ginibre",
+    *,
+    eigenvalues: Sequence[float] = (),
+    rank: int = None,
+    seed: int | SeedSequence | Generator = None,
+    dtype: LayerType = None,
+):
     r"""Creates a random density matrix of the desired dimensions.
 
     Parameters
@@ -631,7 +662,12 @@ def _rand_dm_ginibre(N, rank, generator):
     return rho
 
 
-def rand_kraus_map(dimensions, *, seed=None, dtype=None):
+def rand_kraus_map(
+    dimensions: SpaceLike,
+    *,
+    seed: int | SeedSequence | Generator = None,
+    dtype: LayerType = None,
+):
     """
     Creates a random CPTP map on an N-dimensional Hilbert space in Kraus
     form.
@@ -671,7 +707,13 @@ def rand_kraus_map(dimensions, *, seed=None, dtype=None):
     return [Qobj(x, dims=dims, copy=False).to(dtype) for x in oper_list]
 
 
-def rand_super(dimensions, *, superrep="super", seed=None, dtype=None):
+def rand_super(
+    dimensions: SpaceLike,
+    *,
+    superrep: Literal["super", "choi", "chi"] = "super",
+    seed: int | SeedSequence | Generator = None,
+    dtype: LayerType = None,
+):
     """
     Returns a randomly drawn superoperator acting on operators acting on
     N dimensions.
@@ -712,9 +754,15 @@ def rand_super(dimensions, *, superrep="super", seed=None, dtype=None):
     return out
 
 
-def rand_super_bcsz(dimensions, enforce_tp=True, rank=None, *,
-                    superrep="super", seed=None,
-                    dtype=None):
+def rand_super_bcsz(
+    dimensions: SpaceLike,
+    enforce_tp: bool = True,
+    rank: int = None,
+    *,
+    superrep: Literal["super", "choi", "chi"] = "super",
+    seed: int | SeedSequence | Generator = None,
+    dtype: LayerType = None,
+):
     """
     Returns a random superoperator drawn from the Bruzda
     et al ensemble for CPTP maps [BCSZ08]_. Note that due to
@@ -816,8 +864,14 @@ def rand_super_bcsz(dimensions, enforce_tp=True, rank=None, *,
     return out
 
 
-def rand_stochastic(dimensions, density=0.75, kind='left',
-                    *, seed=None, dtype=None):
+def rand_stochastic(
+    dimensions: SpaceLike,
+    density: float = 0.75,
+    kind: Literal["left", "right"] = "left",
+    *,
+    seed: int | SeedSequence | Generator = None,
+    dtype: LayerType = None,
+):
     """Generates a random stochastic matrix.
 
     Parameters

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -55,9 +55,9 @@ def _implicit_tensor_dimensions(dimensions, superoper=False):
         Dimension list in the form required by ``Qobj`` creation.
     """
     if isinstance(dimensions, Space):
-        pass
+        dimensions = dimensions.as_list()
     if not isinstance(dimensions, list):
-        dimensions = Space(dimensions)
+        dimensions = [dimensions]
     flat = flatten(dimensions)
     if not all(isinstance(x, numbers.Integral) and x >= 0 for x in flat):
         raise ValueError("All dimensions must be integers >= 0")

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -6,6 +6,7 @@ import pytest
 
 from qutip import qeye, num, to_kraus, kraus_to_choi, CoreOptions, Qobj
 from qutip import data as _data
+from qutip.dimensions import Space
 from qutip.random_objects import (
     rand_herm,
     rand_unitary,
@@ -22,8 +23,9 @@ from qutip.random_objects import (
     12,
     [8],
     [2, 2, 3],
-    [[2], [2]]
-], ids=["int", "list", "tensor", "super"])
+    [[2], [2]],
+    Space(3),
+], ids=["int", "list", "tensor", "super", "Space"])
 def dimensions(request):
     return request.param
 

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -6,7 +6,7 @@ import pytest
 
 from qutip import qeye, num, to_kraus, kraus_to_choi, CoreOptions, Qobj
 from qutip import data as _data
-from qutip.dimensions import Space
+from qutip.core.dimensions import Space
 from qutip.random_objects import (
     rand_herm,
     rand_unitary,
@@ -47,6 +47,8 @@ def _assert_density(qobj, density):
 def _assert_metadata(random_qobj, dims, dtype=None, super=False, ket=False):
     if isinstance(dims, int):
         dims = [dims]
+    elif isinstance(dims, Space):
+        dims = dims.as_list()
     N = np.prod(dims)
     if super and not isinstance(dims[0], list):
         target_dims_0 = [dims, dims]
@@ -97,7 +99,10 @@ def test_rand_herm_Eigs(dimensions, density):
     """
     Random Qobjs: Hermitian matrix - Eigs given
     """
-    N = np.prod(dimensions)
+    if isinstance(dimensions, Space):
+        N = dimensions.size
+    else:
+        N = np.prod(dimensions)
     eigs = np.random.random(N)
     eigs /= np.sum(eigs)
     eigs.sort()
@@ -143,8 +148,11 @@ def test_rand_dm(dimensions, kw, dtype, distribution):
     """
     Random Qobjs: Density matrix
     """
-    N = np.prod(dimensions)
-    print(N, kw)
+    if isinstance(dimensions, Space):
+        N = dimensions.size
+    else:
+        N = np.prod(dimensions)
+
     if "eigenvalues" in kw:
         eigs = np.random.random(N)
         eigs /= np.sum(eigs)
@@ -240,6 +248,8 @@ def test_rand_super_bcsz(dimensions, dtype, rank, superrep):
 
     random_qobj = rand_super_bcsz(dimensions, rank=rank,
                                   dtype=dtype, superrep=superrep)
+    if isinstance(dimensions, Space):
+        dimensions = dimensions.as_list()
     assert random_qobj.issuper
     with CoreOptions(atol=1e-9):
         assert random_qobj.iscptp

--- a/qutip/typing.py
+++ b/qutip/typing.py
@@ -41,8 +41,6 @@ SpaceLike = Union[int, list[int], list[list[int]], "Space"]
 
 
 DimensionLike = Union[
-    list[list[int], list[int]],
-    list[list[list[int]], list[list[int]]],
-    list["Space", "Space"],
+    list[SpaceLike, SpaceLike],
     "Dimensions",
 ]

--- a/qutip/typing.py
+++ b/qutip/typing.py
@@ -35,3 +35,14 @@ QobjEvoLike = Union["Qobj", "QobjEvo", ElementType, Sequence[ElementType]]
 
 
 LayerType = Union[str, type]
+
+
+SpaceLike = Union[int, list[int], list[list[int]], "Space"]
+
+
+DimensionLike = Union[
+    list[list[int], list[int]],
+    list[list[list[int]], list[list[int]]],
+    list["Space", "Space"],
+    "Dimensions",
+]


### PR DESCRIPTION
**Description**
Add type hints to function that create `Qobj` (`states.py`, `operators.py`, `gates.py` and `random_object.py`).
I also ran `mypy` on these files and fixed easy issues (`Qobj * Qobj` -> `Qobj @ Qobj`).

Some points to look at more closely: 
- We have a lot of `int, list of int, list of list of int, Space` etc. But what is actually accepted can change:
  - `basis` can take super operators dimension to create an `operator-ket`, but not if `offset` is used.
    Should we raise an error and officially not support these case or arrange it so offset is `supported`?
  - Is `SpaceLike` an alias useful for these case or just confusing?
- Array of Qobj output have been changed to list of Qobj.
- I did not update most docstring. `qdiags` dims are `DimensionLike` in type hints, but `list` in the docstring.
- `jmat` return a single `Qobj` or a list of `Qobj`... For typing, it would be nicer if it always returned a single operator. There is also no advantage to computing the operators together.
- `numbers.Number` is not a valid type according to mypy etc. (`Qobj.__mul__` is always raising errors...)