### PR TITLE
Bug.prop uneven

### DIFF
--- a/doc/changes/2532.bugfix
+++ b/doc/changes/2532.bugfix
@@ -1,0 +1,1 @@
+`propagator` now accepts list format `c_ops` like `mesolve` does.

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -48,7 +48,8 @@ def propagator(
         will always be the identity matrix.
 
     c_ops : list, optional
-        List of Qobj or QobjEvo collapse operators.
+        List of collapse operators as Qobj, QobjEvo or list that can be made
+        into QobjEvo.
 
     args : dictionary, optional
         Parameters to callback functions for time-dependent Hamiltonians and
@@ -59,13 +60,22 @@ def propagator(
 
     **kwargs :
         Extra parameters to use when creating the
-        :obj:`.QobjEvo` from a list format ``H``.
+        :obj:`.QobjEvo` from a list format ``H``. The most common as ``tlist``
+        and ``order`` for spline time dependance. See :obj:`.QobjEvo` for the
+        full list.
 
     Returns
     -------
     U : :obj:`.Qobj`, list
         Instance representing the propagator(s) :math:`U(t)`. Return a single
         Qobj when ``t`` is a number or a list when ``t`` is a list.
+
+    Notes
+    -----
+    Unlike :func:`.sesolve` or :func:`.mesolve`, the output times ``t`` are not
+    used for time dependent system with array based. ``tlist`` must be passed
+    as a keyword argument in those case. ``tlist`` and ``t`` can have different
+    length and values.
 
     """
     if isinstance(t, numbers.Real):
@@ -78,7 +88,10 @@ def propagator(
     if not isinstance(H, (Qobj, QobjEvo)):
         H = QobjEvo(H, args=args, **kwargs)
 
-    if c_ops:
+    if isinstance(c_ops, list):
+        c_ops = [QobjEvo(op, args=args, **kwargs) for op in c_ops)]
+
+    if c_ops is not None:
         H = liouvillian(H, c_ops)
 
     U0 = qeye_like(H)

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -60,9 +60,9 @@ def propagator(
 
     **kwargs :
         Extra parameters to use when creating the
-        :obj:`.QobjEvo` from a list format ``H``. The most common as ``tlist``
-        and ``order`` for spline time dependance. See :obj:`.QobjEvo` for the
-        full list.
+        :obj:`.QobjEvo` from a list format ``H``. The most common are ``tlist``
+        and ``order`` for array-based time dependance. See :obj:`.QobjEvo` for
+        the full list.
 
     Returns
     -------
@@ -72,9 +72,9 @@ def propagator(
 
     Notes
     -----
-    Unlike :func:`.sesolve` or :func:`.mesolve`, the output times ``t`` are not
-    used for time dependent system with array based. ``tlist`` must be passed
-    as a keyword argument in those case. ``tlist`` and ``t`` can have different
+    Unlike :func:`.sesolve` or :func:`.mesolve`, the output times in ``t`` are
+    not used for array time dependent system. ``tlist`` must be passed as a
+    keyword argument in those case. ``tlist`` and ``t`` can have different
     length and values.
 
     """
@@ -89,9 +89,9 @@ def propagator(
         H = QobjEvo(H, args=args, **kwargs)
 
     if isinstance(c_ops, list):
-        c_ops = [QobjEvo(op, args=args, **kwargs) for op in c_ops)]
+        c_ops = [QobjEvo(op, args=args, **kwargs) for op in c_ops]
 
-    if c_ops is not None:
+    if c_ops:
         H = liouvillian(H, c_ops)
 
     U0 = qeye_like(H)

--- a/qutip/tests/solver/test_propagator.py
+++ b/qutip/tests/solver/test_propagator.py
@@ -2,11 +2,11 @@ import numpy as np
 from scipy.integrate import trapezoid
 from qutip import (destroy, propagator, Propagator, propagator_steadystate,
                    steadystate, tensor, qeye, basis, QobjEvo, sesolve,
-                   liouvillian)
+                   liouvillian, rand_dm)
 import qutip
 import pytest
 from qutip.solver.brmesolve import BRSolver
-from qutip.solver.mesolve import MESolver
+from qutip.solver.mesolve import MESolver, mesolve
 from qutip.solver.sesolve import SESolver
 from qutip.solver.mcsolve import MCSolver
 
@@ -47,6 +47,20 @@ def testPropHOTd():
     ts = np.linspace(0, 1, 101)
     U2 = (-1j * H * trapezoid(1 + func(ts), ts)).expm()
     assert (U - U2).norm('max') < 1e-4
+
+
+def testPropHOTd():
+    "Propagator: func array td format + open"
+    a = destroy(5)
+    H = a.dag()*a
+    ts = np.linspace(-0.01, 1.01, 103)
+    coeffs = np.cos(ts)
+    Htd = [H, [H, coeffs]]
+    rho_0 = rand_dm(5)
+    rho_1_prop = propagator(Htd, 1, c_ops=[a], tlist=ts)(rho_0)
+    rho_1_me = mesolve(QobjEvo(Htd, tlist=ts), rho_0, [0, 1], [a]).final_state
+
+    assert (rho_1_prop - rho_1_me).norm('max') < 1e-4
 
 
 def testPropObjTd():


### PR DESCRIPTION
**Description**
`propagator` accept list format `H` but only pre-made `QobjEvo` for `c_ops`.
This make it also accept list `c_ops`.

Also make clear in the documentation to pass `tlist` when using array format.
Propagator's `t` can be a scalar and the output time should not be forced to be the same as the sampling times.

**Related issues or PRs**
fix #2532