### PR TITLE
Add types hints qutip/core

### DIFF
--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -7,14 +7,20 @@ from . import Qobj, QobjEvo, liouvillian, coefficient, sprepost
 from ._brtools import SpectraCoefficient, _EigenBasisTransform
 from .cy.coefficient import InterCoefficient, Coefficient
 from ._brtensor import _BlochRedfieldElement
-
+from ..typing import CoeffProtocol
 
 __all__ = ['bloch_redfield_tensor', 'brterm']
 
 
-def bloch_redfield_tensor(H, a_ops, c_ops=[], sec_cutoff=0.1,
-                          fock_basis=False, sparse_eigensolver=False,
-                          br_dtype='sparse'):
+def bloch_redfield_tensor(
+    H: Qobj | QobjEvo,
+    a_ops: list[tuple[Qobj | QobjEvo, Coefficient | str | CoeffProtocol]],
+    c_ops: list[Qobj | QobjEvo] = None,
+    sec_cutoff: float = 0.1,
+    fock_basis: bool = False,
+    sparse_eigensolver: bool = False,
+    br_dtype: str = 'sparse',
+):
     """
     Calculates the Bloch-Redfield tensor for a system given
     a set of operators and corresponding spectral functions that describes the
@@ -46,10 +52,10 @@ def bloch_redfield_tensor(H, a_ops, c_ops=[], sec_cutoff=0.1,
         .. code-block::
 
             a_ops = [
-                (a+a.dag(), ('w>0', args={"w": 0})),
+                (a+a.dag(), coefficient('w>0', args={"w": 0})),
                 (QobjEvo(a+a.dag()), 'w > exp(-t)'),
                 (QobjEvo([b+b.dag(), lambda t: ...]), lambda w: ...)),
-                (c+c.dag(), SpectraCoefficient(coefficient(array, tlist=ws))),
+                (c+c.dag(), SpectraCoefficient(coefficient(ws, tlist=ts))),
             ]
 
 
@@ -102,8 +108,15 @@ def bloch_redfield_tensor(H, a_ops, c_ops=[], sec_cutoff=0.1,
         return R, H_transform.as_Qobj()
 
 
-def brterm(H, a_op, spectra, sec_cutoff=0.1,
-           fock_basis=False, sparse_eigensolver=False, br_dtype='sparse'):
+def brterm(
+    H: Qobj | QobjEvo,
+    a_op: Qobj | QobjEvo,
+    spectra: Coefficient | CoeffProtocol | str,
+    sec_cutoff: float = 0.1,
+    fock_basis: bool = False,
+    sparse_eigensolver: bool = False,
+    br_dtype: str = 'sparse',
+):
     """
     Calculates the contribution of one coupling operator to the Bloch-Redfield
     tensor.

--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -1,8 +1,9 @@
 import os
 import inspect
 import numpy as np
-from qutip.settings import settings as qset
+from typing import overload
 
+from qutip.settings import settings as qset
 from . import Qobj, QobjEvo, liouvillian, coefficient, sprepost
 from ._brtools import SpectraCoefficient, _EigenBasisTransform
 from .cy.coefficient import InterCoefficient, Coefficient
@@ -12,6 +13,18 @@ from ..typing import CoeffProtocol
 __all__ = ['bloch_redfield_tensor', 'brterm']
 
 
+@overload
+def bloch_redfield_tensor(
+    H: Qobj,
+    a_ops: list[tuple[Qobj, Coefficient | str | CoeffProtocol]],
+    c_ops: list[Qobj | QobjEvo] = None,
+    sec_cutoff: float = 0.1,
+    fock_basis: bool = False,
+    sparse_eigensolver: bool = False,
+    br_dtype: str = 'sparse',
+) -> Qobj: ...
+
+@overload
 def bloch_redfield_tensor(
     H: Qobj | QobjEvo,
     a_ops: list[tuple[Qobj | QobjEvo, Coefficient | str | CoeffProtocol]],
@@ -20,7 +33,17 @@ def bloch_redfield_tensor(
     fock_basis: bool = False,
     sparse_eigensolver: bool = False,
     br_dtype: str = 'sparse',
-):
+) -> QobjEvo: ...
+
+def bloch_redfield_tensor(
+    H: Qobj | QobjEvo,
+    a_ops: list[tuple[Qobj | QobjEvo, Coefficient | str | CoeffProtocol]],
+    c_ops: list[Qobj | QobjEvo] = None,
+    sec_cutoff: float = 0.1,
+    fock_basis: bool = False,
+    sparse_eigensolver: bool = False,
+    br_dtype: str = 'sparse',
+) -> Qobj | QobjEvo:
     """
     Calculates the Bloch-Redfield tensor for a system given
     a set of operators and corresponding spectral functions that describes the
@@ -107,6 +130,27 @@ def bloch_redfield_tensor(
                         False, br_dtype=br_dtype)[0]
         return R, H_transform.as_Qobj()
 
+@overload
+def brterm(
+    H: Qobj,
+    a_op: Qobj,
+    spectra: Coefficient | CoeffProtocol | str,
+    sec_cutoff: float = 0.1,
+    fock_basis: bool = False,
+    sparse_eigensolver: bool = False,
+    br_dtype: str = 'sparse',
+) -> Qobj: ...
+
+@overload
+def brterm(
+    H: Qobj | QobjEvo,
+    a_op: Qobj | QobjEvo,
+    spectra: Coefficient | CoeffProtocol | str,
+    sec_cutoff: float = 0.1,
+    fock_basis: bool = False,
+    sparse_eigensolver: bool = False,
+    br_dtype: str = 'sparse',
+) -> QobjEvo: ...
 
 def brterm(
     H: Qobj | QobjEvo,
@@ -116,7 +160,7 @@ def brterm(
     fock_basis: bool = False,
     sparse_eigensolver: bool = False,
     br_dtype: str = 'sparse',
-):
+) -> Qobj | QobjEvo:
     """
     Calculates the contribution of one coupling operator to the Bloch-Redfield
     tensor.

