### PR TITLE
Small tests fixes

### DIFF
--- a/qutip/distributions.py
+++ b/qutip/distributions.py
@@ -315,7 +315,7 @@ class TwoModeQuadratureCorrelation(Distribution):
                     sqrt(sqrt(pi) * 2 ** n2 * factorial(n2)) * \
                     exp(-X2 ** 2 / 2.0) * np.polyval(hermite(n2), X2)
                 i = state_number_index([N, N], [n1, n2])
-                p += kn1 * kn2 * psi.data_as()[i, 0]
+                p += kn1 * kn2 * psi.full()[i, 0]
 
         self.data = abs(p) ** 2
 
@@ -352,7 +352,7 @@ class TwoModeQuadratureCorrelation(Distribution):
                 for p1 in range(N):
                     for p2 in range(N):
                         j = state_number_index([N, N], [p1, p2])
-                        p += M1[n1, p1] * M2[n2, p2] * rho.data_as()[i, j]
+                        p += M1[n1, p1] * M2[n2, p2] * rho.full()[i, j]
 
         self.data = p
 
@@ -484,4 +484,4 @@ class HarmonicOscillatorProbabilityFunction(Distribution):
                     exp(-self.xvecs[0] ** 2 / 2.0) * \
                     np.polyval(hermite(n), self.xvecs[0])
 
-                self.data += np.conjugate(k_n) * k_m * rho.data_as()[m, n]
+                self.data += np.conjugate(k_n) * k_m * rho.full()[m, n]

--- a/qutip/tests/core/test_environment.py
+++ b/qutip/tests/core/test_environment.py
@@ -3,7 +3,7 @@ import pytest
 from numbers import Number
 
 import numpy as np
-import mpmath as mp
+mp = pytest.importorskip("mpmath")
 from scipy.integrate import quad_vec
 from qutip.utilities import n_thermal
 

--- a/qutip/tests/test_visualization.py
+++ b/qutip/tests/test_visualization.py
@@ -653,21 +653,23 @@ def test_plot_schmidt_Error():
     plt.close()
 
 
+@pytest.fixture(params=["ket", "oper"])
+def state(request):
+    if request.param == "ket":
+        return qutip.basis([2, 2], [0, 0])
+    else:
+        return qutip.fock_dm([2, 2], [0, 0])
 
-@pytest.mark.parametrize(
-    "state",  [qutip.basis([2, 2], [0, 0]), qutip.ket2dm(qutip.basis([1, 1], [0, 0]))]
-)
+
 def test_TwoModeQuadratureCorrelation(state):
     corr = qutip.TwoModeQuadratureCorrelation(state)
 
     assert isinstance(corr, qutip.distributions.TwoModeQuadratureCorrelation)
 
-@pytest.mark.parametrize(
-    "state",  [qutip.basis([2, 2], [0, 0]), qutip.ket2dm(qutip.basis([1, 1], [0, 0]))]
-)   
+
 def test_TwoModeQuadratureCorrelation_plot(state):
     corr = qutip.TwoModeQuadratureCorrelation(state)
-    
+
     fig, ax = corr.visualize()
     plt.close()
 
@@ -675,21 +677,15 @@ def test_TwoModeQuadratureCorrelation_plot(state):
     assert isinstance(ax, mpl.axes.Axes)
 
 
-
-@pytest.mark.parametrize(
-    "state",  [qutip.basis([2, 2], [0, 0]), qutip.ket2dm(qutip.basis([1, 1], [0, 0]))]
-)
 def test_HarmonicOscillatorWaveFunction(state):
     corr = qutip.HarmonicOscillatorWaveFunction(state)
 
     assert isinstance(corr, qutip.distributions.HarmonicOscillatorWaveFunction)
 
-@pytest.mark.parametrize(
-    "state",  [qutip.basis([2, 2], [0, 0]), qutip.ket2dm(qutip.basis([1, 1], [0, 0]))]
-)   
+
 def test_HarmonicOscillatorWaveFunction_plot(state):
     corr = qutip.HarmonicOscillatorWaveFunction(state)
-    
+
     fig, ax = corr.visualize()
     plt.close()
 
@@ -697,21 +693,15 @@ def test_HarmonicOscillatorWaveFunction_plot(state):
     assert isinstance(ax, mpl.axes.Axes)
 
 
-
-@pytest.mark.parametrize(
-    "state",  [qutip.basis([2, 2], [0, 0]), qutip.ket2dm(qutip.basis([1, 1], [0, 0]))]
-)
 def test_HarmonicOscillatorProbabilityFunction(state):
     corr = qutip.HarmonicOscillatorProbabilityFunction(state)
 
     assert isinstance(corr, qutip.distributions.HarmonicOscillatorProbabilityFunction)
 
-@pytest.mark.parametrize(
-    "state",  [qutip.basis([2, 2], [0, 0]), qutip.ket2dm(qutip.basis([1, 1], [0, 0]))]
-)   
+
 def test_HarmonicOscillatorProbabilityFunction_plot(state):
     corr = qutip.HarmonicOscillatorProbabilityFunction(state)
-    
+
     fig, ax = corr.visualize()
     plt.close()
 


### PR DESCRIPTION
**Description**
- `mpmath` is optional, so skip tests that uses it when not installed.
This skip all tests in that file when missing. If some bath feature should be tested even when missing, we should skip only these tests .

- Remove `ket2dm(basis(...))` from `parametrize` in visualization tests. Function in parametrize decorator are called when tests are collected, while inside fixture they are call when tests are run.
Also use a larger state for the density matrix tests. `basis(1)` can be both `ket`, `bra` and `operator`... 

- Use `full` in distribution. When using a `fock_dm` instead of a `ket2dm(basis(...))`, `data_as` returned a `dia_matrix` which did not works in that case. 