### PR TITLE
More types hints for solvers

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -368,6 +368,7 @@ autodoc_type_aliases = {
     'CoefficientLike': 'CoefficientLike',
     'ElementType': 'ElementType',
     'QobjEvoLike': 'QobjEvoLike',
+    'EopsLike': 'EopsLike',
     'LayerType': 'LayerType',
     'ArrayLike': 'ArrayLike'
 }

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -53,6 +53,7 @@ coefficient_builders = {
     np.ndarray: InterCoefficient,
     scipy.interpolate.PPoly: InterCoefficient.from_PPoly,
     scipy.interpolate.BSpline: InterCoefficient.from_Bspline,
+    numbers.Number: ConstantCoefficient,
 }
 
 

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -745,7 +745,7 @@ cdef class ConstantCoefficient(Coefficient):
     """
     cdef complex value
 
-    def __init__(self, complex value):
+    def __init__(self, complex value, **_):
         self.value = value
 
     def replace_arguments(self, _args=None, **kwargs):

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -253,7 +253,7 @@ class BRSolver(Solver):
 
     def __init__(
         self,
-        H: QobjEvoLike,
+        H: Qobj | QobjEvo,
         a_ops: list[tuple[Qobj | QobjEvo, Coefficient]],
         c_ops: Qobj | QobjEvo | list[QobjEvoLike] = None,
         sec_cutoff: float = 0.1,

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -55,7 +55,7 @@ def brmesolve(
         Nested list of system operators that couple to the environment,
         and the corresponding bath spectra.
 
-        a_op : :obj:`.Qobj`, :obj:`.QobjEvo`
+        a_op : :obj:`.Qobj`, :obj:`.QobjEvo`, :obj:`.QobjEvo` compatible format
             The operator coupling to the environment. Must be hermitian.
 
         spectra : :obj:`.Coefficient`, str, func
@@ -75,7 +75,7 @@ def brmesolve(
             a_ops = [
                 (a+a.dag(), ('w>0', args={"w": 0})),
                 (QobjEvo(a+a.dag()), 'w > exp(-t)'),
-                (QobjEvo([b+b.dag(), lambda t: ...]), lambda w: ...)),
+                ([[b+b.dag(), lambda t: ...]], lambda w: ...)),
                 (c+c.dag(), SpectraCoefficient(coefficient(array, tlist=ws))),
             ]
 
@@ -88,7 +88,7 @@ def brmesolve(
             of the spectra.
 
     e_ops : list, dict, :obj:`.Qobj` or callback function, optional
-        Single, list or dict of operators for which to evaluate
+        Single operator, or list or dict of operators, for which to evaluate
         expectation values. Operator can be Qobj, QobjEvo or callables with the
         signature `f(t: float, state: Qobj) -> Any`.
         Callable signature must be, `f(t: float, state: Qobj)`.

--- a/qutip/solver/floquet.py
+++ b/qutip/solver/floquet.py
@@ -530,7 +530,7 @@ def floquet_tensor(
 
 
 def fsesolve(
-    H: QobjEvoLike,
+    H: QobjEvoLike | FloquetBasis,
     psi0: Qobj,
     tlist: ArrayLike,
     e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
@@ -613,12 +613,12 @@ def fsesolve(
 
 
 def fmmesolve(
-    H: QobjEvoLike,
+    H: QobjEvoLike | FloquetBasis,
     rho0: Qobj,
     tlist: ArrayLike,
     c_ops: list[Qobj] = None,
     e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
-    spectra_cb: list[Callable[[float], complex]]= None,
+    spectra_cb: list[Callable[[float], complex]] = None,
     T: float = 0.0,
     w_th: float = 0.0,
     args: dict[str, Any] = None,
@@ -875,7 +875,7 @@ class FMESolver(MESolver):
         if args:
             raise ValueError("FMESolver cannot update arguments")
 
-    def start(self, state0: Qobj, t0: float, *, floquet: bool=False) -> None:
+    def start(self, state0: Qobj, t0: float, *, floquet: bool = False) -> None:
         """
         Set the initial state and time for a step evolution.
         ``options`` for the evolutions are read at this step.

--- a/qutip/solver/floquet.py
+++ b/qutip/solver/floquet.py
@@ -6,7 +6,9 @@ __all__ = [
     "FMESolver",
 ]
 
+from typing import Any, overload, TypeVar, Literal, Callable
 import numpy as np
+from numpy.typing import ArrayLike
 from qutip.core import data as _data
 from qutip.core.data import Data
 from qutip import Qobj, QobjEvo
@@ -17,6 +19,7 @@ from .integrator import Integrator
 from .result import Result
 from time import time
 from ..ui.progressbar import progress_bars
