### PR TITLE
Update docstring of simdiag

### DIFF
--- a/qutip/simdiag.py
+++ b/qutip/simdiag.py
@@ -66,7 +66,7 @@ def simdiag(ops, evals: bool = True, *,
     Returns
     -------
     eigs : tuple
-        Tuple of arrays representing eigvecs and eigvals of quantum objects
+        Tuple of arrays representing eigvals and eigvecs of quantum objects
         corresponding to simultaneous eigenvectors and eigenvalues for each
         operator.
 


### PR DESCRIPTION
The ordering of the return type is (eigenvalues, eigenvectors), not the other way round.