--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -17,7 +17,7 @@ __all__ = ['bloch_redfield_tensor', 'brterm']
 def bloch_redfield_tensor(
     H: Qobj,
     a_ops: list[tuple[Qobj, Coefficient | str | CoeffProtocol]],
-    c_ops: list[Qobj | QobjEvo] = None,
+    c_ops: list[Qobj] = None,
     sec_cutoff: float = 0.1,
     fock_basis: bool = False,
     sparse_eigensolver: bool = False,

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -8,7 +8,9 @@ import numpy as np
 import numbers
 from operator import getitem
 from functools import partial
+from typing import Literal
 from qutip.settings import settings
+from qutip.typing import SpaceLike, DimensionLike
 
 
 __all__ = ["to_tensor_rep", "from_tensor_rep", "Space", "Dimensions"]
@@ -351,7 +353,7 @@ def _frozen(*args, **kwargs):
 
 
 class MetaSpace(type):
-    def __call__(cls, *args, rep=None):
+    def __call__(cls, *args: SpaceLike, rep: str = None) -> Space:
         """
         Select which subclass is instantiated.
         """
@@ -399,7 +401,11 @@ class MetaSpace(type):
             cls._stored_dims[args] = instance
         return cls._stored_dims[args]
 
-    def from_list(cls, list_dims, rep=None):
+    def from_list(
+        cls,
+        list_dims: list[int] | list[list[int]],
+        rep: str = None
+    ) -> Space:
         if len(list_dims) == 0:
             raise ValueError("Empty list can't be used as dims.")
         elif (
@@ -449,7 +455,7 @@ class Space(metaclass=MetaSpace):
         self._pure_dims = True
         self.__setitem__ = _frozen
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return self is other or (
             type(other) is type(self)
             and other.size == self.size
@@ -458,16 +464,16 @@ class Space(metaclass=MetaSpace):
     def __hash__(self):
         return hash(self.size)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Space({self.size})"
 
-    def as_list(self):
+    def as_list(self) -> list[int]:
         return [self.size]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.as_list())
 
-    def dims2idx(self, dims):
+    def dims2idx(self, dims: list[int]) -> int:
         """
         Transform dimensions indices to full array indices.
         """
@@ -479,7 +485,7 @@ class Space(metaclass=MetaSpace):
             raise TypeError("Dimensions must be integers")
         return dims[0]
 
-    def idx2dims(self, idx):
+    def idx2dims(self, idx: int) -> list[int]:
         """
         Transform full array indices to dimensions indices.
         """
@@ -487,7 +493,7 @@ class Space(metaclass=MetaSpace):
             raise IndexError("Index out of range")
         return [idx]
 
-    def step(self):
+    def step(self) -> list[int]:
         """
         Get the step in the array between for each dimensions index.
 
@@ -496,11 +502,11 @@ class Space(metaclass=MetaSpace):
         """
         return [1]
 
-    def flat(self):
+    def flat(self) -> list[int]:
         """ Dimensions as a flat list. """
         return [self.size]
 
-    def remove(self, idx):
+    def remove(self, idx: int):
         """
         Remove a Space from a Dimensons or complex Space.
 
@@ -508,7 +514,7 @@ class Space(metaclass=MetaSpace):
         """
         raise RuntimeError("Cannot delete a flat space.")
 
-    def replace(self, idx, new):
+    def replace(self, idx: int, new: int) -> Space:
         """
         Reshape a Space from a Dimensons or complex Space.
 
@@ -520,10 +526,10 @@ class Space(metaclass=MetaSpace):
             )
         return Space(new)
 
-    def replace_superrep(self, super_rep):
+    def replace_superrep(self, super_rep: str) -> Space:
         return self
 
-    def scalar_like(self):
+    def scalar_like(self) -> SpaceLike:
         return Field()
 
 
@@ -537,28 +543,28 @@ class Field(Space):
         self._pure_dims = True
         self.__setitem__ = _frozen
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return type(other) is Field
 
     def __hash__(self):
         return hash(0)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Field()"
 
-    def as_list(self):
+    def as_list(self) -> list[int]:
         return [1]
 
-    def step(self):
+    def step(self) -> list[int]:
         return [1]
 
-    def flat(self):
+    def flat(self) -> list[int]:
         return [1]
 
-    def remove(self, idx):
+    def remove(self, idx: int) -> Space:
         return self
 
-    def replace(self, idx, new):
+    def replace(self, idx: int, new: int) -> Space:
         return Space(new)
 
 
@@ -570,15 +576,15 @@ class Compound(Space):
     _stored_dims = {}
 
     def __init__(self, *spaces):
-        self.spaces = []
+        spaces_ = []
         if len(spaces) <= 1:
             raise ValueError("Compound need multiple space to join.")
         for space in spaces:
             if isinstance(space, Compound):
-                self.spaces += space.spaces
+                spaces_ += space.spaces
             else:
-                self.spaces += [space]
-        self.spaces = tuple(self.spaces)
+                spaces_ += [space]
+        self.spaces = tuple(spaces_)
         self.size = np.prod([space.size for space in self.spaces])
         self.issuper = all(space.issuper for space in self.spaces)
         if not self.issuper and any(space.issuper for space in self.spaces):
@@ -596,7 +602,7 @@ class Compound(Space):
             )
         self.__setitem__ = _frozen
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return self is other or (
             type(other) is type(self) and
             self.spaces == other.spaces
@@ -605,14 +611,14 @@ class Compound(Space):
     def __hash__(self):
         return hash(self.spaces)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         parts_rep = ", ".join(repr(space) for space in self.spaces)
         return f"Compound({parts_rep})"
 
-    def as_list(self):
+    def as_list(self) -> list[int]:
         return sum([space.as_list() for space in self.spaces], [])
 
-    def dims2idx(self, dims):
+    def dims2idx(self, dims-> list[int]) -> int:
         if len(dims) != len(self.spaces):
             raise ValueError("Length of supplied dims does not match the number of subspaces.")
         pos = 0
@@ -622,14 +628,14 @@ class Compound(Space):
             step *= space.size
         return pos
 
-    def idx2dims(self, idx):
+    def idx2dims(self, idx: int) -> list[int]:
         dims = []
         for space in self.spaces[::-1]:
             idx, dim = divmod(idx, space.size)
             dims = space.idx2dims(dim) + dims
         return dims
 
-    def step(self):
+    def step(self) -> list[int]:
         steps = []
         step = 1
         for space in self.spaces[::-1]:
@@ -637,10 +643,10 @@ class Compound(Space):
             step *= space.size
         return steps
 
-    def flat(self):
+    def flat(self) -> list[int]:
         return sum([space.flat() for space in self.spaces], [])
 
-    def remove(self, idx):
+    def remove(self, idx: int) -> Space:
         new_spaces = []
         for space in self.spaces:
             n_indices = len(space.flat())
@@ -651,7 +657,7 @@ class Compound(Space):
             return Compound(*new_spaces)
         return Field()
 
-    def replace(self, idx, new):
+    def replace(self, idx: int, new: int) -> Space:
         new_spaces = []
         for space in self.spaces:
             n_indices = len(space.flat())
@@ -662,19 +668,19 @@ class Compound(Space):
             idx -= n_indices
         return Compound(*new_spaces)
 
-    def replace_superrep(self, super_rep):
+    def replace_superrep(self, super_rep: str) -> Space:
         return Compound(
             *[space.replace_superrep(super_rep) for space in self.spaces]
         )
 
-    def scalar_like(self):
-        return [space.scalar_like() for space in self.spaces]
+    def scalar_like(self) -> Space:
+        return Compound([space.scalar_like() for space in self.spaces])
 
 
 class SuperSpace(Space):
     _stored_dims = {}
 
-    def __init__(self, oper, rep='super'):
+    def __init__(self, oper: Dimensions, rep: str = 'super'):
         self.oper = oper
         self.superrep = rep
         self.size = oper.shape[0] * oper.shape[1]
@@ -682,7 +688,7 @@ class SuperSpace(Space):
         self._pure_dims = oper._pure_dims
         self.__setitem__ = _frozen
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return (
             self is other
             or self.oper == other
@@ -696,47 +702,47 @@ class SuperSpace(Space):
     def __hash__(self):
         return hash((self.oper, self.superrep))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Super({repr(self.oper)}, rep={self.superrep})"
 
-    def as_list(self):
+    def as_list(self) -> list[list[int]]:
         return self.oper.as_list()
 
-    def dims2idx(self, dims):
+    def dims2idx(self, dims: list[int]) -> int:
         posl, posr = self.oper.dims2idx(dims)
         return posl + posr * self.oper.shape[0]
 
-    def idx2dims(self, idx):
+    def idx2dims(self, idx: int) -> list[int]:
         posl = idx % self.oper.shape[0]
         posr = idx // self.oper.shape[0]
         return self.oper.idx2dims(posl, posr)
 
-    def step(self):
+    def step(self) -> list[int]:
         stepl, stepr = self.oper.step()
         step = self.oper.shape[0]
         return stepl + [step * N for N in stepr]
 
-    def flat(self):
+    def flat(self) -> list[int]:
         return sum(self.oper.flat(), [])
 
-    def remove(self, idx):
+    def remove(self, idx: int) -> Space:
         new_dims = self.oper.remove(idx)
         if new_dims.type == 'scalar':
             return Field()
         return SuperSpace(new_dims, rep=self.superrep)
 
-    def replace(self, idx, new):
+    def replace(self, idx: int, new: int) -> Space:
         return SuperSpace(self.oper.replace(idx, new), rep=self.superrep)
 
-    def replace_superrep(self, super_rep):
+    def replace_superrep(self, super_rep: str) -> Space:
         return SuperSpace(self.oper, rep=super_rep)
 
-    def scalar_like(self):
-        return self.oper.scalar_like()
+    def scalar_like(self) -> Space:
+        return SuperSpace(self.oper.scalar_like(), rep=self.superrep)
 
 
 class MetaDims(type):
-    def __call__(cls, *args, rep=None):
+    def __call__(cls, *args: DimensionLike, rep: str = None) -> Dimensions:
         if len(args) == 1 and isinstance(args[0], Dimensions):
             return args[0]
         elif len(args) == 1 and len(args[0]) == 2:
@@ -761,9 +767,9 @@ class MetaDims(type):
 
 class Dimensions(metaclass=MetaDims):
     _stored_dims = {}
-    _type = None
+    _type: str = None
 
-    def __init__(self, from_, to_):
+    def __init__(self, from_: Space, to_: Space):
         self.from_ = from_
         self.to_ = to_
         self.shape = to_.size, from_.size
@@ -801,7 +807,7 @@ class Dimensions(metaclass=MetaDims):
                 self.superrep = 'mixed'
         self.__setitem__ = _frozen
 
-    def __eq__(self, other):
+    def __eq__(self, other: Dimensions) -> bool:
         if isinstance(other, Dimensions):
             return (
                 self is other
@@ -812,7 +818,7 @@ class Dimensions(metaclass=MetaDims):
             )
         return NotImplemented
 
-    def __ne__(self, other):
+    def __ne__(self, other: Dimensions) -> bool:
         if isinstance(other, Dimensions):
             return not (
                 self is other
@@ -823,7 +829,7 @@ class Dimensions(metaclass=MetaDims):
             )
         return NotImplemented
 
-    def __matmul__(self, other):
+    def __matmul__(self, other: Dimensions) -> Dimensions:
         if self.from_ != other.to_:
             raise TypeError(f"incompatible dimensions {self} and {other}")
         args = other.from_, self.to_
@@ -834,19 +840,19 @@ class Dimensions(metaclass=MetaDims):
     def __hash__(self):
         return hash((self.to_, self.from_))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Dimensions({repr(self.from_)}, {repr(self.to_)})"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.as_list())
 
-    def as_list(self):
+    def as_list(self) -> list:
         """
         Return the list representation of the Dimensions object.
         """
         return [self.to_.as_list(), self.from_.as_list()]
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Literal[0, 1]) -> Space:
         if key == 0:
             return self.to_
         elif key == 1:
@@ -865,7 +871,7 @@ class Dimensions(metaclass=MetaDims):
         """
         return [self.to_.idx2dims(idxl), self.from_.idx2dims(idxr)]
 
-    def step(self):
+    def step(self) -> list[list[int]]:
         """
         Get the step in the array between for each dimensions index.
 
@@ -874,7 +880,7 @@ class Dimensions(metaclass=MetaDims):
         """
         return [self.to_.step(), self.from_.step()]
 
-    def flat(self):
+    def flat(self) -> list[list[int]]:
         """ Dimensions as a flat list. """
         return [self.to_.flat(), self.from_.flat()]
 
@@ -907,7 +913,7 @@ class Dimensions(metaclass=MetaDims):
             np.argsort(stepr)[::-1] + len(stepl)
         ]))
 
