### PR TITLE
Update macos version used in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,7 @@ jobs:
           - case-name: macos
             # setup-miniconda not compatible with macos-latest presently.
             # https://github.com/conda-incubator/setup-miniconda/issues/344
-            os: macos-12
+            os: macos-latest
             python-version: "3.12"
             numpy-build: ">=2.0.0"
             numpy-requirement: ">=2.0.0"
@@ -97,7 +97,7 @@ jobs:
             nomkl: 1
 
           - case-name: macos - numpy fallback
-            os: macos-12
+            os: macos-latest
             python-version: "3.11"
             numpy-build: ">=2.0.0"
             numpy-requirement: ">=1.25,<1.26"

--- a/qutip/tests/core/data/test_csr.py
+++ b/qutip/tests/core/data/test_csr.py
@@ -74,6 +74,8 @@ class TestClassMethods:
     ))
     @pytest.mark.parametrize('c_type', _dtype_int + _dtype_uint)
     @pytest.mark.parametrize('r_type', _dtype_int + _dtype_uint)
+    # uint on macos raise a RuntimeWarning
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     def test_init_from_tuple_allowed_dtypes(self, d_type, c_type, r_type):
         """
         Test that initialisation can use a variety of dtypes and converts into


### PR DESCRIPTION
**Description**
`macos-12` that we use in tests is deprecated and will be removed soon. (https://github.com/actions/runner-images/issues/10721) The issue with `macos-latest` and miniconda is solved, so we can use it once again. 

There is however a warning appearing when converting an array to unsigned int. I had to add a filter for it for the tests to pass.