+from ..typing import EopsLike, QobjEvoLike
 
 
 class FloquetBasis:
@@ -37,13 +40,13 @@ class FloquetBasis:
 
     def __init__(
         self,
-        H,
-        T,
-        args=None,
-        options=None,
-        sparse=False,
-        sort=True,
-        precompute=None,
+        H: QobjEvoLike,
+        T: float,
+        args: dict[str, Any] = None,
+        options: dict[str, Any] = None,
+        sparse: bool = False,
+        sort: bool = True,
+        precompute: ArrayLike = None,
     ):
         """
         Parameters
@@ -120,7 +123,13 @@ class FloquetBasis:
             for ket in _data.split_columns(kets_mat)
         ]
 
-    def mode(self, t, data=False):
+    @overload
+    def mode(self, t: float, data: Literal[False]) -> Qobj: ...
+
+    @overload
+    def mode(self, t: float, data: Literal[True]) -> Data: ...
+
+    def mode(self, t: float, data: bool = False):
         """
         Calculate the Floquet modes at time ``t``.
 
@@ -151,7 +160,13 @@ class FloquetBasis:
         else:
             return self._as_ketlist(kets_mat)
 
-    def state(self, t, data=False):
+    @overload
+    def state(self, t: float, data: Literal[False]) -> Qobj: ...
+
+    @overload
+    def state(self, t: float, data: Literal[True]) -> Data: ...
+
+    def state(self, t: float, data: bool = False):
         """
         Evaluate the floquet states at time t.
 
@@ -180,7 +195,13 @@ class FloquetBasis:
         else:
             return self._as_ketlist(states_mat)
 
-    def from_floquet_basis(self, floquet_basis, t=0):
+    QobjOrData = TypeVar("QobjOrData", Qobj, Data)
+
+    def from_floquet_basis(
+        self,
+        floquet_basis: QobjOrData,
+        t: float = 0
+    ) -> QobjOrData:
         """
         Transform a ket or density matrix from the Floquet basis at time ``t``
         to the lab basis.
@@ -218,7 +239,11 @@ class FloquetBasis:
             return Qobj(lab_basis, dims=dims)
         return lab_basis
 
-    def to_floquet_basis(self, lab_basis, t=0):
+    def to_floquet_basis(
+        self,
+        lab_basis: QobjOrData,
+        t: float = 0
+    ) -> QobjOrData:
         """
         Transform a ket or density matrix in the lab basis
         to the Floquet basis at time ``t``.
@@ -444,7 +469,15 @@ def _floquet_master_equation_tensor(A):
     return _data.add(R, S)
 
 
-def floquet_tensor(H, c_ops, spectra_cb, T=0, w_th=0.0, kmax=5, nT=100):
+def floquet_tensor(
+    H: QobjEvo | FloquetBasis,
+    c_ops: list[Qobj],
+    spectra_cb: list[Callable[[float], complex]],
+    T: float = 0,
+    w_th: float = 0.0,
+    kmax: int = 5,
+    nT: int = 100,
+) -> Qobj:
     """
     Construct a tensor that represents the master equation in the floquet
     basis.
@@ -456,16 +489,16 @@ def floquet_tensor(H, c_ops, spectra_cb, T=0, w_th=0.0, kmax=5, nT=100):
     H : :obj:`.QobjEvo`, :obj:`.FloquetBasis`
         Periodic Hamiltonian a floquet basis system.
 
-    T : float, optional
-        The period of the time-dependence of the hamiltonian. Optional if ``H``
-        is a ``FloquetBasis`` object.
-
     c_ops : list of :class:`.Qobj`
         list of collapse operators.
 
     spectra_cb : list callback functions
         List of callback functions that compute the noise power spectrum as
         a function of frequency for the collapse operators in `c_ops`.
+
+    T : float, optional
+        The period of the time-dependence of the hamiltonian. Optional if ``H``
+        is a ``FloquetBasis`` object.
 
     w_th : float, default: 0.0
         The temperature in units of frequency.
@@ -496,7 +529,15 @@ def floquet_tensor(H, c_ops, spectra_cb, T=0, w_th=0.0, kmax=5, nT=100):
     return Qobj(r, dims=[dims, dims], superrep="super", copy=False)
 
 
