### PR TITLE
Fix failing test with mkl windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -211,6 +211,7 @@ jobs:
         # to see if something hung.
         timeout-minutes: 60
         run: |
+          export MKL_VERBOSE=2
           if [[ -n "${{ matrix.openmp }}" ]]; then
             # Force OpenMP runs to use more threads, even if there aren't
             # actually that many CPUs.  We have to check any dispatch code is

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -56,7 +56,7 @@ def about():
     print("Number of CPUs:     %s" % settings.num_cpus)
     print("BLAS Info:          %s" % _blas_info())
     # print("OPENMP Installed:   %s" % str(qutip.settings.has_openmp))
-    print("INTEL MKL Ext:      %s" % str(settings.has_mkl))
+    print("INTEL MKL Ext:      %s" % settings.mkl_lib_location)
     print("Platform Info:      %s (%s)" % (platform.system(),
                                            platform.machine()))
     qutip_install_path = os.path.dirname(inspect.getsourcefile(qutip))

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -80,6 +80,10 @@ def _find_mkl():
     distributions.
     """
     plat = sys.platform
+    # TODO: fix the mkl handling on windows or use modules like pydiso to do it
+    # for us.
+    # if plat.startswith("win"):
+    #     return ""
     python_dir = os.path.dirname(sys.executable)
     if plat in ['darwin', 'linux2', 'linux']:
         python_dir = os.path.dirname(python_dir)

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -82,8 +82,8 @@ def _find_mkl():
     plat = sys.platform
     # TODO: fix the mkl handling on windows or use modules like pydiso to do it
     # for us.
-    # if plat.startswith("win"):
-    #     return ""
+    if plat.startswith("win"):
+        return ""
     python_dir = os.path.dirname(sys.executable)
     if plat in ['darwin', 'linux2', 'linux']:
         python_dir = os.path.dirname(python_dir)


### PR DESCRIPTION
**Description**
Since merging #2497, mkl tests on windows fails from segfault.
I am not sure of the source of the error:
Since the library was not found before the PR, the bug can have been there for a long time, but the tests passed in #2497.
Just settings mkl to verbose is enough for the tests to passes...

I don't think relying on the verbose options is a good idea so I made it unable to find mkl on windows for this PR.

We will need to find a more reliable way to use it, `ctypes` does not look at the header file so it guess the types from our call. Maybe some version of mkl are 32 bit and other 64 bit and we are not adapting.

 [pydiso](https://github.com/simpeg/pydiso) looks promising.
