### PR TITLE
Build wheels for mac with intel chips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # between 13 and 14, mac changed from intel chip to apple silicon
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
     env:
       # Set up wheels matrix.  This is CPython 3.10--3.12 for all OS targets.
       CIBW_BUILD: "cp3{10,11,12}-*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,8 +87,6 @@ jobs:
           # Mac
           # Mac has issues with MKL since september 2022.
           - case-name: macos
-            # setup-miniconda not compatible with macos-latest presently.
-            # https://github.com/conda-incubator/setup-miniconda/issues/344
             os: macos-latest
             python-version: "3.12"
             numpy-build: ">=2.0.0"
@@ -97,7 +95,7 @@ jobs:
             nomkl: 1
 
           - case-name: macos - numpy fallback
-            os: macos-latest
+            os: macos-13  # Test on intel cpus
             python-version: "3.11"
             numpy-build: ">=2.0.0"
             numpy-requirement: ">=1.25,<1.26"
@@ -145,6 +143,7 @@ jobs:
           python -m pip install loky tqdm mpmath  # extras
           python -m pip install "coverage${{ matrix.coverage-requirement }}" chardet
           python -m pip install pytest-cov coveralls pytest-fail-slow
+          python -m pip install setuptools
 
           if [[ "${{ matrix.pypi }}" ]]; then
             pip install "numpy${{ matrix.numpy-build }}"


### PR DESCRIPTION
**Description**
From a discussion on discord between Jake and Simon.
We are no longer building wheels for mac with intel chips.
`macos-13`: intel chips
`macos-latest`: apple silicon

Changed the tests so both mac versions are covered.