-def fsesolve(H, psi0, tlist, e_ops=None, T=0.0, args=None, options=None):
+def fsesolve(
+    H: QobjEvoLike,
+    psi0: Qobj,
+    tlist: ArrayLike,
+    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
+    T: float = 0.0,
+    args: dict[str, Any] = None,
+    options: dict[str, Any] = None,
+) -> Result:
     """
     Solve the Schrodinger equation using the Floquet formalism.
 
@@ -513,10 +554,12 @@ def fsesolve(H, psi0, tlist, e_ops=None, T=0.0, args=None, options=None):
     tlist : *list* / *array*
         List of times for :math:`t`.
 
-    e_ops : list of :class:`.Qobj` / callback function, optional
-        List of operators for which to evaluate expectation values. If this
-        list is empty, the state vectors for each time in `tlist` will be
-        returned instead of expectation values.
+    e_ops : list or dict of :class:`.Qobj` / callback function, optional
+        Single, list or dict of operators for which to evaluate
+        expectation values. Operator can be Qobj, QobjEvo or callables with the
+        signature `f(t: float, state: Qobj) -> Any`.
+        See :func:`~qutip.core.expect.expect` for more detail of operator
+        expectation.
 
     T : float, default=tlist[-1]
         The period of the time-dependence of the hamiltonian.
@@ -569,17 +612,17 @@ def fsesolve(H, psi0, tlist, e_ops=None, T=0.0, args=None, options=None):
 
 
 def fmmesolve(
-    H,
-    rho0,
-    tlist,
-    c_ops=None,
-    e_ops=None,
-    spectra_cb=None,
-    T=0,
-    w_th=0.0,
-    args=None,
-    options=None,
-):
+    H: QobjEvoLike,
+    rho0: Qobj,
+    tlist: ArrayLike,
+    c_ops: list[Qobj] = None,
+    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
+    spectra_cb: list[Callable[[float], complex]]= None,
+    T: float = 0.0,
+    w_th: float = 0.0,
+    args: dict[str, Any] = None,
+    options: dict[str, Any] = None,
+ ) -> "FloquetResult":
     """
     Solve the dynamics for the system using the Floquet-Markov master equation.
 
@@ -601,8 +644,13 @@ def fmmesolve(
         supported. Fall back on :func:`fsesolve` if not provided.
 
     e_ops : list of :class:`.Qobj` / callback function, optional
-        List of operators for which to evaluate expectation values.
-        The states are reverted to the lab basis before applying the
+        Single, list or dict of operators for which to evaluate
+        expectation values. Operator can be Qobj, QobjEvo or callables with the
+        signature `f(t: float, state: Qobj) -> Any`.
+        See :func:`~qutip.core.expect.expect` for more detail of operator
+        expectation.
+        The states are reverted to the lab basis before computing the
+        expectation values.
 
     spectra_cb : list callback functions, default: ``lambda w: (w > 0)``
         List of callback functions that compute the noise power spectrum as
@@ -773,7 +821,14 @@ class FMESolver(MESolver):
     }
 
     def __init__(
-        self, floquet_basis, a_ops, w_th=0.0, *, kmax=5, nT=None, options=None
+        self,
+        floquet_basis: FloquetBasis,
+        a_ops: list[tuple[Qobj, Callable[[float], float]]],
+        w_th: float = 0.0,
+        *,
+        kmax: int = 5,
+        nT: int = None,
+        options: dict[str, Any] = None,
     ):
         self.options = options
         if isinstance(floquet_basis, FloquetBasis):
@@ -818,7 +873,7 @@ class FMESolver(MESolver):
         if args:
             raise ValueError("FMESolver cannot update arguments")
 
-    def start(self, state0, t0, *, floquet=False):
+    def start(self, state0: Qobj, t0: float, *, floquet: bool=False) -> None:
         """
         Set the initial state and time for a step evolution.
         ``options`` for the evolutions are read at this step.
@@ -839,7 +894,14 @@ class FMESolver(MESolver):
             state0 = self.floquet_basis.to_floquet_basis(state0, t0)
         super().start(state0, t0)
 
-    def step(self, t, *, args=None, copy=True, floquet=False):
+    def step(
+        self,
+        t: float,
+        *,
+        args: dict[str, Any] = None,
+        copy: bool = True,
+        floquet: bool = False,
+    ) -> Qobj:
         """
         Evolve the state to ``t`` and return the state as a :obj:`.Qobj`.
 
@@ -873,7 +935,15 @@ class FMESolver(MESolver):
             state = state.copy()
         return state
 
