### PR TITLE
Use openblas for 'Windows - numpy fallback' tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,6 +120,7 @@ jobs:
             oldcython: 1
             nocython: 1
             condaforge: 1
+            nomkl: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
     steps:


### PR DESCRIPTION
**Description**
The windows tests are failing. The reason is not clear, but it has to do with the base mathematics library. 
This change the tests to use OpenBlas instead of MKL, which does not have the issue.

fix #2563