### PR TITLE
Adapt to download / upload artifacts v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
       CIBW_BUILD: "cp3{10,11,12}-*"
       # Numpy and SciPy do not supply wheels for i686 or win32 for
       # Python 3.10+, so we skip those:
-      CIBW_SKIP: "*-musllinux* cp3{10,11,12}-manylinux_i686 cp3{10,11,12}-win32"
+      CIBW_SKIP: "*-musllinux* *-manylinux_i686 *-win32"
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
@@ -125,9 +125,9 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          # cibuildwheel does the heavy lifting for us. Originally tested on
-          # 2.11.3, but should be fine at least up to any minor new release.
-          python -m pip install 'cibuildwheel==2.11.*'
+          # cibuildwheel does the heavy lifting for us. Tested on
+          # 2.19, but should be fine at least up to any minor new release.
+          python -m pip install 'cibuildwheel==2.19.*'
 
       - name: Build wheels
         shell: bash
@@ -145,15 +145,11 @@ jobs:
 
   deploy:
     name: "Deploy to PyPI if desired"
-
-    # if: ${{ github.event.inputs.confirm_ref != '' && github.event.inputs.confirm_ref != 'test' }}
     needs: [deploy_test, build_sdist, build_wheels]
     runs-on: ubuntu-latest
     env:
       TWINE_USERNAME: __token__
-      # TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       TWINE_NON_INTERACTIVE: 1
-      # TWINE_REPOSITORY: pypi
 
     steps:
       - name: Download build artifacts to local runner
@@ -167,7 +163,7 @@ jobs:
       - name: Check wheels
         run: |
           ls -R wheels
