### PR TITLE
Fix bad merge of `dev.major`

### DIFF
--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -208,7 +208,7 @@ class CoreOptions(QutipOptions):
 
     def __setitem__(self, key: str, value: Any) -> None:
         # Let the dict catch the KeyError
-        self.options[key] = value
+        super().__setitem__(key, value)
 
 
 # Creating the instance of core options to use everywhere.

--- a/qutip/tests/core/test_numpy_backend.py
+++ b/qutip/tests/core/test_numpy_backend.py
@@ -3,10 +3,11 @@ import numpy
 from unittest.mock import Mock
 
 from qutip.core.numpy_backend import np
-from qutip import CoreOptions
+from qutip import CoreOptions, settings
 
 # Mocking JAX to demonstrate backend switching
-mock_jax = Mock()
+mock_jax = Mock
+mock_jax.sum = Mock(return_value="jax_sum")
 mock_np = numpy
 
 
@@ -16,7 +17,11 @@ class TestNumpyBackend:
             assert np.sum([1, 2, 3]) == numpy.sum([1, 2, 3])
             assert np.sum is numpy.sum
 
+    def test_coreoptions_setattr(self):
+        with CoreOptions():
+            settings.core["numpy_backend"] = mock_jax
+            assert np.sum([1, 2, 3]) == "jax_sum"
+
     def test_getattr_jax(self):
         with CoreOptions(numpy_backend=mock_jax):
-            mock_jax.sum = Mock(return_value="jax_sum")
             assert np.sum([1, 2, 3]) == "jax_sum"


### PR DESCRIPTION
**Description**
In #2513, I forgot to update `CoreOptions.__setattr__` which was newly created when adding type hints.
All our tests changed options only using context, so it was missed.