-    def remove(self, idx):
+    def remove(self, idx: int | list[int]) -> Dimensions:
         """
         Remove a Space from a Dimensons or complex Space.
 
@@ -926,7 +932,7 @@ class Dimensions(metaclass=MetaDims):
             self.to_.remove(idx_to),
         )
 
-    def replace(self, idx, new):
+    def replace(self, idx: int, new: int) -> Dimensions:
         """
         Reshape a Space from a Dimensons or complex Space.
 
@@ -942,7 +948,7 @@ class Dimensions(metaclass=MetaDims):
 
         return Dimensions(new_from, new_to)
 
-    def replace_superrep(self, super_rep):
+    def replace_superrep(self, super_rep: str) -> Dimensions:
         if not self.issuper and super_rep is not None:
             raise TypeError("Can't set a superrep of a non super object.")
         return Dimensions(
@@ -950,5 +956,5 @@ class Dimensions(metaclass=MetaDims):
             self.to_.replace_superrep(super_rep)
         )
 
-    def scalar_like(self):
-        return [self.to_.scalar_like(), self.from_.scalar_like()]
+    def scalar_like(self) -> Dimensions:
+        return Dimensions([self.to_.scalar_like(), self.from_.scalar_like()])

--- a/qutip/core/expect.py
+++ b/qutip/core/expect.py
@@ -1,11 +1,33 @@
 __all__ = ['expect', 'variance']
 
 import numpy as np
+from typing import overload, Sequence
 
 from .qobj import Qobj
 from . import data as _data
 from ..settings import settings
 
+
+@overload
+def expect(oper: Qobj, state: Qobj) -> complex: ...
+
+@overload
+def expect(
+    oper: Qobj,
+    state: Qobj | Sequence[Qobj],
+) -> np.typing.NDArray[complex]: ...
+
+@overload
+def expect(
+    oper: Qobj | Sequence[Qobj],
+    state: Qobj,
+) -> list[complex]: ...
+
+@overload
+def expect(
+    oper: Qobj | Sequence[Qobj],
+    state: Qobj | Sequence[Qobj]
+) -> list[np.typing.NDArray[complex]]: ...
 
 def expect(oper, state):
     """
@@ -16,17 +38,18 @@ def expect(oper, state):
 
     Parameters
     ----------
-    oper : qobj/array-like
+    oper : qobj / list of Qobj
         A single or a `list` of operators for expectation value.
 
-    state : qobj/array-like
+    state : qobj / list of Qobj
         A single or a `list` of quantum states or density matrices.
 
     Returns
     -------
-    expt : float/complex/array-like
-        Expectation value.  ``real`` if ``oper`` is Hermitian, ``complex``
-        otherwise. A (nested) array of expectaction values if ``state`` or
+    expt : float / complex / list / array
+        Expectation value(s).  ``real`` if ``oper`` is Hermitian, ``complex``
+        otherwise. If multiple ``oper`` are passed, a list of array
+        A (nested) array of expectaction values if ``state`` or
         ``oper`` are arrays.
 
     Examples
@@ -38,16 +61,10 @@ def expect(oper, state):
     if isinstance(state, Qobj) and isinstance(oper, Qobj):
         return _single_qobj_expect(oper, state)
 
-    elif isinstance(oper, (list, np.ndarray)):
-        if isinstance(state, Qobj):
-            dtype = np.complex128
-            if all(op.isherm for op in oper) and (state.isket or state.isherm):
-                dtype = np.float64
-            return np.array([_single_qobj_expect(op, state) for op in oper],
-                            dtype=dtype)
+    elif isinstance(oper, Sequence):
         return [expect(op, state) for op in oper]
 
-    elif isinstance(state, (list, np.ndarray)):
+    elif isinstance(state, Sequence):
         dtype = np.complex128
         if oper.isherm and all(op.isherm or op.isket for op in state):
             dtype = np.float64
@@ -81,16 +98,22 @@ def _single_qobj_expect(oper, state):
     return out
 
 
+@overload
+def variance(oper: Qobj, state: Qobj) -> complex:
+
+@overload
+def variance(oper: Qobj, state: list[Qobj]) -> np.typing.NDArray[complex]:
+
 def variance(oper, state):
     """
     Variance of an operator for the given state vector or density matrix.
 
     Parameters
     ----------
-    oper : qobj
+    oper : Qobj
         Operator for expectation value.
 
-    state : qobj/list
+    state : Qobj / list of Qobj
         A single or ``list`` of quantum states or density matrices..
 
     Returns

--- a/qutip/core/expect.py
+++ b/qutip/core/expect.py
@@ -99,10 +99,10 @@ def _single_qobj_expect(oper, state):
 
 
 @overload
-def variance(oper: Qobj, state: Qobj) -> complex:
+def variance(oper: Qobj, state: Qobj) -> complex: ...
 
 @overload
