### PR TITLE
Fix the failing test with numpy 2.1 on windows

### DIFF
--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -208,7 +208,12 @@ class TestMESolveDecay:
         H = qutip.Qobj([[1, -0.1j], [-0.1j, 1]])
         H = qutip.spre(H) + qutip.spost(H.dag()) # ensure use of MeSolve
         psi0 = qutip.basis(2, 0)
-        options = {"normalize_output": True, "progress_bar": None}
+        options = {
+            "normalize_output": True,
+            "progress_bar": None,
+            "atol": 1e-5,
+            "nsteps": 1e5,
+        }
 
         if state_type in {"ket", "dm"}:
             if state_type == "dm":


### PR DESCRIPTION
**Description**
A test was failing since the numpy 2.1 release on windows. 
It seems to be related the the way low level libraries are linked, a lower precision was used on windows...

Loosening the ODE tolerance fix the issue.