### PR TITLE
Remove unused fft import

### DIFF
--- a/qutip/solver/correlation.py
+++ b/qutip/solver/correlation.py
@@ -5,7 +5,6 @@ __all__ = [
 ]
 
 import numpy as np
-import scipy.fftpack
 
 from ..core import (
     Qobj, QobjEvo, liouvillian, spre, unstack_columns, stack_columns,


### PR DESCRIPTION
**Description**
We import `scipy.fftpack`, but never used it.
In the past, importing it caused some issue (#1915).
closes #1915