-def variance(oper: Qobj, state: list[Qobj]) -> np.typing.NDArray[complex]:
+def variance(oper: Qobj, state: list[Qobj]) -> np.typing.NDArray[complex]: ...
 
 def variance(oper, state):
     """

--- a/qutip/core/expect.py
+++ b/qutip/core/expect.py
@@ -48,7 +48,7 @@ def expect(oper, state):
     -------
     expt : float / complex / list / array
         Expectation value(s).  ``real`` if ``oper`` is Hermitian, ``complex``
-        otherwise. If multiple ``oper`` are passed, a list of array
+        otherwise. If multiple ``oper`` are passed, a list of array.
         A (nested) array of expectaction values if ``state`` or
         ``oper`` are arrays.
 

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -88,7 +88,7 @@ shape = [4, 4], type = oper, isherm = False
 @overload
 def jmat(
     j: float,
-    which: NoneType,
+    which: Literal[None],
     *,
     dtype: LayerType = None
 ) -> tuple[Qobj]: ...

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 import numpy as np
-from typing import Literal
+from typing import Literal, overload
 from . import data as _data
 from .qobj import Qobj
 from .dimensions import Space
@@ -85,9 +85,25 @@ shape = [4, 4], type = oper, isherm = False
     )
 
 
+@overload
 def jmat(
     j: float,
-    which: Literal["x", "y", "z", "+", "-"] = None,
+    which: NoneType,
+    *,
+    dtype: LayerType = None
+) -> tuple[Qobj]: ...
+
+@overload
+def jmat(
+    j: float,
+    which: Literal["x", "y", "z", "+", "-"],
+    *,
+    dtype: LayerType = None
+) -> Qobj: ...
+
+def jmat(
+    j: float,
+    which: Literal["x", "y", "z", "+", "-", None] = None,
     *,
     dtype: LayerType = None
 ) -> Qobj | tuple[Qobj]:

--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -1,4 +1,6 @@
 from ..settings import settings
+from typing import overload, Literal, Any
+import types
 
 __all__ = ["CoreOptions"]
 
@@ -10,7 +12,8 @@ class QutipOptions:
     Define basic method to wrap an ``options`` dict.
     Default options are in a class _options dict.
     """
-    _options = {}
+
+    _options: dict[str, Any] = {}
     _settings_name = None  # Where the default is in settings
 
     def __init__(self, **options):
@@ -20,24 +23,24 @@ class QutipOptions:
         if options:
             raise KeyError(f"Options {set(options)} are not supported.")
 
-    def __contains__(self, key):
+    def __contains__(self, key: str) -> bool:
         return key in self.options
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         # Let the dict catch the KeyError
         return self.options[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Any) -> None:
         # Let the dict catch the KeyError
         self.options[key] = value
 
-    def __repr__(self, full=True):
+    def __repr__(self, full: bool = True) -> str:
         out = [f"<{self.__class__.__name__}("]
         for key, value in self.options.items():
             if full or value != self._options[key]:
                 out += [f"    '{key}': {repr(value)},"]
         out += [")>"]
-        if len(out)-2:
+        if len(out) - 2:
             return "\n".join(out)
         else:
             return "".join(out)
@@ -46,7 +49,12 @@ class QutipOptions:
         self._backup = getattr(settings, self._settings_name)
         setattr(settings, self._settings_name, self)
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        exc_traceback: types.TracebackType | None,
+    ) -> None:
         setattr(settings, self._settings_name, self._backup)
 
 
@@ -110,6 +118,7 @@ class CoreOptions(QutipOptions):
         known to ``qutip.data.to`` is accepted. When ``None``, these functions
         will default to a sensible data type.
     """
+
     _options = {
         # use auto tidyup
         "auto_tidyup": True,
@@ -130,6 +139,55 @@ class CoreOptions(QutipOptions):
         "auto_real_casting": True,
     }
     _settings_name = "core"
+
+    @overload
+    def __getitem__(
+        self,
+        key: Literal["auto_tidyup", "auto_tidyup_dims", "auto_real_casting"],
+    ) -> bool: ...
+
+    @overload
+    def __getitem__(
+        self, key: Literal["atol", "rtol", "auto_tidyup_atol"]
+    ) -> float: ...
+
+    @overload
+    def __getitem__(
+        self, key: Literal["function_coefficient_style"]
+    ) -> str: ...
+
+    @overload
+    def __getitem__(self, key: Literal["default_dtype"]) -> str | None: ...
+
+    def __getitem__(self, key: str) -> Any:
+        # Let the dict catch the KeyError
+        return self.options[key]
+
+    @overload
+    def __setitem__(
+        self,
+        key: Literal["auto_tidyup", "auto_tidyup_dims", "auto_real_casting"],
+        value: bool,
+    ) -> None: ...
+
+    @overload
+    def __setitem__(
+        self, key: Literal["atol", "rtol", "auto_tidyup_atol"], value: float
+    ) -> None: ...
+
+    @overload
+    def __setitem__(
+        self, key: Literal["function_coefficient_style"], value: str
+    ) -> None: ...
+
+    @overload
+    def __setitem__(
+        self, key: Literal["default_dtype"], value: str | None
+    ) -> None: ...
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        # Let the dict catch the KeyError
+        self.options[key] = value
 
 
 # Creating the instance of core options to use everywhere.

--- a/qutip/core/properties.py
+++ b/qutip/core/properties.py
@@ -29,7 +29,7 @@ def issuper(x: Qobj | QobjEvo) -> bool:
     return isinstance(x, (Qobj, QobjEvo)) and x.type in ['super']
 
 
-def isherm(x: Qobj):
-    if not isinstance(x, Qobj) -> bool:
+def isherm(x: Qobj) -> bool:
+    if not isinstance(x, Qobj):
         raise TypeError(f"Invalid input type, got {type(x)}, exected Qobj")
     return x.isherm

--- a/qutip/core/properties.py
+++ b/qutip/core/properties.py
@@ -5,31 +5,31 @@ __all__ = [
 ]
 
 
-def isbra(x: Qobj | QobjEvo):
+def isbra(x: Qobj | QobjEvo) -> bool:
     return isinstance(x, (Qobj, QobjEvo)) and x.type in ['bra', 'scalar']
 
 
-def isket(x: Qobj | QobjEvo):
+def isket(x: Qobj | QobjEvo) -> bool:
     return isinstance(x, (Qobj, QobjEvo)) and x.type in ['ket', 'scalar']
 
 
-def isoper(x: Qobj | QobjEvo):
+def isoper(x: Qobj | QobjEvo) -> bool:
     return isinstance(x, (Qobj, QobjEvo)) and x.type in ['oper', 'scalar']
 
 
-def isoperbra(x: Qobj | QobjEvo):
+def isoperbra(x: Qobj | QobjEvo) -> bool:
     return isinstance(x, (Qobj, QobjEvo)) and x.type in ['operator-bra']
 
 
-def isoperket(x: Qobj | QobjEvo):
+def isoperket(x: Qobj | QobjEvo) -> bool:
     return isinstance(x, (Qobj, QobjEvo)) and x.type in ['operator-ket']
 
 
-def issuper(x: Qobj | QobjEvo):
+def issuper(x: Qobj | QobjEvo) -> bool:
     return isinstance(x, (Qobj, QobjEvo)) and x.type in ['super']
 
 
 def isherm(x: Qobj):
-    if not isinstance(x, Qobj):
+    if not isinstance(x, Qobj) -> bool:
         raise TypeError(f"Invalid input type, got {type(x)}, exected Qobj")
     return x.isherm

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -113,12 +113,10 @@ class Qobj:
 
     Parameters
     ----------
-    inpt: array_like, data object or :obj:`.Qobj`
+    arg: array_like, data object or :obj:`.Qobj`
         Data for vector/matrix representation of the quantum object.
     dims: list
         Dimensions of object used for tensor products.
-    shape: list
-        Shape of underlying data structure (matrix shape).
     copy: bool
         Flag specifying whether Qobj should get a copy of the
         input data, or use the original.
@@ -373,7 +371,7 @@ class Qobj:
         )
 
     @_require_equal_type
-    def __add__(self, other: Qobj | numbers.Number) -> Qobj:
+    def __add__(self, other: Qobj | complex) -> Qobj:
         if other == 0:
             return self.copy()
         return Qobj(_data.add(self._data, other._data),
@@ -381,11 +379,11 @@ class Qobj:
                     isherm=(self._isherm and other._isherm) or None,
                     copy=False)
 
-    def __radd__(self, other: Qobj | numbers.Number) -> Qobj:
+    def __radd__(self, other: Qobj | complex) -> Qobj:
         return self.__add__(other)
 
     @_require_equal_type
-    def __sub__(self, other: Qobj | numbers.Number) -> Qobj:
+    def __sub__(self, other: Qobj | complex) -> Qobj:
         if other == 0:
             return self.copy()
         return Qobj(_data.sub(self._data, other._data),
@@ -393,10 +391,10 @@ class Qobj:
                     isherm=(self._isherm and other._isherm) or None,
                     copy=False)
 
-    def __rsub__(self, other: Qobj | numbers.Number) -> Qobj:
+    def __rsub__(self, other: Qobj | complex) -> Qobj:
         return self.__neg__().__add__(other)
 
-    def __mul__(self, other: numbers.Number) -> Qobj:
+    def __mul__(self, other: complex) -> Qobj:
         """
         If other is a Qobj, we dispatch to __matmul__. If not, we
         check that other is a valid complex scalar, i.e., we can do
