### PR TITLE
Only use coveralls for selected cases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
             semidefinite: 1
             oldcython: 1
             pypi: 1
+            coveralls: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
           # Python 3.12 and latest numpy
@@ -69,6 +70,7 @@ jobs:
             # Install mpi4py to test mpi_pmap
             # Should be enough to include this in one of the runs
             includempi: 1
+            coveralls: 1
 
           # Python 3.10, no mkl, scipy 1.9, numpy 1.23
           # Scipy 1.9 did not support cython 3.0 yet.
@@ -82,6 +84,7 @@ jobs:
             condaforge: 1
             oldcython: 1
             nomkl: 1
+            coveralls: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
           # Mac
@@ -101,6 +104,7 @@ jobs:
             numpy-requirement: ">=1.25,<1.26"
             condaforge: 1
             nomkl: 1
+            coveralls: 1
 
           - case-name: Windows
             os: windows-latest
@@ -119,6 +123,7 @@ jobs:
             nocython: 1
             condaforge: 1
             nomkl: 1
+            coveralls: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
     steps:
@@ -250,6 +255,7 @@ jobs:
           #     force coloured output in the terminal
 
       - name: Upload to Coveralls
+        if: ${{ matrix.coveralls }}
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
           COVERALLS_FLAG_NAME: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.case-name }}


### PR DESCRIPTION
**Description**
I merged #2589 as it was approved not remembering why it was on hold...
`coveralls` does not support python 3.13, so even if the tests passes, the action fail.

Here I skip the step that upload the coverage for python 3.13 tests.

