### PR TITLE
Add einsum

### DIFF
--- a/doc/changes/2545.feature
+++ b/doc/changes/2545.feature
@@ -1,0 +1,1 @@
+Implements a numpy.einsum version for Qobj dimensions (Evaluates the Einstein summation convention on the operands.)

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -351,6 +351,11 @@ def from_tensor_rep(tensorrep, dims):
 def _frozen(*args, **kwargs):
     raise RuntimeError("Dimension cannot be modified.")
 
+def einsum(subscripts, *operands, out=None, dtype=None, order='K', casting='safe', optimize=False):
+    operands_array = [to_tensor_rep(op) for op in operands]
+    result = np.einsum(subscripts, *operands_array)
+    dims = [[d] for d in result.shape]
+    return from_tensor_rep(result, dims)
 
 class MetaSpace(type):
     def __call__(cls, *args: SpaceLike, rep: str = None) -> "Space":

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -369,7 +369,7 @@ def einsum(subscripts, *operands):
     Qobj (numpy.complex128)
         Result of einsum as Qobj (numpy.complex128 if result is scalar)
     """
-    operands_array = [to_tensor_rep(op) for op in operands]
+    operands_array = [to_tensor_rep(op).reshape(op.shape) for op in operands]
     result = np.einsum(subscripts, *operands_array)
     if result.shape == ():
         return result

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -354,7 +354,7 @@ def _frozen(*args, **kwargs):
 def einsum(subscripts, *operands):
     """
     Implementation of numpy.einsum for Qobj.
-    Returns the result of einsum as a Qobj (or numpy.complex128 if the result is a scalar).
+    Evaluates the Einstein summation convention on the operands.
     Parameters
     ----------
     subscripts: str

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -351,9 +351,29 @@ def from_tensor_rep(tensorrep, dims):
 def _frozen(*args, **kwargs):
     raise RuntimeError("Dimension cannot be modified.")
 
-def einsum(subscripts, *operands, out=None, dtype=None, order='K', casting='safe', optimize=False):
+def einsum(subscripts, *operands):
+    """
+    Implementation of numpy.einsum for Qobj.
+    Returns the result of einsum as a Qobj (or numpy.complex128 if the result is a scalar).
+    Parameters
+    ----------
+    subscripts: str
+        Specifies the subscripts for summation as comma separated list of subscript labels.
+        An implicit (classical Einstein summation) calculation is performed unless the explicit
+        indicator ‘->’ is included as well as subscript labels of the precise output form.
+
+    operands: list of array_like
+        These are the arrays for the operation.
+    
+    Returns
+    -------
+    Qobj (numpy.complex128)
+        Result of einsum as Qobj (numpy.complex128 if result is scalar)
+    """
     operands_array = [to_tensor_rep(op) for op in operands]
     result = np.einsum(subscripts, *operands_array)
+    if result.shape == ():
+        return result
     dims = [[d] for d in result.shape]
     return from_tensor_rep(result, dims)
 

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -369,11 +369,11 @@ def einsum(subscripts, *operands):
     Qobj (numpy.complex128)
         Result of einsum as Qobj (numpy.complex128 if result is scalar)
     """
-    operands_array = [to_tensor_rep(op).reshape(op.shape) for op in operands]
+    operands_array = [to_tensor_rep(op) for op in operands]
     result = np.einsum(subscripts, *operands_array)
     if result.shape == ():
         return result
-    dims = [[d] for d in result.shape]
+    dims = [d for d in result.shape[:result.ndim // 2]], [[d for d in result.shape[result.ndim // 2:]]]
     return from_tensor_rep(result, dims)
 
 

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -351,6 +351,7 @@ def from_tensor_rep(tensorrep, dims):
 def _frozen(*args, **kwargs):
     raise RuntimeError("Dimension cannot be modified.")
 
+
 def einsum(subscripts, *operands):
     """
     Implementation of numpy.einsum for Qobj.
@@ -358,13 +359,11 @@ def einsum(subscripts, *operands):
     Parameters
     ----------
     subscripts: str
-        Specifies the subscripts for summation as comma separated list of subscript labels.
-        An implicit (classical Einstein summation) calculation is performed unless the explicit
-        indicator ‘->’ is included as well as subscript labels of the precise output form.
-
+        Specifies the subscripts for summation as comma
+        separated list of subscript labels.
     operands: list of array_like
         These are the arrays for the operation.
-    
+
     Returns
     -------
     Qobj (numpy.complex128)
@@ -376,6 +375,7 @@ def einsum(subscripts, *operands):
         return result
     dims = [[d] for d in result.shape]
     return from_tensor_rep(result, dims)
+
 
 class MetaSpace(type):
     def __call__(cls, *args: SpaceLike, rep: str = None) -> "Space":

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -373,7 +373,8 @@ def einsum(subscripts, *operands):
     result = np.einsum(subscripts, *operands_array)
     if result.shape == ():
         return result