@@ -430,7 +428,7 @@ class Qobj:
                     isunitary=isunitary,
                     copy=False)
 
-    def __rmul__(self, other: numbers.Number) -> Qobj:
+    def __rmul__(self, other: complex) -> Qobj:
         # Shouldn't be here unless `other.__mul__` has already been tried, so
         # we _shouldn't_ check that `other` is `Qobj`.
         return self.__mul__(other)
@@ -452,7 +450,7 @@ class Qobj:
             copy=False
         )
 
-    def __truediv__(self, other: numbers.Number) -> Qobj:
+    def __truediv__(self, other: complex) -> Qobj:
         return self.__mul__(1 / other)
 
     def __neg__(self) -> Qobj:
@@ -648,7 +646,7 @@ class Qobj:
         self,
         norm: Literal["l2", "max", "fro", "tr", "one"] = None,
         kwargs: dict[str, Any] = None
-    ) -> numbers.Number:
+    ) -> float:
         """
         Norm of a quantum object.
 
@@ -708,7 +706,7 @@ class Qobj:
                     isherm=True,
                     copy=False)
 
-    def tr(self) -> numbers.Number:
+    def tr(self) -> complex:
         """Trace of a quantum object.
 
         Returns
@@ -724,7 +722,7 @@ class Qobj:
             out = out.real
         return out
 
-    def purity(self) -> numbers.Number:
+    def purity(self) -> complex:
         """Calculate purity of a quantum object.
 
         Returns
@@ -1390,7 +1388,7 @@ class Qobj:
             right = right.adjoint()
         return _data.inner_op(left, op, right, bra.isket)
 
-    def overlap(self, other: Qobj) -> numbers.Number:
+    def overlap(self, other: Qobj) -> complex:
         """
         Overlap between two state vectors or two operators.
 
@@ -1624,7 +1622,7 @@ class Qobj:
                 warnings.warn("Ground state may be degenerate.", UserWarning)
         return evals[0], evecs[0]
 
-    def dnorm(self, B: Qobj = None) -> numbers.Number:
+    def dnorm(self, B: Qobj = None) -> float:
         """Calculates the diamond norm, or the diamond distance to another
         operator.
 

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -15,6 +15,7 @@ from .. import __version__
 from ..settings import settings
 from . import data as _data
 from qutip.typing import LayerType, DimensionLike
+import qutip
 from .dimensions import (
     enumerate_flat, collapse_dims_super, flatten, unflatten, Dimensions
 )
@@ -316,10 +317,6 @@ class Qobj:
     def data(self) -> _data.Data:
         return self._data
 
-    @property
-    def dtype(self):
-        return type(self._data)
-
     @data.setter
     def data(self, data: _data.Data):
         if not isinstance(data, _data.Data):
@@ -328,6 +325,10 @@ class Qobj:
             raise ValueError('Provided data do not match the dimensions: ' +
                              f"{self._dims.shape} vs {data.shape}")
         self._data = data
+
+    @property
+    def dtype(self):
+        return type(self._data)
 
     def to(self, data_type: LayerType, copy: bool=False) -> Qobj:
         """
@@ -544,7 +545,7 @@ class Qobj:
         if self.issuper:
             if other.isket:
                 other = other.proj()
-            return vector_to_operator(self @ operator_to_vector(other))
+            return qutip.vector_to_operator(self @ qutip.operator_to_vector(other))
         return self.__matmul__(other)
 
     def __getstate__(self):
@@ -591,7 +592,7 @@ class Qobj:
         Syntax shortcut for tensor:
         A & B ==> tensor(A, B)
         """
-        return tensor(self, other)
+        return qutip.tensor(self, other)
 
     def dag(self) -> Qobj:
         """Get the Hermitian adjoint of the quantum object."""
@@ -633,9 +634,9 @@ class Qobj:
         # is only valid for completely positive maps.
         if not self.iscp:
             raise ValueError("Dual channels are only implemented for CP maps.")
-        J = to_choi(self)
+        J = qutip.to_choi(self)
         tensor_idxs = enumerate_flat(J.dims)
-        J_dual = tensor_swap(J, *(
+        J_dual = qutip.tensor_swap(J, *(
                 list(zip(tensor_idxs[0][1], tensor_idxs[0][0])) +
                 list(zip(tensor_idxs[1][1], tensor_idxs[1][0]))
         )).trans()
@@ -994,16 +995,16 @@ class Qobj:
         obj : :class:`.Qobj`
             Normalized quantum object.  Will be the `self` object if in place.
         """
-        norm = self.norm(norm=norm, kwargs=kwargs)
+        norm_ = self.norm(norm=norm, kwargs=kwargs)
         if inplace:
-            self.data = _data.mul(self.data, 1 / norm)
-            self._isherm = self._isherm if norm.imag == 0 else None
+            self.data = _data.mul(self.data, 1 / norm_)
+            self._isherm = self._isherm if norm_.imag == 0 else None
             self._isunitary = (self._isunitary
-                               if abs(norm) - 1 < settings.core['atol']
+                               if abs(norm_) - 1 < settings.core['atol']
                                else None)
             out = self
         else:
-            out = self / norm
+            out = self / norm_
         return out
 
     def ptrace(self, sel: int | list[int], dtype: LayerType = None) -> Qobj:
@@ -1055,10 +1056,10 @@ class Qobj:
             sel = [sel]
         if self.isoperket:
             dims = self.dims[0]
-            data = vector_to_operator(self).data
+            data = qutip.vector_to_operator(self).data
         elif self.isoperbra:
             dims = self.dims[1]
-            data = vector_to_operator(self.dag()).data
+            data = qutip.vector_to_operator(self.dag()).data
         elif self.issuper or self.isoper:
             dims = self.dims
             data = self.data
@@ -1072,9 +1073,9 @@ class Qobj:
         new_dims = [[dims[x] for x in sel]] * 2 if sel else None
         out = Qobj(new_data, dims=new_dims, copy=False)
         if self.isoperket:
-            return operator_to_vector(out)
+            return qutip.operator_to_vector(out)
         if self.isoperbra:
-            return operator_to_vector(out).dag()
+            return qutip.operator_to_vector(out).dag()
         return out
 
     def contract(self, inplace: bool = False) -> Qobj:
