### PR TITLE
Update solver's signature to take `e_ops` and `args` as keyword only.

### DIFF
--- a/doc/changes/2489.misc
+++ b/doc/changes/2489.misc
@@ -1,0 +1,4 @@
+Make `e_ops`, `args` and `options` keyword only.
+Solver were inconsistent with `e_ops` usually following `c_ops` but sometime
+preceding it. Setting it as keyword only remove the need to memorize the 
+signature of each solver.

--- a/doc/guide/dynamics/dynamics-bloch-redfield.rst
+++ b/doc/guide/dynamics/dynamics-bloch-redfield.rst
@@ -403,7 +403,7 @@ A full example is:
     ]]
     e_ops = [a.dag() * a, a + a.dag()]
 
-    res_brme = brmesolve(H, psi0, times, a_ops, e_ops)
+    res_brme = brmesolve(H, psi0, times, a_ops, e_ops=e_ops)
 
     plt.figure()
     plt.plot(times, res_brme.expect[0], label=r'$a^{+}a$')

--- a/doc/guide/dynamics/dynamics-master.rst
+++ b/doc/guide/dynamics/dynamics-master.rst
@@ -99,7 +99,7 @@ plotting functions:
     >>> H = 2*np.pi * 0.1 * sigmax()
     >>> psi0 = basis(2, 0)
     >>> times = np.linspace(0.0, 10.0, 100)
-    >>> result = sesolve(H, psi0, times, [sigmaz(), sigmay()])
+    >>> result = sesolve(H, psi0, times, e_ops=[sigmaz(), sigmay()])
     >>> fig, ax = plt.subplots()
     >>> ax.plot(result.times, result.expect[0])
     >>> ax.plot(result.times, result.expect[1])
@@ -117,7 +117,7 @@ instance that contains a list of state vectors for the times specified in
     :context: close-figs
 
     >>> times = [0.0, 1.0]
