### PR TITLE
c_{k,real} should not have -i in the math section

### DIFF
--- a/doc/guide/heom/bosonic.rst
+++ b/doc/guide/heom/bosonic.rst
@@ -271,7 +271,7 @@ coefficients of this expansion are, for the real part, :math:`C_{real}(t)`:
     \end{cases}
 
     c_{k,real} &= \begin{cases}
-        \lambda \gamma [\cot(\beta \gamma / 2) - i]             & k = 0\\
+        \lambda \gamma [\cot(\beta \gamma / 2) ]             & k = 0\\
         \frac{4 \lambda \gamma \nu_k }{ (\nu_k^2 - \gamma^2)\beta}    & k \geq 1\\
     \end{cases}
 


### PR DESCRIPTION
**Description**
In the guide for using HEOM with a bosonic bath, in the description of the Drude Lorentz BCF the Matsubara terms are split between real and imaginary parts. However, in the maths section of the real part, $c_{k,real}$ the $-i$ term remains for $k=0$.  In the python section it is already correctly removed.
This was fixed

for k=0 changed  $` c_{k,real} = \lambda \gamma   [\cot(\beta \gamma / 2) - i] `$ to  $` c_{k,real} = \lambda \gamma   [\cot(\beta \gamma / 2)] `$



