### PR TITLE
Allow repeating tests without quitting Python

### DIFF
--- a/doc/changes/2538.misc
+++ b/doc/changes/2538.misc
@@ -1,0 +1,1 @@
+Allow tests to be executed multiple times in one Python session

--- a/qutip/tests/core/data/test_convert.py
+++ b/qutip/tests/core/data/test_convert.py
@@ -66,7 +66,8 @@ def test_converters(from_, base, to_, dtype):
 
 dtype_names = list(data.to._str2type.keys()) + list(data.to.dtypes)
 dtype_types = list(data.to._str2type.values()) + list(data.to.dtypes)
-@pytest.mark.parametrize(['input', 'type_'], zip(dtype_names, dtype_types),
+dtype_combinations = list(zip(dtype_names, dtype_types))
+@pytest.mark.parametrize(['input', 'type_'], dtype_combinations,
                          ids=[str(dtype) for dtype in dtype_names])
 def test_parse(input, type_):
     assert data.to.parse(input) is type_

--- a/qutip/tests/core/test_states.py
+++ b/qutip/tests/core/test_states.py
@@ -273,7 +273,8 @@ def _id_func(val):
 # Obtain all valid dtype from `to`
 dtype_names = list(qutip.data.to._str2type.keys()) + list(qutip.data.to.dtypes)
 dtype_types = list(qutip.data.to._str2type.values()) + list(qutip.data.to.dtypes)
-@pytest.mark.parametrize(['alias', 'dtype'], zip(dtype_names, dtype_types),
+dtype_combinations = list(zip(dtype_names, dtype_types))
+@pytest.mark.parametrize(['alias', 'dtype'], dtype_combinations,
                          ids=[str(dtype) for dtype in dtype_names])
 @pytest.mark.parametrize(['func', 'args'], [
     (qutip.basis, (5, 1)),

--- a/qutip/tests/test_random.py
+++ b/qutip/tests/test_random.py
@@ -310,7 +310,8 @@ def test_kraus_map(dimensions, dtype):
 
 dtype_names = list(_data.to._str2type.keys()) + list(_data.to.dtypes)
 dtype_types = list(_data.to._str2type.values()) + list(_data.to.dtypes)
-@pytest.mark.parametrize(['alias', 'dtype'], zip(dtype_names, dtype_types),
+dtype_combinations = list(zip(dtype_names, dtype_types))
+@pytest.mark.parametrize(['alias', 'dtype'], dtype_combinations,
                          ids=[str(dtype) for dtype in dtype_names])
 @pytest.mark.parametrize('func', [
     rand_herm,


### PR DESCRIPTION
**Description**
The `4.x` documentation suggests that the user test the installation by
```python
import qutip.testing
qutip.testing.run()
```
and when something fails (e.g. due to missing `matplotlib`), the obvious reaction would be to re-execute `qutip.testing.run()`. However, this does not currently work, because passing a `zip` generator to `pytest.parametrize` limits that test case to be executed only once. This PR does nothing but allowing tests to be executed multiple times in one Python session.

P.S. I would recommend backporting the new shell testing command `pytest qutip/qutip/tests` to the `4.x` documentation.