-    def run(self, state0, tlist, *, floquet=False, args=None, e_ops=None):
+    def run(
+        self,
+        state0: Qobj,
+        tlist: ArrayLike,
+        *,
+        floquet: bool = False,
+        args: dict[str, Any] = None,
+        e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
+    ) -> FloquetResult:
         """
         Calculate the evolution of the quantum system.
 
@@ -896,13 +966,13 @@ class FMESolver(MESolver):
         floquet : bool, optional {False}
             Whether the initial state in the floquet basis or laboratory basis.
 
-        args : dict, optional {None}
+        args : dict, optional
             Not supported
 
-        e_ops : list {None}
-            List of Qobj, QobjEvo or callable to compute the expectation
-            values. Function[s] must have the signature
-            f(t : float, state : Qobj) -> expect.
+        e_ops : list or dict, optional
+            List or dict of Qobj, QobjEvo or callable to compute the
+            expectation values. Function[s] must have the signature
+            ``f(t : float, state : Qobj) -> expect``.
 
         Returns
         -------

--- a/qutip/solver/floquet.py
+++ b/qutip/solver/floquet.py
@@ -19,7 +19,7 @@ from .integrator import Integrator
 from .result import Result
 from time import time
 from ..ui.progressbar import progress_bars
-from ..typing import EopsLike, QobjEvoLike
+from ..typing import EopsLike, QobjEvoLike, QobjOrData
 
 
 class FloquetBasis:
@@ -194,8 +194,6 @@ class FloquetBasis:
             return states_mat
         else:
             return self._as_ketlist(states_mat)
-
-    QobjOrData = TypeVar("QobjOrData", Qobj, Data)
 
     def from_floquet_basis(
         self,

--- a/qutip/solver/floquet.py
+++ b/qutip/solver/floquet.py
@@ -47,7 +47,7 @@ class FloquetBasis:
         sparse: bool = False,
         sort: bool = True,
         precompute: ArrayLike = None,
-        tlist: ArrayLike = None,
+        times: ArrayLike = None,
     ):
         """
         Parameters

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -6,17 +6,18 @@ __all__ = ['mcsolve', "MCSolver"]
 import numpy as np
 from numpy.typing import ArrayLike
 from numpy.random import SeedSequence
+from time import time
+from typing import Any, Callable
+import warnings
+
 from ..core import QobjEvo, spre, spost, Qobj, unstack_columns, qzero_like
-from ..typing import QobjEvoLike
+from ..typing import QobjEvoLike, EopsLike
 from .multitraj import MultiTrajSolver, _MultiTrajRHS, _InitialConditions
 from .solver_base import Solver, Integrator, _solver_deprecation
 from .multitrajresult import McResult
 from .mesolve import mesolve, MESolver
 from ._feedback import _QobjFeedback, _DataFeedback, _CollapseFeedback
 import qutip.core.data as _data
