### PR TITLE
Enable `mcsolve` with `jax.grad`

### DIFF
--- a/doc/changes/2499.feature
+++ b/doc/changes/2499.feature
@@ -1,0 +1,1 @@
+Enable mcsolve with jax.grad using numpy_backend

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 __all__ = ['mcsolve', "MCSolver"]
 
-import numpy as np
+from ..core.numpy_backend import np
 from numpy.typing import ArrayLike
 from numpy.random import SeedSequence
 from ..core import QobjEvo, spre, spost, Qobj, unstack_columns, qzero_like

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -7,9 +7,9 @@ from .parallel import _get_map
 from time import time
 from .solver_base import Solver
 from ..core import QobjEvo, Qobj
-import numpy as np
+from ..core.numpy_backend import np
 from numpy.typing import ArrayLike
-from numpy.random import SeedSequence
+from numpy.random import SeedSequence, default_rng
 from numbers import Number
 from typing import Any, Callable
 import bisect
@@ -87,7 +87,7 @@ class MultiTrajSolver(Solver):
         else:
             raise TypeError("The system should be a QobjEvo")
         self.options = options
-        self.seed_sequence = np.random.SeedSequence()
+        self.seed_sequence = SeedSequence()
         self._integrator = self._get_integrator()
         self._state_metadata = {}
         self.stats = self._initialize_stats()
@@ -360,15 +360,15 @@ class MultiTrajSolver(Solver):
         """
         if seed is None:
             seeds = self.seed_sequence.spawn(ntraj)
-        elif isinstance(seed, np.random.SeedSequence):
+        elif isinstance(seed, SeedSequence):
             seeds = seed.spawn(ntraj)
         elif not isinstance(seed, list):
-            seeds = np.random.SeedSequence(seed).spawn(ntraj)
+            seeds = SeedSequence(seed).spawn(ntraj)
         elif len(seed) >= ntraj:
             seeds = [
-                seed_ if (isinstance(seed_, np.random.SeedSequence)
+                seed_ if (isinstance(seed_, SeedSequence)
                           or hasattr(seed_, 'random'))
-                else np.random.SeedSequence(seed_)
+                else SeedSequence(seed_)
                 for seed_ in seed[:ntraj]
             ]
         else:
@@ -391,7 +391,7 @@ class MultiTrajSolver(Solver):
             bit_gen = getattr(np.random, self.options['bitgenerator'])
             generator = np.random.Generator(bit_gen(seed))
         else:
-            generator = np.random.default_rng(seed)
+            generator = default_rng(seed)
         return generator
 
 

--- a/qutip/solver/multitrajresult.py
+++ b/qutip/solver/multitrajresult.py
@@ -5,7 +5,7 @@ Note that single trajectories are described by regular `Result` objects from the
 """
 
 from typing import TypedDict
-import numpy as np
+from ..core.numpy_backend import np
 
 from copy import copy
 

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from typing import TypedDict, Any, Callable
-import numpy as np
+from ..core.numpy_backend import np
 from numpy.typing import ArrayLike
 from ..core import Qobj, QobjEvo, expect
 


### PR DESCRIPTION

**Description**
As it is already possible to run `mcsolve` with gpus. The next step in the process to make `mcsolve` work with `grad`.

With the changes, I can get
```
`import qutip_jax as qjax
import qutip as qt
import jax
import jax.numpy as jnp
from functools import partial
qjax.use_jax_backend()

# Define time-dependent functions
@partial(jax.jit, static_argnames=("omega",))
def H_1_coeff(t, omega):
    return 2.0 * jnp.pi * 0.25 * jnp.cos(2.0 * omega * t)

# Hamiltonian components
N = 100
with qt.CoreOptions(default_dtype="jaxdia"):
    a = qt.tensor(qt.qeye(2), qt.destroy(N))
    sm = qt.tensor(qt.destroy(2), qt.qeye(N))
    
H_0 = 2.0 * jnp.pi * a.dag() * a + 2.0 * jnp.pi * sm.dag() * sm
H_1_op = sm * a.dag() + sm.dag() * a
H = [H_0, [H_1_op, qt.coefficient(H_1_coeff, args={"omega": 1.0})]]

# Initial state
state = qt.tensor(qt.fock(2, 0, dtype="jax"), qt.fock(N, 8, dtype="jax"))

# Collapse operators and observables
c_ops = [jnp.sqrt(0.1) * a]
e_ops = [a.dag() * a, sm.dag() * sm]

# Time list
tlist = jnp.linspace(0.0, 100, 2)

# Define the function for which we want to compute the gradient
def f(omega):
    H[1][1] = qt.coefficient(H_1_coeff, args={"omega": omega})
    result = qt.mcsolve(H, state, tlist, c_ops, e_ops, ntraj=10, options={"method": "diffrax"})
    # Return the expectation value of the number operator at tlist[1]
    return result.expect[0][1].real

# Compute the gradient
gradient = jax.grad(f)(1.0)

print("Gradient:", gradient)
`

```


