### PR TITLE
ENR dimensions work with eigenstates

### DIFF
--- a/doc/changes/2595.bugfix
+++ b/doc/changes/2595.bugfix
@@ -1,0 +1,1 @@
+ENR dimensions work with eigenstates

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1507,9 +1507,9 @@ class Qobj:
                                       sort=sort, eigvals=eigvals)
 
         if self.type == 'super':
-            new_dims = [self.dims[0], [1]]
+            new_dims = [self._dims[0], [1]]
         else:
-            new_dims = [self.dims[0], [1]*len(self.dims[0])]
+            new_dims = [self._dims[0], [1]*len(self.dims[0])]
         ekets = np.empty((evecs.shape[1],), dtype=object)
         ekets[:] = [Qobj(vec, dims=new_dims, copy=False)
                     for vec in _data.split_columns(evecs, False)]

--- a/qutip/tests/test_enr_state_operator.py
+++ b/qutip/tests/test_enr_state_operator.py
@@ -189,3 +189,11 @@ def test_steadystate_ENR():
 
     np.testing.assert_allclose(exp_sz_JC,
                                exp_sz_enr, atol=1e-2)
+
+
+def test_eigenstates_ENR():
+    a1, a2 = qutip.enr_destroy([2, 2], 1)
+    H = a1.dag() * a1 + a2.dag() * a2
+    vals, vecs = H.eigenstates()
+    for val, vec in zip(vals, vecs):
+        assert val * vec == H @ vec


### PR DESCRIPTION
**Description**
Use the class dims instead of the list dims in `eigenstates` so it support ENR.

**Related issues or PRs**
fix #2595