-    >>> result = sesolve(H, psi0, times, [])
+    >>> result = sesolve(H, psi0, times)
     >>> result.states
     [Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket
      Qobj data =

--- a/doc/guide/dynamics/dynamics-monte.rst
+++ b/doc/guide/dynamics/dynamics-monte.rst
@@ -392,10 +392,10 @@ a lifetime of 10 microseconds (assuming time is in units of nanoseconds)
     H0 = -0.5 * omega * sigmaz()
     gamma = 1/10000
     data = mcsolve(
-        [H0], psi0, times, [np.sqrt(gamma) * sm], [sm.dag() * sm], ntraj=100
+        [H0], psi0, times, [np.sqrt(gamma) * sm], e_ops=[sm.dag() * sm], ntraj=100
     )
     data_imp = mcsolve(
-        [H0], psi0, times, [np.sqrt(gamma) * sm], [sm.dag() * sm], ntraj=100,
+        [H0], psi0, times, [np.sqrt(gamma) * sm], e_ops=[sm.dag() * sm], ntraj=100,
         options={"improved_sampling": True}
     )
 

--- a/doc/guide/dynamics/dynamics-time.rst
+++ b/doc/guide/dynamics/dynamics-time.rst
@@ -134,7 +134,7 @@ list format and call the solver (in this case :func:`.mesolve`)
     :context: close-figs
 
     H = [H0, [H1, H1_coeff]]
-    output = mesolve(H, psi0, t, c_ops, [ada, sigma_UU, sigma_GG])
+    output = mesolve(H, psi0, t, c_ops, e_ops=[ada, sigma_UU, sigma_GG])
 
 We can call the Monte Carlo solver in the exact same way (if using the default ``ntraj=500``):
 

--- a/doc/guide/dynamics/dynamics-time.rst
+++ b/doc/guide/dynamics/dynamics-time.rst
@@ -145,7 +145,7 @@ We can call the Monte Carlo solver in the exact same way (if using the default `
 .. doctest::
     :skipif: True
 
-    output = mcsolve(H, psi0, t, c_ops, [ada, sigma_UU, sigma_GG])
+    output = mcsolve(H, psi0, t, c_ops, e_ops=[ada, sigma_UU, sigma_GG])
 
 The output from the master equation solver is identical to that shown in the examples,
 the Monte Carlo however will be noticeably off, suggesting we should increase the number
@@ -166,7 +166,7 @@ simple Harmonic oscillator with time-varying decay rate
     psi0 = basis(N, 9)  # initial state
     c_ops = [QobjEvo([a, col_coeff])]  # time-dependent collapse term
     times = np.linspace(0, 10, 100)
-    output = mesolve(H, psi0, times, c_ops, [a.dag() * a])
+    output = mesolve(H, psi0, times, c_ops, e_ops=[a.dag() * a])
 
 
 

--- a/doc/guide/guide-saving.rst
+++ b/doc/guide/guide-saving.rst
@@ -74,7 +74,7 @@ A common use for the :func:`qutip.fileio.file_data_store` function is to store t
     >>> a = destroy(10); H = a.dag() * a ; c_ops = [np.sqrt(0.5) * a, np.sqrt(0.25) * a.dag()]
     >>> psi0 = rand_ket(10)
     >>> times = np.linspace(0, 100, 100)
-    >>> medata = mesolve(H, psi0, times, c_ops, [a.dag() * a, a + a.dag(), -1j * (a - a.dag())])
+    >>> medata = mesolve(H, psi0, times, c_ops, e_ops=[a.dag() * a, a + a.dag(), -1j * (a - a.dag())])
     >>> np.shape(medata.expect)
     (3, 100)
     >>> times.shape

--- a/doc/guide/scripts/correlation_ex3.py
+++ b/doc/guide/scripts/correlation_ex3.py
@@ -16,7 +16,7 @@ c_ops = [np.sqrt(G1 * (1 + n_th)) * a, np.sqrt(G1 * n_th) * a.dag()]
 rho0 = qutip.coherent_dm(N, 2.0)
 
 # first calculate the occupation number as a function of time
-n = qutip.mesolve(H, rho0, taus, c_ops, [a.dag() * a]).expect[0]
+n = qutip.mesolve(H, rho0, taus, c_ops, e_ops=[a.dag() * a]).expect[0]
 
 # calculate the correlation function G1 and normalize with n to obtain g1
 G1 = qutip.correlation_2op_1t(H, rho0, taus, c_ops, a.dag(), a)

--- a/doc/guide/scripts/correlation_ex4.py
+++ b/doc/guide/scripts/correlation_ex4.py
@@ -23,7 +23,7 @@ for state in states:
     rho0 = state['state']
 
     # first calculate the occupation number as a function of time
-    n = qutip.mesolve(H, rho0, taus, c_ops, [a.dag() * a]).expect[0]
+    n = qutip.mesolve(H, rho0, taus, c_ops, e_ops=[a.dag() * a]).expect[0]
 
     # calculate the correlation function G2 and normalize with n(0)n(t) to
     # obtain g2

--- a/doc/guide/scripts/ex_steady.py
+++ b/doc/guide/scripts/ex_steady.py
@@ -27,9 +27,9 @@ fexpt = qutip.expect(a.dag() * a, final_state)
 
 tlist = np.linspace(0, 50, 100)
 # monte-carlo
-mcdata = qutip.mcsolve(H, psi0, tlist, c_op_list, [a.dag() * a], ntraj=100)
+mcdata = qutip.mcsolve(H, psi0, tlist, c_op_list, e_ops=[a.dag() * a], ntraj=100)
 # master eq.
-medata = qutip.mesolve(H, psi0, tlist, c_op_list, [a.dag() * a])
+medata = qutip.mesolve(H, psi0, tlist, c_op_list, e_ops=[a.dag() * a])
 
 plt.plot(tlist, mcdata.expect[0], tlist, medata.expect[0], lw=2)
 # plot steady-state expt. value as horizontal line (should be = 2)

--- a/doc/guide/scripts/floquet_ex1.py
+++ b/doc/guide/scripts/floquet_ex1.py
@@ -29,7 +29,7 @@ for n, t in enumerate(tlist):
     p_ex[n] = qutip.expect(qutip.num(2), psi_t)
 
 # For reference: calculate the same thing with mesolve
-p_ex_ref = qutip.mesolve(H, psi0, tlist, [], [qutip.num(2)], args).expect[0]
+p_ex_ref = qutip.mesolve(H, psi0, tlist, e_ops=[qutip.num(2)], args=args).expect[0]
 
 # plot the results
 pyplot.plot(tlist, np.real(p_ex),     'ro', tlist, 1-np.real(p_ex),     'bo')

--- a/doc/guide/scripts/floquet_ex2.py
+++ b/doc/guide/scripts/floquet_ex2.py
@@ -28,7 +28,7 @@ for n, t in enumerate(tlist):
     p_ex[n] = qutip.expect(qutip.num(2), psi_t)
 
 # For reference: calculate the same thing with mesolve
-p_ex_ref = qutip.mesolve(H, psi0, tlist, [], [qutip.num(2)], args).expect[0]
+p_ex_ref = qutip.mesolve(H, psi0, tlist, e_ops=[qutip.num(2)], args=args).expect[0]
 
 # plot the results
 pyplot.plot(tlist, np.real(p_ex),     'ro', tlist, 1-np.real(p_ex),     'bo')

--- a/doc/guide/scripts/floquet_ex3.py
+++ b/doc/guide/scripts/floquet_ex3.py
@@ -37,9 +37,10 @@ for idx, t in enumerate(tlist):
     p_ex[idx] = qutip.expect(qutip.num(2), psi_t)
 
 # For reference: calculate the same thing with mesolve
-output = qutip.mesolve(H, psi0, tlist,
-                       [np.sqrt(gamma1) * qutip.sigmax()], [qutip.num(2)],
-                       args)
+output = qutip.mesolve(
+    H, psi0, tlist, [np.sqrt(gamma1) * qutip.sigmax()],
+    e_ops=[qutip.num(2)], args=args
+)
 p_ex_ref = output.expect[0]
 
 # plot the results

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -27,7 +27,7 @@ def brmesolve(
     tlist: ArrayLike,
     a_ops: list[tuple[QobjEvoLike, CoefficientLike]] = None,
     sec_cutoff: float = 0.1,
-    *pos_args,
+    *_pos_args,
     c_ops: list[QobjEvoLike] = None,
     e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     args: dict[str, Any] = None,
@@ -93,6 +93,13 @@ def brmesolve(
         Cutoff for secular approximation. Use ``-1`` if secular approximation
         is not used when evaluating bath-coupling terms.
 
+    *_pos_args
+        Temporary shim to update the signature from
+        (..., a_ops, e_ops, c_ops, args, sec_cutoff, options)
+        to (..., a_ops, sec_cutoff, *, e_ops, c_ops, args, options)
+        making e_ops, c_ops, args and options keyword only parameter from
+        qutip 5.3.
+
     c_ops : list of (:obj:`.QobjEvo`, :obj:`.QobjEvo` compatible format), optional
         List of collapse operators.
 
@@ -152,24 +159,24 @@ def brmesolve(
         either an array of expectation values, for operators given in e_ops,
         or a list of states for the times specified by ``tlist``.
     """
-    if pos_args or not isinstance(sec_cutoff, (int, float)):
+    if _pos_args or not isinstance(sec_cutoff, (int, float)):
         # Old signature used
         warnings.warn(
-            "e_ops, c_ops, and args will be positional only"
-            " for all solver from qutip 5.3",
+            "c_ops, e_ops, args and options will be keyword only"
+            " from qutip 5.3",
             FutureWarning
         )
         # Re order for previous signature
         e_ops = sec_cutoff
         sec_cutoff = 0.1
-        if len(pos_args) >= 1:
-            c_ops = pos_args[0]
-        if len(pos_args) >= 2:
-            args = pos_args[1]
-        if len(pos_args) >= 3:
-            sec_cutoff = pos_args[2]
-        if len(pos_args) >= 4:
-            options = pos_args[3]
+        if len(_pos_args) >= 1:
+            c_ops = _pos_args[0]
+        if len(_pos_args) >= 2:
+            args = _pos_args[1]
+        if len(_pos_args) >= 3:
+            sec_cutoff = _pos_args[2]
+        if len(_pos_args) >= 4:
+            options = _pos_args[3]
 
     options = _solver_deprecation(kwargs, options, "br")
     args = args or {}

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -34,7 +34,7 @@ def brmesolve(
     options: dict[str, Any] = None,
     **kwargs
 ):
-    """
+    r"""
     Solves for the dynamics of a system using the Bloch-Redfield master
     equation, given an input Hamiltonian, Hermitian bath-coupling terms and
     their associated spectral functions, as well as possible Lindblad collapse
@@ -47,7 +47,7 @@ def brmesolve(
         QobjEvo. list of [:obj:`.Qobj`, :obj:`.Coefficient`] or callable that
         can be made into :obj:`.QobjEvo` are also accepted.
 
-    psi0: Qobj
+    psi0: :obj:`.Qobj`
         Initial density matrix or state vector (ket).
 
     tlist : array_like
@@ -81,24 +81,26 @@ def brmesolve(
                 (c+c.dag(), SpectraCoefficient(coefficient(array, tlist=ws))),
             ]
 
-        .. note:
-            ``Cubic_Spline`` has been replaced by :obj:`.Coefficient`\:
+        .. note::
+
+            ``Cubic_Spline`` has been replaced by:
                 ``spline = qutip.coefficient(array, tlist=times)``
 
-            Whether the ``a_ops`` is time dependent is decided by the type of
-            the operator: :obj:`.Qobj` vs :obj:`.QobjEvo` instead of the type
-            of the spectra.
+        Whether the ``a_ops`` is time dependent is decided by the type of
+        the operator: :obj:`.Qobj` vs :obj:`.QobjEvo` instead of the type
+        of the spectra.
 
     sec_cutoff : float, default: 0.1
         Cutoff for secular approximation. Use ``-1`` if secular approximation
         is not used when evaluating bath-coupling terms.
 
-    *_pos_args
-        Temporary shim to update the signature from
-        (..., a_ops, e_ops, c_ops, args, sec_cutoff, options)
-        to (..., a_ops, sec_cutoff, *, e_ops, c_ops, args, options)
-        making e_ops, c_ops, args and options keyword only parameter from
-        qutip 5.3.
+    *_pos_args :
+        | Temporary shim to update the signature from
+        | ``(..., a_ops, e_ops, c_ops, args, sec_cutoff, options)``
+        | to
+        | ``(..., a_ops, sec_cutoff, *, e_ops, c_ops, args, options)``
+        | making ``e_ops``, ``c_ops``, ``args`` and ``options`` keyword only
+          parameter from qutip 5.3.
 
     c_ops : list of (:obj:`.QobjEvo`, :obj:`.QobjEvo` compatible format), optional
         List of collapse operators.

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -82,7 +82,7 @@ def brmesolve(
             ]
 
         .. note:
-            ``Cubic_Spline`` has been replaced by :obj:`.Coefficient`:
+            ``Cubic_Spline`` has been replaced by :obj:`.Coefficient`\:
                 ``spline = qutip.coefficient(array, tlist=times)``
 
             Whether the ``a_ops`` is time dependent is decided by the type of

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -6,6 +6,7 @@ equation.
 __all__ = ['brmesolve', 'BRSolver']
 
 from typing import Any
+import warnings
 import numpy as np
 from numpy.typing import ArrayLike
 import inspect
@@ -25,10 +26,11 @@ def brmesolve(
     psi0: Qobj,
     tlist: ArrayLike,
     a_ops: list[tuple[QobjEvoLike, CoefficientLike]] = None,
-    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
-    c_ops: list[QobjEvoLike] = None,
-    args: dict[str, Any] = None,
     sec_cutoff: float = 0.1,
+    *pos_args,
+    c_ops: list[QobjEvoLike] = None,
+    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
+    args: dict[str, Any] = None,
     options: dict[str, Any] = None,
     **kwargs
 ):
@@ -87,11 +89,9 @@ def brmesolve(
             the operator: :obj:`.Qobj` vs :obj:`.QobjEvo` instead of the type
             of the spectra.
 
-    e_ops : list, dict, :obj:`.Qobj` or callback function, optional
-        Single operator, or list or dict of operators, for which to evaluate
-        expectation values. Operator can be Qobj, QobjEvo or callables with the
-        signature `f(t: float, state: Qobj) -> Any`.
-        Callable signature must be, `f(t: float, state: Qobj)`.
+    sec_cutoff : float, default: 0.1
+        Cutoff for secular approximation. Use ``-1`` if secular approximation
+        is not used when evaluating bath-coupling terms.
 
     c_ops : list of (:obj:`.QobjEvo`, :obj:`.QobjEvo` compatible format), optional
         List of collapse operators.
@@ -100,9 +100,11 @@ def brmesolve(
         Dictionary of parameters for time-dependent Hamiltonians and
         collapse operators. The key ``w`` is reserved for the spectra function.
 
-    sec_cutoff : float, default: 0.1
-        Cutoff for secular approximation. Use ``-1`` if secular approximation
-        is not used when evaluating bath-coupling terms.
+    e_ops : list, dict, :obj:`.Qobj` or callback function, optional
+        Single operator, or list or dict of operators, for which to evaluate
+        expectation values. Operator can be Qobj, QobjEvo or callables with the
+        signature `f(t: float, state: Qobj) -> Any`.
+        Callable signature must be, `f(t: float, state: Qobj)`.
 
     options : dict, optional
         Dictionary of options for the solver.
@@ -150,6 +152,25 @@ def brmesolve(
         either an array of expectation values, for operators given in e_ops,
         or a list of states for the times specified by ``tlist``.
     """
+    if pos_args or not isinstance(sec_cutoff, (int, float)):
+        # Old signature used
+        warnings.warn(
+            "e_ops, c_ops, and args will be positional only"
+            " for all solver from qutip 5.3",
+            FutureWarning
+        )
+        # Re order for previous signature
+        e_ops = sec_cutoff
+        sec_cutoff = 0.1
+        if len(pos_args) >= 1:
+            c_ops = pos_args[0]
+        if len(pos_args) >= 2:
+            args = pos_args[1]
+        if len(pos_args) >= 3:
+            sec_cutoff = pos_args[2]
+        if len(pos_args) >= 4:
+            options = pos_args[3]
+
     options = _solver_deprecation(kwargs, options, "br")
     args = args or {}
     H = QobjEvo(H, args=args, tlist=tlist)

--- a/qutip/solver/floquet.py
+++ b/qutip/solver/floquet.py
@@ -594,7 +594,7 @@ def fsesolve(
         # Old signature used
         warnings.warn(
             f"e_ops, args and options will be keyword only"
-            " for all solver from qutip 5.3",
+            " for all solvers from qutip 5.3",
             FutureWarning
         )
         # Re order for previous signature

--- a/qutip/solver/floquet.py
+++ b/qutip/solver/floquet.py
@@ -7,6 +7,7 @@ __all__ = [
 ]
 
 from typing import Any, overload, TypeVar, Literal, Callable
+import warnings
 import numpy as np
 from numpy.typing import ArrayLike
 from qutip.core import data as _data
@@ -533,8 +534,9 @@ def fsesolve(
     H: QobjEvoLike | FloquetBasis,
     psi0: Qobj,
     tlist: ArrayLike,
-    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     T: float = 0.0,
+    *pos_args,
+    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     args: dict[str, Any] = None,
     options: dict[str, Any] = None,
 ) -> Result:
@@ -554,15 +556,15 @@ def fsesolve(
     tlist : *list* / *array*
         List of times for :math:`t`.
 
+    T : float, default=tlist[-1]
+        The period of the time-dependence of the hamiltonian.
+
     e_ops : list or dict of :class:`.Qobj` / callback function, optional
         Single operator, or list or dict of operators, for which to evaluate
         expectation values. Operator can be Qobj, QobjEvo or callables with the
         signature `f(t: float, state: Qobj) -> Any`.
         See :func:`~qutip.core.expect.expect` for more detail of operator
         expectation.
-
-    T : float, default=tlist[-1]
-        The period of the time-dependence of the hamiltonian.
 
     args : dictionary, optional
         Dictionary with variables required to evaluate H.
@@ -588,6 +590,23 @@ def fsesolve(
         contains either an *array* of expectation values or an array of
         state vectors, for the times specified by `tlist`.
     """
+    if pos_args or not isinstance(T, (int, float)):
+        # Old signature used
+        warnings.warn(
+            f"e_ops, args and options will be positional only"
+            " for all solver from qutip 5.3",
+            FutureWarning
+        )
+        # Re order for previous signature
+        e_ops = T
+        T = 0.0
+        if len(pos_args) >= 1:
+            T = pos_args[0]
+        if len(pos_args) >= 2:
+            args = pos_args[1]
+        if len(pos_args) >= 3:
+            options = pos_args[2]
+
     if isinstance(H, FloquetBasis):
         floquet_basis = H
     else:
@@ -617,10 +636,11 @@ def fmmesolve(
     rho0: Qobj,
     tlist: ArrayLike,
     c_ops: list[Qobj] = None,
-    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     spectra_cb: list[Callable[[float], complex]] = None,
     T: float = 0.0,
     w_th: float = 0.0,
+    *pos_args,
+    e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     args: dict[str, Any] = None,
     options: dict[str, Any] = None,
  ) -> "FloquetResult":
@@ -728,6 +748,31 @@ def fmmesolve(
             args=args,
             options=options,
         )
+    if pos_args:
+        # Old signature used
+        warnings.warn(
+            "e_ops, args and options will be positional only"
+            " for all solver from qutip 5.3",
+            FutureWarning
+        )
+        e_ops = spectra_cb
+        spectra_cb = T
+        T = w_th
+        w_th = pos_args[0]
+    elif e_ops or spectra_cb is None:
+        # New signature or extra param not used
+        pass
+    elif isinstance(T, list):
+        # After the `c_ops` we could have the e_ops (old) or spectra_cb (new)
+        # If old signature is used, the spectra_cb will overflow to `T`
+        warnings.warn(
+            "e_ops will be positional only from qutip 5.3 for all solver",
+            FutureWarning
+        )
+        e_ops = spectra_cb
+        spectra_cb = T
+        if w_th:
+            T = w_th
 
     if isinstance(H, FloquetBasis):
         floquet_basis = H

--- a/qutip/solver/floquet.py
+++ b/qutip/solver/floquet.py
@@ -593,7 +593,7 @@ def fsesolve(
     if pos_args or not isinstance(T, (int, float)):
         # Old signature used
         warnings.warn(
-            f"e_ops, args and options will be positional only"
+            f"e_ops, args and options will be keyword only"
             " for all solver from qutip 5.3",
             FutureWarning
         )
@@ -751,7 +751,7 @@ def fmmesolve(
     if pos_args:
         # Old signature used
         warnings.warn(
-            "e_ops, args and options will be positional only"
+            "e_ops, args and options will be keyword only"
             " for all solver from qutip 5.3",
             FutureWarning
         )
@@ -766,7 +766,7 @@ def fmmesolve(
         # After the `c_ops` we could have the e_ops (old) or spectra_cb (new)
         # If old signature is used, the spectra_cb will overflow to `T`
         warnings.warn(
-            "e_ops will be positional only from qutip 5.3 for all solver",
+            "e_ops will be keyword only from qutip 5.3 for all solver",
             FutureWarning
         )
         e_ops = spectra_cb

--- a/qutip/solver/krylovsolve.py
+++ b/qutip/solver/krylovsolve.py
@@ -6,6 +6,7 @@ __all__ = ['krylovsolve']
 from .. import QobjEvo, Qobj
 from .sesolve import SESolver
 from .result import Result
+from .solver_base import _kwargs_migration
 from numpy.typing import ArrayLike
 from typing import Any, Callable
 
@@ -15,6 +16,10 @@ def krylovsolve(
     psi0: Qobj,
     tlist: ArrayLike,
     krylov_dim: int,
+    _e_ops = None,
+    _args = None,
+    _options = None,
+    *,
     e_ops: dict[Any, Qobj | QobjEvo | Callable[[float, Qobj], Any]] = None,
     args: dict[str, Any] = None,
     options: dict[str, Any] = None,
@@ -107,6 +112,9 @@ def krylovsolve(
         vectors or density matrices corresponding to the times in ``tlist`` [if
         ``e_ops`` is an empty list of ``store_states=True`` in options].
     """
+    e_ops = _kwargs_migration(_e_ops, e_ops, "e_ops")
+    args = _kwargs_migration(_args, args, "args")
+    options = _kwargs_migration(_options, options, "options")
     H = QobjEvo(H, args=args, tlist=tlist)
     options = options or {}
     options["method"] = "krylov"

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -13,7 +13,9 @@ import warnings
 from ..core import QobjEvo, spre, spost, Qobj, unstack_columns, qzero_like
 from ..typing import QobjEvoLike, EopsLike
 from .multitraj import MultiTrajSolver, _MultiTrajRHS, _InitialConditions
-from .solver_base import Solver, Integrator, _solver_deprecation
+from .solver_base import (
+    Solver, Integrator, _solver_deprecation, _kwargs_migration
+)
 from .multitrajresult import McResult
 from .mesolve import mesolve, MESolver
 from ._feedback import _QobjFeedback, _DataFeedback, _CollapseFeedback
@@ -25,9 +27,11 @@ def mcsolve(
     state: Qobj,
     tlist: ArrayLike,
     c_ops: QobjEvoLike | list[QobjEvoLike] = (),
+    _e_ops = None,
+    _ntraj = None,
+    *,
     e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     ntraj: int = 500,
-    *,
     args: dict[str, Any] = None,
     options: dict[str, Any] = None,
     seeds: int | SeedSequence | list[int | SeedSequence] = None,
@@ -165,6 +169,9 @@ def mcsolve(
     function should be considered invalid.
     """
     options = _solver_deprecation(kwargs, options, "mc")
+    e_ops = _kwargs_migration(_e_ops, e_ops, "e_ops")
+    ntraj = _kwargs_migration(_ntraj, ntraj, "ntraj")
+
     H = QobjEvo(H, args=args, tlist=tlist)
     if not isinstance(c_ops, (list, tuple)):
         c_ops = [c_ops]

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -14,7 +14,7 @@ from time import time
 from .. import (Qobj, QobjEvo, liouvillian, lindblad_dissipator)
 from ..typing import EopsLike, QobjEvoLike
 from ..core import data as _data
-from .solver_base import Solver, _solver_deprecation
+from .solver_base import Solver, _solver_deprecation, _kwargs_migration
 from .sesolve import sesolve, SESolver
 from ._feedback import _QobjFeedback, _DataFeedback
 from . import Result
@@ -25,6 +25,10 @@ def mesolve(
     rho0: Qobj,
     tlist: ArrayLike,
     c_ops: Qobj | QobjEvo | list[QobjEvoLike] = None,
+    _e_ops = None,
+    _args = None,
+    _options = None,
+    *,
     e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     args: dict[str, Any] = None,
     options: dict[str, Any] = None,
@@ -140,6 +144,9 @@ def mesolve(
         is an empty list of ``store_states=True`` in options].
 
     """
+    e_ops = _kwargs_migration(_e_ops, e_ops, "e_ops")
+    args = _kwargs_migration(_args, args, "args")
+    options = _kwargs_migration(_options, options, "options")
     options = _solver_deprecation(kwargs, options)
     H = QobjEvo(H, args=args, tlist=tlist)
 

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -12,6 +12,7 @@ from .multitraj import MultiTrajSolver
 from .multitrajresult import NmmcResult
 from .mcsolve import MCSolver, MCIntegrator
 from .mesolve import MESolver, mesolve
+from .solver_base import _kwargs_migration
 from .cy.nm_mcsolve import RateShiftCoefficient, SqrtRealCoefficient
 from ..core.coefficient import ConstantCoefficient, Coefficient
 from ..core import (
@@ -34,9 +35,11 @@ def nm_mcsolve(
     state: Qobj,
     tlist: ArrayLike,
     ops_and_rates: list[tuple[Qobj, CoefficientLike]] = (),
+    _e_ops = None,
+    _ntraj = None,
+    *,
     e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     ntraj: int = 500,
-    *,
     args: dict[str, Any] = None,
     options: dict[str, Any] = None,
     seeds: int | SeedSequence | list[int | SeedSequence] = None,
@@ -183,6 +186,8 @@ def nm_mcsolve(
         condition is mixed, the result has additional attributes
         ``initial_states`` and ``ntraj_per_initial_state``.
     """
+    e_ops = _kwargs_migration(_e_ops, e_ops, "e_ops")
+    ntraj = _kwargs_migration(_ntraj, ntraj, "ntraj")
     H = QobjEvo(H, args=args, tlist=tlist)
 
     if len(ops_and_rates) == 0:

--- a/qutip/solver/sesolve.py
+++ b/qutip/solver/sesolve.py
@@ -13,7 +13,7 @@ from typing import Any, Callable
 from .. import Qobj, QobjEvo
 from ..core import data as _data
 from ..typing import QobjEvoLike, EopsLike
-from .solver_base import Solver, _solver_deprecation
+from .solver_base import Solver, _solver_deprecation, _kwargs_migration
 from ._feedback import _QobjFeedback, _DataFeedback
 from . import Result
 
@@ -22,6 +22,10 @@ def sesolve(
     H: QobjEvoLike,
     psi0: Qobj,
     tlist: ArrayLike,
+    _e_ops = None,
+    _args = None,
+    _options = None,
+    *,
     e_ops: EopsLike | list[EopsLike] | dict[Any, EopsLike] = None,
     args: dict[str, Any] = None,
     options: dict[str, Any] = None,
@@ -114,6 +118,9 @@ def sesolve(
         density matrices corresponding to the times in ``tlist`` [if ``e_ops``
         is an empty list of ``store_states=True`` in options].
     """
+    e_ops = _kwargs_migration(_e_ops, e_ops, "e_ops")
+    args = _kwargs_migration(_args, args, "args")
+    options = _kwargs_migration(_options, options, "options")
     options = _solver_deprecation(kwargs, options)
     H = QobjEvo(H, args=args, tlist=tlist)
     solver = SESolver(H, options=options)

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -574,7 +574,7 @@ def _solver_deprecation(kwargs, options, solver="me"):
 def _kwargs_migration(position, keyword, name):
     if position is not None:
         warnings.warn(
-            f"{name} will be positional only from qutip 5.3 for all solver",
+            f"{name} will be keyword only from qutip 5.3 for all solver",
             FutureWarning
         )
         return position

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -569,3 +569,13 @@ def _solver_deprecation(kwargs, options, solver="me"):
     if kwargs:
         raise TypeError(f"unexpected keyword argument {kwargs.keys()}")
     return options
+
+
+def _kwargs_migration(position, keyword, name):
+    if position is not None:
+        warnings.warn(
+            f"{name} will be positional only from qutip 5.3 for all solver",
+            FutureWarning
+        )
+        return position
+    return keyword

--- a/qutip/tests/solver/test_brmesolve.py
+++ b/qutip/tests/solver/test_brmesolve.py
@@ -81,8 +81,8 @@ def test_harmonic_oscillator(n_th):
     a_ops = [[a + a.dag(), S_w]]
     e_ops = [a.dag()*a, a+a.dag()]
 
-    me = qutip.mesolve(H, psi0, times, c_ops, e_ops)
-    brme = brmesolve(H, psi0, times, a_ops, e_ops)
+    me = qutip.mesolve(H, psi0, times, c_ops, e_ops=e_ops)
+    brme = brmesolve(H, psi0, times, a_ops, e_ops=e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
         np.testing.assert_allclose(me_expectation, brme_expectation, atol=1e-2)
 
@@ -111,8 +111,8 @@ def test_jaynes_cummings_zero_temperature_spectral_callable():
     c_ops = [np.sqrt(kappa) * a]
     H = w0*a.dag()*a + w0*sp.dag()*sp + g*(a+a.dag())*(sp+sp.dag())
 
-    me = qutip.mesolve(H, psi0, times, c_ops, e_ops)
-    brme = brmesolve(H, psi0, times, a_ops, e_ops)
+    me = qutip.mesolve(H, psi0, times, c_ops, e_ops=e_ops)
+    brme = brmesolve(H, psi0, times, a_ops, e_ops=e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
         # Accept 5% error.
         np.testing.assert_allclose(me_expectation, brme_expectation, atol=5e-2)
@@ -187,8 +187,8 @@ def test_jaynes_cummings_zero_temperature_spectral_str():
     c_ops = [np.sqrt(kappa) * a]
     H = w0*a.dag()*a + w0*sp.dag()*sp + g*(a+a.dag())*(sp+sp.dag())
 
-    me = qutip.mesolve(H, psi0, times, c_ops, e_ops)
-    brme = brmesolve(H, psi0, times, a_ops, e_ops)
+    me = qutip.mesolve(H, psi0, times, c_ops, e_ops=e_ops)
+    brme = brmesolve(H, psi0, times, a_ops, e_ops=e_ops)
     for me_expectation, brme_expectation in zip(me.expect, brme.expect):
         # Accept 5% error.
         np.testing.assert_allclose(me_expectation, brme_expectation, atol=5e-2)
@@ -290,8 +290,8 @@ def test_hamiltonian_taking_arguments():
     H = w0*a.dag()*a + w0*sp.dag()*sp + g*(a+a.dag())*(sp+sp.dag())
     args = {'ii': 1}
 
-    no_args = brmesolve(H, psi0, times, a_ops, e_ops)
-    args = brmesolve([[H, 'ii']], psi0, times, a_ops, e_ops, args=args)
+    no_args = brmesolve(H, psi0, times, a_ops, e_ops=e_ops)
+    args = brmesolve([[H, 'ii']], psi0, times, a_ops, e_ops=e_ops, args=args)
     for arg, no_arg in zip(args.expect, no_args.expect):
         np.testing.assert_allclose(arg, no_arg, atol=1e-10)
 

--- a/qutip/tests/solver/test_floquet.py
+++ b/qutip/tests/solver/test_floquet.py
@@ -99,12 +99,12 @@ class TestFloquet:
         c_op_mesolve = _convert_c_ops(c_op_fmmesolve, spectrum, vp, ep)
 
         # Solve the floquet-markov master equation
-        p_ex = fmmesolve(H, psi0, tlist, [c_op_fmmesolve], [num(2)],
-                         [spectrum], T, args=args).expect[0]
+        p_ex = fmmesolve(H, psi0, tlist, [c_op_fmmesolve], [spectrum], T,
+                         e_ops=[num(2)], args=args).expect[0]
 
         # Compare with mesolve
         p_ex_ref = mesolve(
-            H, psi0, tlist, c_op_mesolve, [num(2)], args
+            H, psi0, tlist, c_op_mesolve, e_ops=[num(2)], args=args
         ).expect[0]
 
         np.testing.assert_allclose(np.real(p_ex), np.real(p_ex_ref), atol=1e-4)
@@ -144,13 +144,13 @@ class TestFloquet:
 
         # Solve the floquet-markov master equation
         p_ex = fmmesolve(
-            H, psi0, tlist, [c_op_fmmesolve], [num(2)],
-            [spectrum], T, args=args
+            H, psi0, tlist, [c_op_fmmesolve], [spectrum], T,
+            e_ops=[num(2)], args=args
         ).expect[0]
 
         # Compare with mesolve
         p_ex_ref = mesolve(
-            H, psi0, tlist, c_op_mesolve, [num(2)], args
+            H, psi0, tlist, c_op_mesolve, e_ops=[num(2)], args=args
         ).expect[0]
 
         np.testing.assert_allclose(np.real(p_ex), np.real(p_ex_ref), atol=1e-4)
@@ -198,7 +198,9 @@ class TestFloquet:
         p_ex = [expect(num(2), solver.step(t)) for t in tlist]
 
         # Compare with mesolve
-        output2 = mesolve(H, psi0, tlist, c_op_mesolve, [num(2)], args)
+        output2 = mesolve(
+            H, psi0, tlist, c_op_mesolve, e_ops=[num(2)], args=args
+        )
         p_ex_ref = output2.expect[0]
 
         np.testing.assert_allclose(np.real(p_ex), np.real(p_ex_ref),
@@ -251,11 +253,11 @@ class TestFloquet:
 
         # Solve the floquet-markov master equation
         output1 = fmmesolve(
-            H, psi0, tlist, c_ops_fmmesolve, e_ops, noise_spectra, T
+            H, psi0, tlist, c_ops_fmmesolve, noise_spectra, T, e_ops=e_ops,
         )
         p_ex = output1.expect[0]
         # Compare with mesolve
-        output2 = mesolve(H, psi0, tlist, c_op_mesolve, e_ops, args)
+        output2 = mesolve(H, psi0, tlist, c_op_mesolve, e_ops=e_ops, args=args)
         p_ex_ref = output2.expect[0]
 
         np.testing.assert_allclose(np.real(p_ex), np.real(p_ex_ref), atol=1e-4)

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -294,7 +294,7 @@ def test_expectation_outputs(keep_runs_results, improved_sampling,
     times = np.linspace(0, 10, 5)
     c_ops = [a, sm]
     e_ops = [a.dag()*a, sm.dag()*sm, a]
-    data = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj,
+    data = mcsolve(H, state, times, c_ops, e_ops=e_ops, ntraj=ntraj,
                    options={"keep_runs_results": keep_runs_results,
                             'map': 'serial',
                             "improved_sampling": improved_sampling})
@@ -432,7 +432,7 @@ def test_timeout(improved_sampling, mixed_initial_state):
     n_th = 0.05
     c_ops = np.sqrt(coupling * (n_th + 1)) * a
     e_ops = [qutip.num(size)]
-    res = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj,
+    res = mcsolve(H, state, times, c_ops, e_ops=e_ops, ntraj=ntraj,
                   options={'map': 'serial',
                            "improved_sampling": improved_sampling},
                   timeout=1e-6)
@@ -453,12 +453,12 @@ def test_target_tol(improved_sampling):
 
     options = {'map': 'serial', "improved_sampling": improved_sampling}
 
-    res = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj, options=options,
-                  target_tol = 0.5)
+    res = mcsolve(H, state, times, c_ops, e_ops=e_ops, ntraj=ntraj,
+                  options=options, target_tol=0.5)
     assert res.stats['end_condition'] == 'target tolerance reached'
 
-    res = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj, options=options,
-                  target_tol = 1e-6)
+    res = mcsolve(H, state, times, c_ops, e_ops=e_ops, ntraj=ntraj,
+                  options=options, target_tol=1e-6)
     assert res.stats['end_condition'] == 'ntraj reached'
 
 @pytest.mark.parametrize("improved_sampling", [True, False])
@@ -478,11 +478,12 @@ def test_super_H(improved_sampling, mixed_initial_state):
     n_th = 0.05
     c_ops = np.sqrt(coupling * (n_th + 1)) * a
     e_ops = [qutip.num(size)]
-    mc_expected = mcsolve(H, state, times, c_ops, e_ops, ntraj=ntraj,
+    mc_expected = mcsolve(H, state, times, c_ops, e_ops=e_ops, ntraj=ntraj,
                           target_tol=(0.1 if state.isket else None),
                           options={'map': 'serial',
                                    "improved_sampling": improved_sampling})
-    mc = mcsolve(qutip.liouvillian(H), state, times, c_ops, e_ops, ntraj=ntraj,
+    mc = mcsolve(qutip.liouvillian(H), state, times, c_ops,
+                 e_ops=e_ops, ntraj=ntraj,
                  target_tol=(0.1 if state.isket else None),
                  options={'map': 'serial',
                           "improved_sampling": improved_sampling})

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -87,9 +87,8 @@ class TestMESolveDecay:
         psi0 = qutip.basis(self.N, 9)  # initial state
         c_op_list = [cte_c_ops]
         options = {"progress_bar": None}
-        medata = mesolve(H, psi0, self.tlist, c_op_list, [H],
-                         args={"kappa": self.kappa},
-                         options=options)
+        medata = mesolve(H, psi0, self.tlist, c_op_list, e_ops=[H],
+                         args={"kappa": self.kappa}, options=options)
         expt = medata.expect[0]
         actual_answer = 9.0 * np.exp(-self.kappa * self.tlist)
         np.testing.assert_allclose(actual_answer, expt, atol=me_error)
@@ -103,7 +102,7 @@ class TestMESolveDecay:
         psi0 = qutip.basis(self.N, 9)  # initial state
         c_op_list = [c_ops]
         options = {"method": method, "progress_bar": None}
-        medata = mesolve(H, psi0, self.tlist, c_op_list, [H],
+        medata = mesolve(H, psi0, self.tlist, c_op_list, e_ops=[H],
                          args={"kappa": self.kappa}, options=options)
         expt = medata.expect[0]
         actual_answer = 9.0 * np.exp(-self.kappa * (1.0 - np.exp(-self.tlist)))
@@ -116,9 +115,8 @@ class TestMESolveDecay:
         psi0 = qutip.basis(self.N, 9)  # initial state
         c_op_list = [c_ops, c_ops_1]
         options = {"progress_bar": None}
-        medata = mesolve(H, psi0, self.tlist, c_op_list, [H],
-                         args={"kappa": self.kappa},
-                         options=options)
+        medata = mesolve(H, psi0, self.tlist, c_op_list, e_ops=[H],
+                         args={"kappa": self.kappa}, options=options)
         expt = medata.expect[0]
         actual_answer = 9.0 * np.exp(-2 * self.kappa *
                                      (1.0 - np.exp(-self.tlist)))
@@ -130,9 +128,8 @@ class TestMESolveDecay:
         psi0 = qutip.basis(self.N, 9)  # initial state
         c_op_list = [c_ops]
         options = {"progress_bar": None}
-        medata = mesolve(H, psi0, self.tlist, c_op_list, [self.ada],
-                         args={"kappa": self.kappa},
-                         options=options)
+        medata = mesolve(H, psi0, self.tlist, c_op_list, e_ops=[self.ada],
+                         args={"kappa": self.kappa}, options=options)
         expt = medata.expect[0]
         actual_answer = 9.0 * np.exp(-self.kappa *
                                      (1.0 - np.exp(-self.tlist)))
@@ -149,9 +146,8 @@ class TestMESolveDecay:
         else:
             c_op_list = [[c_ops, c_ops]]
         options = {"progress_bar": None}
-        medata = mesolve(H, psi0, self.tlist, c_op_list, [self.ada],
-                         args={"kappa": self.kappa},
-                         options=options)
+        medata = mesolve(H, psi0, self.tlist, c_op_list, e_ops=[self.ada],
+                         args={"kappa": self.kappa}, options=options)
         expt = medata.expect[0]
         actual_answer = 9.0 * np.exp(-4 * self.kappa *
                                      (1.0 - np.exp(-self.tlist)))
@@ -167,10 +163,10 @@ class TestMESolveDecay:
         E0 = qutip.sprepost(qutip.qeye(self.N), qutip.qeye(self.N))
         options = {"progress_bar": None}
         c_op_list = [c_ops]
-        out1 = mesolve(H, psi0, self.tlist, c_op_list, [],
+        out1 = mesolve(H, psi0, self.tlist, c_op_list,
                        args={"kappa": self.kappa},
                        options=options)
-        out2 = mesolve(H, E0, self.tlist, c_op_list, [],
+        out2 = mesolve(H, E0, self.tlist, c_op_list,
                        args={"kappa": self.kappa},
                        options=options)
 
@@ -188,10 +184,10 @@ class TestMESolveDecay:
         E0 = qutip.sprepost(qutip.qeye(self.N), qutip.qeye(self.N))
         options = {"progress_bar": None}
         c_op_list = [c_ops]
-        out1 = mesolve(L, psi0, self.tlist, c_op_list, [],
+        out1 = mesolve(L, psi0, self.tlist, c_op_list,
                        args={"kappa": self.kappa},
                        options=options)
-        out2 = mesolve(L, E0, self.tlist, c_op_list, [],
+        out2 = mesolve(L, E0, self.tlist, c_op_list,
                        args={"kappa": self.kappa},
                        options=options)
 
@@ -399,10 +395,10 @@ class TestJCModelEvolution:
 
         # evolve and calculate expectation values
         output = mesolve(
-            H, psi0, tlist, c_op_list, [a.dag() * a, sm.dag() * sm],
+            H, psi0, tlist, c_op_list, e_ops=[a.dag() * a, sm.dag() * sm],
             options=options)
         if oper_evo:
-            output2 = mesolve(H, E0, tlist, c_op_list, [])
+            output2 = mesolve(H, E0, tlist, c_op_list)
             return output, output2
         return output.expect[0], output.expect[1]
 

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -457,7 +457,7 @@ def test_expectation_outputs(keep_runs_results, improved_sampling,
     total_ops = len(ops_and_rates) + 1
     e_ops = [a.dag()*a, sm.dag()*sm, a]
     data = nm_mcsolve(
-        H, state, times, ops_and_rates, e_ops, ntraj=ntraj,
+        H, state, times, ops_and_rates, e_ops=e_ops, ntraj=ntraj,
         options={
             "keep_runs_results": keep_runs_results,
             "map": "serial",
@@ -591,7 +591,7 @@ def test_timeout(improved_sampling, mixed_initial_state):
     ]
     e_ops = [qutip.num(size)]
     res = nm_mcsolve(
-        H, state, times, ops_and_rates, e_ops, ntraj=ntraj,
+        H, state, times, ops_and_rates, e_ops=e_ops, ntraj=ntraj,
         options={'map': 'serial', "improved_sampling": improved_sampling},
         timeout=1e-6,
     )
@@ -618,13 +618,13 @@ def test_super_H(improved_sampling, mixed_initial_state):
     ]
     e_ops = [qutip.num(size)]
     mc_expected = nm_mcsolve(
-        H, state, times, ops_and_rates, e_ops, ntraj=ntraj,
+        H, state, times, ops_and_rates, e_ops=e_ops, ntraj=ntraj,
         target_tol=(0.1 if state.isket else None),
         options={'map': 'serial', "improved_sampling": improved_sampling},
     )
     mc = nm_mcsolve(
-        qutip.liouvillian(H), state, times, ops_and_rates, e_ops, ntraj=ntraj,
-        target_tol=(0.1 if state.isket else None),
+        qutip.liouvillian(H), state, times, ops_and_rates, e_ops=e_ops,
+        ntraj=ntraj, target_tol=(0.1 if state.isket else None),
         options={'map': 'serial', "improved_sampling": improved_sampling})
     np.testing.assert_allclose(mc_expected.expect[0], mc.expect[0], atol=0.65)
 

--- a/qutip/tests/solver/test_qubit_evolution.py
+++ b/qutip/tests/solver/test_qubit_evolution.py
@@ -22,9 +22,9 @@ def _qubit_integrate(tlist, psi0, epsilon, delta, g1, g2, solver):
     e_ops = [sigmax(), sigmay(), sigmaz()]
 
     if solver == "me":
-        output = mesolve(H, psi0, tlist, c_op_list, e_ops)
+        output = mesolve(H, psi0, tlist, c_op_list, e_ops=e_ops)
     elif solver == "mc":
-        output = mcsolve(H, psi0, tlist, c_op_list, e_ops, ntraj=750)
+        output = mcsolve(H, psi0, tlist, c_op_list, e_ops=e_ops, ntraj=750)
     else:
         raise ValueError("unknown solver")
 

--- a/qutip/tests/solver/test_sesolve.py
+++ b/qutip/tests/solver/test_sesolve.py
@@ -57,9 +57,11 @@ class TestSeSolve():
         options = {"progress_bar": None}
 
         if unitary_op is None:
-            output = sesolve(H, psi0, self.tlist,
-                             [qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()],
-                             args=self.args, options=options)
+            output = sesolve(
+                H, psi0, self.tlist,
+                e_ops=[qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()],
+                args=self.args, options=options
+            )
             sx, sy, sz = output.expect[0], output.expect[1], output.expect[2]
         else:
             output = sesolve(H, unitary_op, self.tlist, args=self.args,
@@ -125,9 +127,11 @@ class TestSeSolve():
         H = [[self.H1, 'exp(-alpha*t)']]
 
         if unitary_op is None:
-            output = sesolve(H, psi0, self.tlist,
-                             [qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()],
-                             args=self.args, options=options)
+            output = sesolve(
+                H, psi0, self.tlist,
+                e_ops=[qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()],
+                args=self.args, options=options
+            )
             sx, sy, sz = output.expect[0], output.expect[1], output.expect[2]
         else:
             output = sesolve(H, unitary_op, self.tlist,
@@ -179,10 +183,11 @@ class TestSeSolve():
             "normalize_output": normalize,
             "progress_bar": None
         }
-        out_s = sesolve(H, psi0, self.tlist, [qutip.sigmax(),
-                                              qutip.sigmay(),
-                                              qutip.sigmaz()],
-                        options=options, args=args)
+        out_s = sesolve(
+            H, psi0, self.tlist,
+            e_ops=[qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()],
+            options=options, args=args
+        )
         xs, ys, zs = out_s.expect[0], out_s.expect[1], out_s.expect[2]
         xss = [qutip.expect(qutip.sigmax(), U) for U in out_s.states]
         yss = [qutip.expect(qutip.sigmay(), U) for U in out_s.states]

--- a/qutip/tests/solver/test_steadystate.py
+++ b/qutip/tests/solver/test_steadystate.py
@@ -217,8 +217,9 @@ def test_steadystate_floquet(sparse):
     T_max = 20 * 2 * np.pi / gam
     t_l = np.linspace(0, T_max, 20000)
 
-    expect_me = qutip.mesolve(H_t, psi0, t_l,
-                              c_ops, [sz], args=args).expect[0]
+    expect_me = qutip.mesolve(
+        H_t, psi0, t_l, c_ops, e_ops=[sz], args=args
+    ).expect[0]
 
     rho_ss = qutip.steadystate_floquet(H, c_ops,
                                        A_l * sx, w_l, n_it=3, sparse=sparse)

--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -58,7 +58,8 @@ def test_smesolve(heterodyne, system):
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
 
     times = np.linspace(0, 0.1, 21)
-    res_ref = mesolve(H, psi0, times, c_ops + sc_ops, e_ops, args={"w": 2})
+    res_ref = mesolve(H, psi0, times, c_ops + sc_ops,
+                      e_ops=e_ops, args={"w": 2})
 
     options = {
         "store_measurement": False,
@@ -94,7 +95,8 @@ def test_smesolve_methods(method, heterodyne, system):
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
 
     times = np.linspace(0, 0.1, 21)
-    res_ref = mesolve(H, psi0, times, c_ops + sc_ops, e_ops, args={"w": 2})
+    res_ref = mesolve(H, psi0, times, c_ops + sc_ops,
+                      e_ops=e_ops, args={"w": 2})
 
     options = {
         "store_measurement": True,
@@ -158,7 +160,7 @@ def test_ssesolve(heterodyne, system):
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
 
     times = np.linspace(0, 0.1, 21)
-    res_ref = mesolve(H, psi0, times, sc_ops, e_ops, args={"w": 2})
+    res_ref = mesolve(H, psi0, times, sc_ops, e_ops=e_ops, args={"w": 2})
 
     options = {
         "map": "serial",
@@ -197,7 +199,7 @@ def test_ssesolve_method(method, heterodyne, system):
     e_ops = [a.dag() * a, a + a.dag(), (-1j)*(a - a.dag())]
 
     times = np.linspace(0, 0.1, 21)
-    res_ref = mesolve(H, psi0, times, sc_ops, e_ops, args={"w": 2})
+    res_ref = mesolve(H, psi0, times, sc_ops, e_ops=e_ops, args={"w": 2})
 
     options = {
         "store_measurement": True,

--- a/qutip/tests/solver/test_transfertensor.py
+++ b/qutip/tests/solver/test_transfertensor.py
@@ -33,11 +33,11 @@ def test_ttmsolve_jc_model(call):
 
     # calculate exact solution using mesolve
     times = np.arange(0, 5.0, 0.1)
-    exactsol = qutip.mesolve(H, rho0, times, c_ops, [sz])
+    exactsol = qutip.mesolve(H, rho0, times, c_ops, e_ops=[sz])
 
     if not call:
         learning_times = np.arange(0, 2.0, 0.1)
-        Et_list = qutip.mesolve(H, E0, learning_times, c_ops, []).states
+        Et_list = qutip.mesolve(H, E0, learning_times, c_ops).states
         learning_maps = [ptracesuper @ Et @ superrho0cav for Et in Et_list]
     else:
         prop = qutip.Propagator(qutip.liouvillian(H, c_ops))

--- a/qutip/tests/test_animation.py
+++ b/qutip/tests/test_animation.py
@@ -9,7 +9,7 @@ plt = pytest.importorskip("matplotlib.pyplot")
 def test_result_state():
     H = qutip.rand_dm(2)
     tlist = np.linspace(0, 3*np.pi, 2)
-    results = qutip.mesolve(H, H, tlist, [], [])
+    results = qutip.mesolve(H, H, tlist)
 
     fig, ani = qutip.anim_fock_distribution(results)
     plt.close()
@@ -21,8 +21,7 @@ def test_result_state():
 def test_result_state_ValueError():
     H = qutip.rand_dm(2)
     tlist = np.linspace(0, 3*np.pi, 2)
-    results = qutip.mesolve(H, H, tlist, [], [],
-                            options={"store_states": False})
+    results = qutip.mesolve(H, H, tlist, options={"store_states": False})
 
     text = 'Nothing to visualize. You might have forgotten ' +\
            'to set options={"store_states": True}.'

--- a/qutip/tests/test_visualization.py
+++ b/qutip/tests/test_visualization.py
@@ -462,7 +462,7 @@ def test_plot_expectation_values(n_of_results, n_of_e_ops, one_axes, args):
     e_ops = [qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()]
     times = np.linspace(0, 10, 100)
     psi0 = (qutip.basis(2, 0) + qutip.basis(2, 1)).unit()
-    result = qutip.mesolve(H, psi0, times, [], e_ops[:n_of_e_ops])
+    result = qutip.mesolve(H, psi0, times, e_ops=e_ops[:n_of_e_ops])
 
     if n_of_results == 1:
         results = result


### PR DESCRIPTION
**Description**
The signatures of the `__solve` functions are not consistent. Most time the `e_ops` comes after the `c_ops`, but this is not always the case.
Making `e_ops`, `args` and `options` keyword fix this issues. (see #2489).
Using `e_ops`, etc. positionally will raise a `FutureWarning`, with the full removal planed for qutip 5.3.

For `brmesolve`, the transition is not clean as `e_ops` was before `c_ops`. Both can take the same input, so that no confusion happen between the two, in that case `c_ops` was also made keyword only. For that solver, the `a_ops` replace the `c_ops` as the main mixing with the environment and should not be used that much.

**Related issues or PRs**
fix #2489