### PR TITLE
Fixed the sqrtiswap logic gate error

### DIFF
--- a/doc/changes/2571.bugfix
+++ b/doc/changes/2571.bugfix
@@ -1,0 +1,1 @@
+Fixed the sqrtiswap logic gate error

--- a/qutip/core/gates.py
+++ b/qutip/core/gates.py
@@ -583,8 +583,8 @@ def sqrtiswap(*, dtype: LayerType = None) -> Qobj:
         np.array(
             [
                 [1, 0, 0, 0],
-                [0, 1 / np.sqrt(2), 1j / np.sqrt(2), 0],
-                [0, 1j / np.sqrt(2), 1 / np.sqrt(2), 0],
+                [0, 1 / np.sqrt(2), -1j / np.sqrt(2), 0],
+                [0, -1j / np.sqrt(2), 1 / np.sqrt(2), 0],
                 [0, 0, 0, 1],
             ]
         ),


### PR DESCRIPTION
**Description**
Fixed the sqrtiswap logic gate error. 

$$
\sqrt{i \text { SWAP }} = 
\left[\begin{array}{cccc}
1 & 0 & 0 & 0 \\
0 & 1 / \sqrt{2} & -i / \sqrt{2} & 0 \\
0 & -i / \sqrt{2} & 1 / \sqrt{2} & 0 \\
0 & 0 & 0 & 1
\end{array}\right]
$$