### PR TITLE
fix expm, cosm, sinm to work with jax

### DIFF
--- a/doc/changes/2484.bugfix
+++ b/doc/changes/2484.bugfix
@@ -1,0 +1,1 @@
+This change makes expm, cosm, sinm work with jax.

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -965,6 +965,7 @@ shape = [4, 4], type = oper, isHerm = False
      [ 0.00000000+0.j -0.30142443+0.j  0.00000000+0.j  0.95349007+0.j]]
 
     """
+    dtype = dtype or settings.core["default_dtype"] or _data.Dense
     asq = destroy(N, offset=offset, dtype=dtype) ** 2
     op = 0.5*np.conj(z)*asq - 0.5*z*asq.dag()
     out = op.expm(dtype=dtype)

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -822,6 +822,11 @@ class Qobj:
         """
         if not self._dims.issquare:
             raise TypeError("expm is only valid for square operators")
+        if isinstance(self.data, _data.CSR):
+            return Qobj(_data.expm(self._data, dtype=dtype),
+                    dims=self._dims,
+                    isherm=self._isherm,
+                    copy=False)
         return Qobj(_data.expm(self._data, dtype=self.dtype),
                     dims=self._dims,
                     isherm=self._isherm,

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -828,7 +828,7 @@ class Qobj:
                         dims=self._dims,
                         isherm=self._isherm,
                         copy=False)
-        return Qobj(_data.expm(self._data, dtype=dtype),
+        return Qobj(_data.expm(self._data, dtype=self.dtype),
                     dims=self._dims,
                     isherm=self._isherm,
                     copy=False)

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -822,7 +822,7 @@ class Qobj:
         """
         if not self._dims.issquare:
             raise TypeError("expm is only valid for square operators")
-        return Qobj(_data.expm(self._data, dtype=dtype),
+        return Qobj(_data.expm(self._data, dtype=self.dtype),
                     dims=self._dims,
                     isherm=self._isherm,
                     copy=False)

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -822,9 +822,7 @@ class Qobj:
         """
         if not self._dims.issquare:
             raise TypeError("expm is only valid for square operators")
-        if isinstance(self.data, (_data.CSR, _data.Dia)):
-            dtype = self.dtype
-        else:
+        if not isinstance(self.data, (_data.CSR, _data.Dia)):
             dtype = None
         return Qobj(_data.expm(self._data, dtype=dtype),
                     dims=self._dims,

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -798,7 +798,7 @@ class Qobj:
             out = np.real(out)
         return out
 
-    def expm(self, dtype: LayerType = _data.Dense) -> Qobj:
+    def expm(self, dtype: LayerType = None) -> Qobj:
         """Matrix exponential of quantum operator.
 
         Input operator must be square.
@@ -806,9 +806,7 @@ class Qobj:
         Parameters
         ----------
         dtype : type
-            The data-layer type that should be output.  As the matrix
-            exponential is almost dense, this defaults to outputting dense
-            matrices.
+            The data-layer type that should be output.
 
         Returns
         -------
@@ -822,8 +820,8 @@ class Qobj:
         """
         if not self._dims.issquare:
             raise TypeError("expm is only valid for square operators")
-        if not isinstance(self.data, (_data.CSR, _data.Dia)):
-            dtype = None
+        if dtype is None and isinstance(self.data, (_data.CSR, _data.Dia)):
+            dtype = _data.Dense
         return Qobj(_data.expm(self._data, dtype=dtype),
                     dims=self._dims,
                     isherm=self._isherm,

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -824,9 +824,9 @@ class Qobj:
             raise TypeError("expm is only valid for square operators")
         if isinstance(self.data, _data.CSR):
             return Qobj(_data.expm(self._data, dtype=dtype),
-                    dims=self._dims,
-                    isherm=self._isherm,
-                    copy=False)
+                        dims=self._dims,
+                        isherm=self._isherm,
+                        copy=False)
         return Qobj(_data.expm(self._data, dtype=self.dtype),
                     dims=self._dims,
                     isherm=self._isherm,

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -822,13 +822,11 @@ class Qobj:
         """
         if not self._dims.issquare:
             raise TypeError("expm is only valid for square operators")
-        if isinstance(self.data, _data.CSR) or isinstance(
-            self.data, _data.Dia):
-            return Qobj(_data.expm(self._data, dtype=_data.Dense),
-                        dims=self._dims,
-                        isherm=self._isherm,
-                        copy=False)
-        return Qobj(_data.expm(self._data, dtype=self.dtype),
+        if isinstance(self.data, (_data.CSR, _data.Dia)):
+            dtype = self.dtype
+        else:
+            dtype = None
+        return Qobj(_data.expm(self._data, dtype=dtype),
                     dims=self._dims,
                     isherm=self._isherm,
                     copy=False)

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -798,7 +798,7 @@ class Qobj:
             out = np.real(out)
         return out
 
-    def expm(self, dtype: LayerType = _data.Dense) -> Qobj:
+    def expm(self, dtype) -> Qobj:
         """Matrix exponential of quantum operator.
 
         Input operator must be square.
@@ -822,12 +822,13 @@ class Qobj:
         """
         if not self._dims.issquare:
             raise TypeError("expm is only valid for square operators")
-        if isinstance(self.data, _data.CSR):
-            return Qobj(_data.expm(self._data, dtype=dtype),
+        if isinstance(self.data, _data.CSR) or isinstance(
+            self.data, _data.Dia):
+            return Qobj(_data.expm(self._data, dtype=_data.Dense),
                         dims=self._dims,
                         isherm=self._isherm,
                         copy=False)
-        return Qobj(_data.expm(self._data, dtype=self.dtype),
+        return Qobj(_data.expm(self._data, dtype=dtype),
                     dims=self._dims,
                     isherm=self._isherm,
                     copy=False)

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -798,7 +798,7 @@ class Qobj:
             out = np.real(out)
         return out
 
-    def expm(self, dtype) -> Qobj:
+    def expm(self, dtype: LayerType = _data.Dense) -> Qobj:
         """Matrix exponential of quantum operator.
 
         Input operator must be square.


### PR DESCRIPTION
**Description**
In accordance with our ongoing effort to make `qobj` work with `jax`. This change makes `expm`, `cosm`, `sinm` work with `jax`.
