### PR TITLE
Add example of `SMESolver.run_from_experiement` in the guide.

### DIFF
--- a/doc/guide/dynamics/dynamics-stochastic.rst
+++ b/doc/guide/dynamics/dynamics-stochastic.rst
@@ -223,7 +223,10 @@ notebooks available on the `QuTiP Tutorials page <https://qutip.org/tutorials.ht
 
 * `Heterodyne detection <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/time-evolution/015_smesolve-heterodyne.ipynb>`_
 * `Inefficient detection <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/time-evolution/016_smesolve-inefficient-detection.ipynb>`_
-* `Feedback control <https://github.com/jrjohansson/reproduced-papers/blob/master/Reproduce-SIAM-JCO-46-445-2007-Mirrahimi.ipynb>`_
+
+..
+  TODO: Add back when the notebook is migrated
+  * `Feedback control <https://github.com/jrjohansson/reproduced-papers/blob/master/Reproduce-SIAM-JCO-46-445-2007-Mirrahimi.ipynb>`_
 
 
 The stochastic solvers share many features with :func:`.mcsolve`, such as

--- a/doc/guide/dynamics/dynamics-stochastic.rst
+++ b/doc/guide/dynamics/dynamics-stochastic.rst
@@ -194,17 +194,19 @@ Let use the measurement output ``J_x`` of the first trajectory of the previous s
 
 .. code-block::
 
-    # Only available from the class interface.
+    # Create a stochastic solver instance with the some Hamiltonian as the
+    # previous evolution.
     solver = SMESolver(
         H, sc_ops=[np.sqrt(KAPPA) * a],
         options={"dt": 0.00125, "store_measurement": True,}
     )
 
+    # Run the evolution, noise
     recreated_solution = solver.run_from_experiment(
-        rho_0, tlist,
-        noise=stoc_solution.measurements[0],
+        rho_0, tlist, stoc_solution.measurements[0],
         e_ops=[H],
-        measurement=True, # The ``noise`` input is a measurement.
+        # The third parameter is a measurement, not Gaussian noise
+        measurement=True,
     )
 
 This will recompute the states, expectation values and wiener increments for that trajectory.

--- a/doc/guide/dynamics/dynamics-stochastic.rst
+++ b/doc/guide/dynamics/dynamics-stochastic.rst
@@ -178,19 +178,44 @@ in ``result.measurements``.
     ax.set_xlabel('Time')
     ax.legend()
 
-..
-    TODO merge qutip-tutorials#61
-    For other examples on :func:`qutip.solver.stochastic.smesolve`, see the
-    `following notebook <...>`_, as well as these notebooks available at
-    `QuTiP Tutorials page <https://qutip.org/tutorials.html>`_:
-    `heterodyne detection <...>`_,
-    `inefficient detection <...>`_, and
-    `feedback control <https://github.com/jrjohansson/reproduced-papers/blob/master/Reproduce-SIAM-JCO-46-445-2007-Mirrahimi.ipynb>`_.
+For other examples on :func:`qutip.solver.stochastic.smesolve`, see the
+notebooks available at `QuTiP Tutorials page <https://qutip.org/tutorials.html>`_:
+
+`heterodyne detection <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/time-evolution/015_smesolve-heterodyne.ipynb>`_,
+`inefficient detection <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/time-evolution/016_smesolve-inefficient-detection.ipynb>`_, and
+`feedback control <https://github.com/jrjohansson/reproduced-papers/blob/master/Reproduce-SIAM-JCO-46-445-2007-Mirrahimi.ipynb>`_.
 
 
 The stochastic solvers share many features with :func:`.mcsolve`, such as
 end conditions, seed control and running in parallel. See the sections
 :ref:`monte-ntraj`, :ref:`monte-seeds` and :ref:`monte-parallel` for details.
