### PR TITLE
Optimize `numpy_backend`

### DIFF
--- a/qutip/core/numpy_backend.py
+++ b/qutip/core/numpy_backend.py
@@ -1,14 +1,11 @@
 from ..settings import settings
 
-
 class NumpyBackend:
-    @property
-    def backend(self):
-        return settings.core["numpy_backend"]
+    def _qutip_setting_backend(self, np):
+        self.np = np
 
     def __getattr__(self, name):
-        backend = object.__getattribute__(self, 'backend')
-        return getattr(backend, name)
+        return getattr(self.np, name)
 
 
 # Initialize the numpy backend

--- a/qutip/core/numpy_backend.py
+++ b/qutip/core/numpy_backend.py
@@ -1,11 +1,12 @@
 from ..settings import settings
 
+
 class NumpyBackend:
     def _qutip_setting_backend(self, np):
-        self.np = np
+        self._qt_np = np
 
     def __getattr__(self, name):
-        return getattr(self.np, name)
+        return getattr(self._qt_np, name)
 
 
 # Initialize the numpy backend


### PR DESCRIPTION
**Description**
Change numpy_backend to contain the numpy implementation in an attribute instead of reading it from the settings each time. This is done by making the options work as a property, when it is set, it update the `np` instance.