-    dims = [d for d in result.shape[:result.ndim // 2]], [[d for d in result.shape[result.ndim // 2:]]]
+    dims = [d for d in result.shape[:result.ndim // 2]],
+    [[d for d in result.shape[result.ndim // 2:]]]
     return from_tensor_rep(result, dims)
 
 

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -373,8 +373,10 @@ def einsum(subscripts, *operands):
     result = np.einsum(subscripts, *operands_array)
     if result.shape == ():
         return result
-    dims = [d for d in result.shape[:result.ndim // 2]],
-    [[d for d in result.shape[result.ndim // 2:]]]
+    dims = [
+        [d for d in result.shape[:result.ndim // 2]],
+        [d for d in result.shape[result.ndim // 2:]]
+    ]
     return from_tensor_rep(result, dims)
 
 

--- a/qutip/tests/core/test_dimensions.py
+++ b/qutip/tests/core/test_dimensions.py
@@ -6,7 +6,7 @@ import qutip
 from qutip.core.dimensions import (
     flatten, unflatten, enumerate_flat, deep_remove, deep_map,
     dims_idxs_to_tensor_idxs, dims_to_tensor_shape, dims_to_tensor_perm,
-    collapse_dims_super, collapse_dims_oper, Dimensions
+    collapse_dims_super, collapse_dims_oper, einsum, Dimensions
 )
 
 
@@ -189,3 +189,13 @@ def test_dims_comparison():
     assert Dimensions([[1], [2]])[0] != Dimensions([[1], [2]])[1]
     assert not Dimensions([[1], [2]])[1] != Dimensions([[1], [2]])[1]
     assert not Dimensions([[1], [2]])[0] != Dimensions([[1], [2]])[0]
+
+
+@pytest.mark.parametrize(["subscripts", "operands", "expected"], [
+    pytest.param("ii", [qutip.sigmaz()], 0),
+    pytest.param("ij", [qutip.sigmax()], qutip.sigmax()),
+    pytest.param("ij->ji", [qutip.sigmay()], qutip.sigmay().trans()),
+    pytest.param("ij,ji", [qutip.sigmaz(), qutip.sigmaz()], 2),
+])
+def test_einsum(subscripts, operands, expected):
+    assert einsum(subscripts, *operands) == expected

--- a/qutip/tests/core/test_dimensions.py
+++ b/qutip/tests/core/test_dimensions.py
@@ -196,6 +196,9 @@ def test_dims_comparison():
     pytest.param("ij", [qutip.sigmax()], qutip.sigmax()),
     pytest.param("ij->ji", [qutip.sigmay()], qutip.sigmay().trans()),
     pytest.param("ij,ji", [qutip.sigmaz(), qutip.sigmaz()], 2),
+    pytest.param("ii", [qutip.tensor(qutip.thermal_dm(2,1), qutip.thermal_dm(2,1))], 1),
+    pytest.param("ik, kj", [qutip.tensor(qutip.sigmaz(), qutip.sigmaz()), 
+                             qutip.tensor(qutip.sigmaz(), qutip.sigmaz())], qutip.qeye(4))
 ])
 def test_einsum(subscripts, operands, expected):
     assert einsum(subscripts, *operands) == expected

--- a/qutip/tests/core/test_dimensions.py
+++ b/qutip/tests/core/test_dimensions.py
@@ -198,7 +198,9 @@ def test_dims_comparison():
     pytest.param("ij,ji", [qutip.sigmaz(), qutip.sigmaz()], 2),
     pytest.param("ii", [qutip.tensor(qutip.thermal_dm(2,1), qutip.thermal_dm(2,1))], 1),
     pytest.param("ik, kj", [qutip.tensor(qutip.sigmaz(), qutip.sigmaz()), 
-                             qutip.tensor(qutip.sigmaz(), qutip.sigmaz())], qutip.qeye(4))
+                             qutip.tensor(qutip.sigmaz(), qutip.sigmaz())], qutip.qeye(4)),
+    pytest.param("ik, kj", [qutip.tensor(qutip.sigmaz(), qutip.sigmaz(), qutip.sigmaz()), 
+                             qutip.tensor(qutip.sigmaz(), qutip.sigmaz(), qutip.sigmaz())], qutip.qeye(8))
 ])
 def test_einsum(subscripts, operands, expected):
     assert einsum(subscripts, *operands) == expected

--- a/qutip/tests/core/test_dimensions.py
+++ b/qutip/tests/core/test_dimensions.py
@@ -196,11 +196,10 @@ def test_dims_comparison():
     pytest.param("ij", [qutip.sigmax()], qutip.sigmax()),
     pytest.param("ij->ji", [qutip.sigmay()], qutip.sigmay().trans()),
     pytest.param("ij,ji", [qutip.sigmaz(), qutip.sigmaz()], 2),
-    pytest.param("ii", [qutip.tensor(qutip.thermal_dm(2,1), qutip.thermal_dm(2,1))], 1),
-    pytest.param("ik, kj", [qutip.tensor(qutip.sigmaz(), qutip.sigmaz()), 
-                             qutip.tensor(qutip.sigmaz(), qutip.sigmaz())], qutip.qeye(4)),
-    pytest.param("ik, kj", [qutip.tensor(qutip.sigmaz(), qutip.sigmaz(), qutip.sigmaz()), 
-                             qutip.tensor(qutip.sigmaz(), qutip.sigmaz(), qutip.sigmaz())], qutip.qeye(8))
+    pytest.param("ijij", [qutip.tensor(qutip.thermal_dm(2,1), qutip.thermal_dm(2,1))], 1),
+    pytest.param("ikjl,jm->ikml", [qutip.tensor(qutip.sigmaz(), qutip.sigmaz()), 
+                             qutip.sigmaz()], qutip.tensor(qutip.qeye(2), qutip.sigmaz())),
+    pytest.param("ijkl->kjil", [qutip.tensor(qutip.sigmam(), qutip.sigmaz())], qutip.tensor(qutip.sigmap(), qutip.sigmaz()))
 ])
 def test_einsum(subscripts, operands, expected):
     assert einsum(subscripts, *operands) == expected


### PR DESCRIPTION
**Description**
Added a einsum, a numpy.einsum (Evaluates the Einstein summation convention on the operands.) version for Qobj dimensions.

**Related issues or PRs**
fixes #2340

** Question: Not sure if I should update the documentation and how. Just in case I did not modify the docs yet.