+
+
+Run with known noise
+====================
+
+In situations where instead of running multiple trajectories, we want to reproduce a single trajectory from known measurements or noise.
+In these cases, we can use :method:`~qutip.solver.stochastic.SMESolver.run_from_experiment`.
+We can rerun the first trajectory of the previous simulation with:
+
+.. code-block::
+
+    # Use the class
+    solver = SMESolver(
+        H, sc_ops=[np.sqrt(KAPPA) * a],
+        options={"dt": 0.00125, "store_measurement": True,}
+    )
+
+    recreated_solution = solver.run_from_experiment(
+        rho_0,
+        e_ops=[H],
+        noise=stoc_solution.measurements[0]
+        measurement=True,
+    )
+
+This will recompute the wiener increment and expectation values for that trajectory.
+
+When using this mode of evolution, the measurement use the state at the beginning of the time step, instead of the end as per normal evolutions' default.
 
 
 .. plot::

--- a/doc/guide/dynamics/dynamics-stochastic.rst
+++ b/doc/guide/dynamics/dynamics-stochastic.rst
@@ -144,7 +144,7 @@ where :math:`x` is the operator build from the ``sc_ops`` as
     x_n = S_n + S_n^\dagger
 
 
-The results are available in ``result.measurements``.
+The results are available in ``result.measurement``.
 
 .. plot::
     :context: reset
@@ -205,7 +205,7 @@ Let use the measurement output ``J_x`` of the first trajectory of the previous s
     recreated_solution = solver.run_from_experiment(
         rho_0, tlist, stoc_solution.measurements[0],
         e_ops=[H],
-        # The third parameter is a measurement, not Gaussian noise
+        # The third parameter is the measurement, not the Wiener increment
         measurement=True,
     )
 
@@ -213,16 +213,17 @@ This will recompute the states, expectation values and wiener increments for tha
 
 .. note::
 
-  The measurements in the result is computed from the state at the end of the time step.
+  The measurement in the result is by default computed from the state at the end of the time step.
   However, when using ``run_from_experiment`` with measurement input, the state at the start of the time step is used.
+  To obtain the measurement at the start of the time step in the output of ``smesolve``, one may use the option ``{'store_measurement': 'start'}``.
 
 
 For other examples on :func:`qutip.solver.stochastic.smesolve`, see the
-notebooks available at `QuTiP Tutorials page <https://qutip.org/tutorials.html>`_:
+notebooks available on the `QuTiP Tutorials page <https://qutip.org/tutorials.html>`_:
 
-`heterodyne detection <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/time-evolution/015_smesolve-heterodyne.ipynb>`_,
-`inefficient detection <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/time-evolution/016_smesolve-inefficient-detection.ipynb>`_, and
-`feedback control <https://github.com/jrjohansson/reproduced-papers/blob/master/Reproduce-SIAM-JCO-46-445-2007-Mirrahimi.ipynb>`_.
+* `Heterodyne detection <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/time-evolution/015_smesolve-heterodyne.ipynb>`_
+* `Inefficient detection <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/time-evolution/016_smesolve-inefficient-detection.ipynb>`_
+* `Feedback control <https://github.com/jrjohansson/reproduced-papers/blob/master/Reproduce-SIAM-JCO-46-445-2007-Mirrahimi.ipynb>`_
 
 
 The stochastic solvers share many features with :func:`.mcsolve`, such as

--- a/doc/guide/dynamics/dynamics-stochastic.rst
+++ b/doc/guide/dynamics/dynamics-stochastic.rst
@@ -188,7 +188,7 @@ Run from known measurements
 ===========================
 
 In situations where instead of running multiple trajectories, we want to reproduce a single trajectory from known noise or measurements obtained in lab.
-In these cases, we can use :method:`~qutip.solver.stochastic.SMESolver.run_from_experiment`.
+In these cases, we can use :meth:`~qutip.solver.stochastic.SMESolver.run_from_experiment`.
 
 Let use the measurement output ``J_x`` of the first trajectory of the previous simulation as the input to recompute a trajectory:
 


### PR DESCRIPTION
**Description**
Add a simple example for `run_from_experiement` in the guide.
Also restore the link to the stochastic tutorial notebooks.