### PR TITLE
Add installed family package information to qutip.about()

### DIFF
--- a/doc/changes/2604.feature
+++ b/doc/changes/2604.feature
@@ -1,0 +1,2 @@
+Added QuTiP family package information to qutip.about().
+The information is provided by a new QuTiP family package entry point.

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -66,26 +66,24 @@ def about():
 
     # family packages
 
-    print("Installed QuTiP family packages:")
+    print("Installed QuTiP family packages")
+    print("-------------------------------")
     print()
 
     entrypoints = importlib.metadata.entry_points(group="qutip.family")
 
     if not entrypoints:
         print("No QuTiP family packages installed.")
-        print()
 
     for ep in entrypoints:
         family_mod = ep.load()
         try:
-            title, lines = family_mod.about()
+            pkg, version = family_mod.version()
         except Exception as exc:
-            title, lines = ep.name, [str(exc)]
-        print(title)
-        print("-" * len(title))
-        for line in lines:
-            print(line)
-        print()
+            pkg, version = ep.name, [str(exc)]
+        print("%s: %s" % (pkg, version))
+
+    print()
 
     # citation
     longbar = "=" * 80

--- a/qutip/about.py
+++ b/qutip/about.py
@@ -5,6 +5,7 @@ __all__ = ['about']
 
 import sys
 import os
+import importlib
 import platform
 import numpy
 import scipy
@@ -16,7 +17,7 @@ from qutip.settings import _blas_info, settings
 def about():
     """
     About box for QuTiP. Gives version numbers for QuTiP, NumPy, SciPy, Cython,
-    and MatPlotLib.
+    and MatPlotLib and information about installed QuTiP family packages.
     """
     print("")
     print("QuTiP: Quantum Toolbox in Python")
@@ -61,6 +62,30 @@ def about():
                                            platform.machine()))
     qutip_install_path = os.path.dirname(inspect.getsourcefile(qutip))
     print("Installation path:  %s" % qutip_install_path)
+    print()
+
+    # family packages
+
+    print("Installed QuTiP family packages:")
+    print()
+
+    entrypoints = importlib.metadata.entry_points(group="qutip.family")
+
+    if not entrypoints:
+        print("No QuTiP family packages installed.")
+        print()
+
+    for ep in entrypoints:
+        family_mod = ep.load()
+        try:
+            title, lines = family_mod.about()
+        except Exception as exc:
+            title, lines = ep.name, [str(exc)]
+        print(title)
+        print("-" * len(title))
+        for line in lines:
+            print(line)
+        print()
 
     # citation
     longbar = "=" * 80

--- a/qutip/tests/test_about.py
+++ b/qutip/tests/test_about.py
@@ -1,0 +1,18 @@
+import qutip
+
+
+def test_qutip_about(capsys):
+    qutip.about()
+    outerr = capsys.readouterr()
+    out = outerr.out.splitlines()
+    assert out[:3] == [
+        "",
+        "QuTiP: Quantum Toolbox in Python",
+        "================================",
+    ]
+    assert out[-3:] == [
+        "Please cite QuTiP in your publication.",
+        "================================================================================",
+        "For your convenience a bibtex reference can be easily generated using `qutip.cite()`",
+    ]
+    assert outerr.err == ""


### PR DESCRIPTION
**Description**

Adds information on installed QuTiP family packages (e.g. qutip-qip) to `qutip.about()` using an improved version of my suggestion in #1870.

Each family package that wishes to be included in the about information should:

* Register a `qutip.family` entry point that points to a module.
* Add a `version` function to the module that returns a tuple of `(package_name, version_string)`.

In future the `qutip.family` entry point might contain additional functions or attributes.

See https://github.com/qutip/qutip-qip/pull/261 for an example entry point implementation in qutip-qip.

**Related issues or PRs**

- #1870 for a first implementation of these ideas.

**Example qubit.about() output**

```
QuTiP: Quantum Toolbox in Python
================================
Copyright (c) QuTiP team 2011 and later.
Current admin team: ...

QuTiP Version:      5.2.0.dev0+d1dda95
...

Installed QuTiP family packages
-------------------------------

qutip-qip: 0.5.0.dev0+1a94cf5

================================================================================
Please cite QuTiP in your publication.
================================================================================
For your convenience a bibtex reference can be easily generated using `qutip.cite()`
```