### PR TITLE
Build wheels for python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
         # between 13 and 14, mac changed from intel chip to apple silicon
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
     env:
-      # Set up wheels matrix.  This is CPython 3.10--3.12 for all OS targets.
+      # Set up wheels matrix.  This is CPython 3.10--3.13 for all OS targets.
       CIBW_BUILD: "cp3{10,11,12,13}-*"
       # Numpy and SciPy do not supply wheels for i686 or win32 for
       # Python 3.10+, so we skip those:
@@ -127,8 +127,8 @@ jobs:
       - name: Install cibuildwheel
         run: |
           # cibuildwheel does the heavy lifting for us. Tested on
-          # 2.19, but should be fine at least up to any minor new release.
-          python -m pip install 'cibuildwheel==2.19.*'
+          # 2.22, but should be fine at least up to any minor new release.
+          python -m pip install 'cibuildwheel==2.22.*'
 
       - name: Build wheels
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
     env:
       # Set up wheels matrix.  This is CPython 3.10--3.12 for all OS targets.
-      CIBW_BUILD: "cp3{10,11,12}-*"
+      CIBW_BUILD: "cp3{10,11,12,13}-*"
       # Numpy and SciPy do not supply wheels for i686 or win32 for
       # Python 3.10+, so we skip those:
       CIBW_SKIP: "*-musllinux* *-manylinux_i686 *-win32"
@@ -164,7 +164,7 @@ jobs:
       - name: Check wheels
         run: |
           ls -R wheels
-          if ! [[ $(ls wheels/*.whl | wc -l) == 9 ]]; then exit 1; fi
+          if ! [[ $(ls wheels/*.whl | wc -l) == 16 ]]; then exit 1; fi
           if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
           if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
 


### PR DESCRIPTION
**Description**
Yesterdays wheels builds failed due to the check wheels failed.
It check that we will upload the expected number of wheels so that is we don't miss any, but it also failed due to more wheels from `macos-13`. Fixed the check and set wheels to also be build on python 3.13.