-          if ! [[ $(ls wheels/*.whl | wc -l) == 12 ]]; then exit 1; fi
+          if ! [[ $(ls wheels/*.whl | wc -l) == 9 ]]; then exit 1; fi
           if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
           if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
 
@@ -190,10 +186,10 @@ jobs:
           # it is either a missing confirmation (so we shouldn't run this job),
           # 'test' or a valid confirmation.  We don't need to retest the value
           #  of the confirmation, beyond checking that one existed.
-          if [ ${{ github.event.inputs.confirm_ref }} == 'test' ]; then
+          if [ '${{ github.event.inputs.confirm_ref }}' == 'test' ]; then
             export TWINE_REPOSITORY=testpypi
             export TWINE_PASSWORD=${{ secrets.TESTPYPI_TOKEN }}
-          elif [ ${{ github.event.inputs.confirm_ref }} != '' ]; then
+          elif [ '${{ github.event.inputs.confirm_ref }}' != '' ]; then
             export TWINE_REPOSITORY=pypi
             export TWINE_PASSWORD=${{ secrets.PYPI_TOKEN }}
           else
@@ -202,68 +198,5 @@ jobs:
             exit 0
           fi
           echo "Deploy to $TWINE_REPOSITORY"
-          echo "python -m pip install "twine""
-          echo "python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz"
-
-
-  deploy_testpypi:
-    name: "Deploy to TestPyPI if desired"
-    if: false # ${{ github.event.inputs.confirm_ref == 'test' }}
-    needs: [deploy_test, build_sdist, build_wheels]
-    runs-on: ubuntu-latest
-    env:
-      TWINE_USERNAME: __token__
-      TWINE_PASSWORD: ${{ secrets.TESTPYPI_TOKEN }}
-      TWINE_NON_INTERACTIVE: 1
-
-    steps:
-      - name: Download build artifacts to local runner
-        uses: actions/download-artifact@v4
-        with:
-          path: wheels
-          merge-multiple: true
-
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: '3.10'
-
-      - name: Verify this is not a dev version
-        shell: bash
-        run: |
-          python -m pip install wheels/*-cp310-cp310-manylinux*.whl
-          python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
-
-      # We built the zipfile for convenience distributing to Windows users on
-      # our end, but PyPI only needs the tarball.
-      - name: Upload sdist and wheels to TestPyPI
-        run: |
-          ls -R wheels
-          if ! [[ $(ls wheels/*.whl | wc -l) == 12 ]]; then exit 1; fi
-          if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
-          if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
-          # python -m pip install "twine"
-          # python -m twine upload --repository testpypi --verbose wheels/*.whl sdist/*.tar.gz
-
-
-  check_wheels_availble:
-    name: "Check built wheels"
-    if: false # ${{ github.event.inputs.confirm_ref == '' }}
-    needs: [deploy_test, build_sdist, build_wheels]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download build artifacts to local runner
-        uses: actions/download-artifact@v4
-        with:
-          path: wheels
-          merge-multiple: true
-
-      - name: List wheels
-        shell: bash
-        run: |
-          ls -R wheels
-          if ! [[ $(ls wheels/*.whl | wc -l) == 12 ]]; then exit 1; fi
-          if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
-          if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
-          echo "All artifacts available!"
+          python -m pip install "twine"
+          python -m twine upload --verbose wheels/*.whl wheels/*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,18 +145,15 @@ jobs:
 
   deploy:
     name: "Deploy to PyPI if desired"
-    # The confirmation is tested explicitly in `deploy_test`, so we know it is
-    # either a missing confirmation (so we shouldn't run this job), 'test' or a
-    # valid confirmation.  We don't need to retest the value of the
-    # confirmation, beyond checking that one existed.
-    if: ${{ github.event.inputs.confirm_ref != '' && github.event.inputs.confirm_ref != 'test' }}
+
+    # if: ${{ github.event.inputs.confirm_ref != '' && github.event.inputs.confirm_ref != 'test' }}
     needs: [deploy_test, build_sdist, build_wheels]
     runs-on: ubuntu-latest
     env:
       TWINE_USERNAME: __token__
-      TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      # TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       TWINE_NON_INTERACTIVE: 1
-      TWINE_REPOSITORY: pypi
+      # TWINE_REPOSITORY: pypi
 
     steps:
       - name: Download build artifacts to local runner
@@ -164,6 +161,15 @@ jobs:
         with:
           path: wheels
           merge-multiple: true
+
+      # Check that all .whl, .tar.gz and .zip have been properly build
+      # and downloaded.
+      - name: Check wheels
+        run: |
+          ls -R wheels
+          if ! [[ $(ls wheels/*.whl | wc -l) == 12 ]]; then exit 1; fi
+          if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
+          if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -180,17 +186,29 @@ jobs:
       # our end, but PyPI only needs the tarball.
       - name: Upload sdist and wheels to PyPI
         run: |
-          ls -R wheels
-          if ! [[ $(ls wheels/*.whl | wc -l) == 12 ]]; then exit 1; fi
-          if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
-          if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
-          python -m pip install "twine"
-          python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz
+          # The confirmation is tested explicitly in `deploy_test`, so we know
+          # it is either a missing confirmation (so we shouldn't run this job),
+          # 'test' or a valid confirmation.  We don't need to retest the value
+          #  of the confirmation, beyond checking that one existed.
+          if [ ${{ github.event.inputs.confirm_ref }} == 'test' ]; then
+            export TWINE_REPOSITORY=testpypi
+            export TWINE_PASSWORD=${{ secrets.TESTPYPI_TOKEN }}
+          elif [ ${{ github.event.inputs.confirm_ref }} != '' ]; then
+            export TWINE_REPOSITORY=pypi
+            export TWINE_PASSWORD=${{ secrets.PYPI_TOKEN }}
+          else
+            # Exit without deploying
+            echo "Don't update wheels"
+            exit 0
+          fi
+          echo "Deploy to $TWINE_REPOSITORY"
+          echo "python -m pip install "twine""
+          echo "python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz"
 
 
   deploy_testpypi:
     name: "Deploy to TestPyPI if desired"
-    if: ${{ github.event.inputs.confirm_ref == 'test' }}
+    if: false # ${{ github.event.inputs.confirm_ref == 'test' }}
     needs: [deploy_test, build_sdist, build_wheels]
     runs-on: ubuntu-latest
     env:
@@ -224,13 +242,13 @@ jobs:
           if ! [[ $(ls wheels/*.whl | wc -l) == 12 ]]; then exit 1; fi
           if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
           if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
-          python -m pip install "twine"
-          python -m twine upload --repository testpypi --verbose wheels/*.whl sdist/*.tar.gz
+          # python -m pip install "twine"
+          # python -m twine upload --repository testpypi --verbose wheels/*.whl sdist/*.tar.gz
 
 
   check_wheels_availble:
     name: "Check built wheels"
-    if: ${{ github.event.inputs.confirm_ref == '' }}
+    if: false # ${{ github.event.inputs.confirm_ref == '' }}
     needs: [deploy_test, build_sdist, build_wheels]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
 
@@ -161,6 +161,9 @@ jobs:
     steps:
       - name: Download build artifacts to local runner
         uses: actions/download-artifact@v4
+        with:
+          path: wheels
+          merge-multiple: true
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -177,6 +180,10 @@ jobs:
       # our end, but PyPI only needs the tarball.
       - name: Upload sdist and wheels to PyPI
         run: |
+          ls -R wheels
+          if ! [[ $(ls wheels/*.whl | wc -l) == 12 ]]; then exit 1; fi
+          if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
+          if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
           python -m pip install "twine"
           python -m twine upload --verbose wheels/*.whl sdist/*.tar.gz
 
@@ -194,6 +201,9 @@ jobs:
     steps:
       - name: Download build artifacts to local runner
         uses: actions/download-artifact@v4
+        with:
+          path: wheels
+          merge-multiple: true
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -210,5 +220,32 @@ jobs:
       # our end, but PyPI only needs the tarball.
       - name: Upload sdist and wheels to TestPyPI
         run: |
+          ls -R wheels
+          if ! [[ $(ls wheels/*.whl | wc -l) == 12 ]]; then exit 1; fi
+          if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
+          if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
           python -m pip install "twine"
           python -m twine upload --repository testpypi --verbose wheels/*.whl sdist/*.tar.gz
+
+
+  check_wheels_availble:
+    name: "Check built wheels"
+    if: ${{ github.event.inputs.confirm_ref == '' }}
+    needs: [deploy_test, build_sdist, build_wheels]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build artifacts to local runner
+        uses: actions/download-artifact@v4
+        with:
+          path: wheels
+          merge-multiple: true
+
+      - name: List wheels
+        shell: bash
+        run: |
+          ls -R wheels
+          if ! [[ $(ls wheels/*.whl | wc -l) == 12 ]]; then exit 1; fi
+          if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
+          if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
+          echo "All artifacts available!"


### PR DESCRIPTION
**Description**
`actions/upload-artifact@v4` and `actions/download-artifact@v4` have breaking change cause the 5.0.3 release to miss wheels on pypi.

Different jobs in one workflow can't create artifacts with the same name. 
Download artifact only download artifact from one job without the proper options.
(https://github.com/actions/upload-artifact/issues/478)

I also updated cibuildwheel version, we did it in qutip-5.0.X to build wheels for py3.12, but did not push it yet to master.

I also merged the jobs to publish or pypi and testpypi, only some environment variables changed and they could get out of synchronization.

Lastly I added a check that all wheels are available before uploading to pypi. With 5.0.3's first try, only linux's wheel were published,
