### PR TITLE
Add __array__ method to Qobj

### DIFF
--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -740,6 +740,9 @@ class Qobj:
             return _data.norm.l2(self._data)**2
         return _data.trace(_data.matmul(self._data, self._data)).real
 
+    def __array__(self, dtype=None, copy=None) -> np.ndarray:
+        return np.asarray(self.data.to_array(), dtype=dtype)
+
     def full(
         self,
         order: Literal['C', 'F'] = 'C',


### PR DESCRIPTION
Proposal to add the `__array__` method to Qobj, such that one can call `np.asarray(some_qobj)`.