-from time import time
-from typing import Any, Callable
-import warnings
 
 
 def mcsolve(
@@ -24,13 +25,13 @@ def mcsolve(
     state: Qobj,
     tlist: ArrayLike,
     c_ops: QobjEvoLike | list[QobjEvoLike] = (),
-    e_ops: dict[Any, Qobj | QobjEvo | Callable[[float, Qobj], Any]] = None,
+    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     ntraj: int = 500,
     *,
     args: dict[str, Any] = None,
     options: dict[str, Any] = None,
     seeds: int | SeedSequence | list[int | SeedSequence] = None,
-    target_tol: float = None,
+    target_tol: float | tuple[float, float] | list[tuple[float, float]] = None,
     timeout: float = None,
     **kwargs,
 ) -> McResult:
@@ -59,10 +60,10 @@ def mcsolve(
         even if ``H`` is a superoperator. If none are given, the solver will
         defer to ``sesolve`` or ``mesolve``.
 
-    e_ops : list, optional
-        A ``list`` of operator as Qobj, QobjEvo or callable with signature of
-        (t, state: Qobj) for calculating expectation values. When no ``e_ops``
-        are given, the solver will default to save the states.
+    e_ops : :obj:`.Qobj`, callable, list or dict, optional
+        Single, list or dict of operators for which to evaluate
+        expectation values. Operator can be Qobj, QobjEvo or callables with the
+        signature `f(t: float, state: Qobj) -> Any`.
 
     ntraj : int, default: 500
         Maximum number of trajectories to run. Can be cut short if a time limit
@@ -562,8 +563,8 @@ class MCSolver(MultiTrajSolver):
         ntraj: int | list[int] = None,
         *,
         args: dict[str, Any] = None,
-        e_ops: dict[Any, Qobj | QobjEvo | Callable[[float, Qobj], Any]] = None,
-        target_tol: float = None,
+        e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
+        target_tol: float | tuple[float, float] | list[tuple[float, float]] = None,
         timeout: float = None,
         seeds: int | SeedSequence | list[int | SeedSequence] = None,
     ) -> McResult:
@@ -605,10 +606,10 @@ class MCSolver(MultiTrajSolver):
         args : dict, optional
             Change the ``args`` of the rhs for the evolution.
 
-        e_ops : list
-            list of Qobj or QobjEvo to compute the expectation values.
-            Alternatively, function[s] with the signature f(t, state) -> expect
-            can be used.
+        e_ops : :obj:`.Qobj`, callable, list or dict, optional
+            Single, list or dict of operators for which to evaluate
+            expectation values. Operator can be Qobj, QobjEvo or callables with
+            the signature `f(t: float, state: Qobj) -> Any`.
 
         timeout : float, optional
             Maximum time in seconds for the trajectories to run. Once this time

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -454,8 +454,8 @@ class MCSolver(MultiTrajSolver):
 
     def __init__(
         self,
-        H: QobjEvoLike,
-        c_ops: QobjEvoLike | list[QobjEvoLike],
+        H: Qobj | QobjEvo,
+        c_ops: Qobj | QobjEvo | list[Qobj | QobjEvo],
         *,
         options: dict[str, Any] = None,
     ):

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -61,7 +61,7 @@ def mcsolve(
         defer to ``sesolve`` or ``mesolve``.
 
     e_ops : :obj:`.Qobj`, callable, list or dict, optional
-        Single, list or dict of operators for which to evaluate
+        Single operator, or list or dict of operators, for which to evaluate
         expectation values. Operator can be Qobj, QobjEvo or callables with the
         signature `f(t: float, state: Qobj) -> Any`.
 
@@ -607,9 +607,9 @@ class MCSolver(MultiTrajSolver):
             Change the ``args`` of the rhs for the evolution.
 
         e_ops : :obj:`.Qobj`, callable, list or dict, optional
-            Single, list or dict of operators for which to evaluate
-            expectation values. Operator can be Qobj, QobjEvo or callables with
-            the signature `f(t: float, state: Qobj) -> Any`.
+            Single operator, or list or dict of operators, for which to
+            evaluate expectation values. Operator can be Qobj, QobjEvo or
+            callables with the signature `f(t: float, state: Qobj) -> Any`.
 
         timeout : float, optional
             Maximum time in seconds for the trajectories to run. Once this time

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -12,7 +12,7 @@ from numpy.typing import ArrayLike
 from typing import Any, Callable
 from time import time
 from .. import (Qobj, QobjEvo, liouvillian, lindblad_dissipator)
-from ..typing import QobjEvoLike
+from ..typing import EopsLike, QobjEvoLike
 from ..core import data as _data
 from .solver_base import Solver, _solver_deprecation
 from .sesolve import sesolve, SESolver
@@ -24,8 +24,8 @@ def mesolve(
     H: QobjEvoLike,
     rho0: Qobj,
     tlist: ArrayLike,
-    c_ops: QobjEvoLike | list[QobjEvoLike] = None,
-    e_ops: dict[Any, Qobj | QobjEvo | Callable[[float, Qobj], Any]] = None,
+    c_ops: Qobj | QobjEvo | list[QobjEvoLike] = None,
+    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     args: dict[str, Any] = None,
     options: dict[str, Any] = None,
     **kwargs
@@ -87,11 +87,10 @@ def mesolve(
         Single collapse operator, or list of collapse operators, or a list
         of Liouvillian superoperators. None is equivalent to an empty list.
 
-    e_ops : list of :obj:`.Qobj` / callback function, optional
-        Single operator or list of operators for which to evaluate
-        expectation values or callable or list of callable.
-        Callable signature must be, `f(t: float, state: Qobj)`.
-        See :func:`expect` for more detail of operator expectation.
+    e_ops : :obj:`.Qobj`, callable, list or dict, optional
+        Single, list or dict of operators for which to evaluate
+        expectation values. Operator can be Qobj, QobjEvo or callables with the
+        signature `f(t: float, state: Qobj) -> Any`.
 
     args : dict, optional
         dictionary of parameters for time-dependent Hamiltonians and

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -88,7 +88,7 @@ def mesolve(
         of Liouvillian superoperators. None is equivalent to an empty list.
 
     e_ops : :obj:`.Qobj`, callable, list or dict, optional
-        Single, list or dict of operators for which to evaluate
+        Single operator, or list or dict of operators, for which to evaluate
         expectation values. Operator can be Qobj, QobjEvo or callables with the
         signature `f(t: float, state: Qobj) -> Any`.
 

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -174,7 +174,7 @@ class MultiTrajSolver(Solver):
         *,
         args: dict[str, Any] = None,
         e_ops: dict[Any, Qobj | QobjEvo | Callable[[float, Qobj], Any]] = None,
-        target_tol: float = None,
+        target_tol: float | tuple[float, float] | list[tuple[float, float]] = None,
         timeout: float = None,
         seeds: int | SeedSequence | list[int | SeedSequence] = None,
     ) -> MultiTrajResult:

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -92,7 +92,7 @@ class MultiTrajSolver(Solver):
         self._state_metadata = {}
         self.stats = self._initialize_stats()
 
-    def start(self, state0: Qobj, t0: Number, seed: int | SeedSequence = None):
+    def start(self, state0: Qobj, t0: float, seed: int | SeedSequence = None):
         """
         Set the initial state and time for a step evolution.
 
@@ -118,7 +118,7 @@ class MultiTrajSolver(Solver):
         self._integrator.set_state(t0, self._prepare_state(state0), generator)
 
     def step(
-        self, t: Number, *, args: dict[str, Any] = None, copy: bool = True
+        self, t: float, *, args: dict[str, Any] = None, copy: bool = True
     ) -> Qobj:
         """
         Evolve the state to ``t`` and return the state as a :obj:`.Qobj`.

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -76,7 +76,7 @@ def nm_mcsolve(
         :func:`~qutip.core.coefficient.coefficient`.
 
     e_ops : :obj:`.Qobj`, callable, list or dict, optional
-        Single, list or dict of operators for which to evaluate
+        Single operator, or list or dict of operators, for which to evaluate
         expectation values. Operator can be Qobj, QobjEvo or callables with the
         signature `f(t: float, state: Qobj) -> Any`.
 

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -33,7 +33,7 @@ def nm_mcsolve(
     H: QobjEvoLike,
     state: Qobj,
     tlist: ArrayLike,
-    ops_and_rates: list[tuple[Qobj, float | CoefficientLike]] = (),
+    ops_and_rates: list[tuple[Qobj, CoefficientLike]] = (),
     e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     ntraj: int = 500,
     *,

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -573,7 +573,7 @@ class NonMarkovianMCSolver(MCSolver):
     def run(
         self,
         state: Qobj,
-        tlist: Sequence[float],
+        tlist: ArrayLike,
         ntraj: int = 1,
         *,
         args: dict[str, Any] = None,

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -212,10 +212,7 @@ def _parse_op_and_rate(op, rate, **kw):
     """ Sanity check the op and convert rates to coefficients. """
     if not isinstance(op, Qobj):
         raise ValueError("NonMarkovianMCSolver ops must be of type Qobj")
-    if isinstance(rate, numbers.Number):
-        rate = ConstantCoefficient(rate)
-    else:
-        rate = coefficient(rate, **kw)
+    rate = coefficient(rate, **kw)
     return op, rate
 
 
@@ -374,7 +371,7 @@ class NonMarkovianMCSolver(MCSolver):
     def __init__(
         self,
         H: Qobj | QobjEvo,
-        ops_and_rates = Sequence[tuple[Qobj, float | Coefficient]],
+        ops_and_rates: Sequence[tuple[Qobj, float | Coefficient]],
         *,
         options: dict[str, Any] = None,
     ):

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -345,9 +345,6 @@ class NonMarkovianMCSolver(MCSolver):
         just a number (in the case of a constant rate) or, otherwise, a
         :class:`~qutip.core.cy.Coefficient`.
 
-    args : None / dict
-        Arguments for time-dependent Hamiltonian and collapse operator terms.
-
     options : SolverOptions, [optional]
         Options for the evolution.
     """

--- a/qutip/solver/sesolve.py
+++ b/qutip/solver/sesolve.py
@@ -12,7 +12,7 @@ from time import time
 from typing import Any, Callable
 from .. import Qobj, QobjEvo
 from ..core import data as _data
-from ..typing import QobjEvoLike
+from ..typing import QobjEvoLike, EopsLike
 from .solver_base import Solver, _solver_deprecation
 from ._feedback import _QobjFeedback, _DataFeedback
 from . import Result
@@ -22,7 +22,7 @@ def sesolve(
     H: QobjEvoLike,
     psi0: Qobj,
     tlist: ArrayLike,
-    e_ops: dict[Any, Qobj | QobjEvo | Callable[[float, Qobj], Any]] = None,
+    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     args: dict[str, Any] = None,
     options: dict[str, Any] = None,
     **kwargs
@@ -63,12 +63,10 @@ def sesolve(
     tlist : *list* / *array*
         list of times for :math:`t`.
 
-    e_ops : :obj:`.Qobj`, callable, or list, optional
-        Single operator or list of operators for which to evaluate
-        expectation values or callable or list of callable.
-        Callable signature must be, `f(t: float, state: Qobj)`.
-        See :func:`~qutip.core.expect.expect` for more detail of operator
-        expectation.
+    e_ops : :obj:`.Qobj`, callable, list or dict, optional
+        Single, list or dict of operators for which to evaluate
+        expectation values. Operator can be Qobj, QobjEvo or callables with the
+        signature `f(t: float, state: Qobj) -> Any`.
 
     args : dict, optional
         dictionary of parameters for time-dependent Hamiltonians

--- a/qutip/solver/sesolve.py
+++ b/qutip/solver/sesolve.py
@@ -64,7 +64,7 @@ def sesolve(
         list of times for :math:`t`.
 
     e_ops : :obj:`.Qobj`, callable, list or dict, optional
-        Single, list or dict of operators for which to evaluate
+        Single operator, or list or dict of operators, for which to evaluate
         expectation values. Operator can be Qobj, QobjEvo or callables with the
         signature `f(t: float, state: Qobj) -> Any`.
 

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -14,6 +14,7 @@ from .result import Result
 from .integrator import Integrator
 from ..ui.progressbar import progress_bars
 from ._feedback import _ExpectFeedback
+from ..typing import EopsLike
 from time import time
 import warnings
 import numpy as np
@@ -142,7 +143,7 @@ class Solver:
         state0: Qobj,
         tlist: ArrayLike,
         *,
-        e_ops: dict[Any, Qobj | QobjEvo | Callable[[float, Qobj], Any]] = None,
+        e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
         args: dict[str, Any] = None,
     ) -> Result:
         """
@@ -167,9 +168,9 @@ class Solver:
         args : dict, optional
             Change the ``args`` of the rhs for the evolution.
 
-        e_ops : list, optional
-            List of Qobj, QobjEvo or callable to compute the expectation
-            values. Function[s] must have the signature
+        e_ops : Qobj, QobjEvo, callable, list, or dict optional
+            Single, list or dict of Qobj, QobjEvo or callable to compute the
+            expectation values. Function[s] must have the signature
             f(t : float, state : Qobj) -> expect.
 
         Returns

--- a/qutip/solver/stochastic.py
+++ b/qutip/solver/stochastic.py
@@ -308,7 +308,7 @@ class _StochasticRHS(_MultiTrajRHS):
 def smesolve(
     H: QobjEvoLike,
     rho0: Qobj,
-    tlist: np.typing.ArrayLike,
+    tlist: ArrayLike,
     c_ops: Qobj | QobjEvo | Sequence[QobjEvoLike] = (),
     sc_ops: Qobj | QobjEvo | Sequence[QobjEvoLike] = (),
     heterodyne: bool = False,
@@ -346,7 +346,7 @@ def smesolve(
         List of stochastic collapse operators.
 
     e_ops : :obj:`.Qobj`, callable, list or dict, optional
-        Single, list or dict of operators for which to evaluate
+        Single operator, or list or dict of operators, for which to evaluate
         expectation values. Operator can be Qobj, QobjEvo or callables with the
         signature `f(t: float, state: Qobj) -> Any`.
 
@@ -454,7 +454,7 @@ def smesolve(
 def ssesolve(
     H: QobjEvoLike,
     psi0: Qobj,
-    tlist: np.typing.ArrayLike,
+    tlist: ArrayLike,
     sc_ops: QobjEvoLike | Sequence[QobjEvoLike] = (),
     heterodyne: bool = False,
     *,
@@ -487,7 +487,7 @@ def ssesolve(
         List of stochastic collapse operators.
 
     e_ops : :obj:`.Qobj`, callable, list or dict, optional
-        Single, list or dict of operators for which to evaluate
+        Single operator, or list or dict of operators, for which to evaluate
         expectation values. Operator can be Qobj, QobjEvo or callables with the
         signature `f(t: float, state: Qobj) -> Any`.
 
@@ -746,7 +746,7 @@ class StochasticSolver(MultiTrajSolver):
     def run_from_experiment(
         self,
         state: Qobj,
-        tlist: np.typing.ArrayLike,
+        tlist: ArrayLike,
         noise: Sequence[float],
         *,
         args: dict[str, Any] = None,
@@ -777,9 +777,9 @@ class StochasticSolver(MultiTrajSolver):
             Arguments to pass to the Hamiltonian and collapse operators.
 
         e_ops : :obj:`.Qobj`, callable, list or dict, optional
-            Single, list or dict of operators for which to evaluate
-            expectation values. Operator can be Qobj, QobjEvo or callables with the
-            signature `f(t: float, state: Qobj) -> Any`.
+            Single operator, or list or dict of operators, for which to
+            evaluate expectation values. Operator can be Qobj, QobjEvo or
+            callables with the signature `f(t: float, state: Qobj) -> Any`.
 
         measurement : bool, default : False
             Whether the passed noise is the Wiener increments ``dW`` (gaussian

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -110,12 +110,13 @@ def test_solver_pickleable():
         "sin(t)",
     ]
     args = [
-        None,
+        {},
         {'constant': 1},
-        None,
+        {},
     ]
     for rate, arg in zip(rates, args):
-        solver = NonMarkovianMCSolver(H, [(L, rate)], args=arg)
+        op_and_rate = (L, qutip.coefficient(rate, args=arg))
+        solver = NonMarkovianMCSolver(H, [op_and_rate])
         jar = pickle.dumps(solver)
 
         loaded_solver = pickle.loads(jar)
@@ -559,9 +560,9 @@ class TestSeeds:
         size = 10
         a = qutip.destroy(size)
         H = qutip.num(size)
-        ops_and_rates = [(a, 'alpha')]
+        ops_and_rates = [(a, qutip.coefficient('alpha', args={'alpha': 0}))]
         mcsolver = NonMarkovianMCSolver(
-            H, ops_and_rates, args={'alpha': 0}, options={'map': 'serial'},
+            H, ops_and_rates, options={'map': 'serial'},
         )
         mcsolver.start(qutip.basis(size, size-1), 0, seed=5)
         state_1 = mcsolver.step(1, args={'alpha': 1})
@@ -630,12 +631,12 @@ def test_super_H(improved_sampling, mixed_initial_state):
 
 def test_NonMarkovianMCSolver_run():
     size = 10
-    ops_and_rates = [
-        (qutip.destroy(size), 'coupling')
-    ]
     args = {'coupling': 0}
+    ops_and_rates = [
+        (qutip.destroy(size), qutip.coefficient('coupling', args=args))
+    ]
     H = qutip.num(size)
-    solver = NonMarkovianMCSolver(H, ops_and_rates, args=args)
+    solver = NonMarkovianMCSolver(H, ops_and_rates)
     solver.options = {'store_final_state': True}
     res = solver.run(qutip.basis(size, size-1), np.linspace(0, 5.0, 11),
                      e_ops=[qutip.qeye(size)], args={'coupling': 1})
@@ -653,12 +654,12 @@ def test_NonMarkovianMCSolver_run():
 
 def test_NonMarkovianMCSolver_stepping():
     size = 10
-    ops_and_rates = [
-        (qutip.destroy(size), 'coupling')
-    ]
     args = {'coupling': 0}
+    ops_and_rates = [
+        (qutip.destroy(size), qutip.coefficient('coupling', args=args))
+    ]
     H = qutip.num(size)
-    solver = NonMarkovianMCSolver(H, ops_and_rates, args=args)
+    solver = NonMarkovianMCSolver(H, ops_and_rates)
     solver.start(qutip.basis(size, size-1), 0, seed=0)
     state = solver.step(1)
     assert qutip.expect(qutip.qeye(size), state) == pytest.approx(1)

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -756,7 +756,7 @@ def test_mixed_equals_merged(improved_sampling, p):
     ntraj = [3, 9]
 
     solver = qutip.NonMarkovianMCSolver(
-        H, [(L, rate_function)],
+        H, [(L, qutip.coefficient(rate_function))],
         options={'improved_sampling': improved_sampling})
     mixed_result = solver.run(
         [(initial_state1, p), (initial_state2, 1 - p)], tlist, ntraj)

--- a/qutip/typing.py
+++ b/qutip/typing.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union, Any, Protocol
+from typing import Sequence, Union, Any, Protocol, Callable
 from numbers import Number, Real
 import numpy as np
 import scipy.interpolate
@@ -26,6 +26,9 @@ CoefficientLike = Union[
     scipy.interpolate.BSpline,
     Any,
 ]
+
+
+EopsLike = Union["Qobj", "QobjEvo", Callable[[float, "Qobj"], Any]]
 
 
 ElementType = Union[QEvoProtocol, "Qobj", tuple["Qobj", CoefficientLike]]

--- a/qutip/typing.py
+++ b/qutip/typing.py
@@ -19,6 +19,7 @@ class CoeffProtocol(Protocol):
 
 CoefficientLike = Union[
     "Coefficient",
+    float,
     str,
     CoeffProtocol,
     np.ndarray,

--- a/qutip/typing.py
+++ b/qutip/typing.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union, Any, Protocol, Callable
+from typing import Sequence, Union, Any, Protocol, Callable, TypeVar
 from numbers import Number, Real
 import numpy as np
 import scipy.interpolate
@@ -26,6 +26,9 @@ CoefficientLike = Union[
     scipy.interpolate.BSpline,
     Any,
 ]
+
+
+QobjOrData = TypeVar("QobjOrData", "Qobj", "Data")
 
 
 EopsLike = Union["Qobj", "QobjEvo", Callable[[float, "Qobj"], Any]]


### PR DESCRIPTION
**Description**
With this most solver have hints. 

I changed the type for `e_ops` to accept single, list and dict instead of just the dict. We almost never use dict in documentation and it was missing in many docstring, so having it as the only hinted type felt wrong.

I also removed the `args` from the `NonMarkovianMCSolver` to make it match the other solvers. It was not used for the Hamiltonian as was indicated in the docstring.


