### PR TITLE
Improve performance of qt.Qobj by static version check

### DIFF
--- a/doc/changes/2557.misc
+++ b/doc/changes/2557.misc
@@ -1,0 +1,1 @@
+Improve performance of qt.Qobj by using static numpy version check 

--- a/qutip/core/data/dense.pyx
+++ b/qutip/core/data/dense.pyx
@@ -37,10 +37,11 @@ __all__ = [
 class OrderEfficiencyWarning(EfficiencyWarning):
     pass
 
+is_numpy1 = np.lib.NumpyVersion(np.__version__) < '2.0.0b1'
 
 cdef class Dense(base.Data):
     def __init__(self, data, shape=None, copy=True):
-        if np.lib.NumpyVersion(np.__version__) < '2.0.0b1':
+        if is_numpy1:
             # np2 accept None which act as np1's False
             copy = builtins.bool(copy)
         base = np.array(data, dtype=np.complex128, order='K', copy=copy)


### PR DESCRIPTION
**Description**

We improve performance of `Qobj` construction by moving the numpy version check out of the `__init__`. On a microbenchmark
```
import numpy as np
import qutip as qt
x = np.array([1., 0.])
%timeit qt.Qobj(x)
```
performance improves from
```
23.5 μs ± 2.18 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
to
```
8.24 μs ± 732 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