@@ -1639,14 +1640,14 @@ class Qobj:
             from this operator to B.
 
         """
-        return mts.dnorm(self, B)
+        return qutip.dnorm(self, B)
 
     @property
     def ishp(self) -> bool:
         # FIXME: this needs to be cached in the same ways as isherm.
         if self.type in ["super", "oper"]:
             try:
-                J = to_choi(self)
+                J = qutip.to_choi(self)
                 return J.isherm
             except:
                 return False
@@ -1661,7 +1662,7 @@ class Qobj:
         # We can test with either Choi or chi, since the basis
         # transformation between them is unitary and hence preserves
         # the CP and TP conditions.
-        J = self if self.superrep in ('choi', 'chi') else to_choi(self)
+        J = self if self.superrep in ('choi', 'chi') else qutip.to_choi(self)
         # If J isn't hermitian, then that could indicate either that J is not
         # normal, or is normal, but has complex eigenvalues.  In either case,
         # it makes no sense to then demand that the eigenvalues be
@@ -1679,7 +1680,7 @@ class Qobj:
         if self.issuper and self.superrep in ('choi', 'chi'):
             qobj = self
         else:
-            qobj = to_choi(self)
+            qobj = qutip.to_choi(self)
         # Possibly collapse dims.
         if any([len(index) > 1
                 for super_index in qobj.dims
@@ -1701,7 +1702,7 @@ class Qobj:
         if not (self.issuper or self.isoper):
             return False
         reps = ('choi', 'chi')
-        q_oper = to_choi(self) if self.superrep not in reps else self
+        q_oper = qutip.to_choi(self) if self.superrep not in reps else self
         return q_oper.iscp and q_oper.istp
 
     @property
@@ -1794,11 +1795,3 @@ def ptrace(Q: Qobj, sel: int | list[int]) -> Qobj:
     if not isinstance(Q, Qobj):
         raise TypeError("Input is not a quantum object")
     return Q.ptrace(sel)
-
-
-# TRAILING IMPORTS
-# We do a few imports here to avoid circular dependencies.
-from qutip.core.superop_reps import to_choi
-from qutip.core.superoperator import vector_to_operator, operator_to_vector
-from qutip.core.tensor import tensor_swap, tensor
-from qutip.core import metrics as mts

--- a/qutip/core/subsystem_apply.py
+++ b/qutip/core/subsystem_apply.py
@@ -13,7 +13,12 @@ from . import Qobj, qeye, to_kraus, tensor
 from . import data as _data
 
 
-def subsystem_apply(state, channel, mask, reference=False):
+def subsystem_apply(
+    state: Qobj,
+    channel: Qobj,
+    mask: list[bool],
+    reference: bool=False
+)-> Qobj:
     """
     Returns the result of applying the propagator `channel` to the
     subsystems indicated in `mask`, which comprise the density operator

--- a/qutip/core/superop_reps.py
+++ b/qutip/core/superop_reps.py
@@ -81,7 +81,7 @@ def _nq(dims):
     return nq
 
 
-def isqubitdims(dims):
+def isqubitdims(dims: list[list[int]] | list[list[list[int]]]) -> bool:
     """
     Checks whether all entries in a dims list are integer powers of 2.
 
@@ -138,7 +138,7 @@ def _choi_to_kraus(q_oper, tol=1e-9):
 # Individual conversions from Kraus operators are public because the output
 # list of Kraus operators is not itself a quantum object.
 
-def kraus_to_choi(kraus_ops):
+def kraus_to_choi(kraus_ops: list[Qobj]) -> Qobj:
     r"""
     Convert a list of Kraus operators into Choi representation of the channel.
 
@@ -176,7 +176,7 @@ def kraus_to_choi(kraus_ops):
     return Qobj(choi_array, choi_dims, superrep="choi", copy=False)
 
 
-def kraus_to_super(kraus_list):
+def kraus_to_super(kraus_list: list[Qobj]) -> Qobj:
     """
     Convert a list of Kraus operators to a superoperator.
 
@@ -346,7 +346,7 @@ def _choi_to_stinespring(q_oper, threshold=1e-10):
     return A, B
 
 
-def to_choi(q_oper):
+def to_choi(q_oper: Qobj) -> Qobj:
     """
     Converts a Qobj representing a quantum map to the Choi representation,
     such that the trace of the returned operator is equal to the dimension
@@ -389,7 +389,7 @@ def to_choi(q_oper):
         )
 
 
-def to_chi(q_oper):
+def to_chi(q_oper: Qobj) -> Qobj:
     """
     Converts a Qobj representing a quantum map to a representation as a chi
     (process) matrix in the Pauli basis, such that the trace of the returned
@@ -432,7 +432,7 @@ def to_chi(q_oper):
         )
 
 
-def to_super(q_oper):
+def to_super(q_oper: Qobj) -> Qobj:
     """
     Converts a Qobj representing a quantum map to the supermatrix (Liouville)
     representation.
@@ -476,7 +476,7 @@ def to_super(q_oper):
         )
 
 
-def to_kraus(q_oper, tol=1e-9):
+def to_kraus(q_oper: Qobj, tol: float=1e-9) -> list[Qobj]:
     """
     Converts a Qobj representing a quantum map to a list of quantum objects,
     each representing an operator in the Kraus decomposition of the given map.
@@ -515,7 +515,7 @@ def to_kraus(q_oper, tol=1e-9):
     )
 
 
-def to_stinespring(q_oper, threshold=1e-10):
+def to_stinespring(q_oper: Qobj, threshold: float=1e-10) -> tuple[Qobj, Qobj]:
     r"""
     Converts a Qobj representing a quantum map :math:`\Lambda` to a pair of
     partial isometries ``A`` and ``B`` such that

--- a/qutip/core/superoperator.py
+++ b/qutip/core/superoperator.py
@@ -5,7 +5,7 @@ __all__ = [
 ]
 
 import functools
-
+from typing import TypeVar, overload
 import numpy as np
 
 from .qobj import Qobj
@@ -30,7 +30,28 @@ def _map_over_compound_operators(f):
     return out
 
 
-def liouvillian(H=None, c_ops=None, data_only=False, chi=None):
+@overload
+def liouvillian(
+    H: Qobj,
+    c_ops: list[Qobj],
+    data_only: bool,
+    chi: list[float]
+) -> Qobj: ...
+
+@overload
+def liouvillian(
+    H: Qobj | "QobjEvo",
+    c_ops: list[Qobj | "QobjEvo"],
+    data_only: bool,
+    chi: list[float]
+) -> "QobjEvo": ...
+
+def liouvillian(
+    H: Qobj | "QobjEvo" = None,
+    c_ops: list[Qobj | "QobjEvo"] = None,
+    data_only: bool = False,
+    chi: list[float] = None,
+) -> Qobj | "QobjEvo":
     """Assembles the Liouvillian superoperator from a Hamiltonian
     and a ``list`` of collapse operators.
 
@@ -118,7 +139,28 @@ def liouvillian(H=None, c_ops=None, data_only=False, chi=None):
                     copy=False)
 
 
-def lindblad_dissipator(a, b=None, data_only=False, chi=None):
+@overload
+def lindblad_dissipator(
+    a: Qobj,
+    b: Qobj,
+    data_only: bool,
+    chi: list[float]
+) -> Qobj: ...
+
+@overload
+def lindblad_dissipator(
+    a: Qobj | "QobjEvo",
+    b: Qobj | "QobjEvo",
+    data_only: bool,
+    chi: list[float]
+) -> "QobjEvo": ...
+
+def lindblad_dissipator(
+    a: Qobj | "QobjEvo",
+    b: Qobj | "QobjEvo" = None,
+    data_only: bool = False,
+    chi: list[float] = None,
+) -> Qobj | "QobjEvo":
     """
     Lindblad dissipator (generalized) for a single pair of collapse operators
     (a, b), or for a single collapse operator (a) when b is not specified:
@@ -180,7 +222,7 @@ def lindblad_dissipator(a, b=None, data_only=False, chi=None):
 
 
 @_map_over_compound_operators
-def operator_to_vector(op):
+def operator_to_vector(op: Qobj) -> Qobj:
     """
     Create a vector representation given a quantum operator in matrix form.
     The passed object should have a ``Qobj.type`` of 'oper' or 'super'; this
@@ -208,7 +250,7 @@ def operator_to_vector(op):
 
 
 @_map_over_compound_operators
-def vector_to_operator(op):
+def vector_to_operator(op: Qobj) -> Qobj:
     """
     Create a matrix representation given a quantum operator in vector form.
     The passed object should have a ``Qobj.type`` of 'operator-ket'; this
