### PR TITLE
Better mkl lookup

### DIFF
--- a/doc/changes/2497.misc
+++ b/doc/changes/2497.misc
@@ -1,0 +1,1 @@
+Improve mkl lookup function.

--- a/doc/guide/guide-settings.rst
+++ b/doc/guide/guide-settings.rst
@@ -32,7 +32,9 @@ Environment settings
 | `has_mkl`         | True      | Whether qutip can find mkl libraries.                    |
 |                   |           | mkl sparse linear equation solver can be used when True. |
 +-------------------+-----------+----------------------------------------------------------+
-| `mkl_lib`         | True      | Path of the mkl libraries found.                         |
+| `mkl_lib_location`| False     | Path of the mkl library.                                 |
++-------------------+-----------+----------------------------------------------------------+
+| `mkl_lib`         | True      | Mkl libraries loaded with ctypes.                        |
 +-------------------+-----------+----------------------------------------------------------+
 | `ipython`         | True      | Whether running in IPython.                              |
 +-------------------+-----------+----------------------------------------------------------+

--- a/qutip/_mkl/spsolve.py
+++ b/qutip/_mkl/spsolve.py
@@ -388,7 +388,7 @@ def mkl_spsolve(A, b, perm=None, verbose=False, **kwargs):
         row_segs = []
         col_segs = []
         for j in range(nrhs):
-            bj = b[:, j].A.ravel()
+            bj = b[:, j].toarray().ravel()
             xj = lu.solve(bj)
             w = np.flatnonzero(xj)
             segment_length = w.shape[0]

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -115,8 +115,9 @@ def _find_mkl():
             ]
 
         if mkl_libs:
+            # If multiple libs are found, they should all be the same.
             return mkl_libs[-1]
-        return None
+        return ""
 
 
 class Settings:

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -84,40 +84,40 @@ def _find_mkl():
     if plat in ['darwin', 'linux2', 'linux']:
         python_dir = os.path.dirname(python_dir)
 
-        if plat == 'darwin':
-            ext = ".dylib"
-        elif plat == 'win32':
-            ext = ".dll"
-        elif plat in ['linux2', 'linux']:
-            ext = ".so"
-        else:
-            raise Exception('Unknown platfrom.')
+    if plat == 'darwin':
+        ext = ".dylib"
+    elif plat == 'win32':
+        ext = ".dll"
+    elif plat in ['linux2', 'linux']:
+        ext = ".so"
+    else:
+        raise Exception('Unknown platfrom.')
 
-        # Try in default Anaconda location first
+    # Try in default Anaconda location first
+    if plat in ['darwin', 'linux2', 'linux']:
+        lib_dir = '/lib/*'
+    else:
+        lib_dir = r'\Library\bin\*'
+
+    libraries = glob(python_dir + lib_dir)
+    mkl_libs = [lib for lib in libraries if "mkl_rt" in lib]
+
+    if not mkl_libs:
+        # Look in Intel Python distro location
         if plat in ['darwin', 'linux2', 'linux']:
-            lib_dir = '/lib/*'
+            lib_dir = '/ext/lib'
         else:
-            lib_dir = r'\Library\bin\*'
-
+            lib_dir = r'\ext\lib'
         libraries = glob(python_dir + lib_dir)
-        mkl_libs = [lib for lib in libraries if "mkl_rt" in lib]
+        mkl_libs = [
+            lib for lib in libraries
+            if "mkl_rt." in lib and ext in lib
+        ]
 
-        if not mkl_libs:
-            # Look in Intel Python distro location
-            if plat in ['darwin', 'linux2', 'linux']:
-                lib_dir = '/ext/lib'
-            else:
-                lib_dir = r'\ext\lib'
-            libraries = glob(python_dir + lib_dir)
-            mkl_libs = [
-                lib for lib in libraries
-                if "mkl_rt." in lib and ext in lib
-            ]
-
-        if mkl_libs:
-            # If multiple libs are found, they should all be the same.
-            return mkl_libs[-1]
-        return ""
+    if mkl_libs:
+        # If multiple libs are found, they should all be the same.
+        return mkl_libs[-1]
+    return ""
 
 
 class Settings:


### PR DESCRIPTION
**Description**
The mkl finding was sometime missing the library even when available.
Sometime the library can has a version number in the file name:
`libmkl_rt.so.2`, `mkl_rt.2.dll`, with or without a symbolic link to the version less name.
Also it ouly look for it if it's found in numpy's config, but the module mkl is available an could be installed even if numpy does not link to it. Our use using ctypes does not require numpy to be using it to work.

So I changed the lookup function to look for the library without checking is numpy uses it. I also added a new setting, `settings.mkl_lib_location`, which is not read only and allow users to enter the path to their mkl implementation. We only look inside the python library path, this would allow to use libraries installed at the OS level.

Also fixed a bug in mkl spsolve with scipy 1.14 that was missed since mkl tests were skipped.

**Related issues or PRs**
fix #2496