### PR TITLE
QobjEvo support in expect

### DIFF
--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -743,7 +743,7 @@ cdef class ConstantCoefficient(Coefficient):
 
     :obj:`ConstantCoefficient` is returned by ``qutip.coefficent.const(value)``.
     """
-    cdef complex value
+    cdef readonly complex value
 
     def __init__(self, complex value, **_):
         self.value = value
@@ -781,7 +781,7 @@ cdef class ConstantCoefficient(Coefficient):
             and isinstance(right, ConstantCoefficient)
         ):
             return ConstantCoefficient(left.value + right.value)
-        return super().__add__(left, right)
+        return Coefficient.__add__(left, right)
 
     def __mul__(left, right):
         if (
@@ -789,7 +789,7 @@ cdef class ConstantCoefficient(Coefficient):
             and isinstance(right, ConstantCoefficient)
         ):
             return ConstantCoefficient(left.value * right.value)
-        return super().__mul__(left, right)
+        return Coefficient.__mul__(left, right)
 
     def conj(self):
         return ConstantCoefficient(conj(self.value))

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -774,3 +774,25 @@ cdef class ConstantCoefficient(Coefficient):
     cpdef Coefficient copy(self):
         """Return a copy of the :obj:`.Coefficient`."""
         return self
+
+    def __add__(left, right):
+        if (
+            isinstance(left, ConstantCoefficient)
+            and isinstance(right, ConstantCoefficient)
+        ):
+            return ConstantCoefficient(left.value + right.value)
+        return super().__add__(left, right)
+
+    def __mul__(left, right):
+        if (
+            isinstance(left, ConstantCoefficient)
+            and isinstance(right, ConstantCoefficient)
+        ):
+            return ConstantCoefficient(left.value * right.value)
+        return super().__mul__(left, right)
+
+    def conj(self):
+        return ConstantCoefficient(conj(self.value))
+
+    def _cdc(self):
+        return ConstantCoefficient(norm(self.value))

--- a/qutip/core/expect.py
+++ b/qutip/core/expect.py
@@ -97,6 +97,31 @@ def _single_qobj_expect(oper, state):
         out = out.real
     return out
 
+def _single_qobjevo_expect(oper, state):
+    oper = QobjEvo(oper)
+    state = QobjEvo(state)
+    if not isoper(state):
+        state = state @ state.dag()
+
+    op_list = oper.to_list()
+    state_list = state.to_list()
+
+    out_coeff = ConstantCoefficient(0.)
+
+    for op, rho in product(op_list, state_list):
+        if isinstance(op, Qobj):
+            op = [op, ConstantCoefficient(1.)]
+        if isinstance(rho, Qobj):
+            rho = [rho, ConstantCoefficient(1.)]
+        if isinstance(op[0], Qobj) and isinstance(rho[0], Qobj):
+            out_coeff = out_coeff + ConstantCoefficient(_single_qobj_expect(op[0], rho[0])) * op[1] * rho[1]
+            continue
+        # One of the QobjEvo is in the function format: QobjEvo(lambda t, **kw: Qobj(...)
+        raise NotImplementedError("Function based QobjEvo is not yer supported")
+
+    return out_coeff
+
+
 
 @overload
 def variance(oper: Qobj, state: Qobj) -> complex: ...


### PR DESCRIPTION
**Description**
Looking at #2511, we would need to compute the expectation values for time dependent operator and their derivative.

Here I add support for `QobjEvo` in `expect`: `expect(op: QobjEvo, state: QobjEvo) -> Coefficient`.
(List of operators or states not supported.)
