### PR TITLE
Support for scipy1.15 

### DIFF
--- a/qutip/core/data/eigen.py
+++ b/qutip/core/data/eigen.py
@@ -5,7 +5,7 @@ import scipy.sparse.linalg
 from itertools import combinations
 
 from .dense import Dense, from_csr
-from .csr import CSR
+from .csr import CSR, nnz
 from .properties import isherm as _isherm
 from qutip.settings import settings
 
@@ -233,7 +233,19 @@ def eigs_csr(data, /, isherm=None, vecs=True, sort='low', eigvals=0,
         return eigs_dense(from_csr(data), isherm, vecs, sort, eigvals)
     _eigs_check_shape(data)
     eigvals, num_large, num_small = _eigs_fix_eigvals(data, eigvals, sort)
-    isherm = isherm if isherm is not None else _isherm(data)
+
+    if nnz(data) == 0:
+        # With change in ARPACK used with scipy 1.15, zeros matrix input raise
+        # an error.
+        evals = np.zeros(num_large + num_small)
+        evecs = np.zeros((num_large + num_small, data.shape[0]), dtype=complex)
+        for i in range(num_large + num_small):
+            evecs[i, i] = 1.+0j
+        return (evals, Dense(evecs, copy=False)) if vecs else evals
+
+    # eigsh call eigs for complex matrix. Using the Hermitian version only cast
+    # the eigen values to real values.
+    isherm = isherm if isherm is not None else False
     evals, evecs = _eigs_csr(data.as_scipy(), isherm, vecs, eigvals,
                              num_large, num_small, tol, maxiter)
 

--- a/qutip/tests/test_animation.py
+++ b/qutip/tests/test_animation.py
@@ -1,7 +1,7 @@
 import pytest
 import qutip
 import numpy as np
-from scipy.special import sph_harm
+from qutip.wigner import sph_harm_y
 
 mpl = pytest.importorskip("matplotlib")
 plt = pytest.importorskip("matplotlib.pyplot")
@@ -56,7 +56,7 @@ def test_anim_sphereplot():
     theta = np.linspace(0, np.pi, 90)
     phi = np.linspace(0, 2 * np.pi, 60)
     phi_mesh, theta_mesh = np.meshgrid(phi, theta)
-    values = sph_harm(-1, 2, phi_mesh, theta_mesh).T
+    values = sph_harm_y(2, -1, theta_mesh, phi_mesh).T
     fig, ani = qutip.anim_sphereplot([values]*2, theta, phi)
     plt.close()
 

--- a/qutip/tests/test_visualization.py
+++ b/qutip/tests/test_visualization.py
@@ -1,7 +1,7 @@
 import pytest
 import qutip
 import numpy as np
-from scipy.special import sph_harm
+from qutip.wigner import sph_harm_y
 
 mpl = pytest.importorskip("matplotlib")
 plt = pytest.importorskip("matplotlib.pyplot")
@@ -37,7 +37,7 @@ def test_sequential():
     theta = np.linspace(0, np.pi, 90)
     phi = np.linspace(0, 2 * np.pi, 60)
     phi_mesh, theta_mesh = np.meshgrid(phi, theta)
-    values = sph_harm(-1, 2, phi_mesh, theta_mesh).T
+    values = sph_harm_y(2, -1, theta_mesh, phi_mesh).T
     fig, ax = qutip.sphereplot(values, theta, phi)
     plt.close()
 
@@ -206,7 +206,7 @@ def test_sphereplot(args):
     theta = np.linspace(0, np.pi, 90)
     phi = np.linspace(0, 2 * np.pi, 60)
     phi_mesh, theta_mesh = np.meshgrid(phi, theta)
-    values = sph_harm(-1, 2, phi_mesh, theta_mesh).T
+    values = sph_harm_y(2, -1, theta_mesh, phi_mesh).T
     fig, ax = qutip.sphereplot(values, theta, phi, **args)
     plt.close()
 
@@ -218,7 +218,7 @@ def test_sphereplot_anim():
     theta = np.linspace(0, np.pi, 90)
     phi = np.linspace(0, 2 * np.pi, 60)
     phi_mesh, theta_mesh = np.meshgrid(phi, theta)
-    values = sph_harm(-1, 2, phi_mesh, theta_mesh).T
+    values = sph_harm_y(2, -1, theta_mesh, phi_mesh).T
     fig, ani = qutip.sphereplot([values]*2, theta, phi)
     plt.close()
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -12,7 +12,8 @@ import scipy.sparse as sp
 import scipy.fftpack as ft
 import scipy.linalg as la
 import scipy.special
-from scipy.special import genlaguerre, binom, sph_harm, factorial
+from scipy.special import genlaguerre, binom, factorial
+from scipy.special import sph_harm_y, sph_harm
 
 import qutip
 from qutip import Qobj, ket2dm, jmat
@@ -998,6 +999,8 @@ def spin_wigner(rho, theta, phi):
     for k in range(int(2 * j)+1):
         for q in arange(-k, k+1):
             # sph_harm takes azimuthal angle then polar angle as arguments
-            W += _rho_kq(rho, j, k, q) * sph_harm(q, k, PHI, THETA)
+            rhokq = _rho_kq(rho, j, k, q)
+            sph = sph_harm_y(k, q, THETA, PHI)
+            W += rhokq * sph
 
     return W.real, THETA, PHI

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -13,7 +13,16 @@ import scipy.fftpack as ft
 import scipy.linalg as la
 import scipy.special
 from scipy.special import genlaguerre, binom, factorial
-from scipy.special import sph_harm_y, sph_harm
+
+try:
+    from scipy.special import sph_harm_y
+except ImportError:
+    from scipy.special import sph_harm
+
+    def sph_harm_y(n, m, polar, azimuthal):
+        # sph_harm is set for removal.
+        # Same function, but changed parameter order
+        return sph_harm(m, n, azimuthal, polar)
 
 import qutip
 from qutip import Qobj, ket2dm, jmat
@@ -411,13 +420,14 @@ def _wigner_fft(psi, xvec):
     Returns the corresponding density matrix and range
     """
     n = 2*len(psi.T)
-    r1 = np.concatenate((np.array([[0]]),
-                        np.fliplr(psi.conj()),
-                        np.zeros((1, n//2 - 1))), axis=1)
-    r2 = np.concatenate((np.array([[0]]), psi,
-                        np.zeros((1, n//2 - 1))), axis=1)
-    w = la.toeplitz(np.zeros((n//2, 1)), r1) * \
-        np.flipud(la.toeplitz(np.zeros((n//2, 1)), r2))
+    r1 = np.concatenate(
+        (np.array([0]), np.fliplr(psi.conj()).ravel(), np.zeros(n//2 - 1))
+    )
+    r2 = np.concatenate(
+        (np.array([0]), psi.ravel(), np.zeros(n//2 - 1))
+    )
+    w = la.toeplitz(np.zeros(n//2), r1) * \
+        np.flipud(la.toeplitz(np.zeros(n//2), r2))
     w = np.concatenate((w[:, n//2:n], w[:, 0:n//2]), axis=1)
     w = ft.fft(w)
     w = np.real(np.concatenate((w[:, 3*n//4:n+1], w[:, 0:n//4]), axis=1))
@@ -998,9 +1008,6 @@ def spin_wigner(rho, theta, phi):
 
     for k in range(int(2 * j)+1):
         for q in arange(-k, k+1):
-            # sph_harm takes azimuthal angle then polar angle as arguments
-            rhokq = _rho_kq(rho, j, k, q)
-            sph = sph_harm_y(k, q, THETA, PHI)
-            W += rhokq * sph
+            W += _rho_kq(rho, j, k, q) * sph_harm_y(k, q, THETA, PHI)
 
     return W.real, THETA, PHI


### PR DESCRIPTION
**Description**
- Sparse eigen solver fails with empty matrix input. We can easily detect them.
- `sph_harm` is replaced by `sph_harm_y`. It has reversed input. `sph_harm` will exist until 1.17, but is a lot slower for some reason.
- `toeplitz` will change behavior for multi dimension arrays. Our inputs where vector in a 2D array, just removing the extra dimensions remove the warning.