@@ -236,7 +278,10 @@ def vector_to_operator(op):
                 copy=False)
 
 
-def stack_columns(matrix):
+QobjOrArray = TypeVar("QobjOrArray", Qobj, np.ndarray)
+
+
+def stack_columns(matrix: QobjOrArray) -> QobjOrArray:
     """
     Stack the columns in a data-layer type, useful for converting an operator
     into a superoperator representation.
@@ -250,7 +295,10 @@ def stack_columns(matrix):
     return _data.column_stack(matrix)
 
 
-def unstack_columns(vector, shape=None):
+def unstack_columns(
+    vector: QobjOrArray,
+    shape: typle[int, int] = None,
+) -> QobjOrArray:
     """
     Unstack the columns in a data-layer type back into a 2D shape, useful for
     converting an operator in vector form back into a regular operator.  If
@@ -295,8 +343,11 @@ def stacked_index(size, row, col):
     return row + size*col
 
 
+AnyQobj = TypeVar("AnyQobj", Qobj, "QobjEvo")
+
+
 @_map_over_compound_operators
-def spost(A):
+def spost(A: AnyQobj) -> AnyQobj:
     """
     Superoperator formed from post-multiplication by operator A
 
@@ -321,7 +372,7 @@ def spost(A):
 
 
 @_map_over_compound_operators
-def spre(A):
+def spre(A: AnyQobj) -> AnyQobj:
     """Superoperator formed from pre-multiplication by operator A.
 
     Parameters
@@ -351,6 +402,12 @@ def _drop_projected_dims(dims):
     """
     return [d for d in dims if d != 1]
 
+
+@overload
+sprepost(A: Qobj, B: Qobj) -> Qobj: ...
+
+@overload
+sprepost(A: Qobj | "QobjEvo", B: Qobj | "QobjEvo") -> "QobjEvo": ...
 
 def sprepost(A, B):
     """
@@ -468,7 +525,7 @@ def _to_tensor_of_super(q_oper):
     return q_oper.permute(perm_idxs)
 
 
-def reshuffle(q_oper):
+def reshuffle(q_oper: Qobj) -> Qobj:
     """
     Column-reshuffles a super operator or a operator-ket Qobj.
     """

--- a/qutip/core/superoperator.py
+++ b/qutip/core/superoperator.py
@@ -9,6 +9,7 @@ from typing import TypeVar, overload
 import numpy as np
 
 from .qobj import Qobj
+from .cy.qobjevo import QobjEvo
 from . import data as _data
 from .dimensions import Compound, SuperSpace, Space
 
@@ -40,18 +41,18 @@ def liouvillian(
 
 @overload
 def liouvillian(
-    H: Qobj | "QobjEvo",
-    c_ops: list[Qobj | "QobjEvo"],
+    H: Qobj | QobjEvo,
+    c_ops: list[Qobj | QobjEvo],
     data_only: bool,
     chi: list[float]
-) -> "QobjEvo": ...
+) -> QobjEvo: ...
 
 def liouvillian(
-    H: Qobj | "QobjEvo" = None,
-    c_ops: list[Qobj | "QobjEvo"] = None,
+    H: Qobj | QobjEvo = None,
+    c_ops: list[Qobj | QobjEvo] = None,
     data_only: bool = False,
     chi: list[float] = None,
-) -> Qobj | "QobjEvo":
+) -> Qobj | QobjEvo:
     """Assembles the Liouvillian superoperator from a Hamiltonian
     and a ``list`` of collapse operators.
 
@@ -149,18 +150,18 @@ def lindblad_dissipator(
 
 @overload
 def lindblad_dissipator(
-    a: Qobj | "QobjEvo",
-    b: Qobj | "QobjEvo",
+    a: Qobj | QobjEvo,
+    b: Qobj | QobjEvo,
     data_only: bool,
     chi: list[float]
-) -> "QobjEvo": ...
+) -> QobjEvo: ...
 
 def lindblad_dissipator(
-    a: Qobj | "QobjEvo",
-    b: Qobj | "QobjEvo" = None,
+    a: Qobj | QobjEvo,
+    b: Qobj | QobjEvo = None,
     data_only: bool = False,
     chi: list[float] = None,
-) -> Qobj | "QobjEvo":
+) -> Qobj | QobjEvo:
     """
     Lindblad dissipator (generalized) for a single pair of collapse operators
     (a, b), or for a single collapse operator (a) when b is not specified:
@@ -297,7 +298,7 @@ def stack_columns(matrix: QobjOrArray) -> QobjOrArray:
 
 def unstack_columns(
     vector: QobjOrArray,
-    shape: typle[int, int] = None,
+    shape: tuple[int, int] = None,
 ) -> QobjOrArray:
     """
     Unstack the columns in a data-layer type back into a 2D shape, useful for
@@ -343,7 +344,7 @@ def stacked_index(size, row, col):
     return row + size*col
 
 
-AnyQobj = TypeVar("AnyQobj", Qobj, "QobjEvo")
+AnyQobj = TypeVar("AnyQobj", Qobj, QobjEvo)
 
 
 @_map_over_compound_operators
@@ -404,10 +405,10 @@ def _drop_projected_dims(dims):
 
 
 @overload
-sprepost(A: Qobj, B: Qobj) -> Qobj: ...
+def sprepost(A: Qobj, B: Qobj) -> Qobj: ...
 
 @overload
-sprepost(A: Qobj | "QobjEvo", B: Qobj | "QobjEvo") -> "QobjEvo": ...
+def sprepost(A: Qobj | QobjEvo, B: Qobj | QobjEvo) -> QobjEvo: ...
 
 def sprepost(A, B):
     """

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -29,7 +29,13 @@ class _reverse_partial_tensor:
         return tensor(op, self.right)
 
 
-def tensor(*args):
+@overload
+def tensor(*args: Qobj) -> Qobj: ...
+
+@overload
+def tensor(*args: Qobj | "QobjEvo") -> "QobjEvo": ...
+
+def tensor(*args: Qobj | "QobjEvo") -> Qobj | "QobjEvo":
     """Calculates the tensor product of input operators.
 
     Parameters

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -9,8 +9,11 @@ __all__ = [
 
 import numpy as np
 from functools import partial
+from typing import TypeVar, overload
+
 from .operators import qeye
 from .qobj import Qobj
+from .cy.qobjevo import QobjEvo
 from .superoperator import operator_to_vector, reshuffle
 from .dimensions import (
     flatten, enumerate_flat, unflatten, deep_remove, dims_to_tensor_shape,
@@ -18,6 +21,7 @@ from .dimensions import (
 )
 from . import data as _data
 from .. import settings
+from ..typing import LayerType
 
 
 class _reverse_partial_tensor:
@@ -33,9 +37,9 @@ class _reverse_partial_tensor:
 def tensor(*args: Qobj) -> Qobj: ...
 
 @overload
-def tensor(*args: Qobj | "QobjEvo") -> "QobjEvo": ...
+def tensor(*args: Qobj | QobjEvo) -> QobjEvo: ...
 
-def tensor(*args: Qobj | "QobjEvo") -> Qobj | "QobjEvo":
+def tensor(*args: Qobj | QobjEvo) -> Qobj | QobjEvo:
     """Calculates the tensor product of input operators.
 
     Parameters
@@ -112,7 +116,13 @@ shape = [4, 4], type = oper, isHerm = True
                 copy=False)
 
 
