### PR TITLE
Fix `brmsolve` time-dependent a_ops detection

### DIFF
--- a/doc/changes/2530.bugfix
+++ b/doc/changes/2530.bugfix
@@ -1,0 +1,1 @@
+Fix brmesolve detection of contant vs time-dependent system.

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -194,21 +194,22 @@ def brmesolve(
     new_a_ops = []
     a_ops = a_ops or []
     for (a_op, spectra) in a_ops:
-        aop = QobjEvo(a_op, args=args, tlist=tlist)
+        if not isinstance(a_op, Qobj):
+            a_op = QobjEvo(a_op, args=args, tlist=tlist)
         if isinstance(spectra, str):
             new_a_ops.append(
-                (aop, coefficient(spectra, args={**args, 'w':0})))
+                (a_op, coefficient(spectra, args={**args, 'w':0})))
         elif isinstance(spectra, InterCoefficient):
-            new_a_ops.append((aop, SpectraCoefficient(spectra)))
+            new_a_ops.append((a_op, SpectraCoefficient(spectra)))
         elif isinstance(spectra, Coefficient):
-            new_a_ops.append((aop, spectra))
+            new_a_ops.append((a_op, spectra))
         elif callable(spectra):
             sig = inspect.signature(spectra)
             if tuple(sig.parameters.keys()) == ("w",):
                 spec = SpectraCoefficient(coefficient(spectra))
             else:
                 spec = coefficient(spectra, args={**args, 'w':0})
-            new_a_ops.append((aop, spec))
+            new_a_ops.append((a_op, spec))
         else:
             raise TypeError("a_ops's spectra not known")
 


### PR DESCRIPTION
**Description**
When using `brmesolve`, the tensor would always be seen as time-dependent. Which for Bloch Redfield mean computing eigen vectors at each time-step and result is a massive slowdown when not required.

There is no tests, the result does not change. 

**Related issues or PRs**
fix #2530 