### PR TITLE
Support measurement statistics for `jax` and `jaxdia` dtypes

### DIFF
--- a/doc/changes/2493.feature
+++ b/doc/changes/2493.feature
@@ -1,0 +1,1 @@
+Support measurement statistics for `jax` and `jaxdia` dtypes

--- a/qutip/measurement.py
+++ b/qutip/measurement.py
@@ -239,7 +239,7 @@ def measurement_statistics_observable(state, op, tol=None):
 
         if probability >= tol:
             probabilities.append(probability)
-            values.append(np.mean(eigenvalues[present_group]))
+            values.append(np.mean(eigenvalues[np.array(present_group)]))
             projectors.append(projector)
 
         present_group = []


### PR DESCRIPTION
**Description**
This PR fixes Issue 3 mentioned in https://github.com/qutip/qutip-jax/issues/47 on measuring observables with `jax` and `jaxdia` operators via `qutip.measurement.measurement_statistics_observable`, by resolving the deprecation of indexing with lists in JAX.

**Related issues or PRs**
Closes https://github.com/qutip/qutip-jax/issues/47.