-def super_tensor(*args):
+@overload
+def super_tensor(*args: Qobj) -> Qobj: ...
+
+@overload
+def super_tensor(*args: Qobj | QobjEvo) -> QobjEvo: ...
+
+def super_tensor(*args: Qobj | QobjEvo) -> Qobj | QobjEvo:
     """
     Calculate the tensor product of input superoperators, by tensoring together
     the underlying Hilbert spaces on which each vectorized operator acts.
@@ -179,6 +189,12 @@ def _isketlike(q):
 def _isbralike(q):
     return q.isbra or q.isoperbra
 
+
+@overload
+def composite(*args: Qobj) -> Qobj: ...
+
+@overload
+def composite(*args: Qobj | QobjEvo) -> QobjEvo: ...
 
 def composite(*args):
     """
@@ -251,13 +267,18 @@ def _tensor_contract_dense(arr, *pairs):
     return arr
 
 
-def tensor_swap(q_oper, *pairs):
+def tensor_swap(q_oper: Qobj, *pairs: tuple[int, int]) -> Qobj:
     """Transposes one or more pairs of indices of a Qobj.
-    Note that this uses dense representations and thus
-    should *not* be used for very large Qobjs.
+
+    .. note::
+
+        Note that this uses dense representations and thus
+        should *not* be used for very large Qobjs.
 
     Parameters
     ----------
+    q_oper : Qobj
+        Operator to swap dims.
 
     pairs : tuple
         One or more tuples ``(i, j)`` indicating that the
@@ -290,10 +311,13 @@ def tensor_swap(q_oper, *pairs):
     return Qobj(data, dims=dims, superrep=q_oper.superrep, copy=False)
 
 
-def tensor_contract(qobj, *pairs):
+def tensor_contract(qobj: Qobj, *pairs: tuple[int, int]) -> Qobj:
     """Contracts a qobj along one or more index pairs.
-    Note that this uses dense representations and thus
-    should *not* be used for very large Qobjs.
+
+    .. note::
+
+        Note that this uses dense representations and thus
+        should *not* be used for very large Qobjs.
 
     Parameters
     ----------
@@ -420,7 +444,15 @@ def _targets_to_list(targets, oper=None, N=None):
     return targets
 
 
-def expand_operator(oper, dims, targets, dtype=None):
+QobjOrQobjEvo = TypeVar("QobjOrQobjEvo", Qobj, QobjEvo)
+
+
+def expand_operator(
+    oper: QobjOrQobjEvo,
+    dims: list[int],
+    targets: int,
+    dtype: LayerType = None
+) -> QobjOrQobjEvo:
     """
     Expand an operator to one that acts on a system with desired dimensions.
     e.g.

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -34,7 +34,7 @@ def _blas_info():
     return blas
 
 
-def available_cpu_count():
+def available_cpu_count() -> int:
     """
     Get the number of cpus.
     It tries to only get the number available to qutip.
@@ -135,19 +135,19 @@ class Settings:
         self._colorblind_safe = False
 
     @property
-    def has_mkl(self):
+    def has_mkl(self) -> bool:
         """ Whether qutip found an mkl installation. """
         return self.mkl_lib is not None
 
     @property
-    def mkl_lib(self):
+    def mkl_lib(self) -> str | None:
         """ Location of the mkl installation. """
         if self._mkl_lib == "":
             self._mkl_lib = _find_mkl()
         return _find_mkl()
 
     @property
-    def ipython(self):
+    def ipython(self) -> bool:
         """ Whether qutip is running in ipython. """
         try:
             __IPYTHON__
@@ -156,7 +156,7 @@ class Settings:
             return False
 
     @property
-    def eigh_unsafe(self):
+    def eigh_unsafe(self) -> bool:
         """
         Whether `eigh` call is reliable.
         Some implementation of blas have some issues on some OS.
@@ -175,7 +175,7 @@ class Settings:
         )
 
     @property
-    def tmproot(self):
+    def tmproot(self) -> str:
         """
         Location in which qutip place cython string coefficient folders.
         The default is "$HOME/.qutip".
@@ -184,13 +184,13 @@ class Settings:
         return self._tmproot
 
     @tmproot.setter
-    def tmproot(self, root):
+    def tmproot(self, root: str) -> None:
         if not os.path.exists(root):
             os.mkdir(root)
         self._tmproot = root
 
     @property
-    def coeffroot(self):
+    def coeffroot(self) -> str:
         """
         Location in which qutip save cython string coefficient files.
         Usually "{qutip.settings.tmproot}/qutip_coeffs_X.X".
@@ -199,7 +199,7 @@ class Settings:
         return self._coeffroot
 
     @coeffroot.setter
-    def coeffroot(self, root):
+    def coeffroot(self, root: str) -> None:
         if not os.path.exists(root):
             os.mkdir(root)
         if root not in sys.path:
@@ -207,18 +207,18 @@ class Settings:
         self._coeffroot = root
 
     @property
-    def coeff_write_ok(self):
+    def coeff_write_ok(self) -> bool:
         """ Whether qutip has write acces to ``qutip.settings.coeffroot``."""
         return os.access(self.coeffroot, os.W_OK)
 
     @property
-    def _has_openmp(self):
+    def _has_openmp(self) -> bool:
         return False
         # We keep this as a reminder for when openmp is restored: see Pull #652
         # os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
 
     @property
-    def idxint_size(self):
+    def idxint_size(self) -> int:
         """
         Integer type used by ``CSR`` data.
         Sparse ``CSR`` matrices can contain at most ``2**idxint_size``
@@ -228,7 +228,7 @@ class Settings:
         return data.base.idxint_size
 
     @property
-    def num_cpus(self):
+    def num_cpus(self) -> int:
         """
         Number of cpu detected.
         Use the solver options to control the number of cpus used.
@@ -241,7 +241,7 @@ class Settings:
         return num_cpus
 
     @property
-    def colorblind_safe(self):
+    def colorblind_safe(self) -> bool:
         """
         Allow for a colorblind mode that uses different colormaps
         and plotting options by default.
@@ -249,10 +249,10 @@ class Settings:
         return self._colorblind_safe
 
     @colorblind_safe.setter
-    def colorblind_safe(self, value):
+    def colorblind_safe(self, value: bool) -> None:
         self._colorblind_safe = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         lines = ["Qutip settings:"]
         for attr in self.__dir__():
             if not attr.startswith('_') and attr not in ["core", "compile"]:
@@ -260,7 +260,7 @@ class Settings:
         lines.append(f"    compile: {self.compile.__repr__(full=False)}")
         return '\n'.join(lines)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.__str__()
 
 

--- a/qutip/tests/core/test_expect.py
+++ b/qutip/tests/core/test_expect.py
@@ -92,11 +92,10 @@ class TestKnownExpectation:
 
     def test_broadcast_operator_list(self, operators, state, expected):
         result = qutip.expect(operators, state)
-        expected_dtype = (np.float64 if all(op.isherm for op in operators)
-                          else np.complex128)
-        assert isinstance(result, np.ndarray)
-        assert result.dtype == expected_dtype
-        assert list(result) == list(expected)
+        assert len(result) == len(operators)
+        for part, operator, expected_part in zip(result, operators, expected):
+            assert isinstance(part, float if operator.isherm else complex)
+            assert part == expected_part
 
     def test_broadcast_state_list(self, operator, states, expected):
         result = qutip.expect(operator, states)


### PR DESCRIPTION
**Description**
Add hints for most of the remaining user facing function in `qutip/core`.
Fixed the docstring of `Qobj`: fix #2480
Improved the docstring of `expect` to fix the confusion with array input: fix #2456

I changed `numbers.Number` for `complex` as the later is not recognized by static type checkers.
I also changed the way `qobj.py` handle circular import. This makes it easier to import it and `qobjevo.py` without causing circular import elsewhere.

Changed the type of expect output. It was

|  | qobj oper | list oper |
|---|---|---|
| qobj state | scalar | Array |
| list state | Array | list[Array]  |

and now is

|  | qobj oper | list oper |
|---|---|---|
| qobj state | scalar | list |
| list state | Array | list[Array]  |

With multiple operators, the output dtype, float or complex, could change, with multiple states, a list of array was used to the right type was applied used, but for multiple operator, single states, they were forced to use the same dtype.


