### PR TITLE
Update mkl finding to support the 'emscripten' sys.platform.

### DIFF
--- a/doc/changes/2606.bugfix
+++ b/doc/changes/2606.bugfix
@@ -1,0 +1,1 @@
+Update mkl finding to support the 'emscripten' sys.platform.

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -80,10 +80,15 @@ def _find_mkl():
     distributions.
     """
     plat = sys.platform
-    # TODO: fix the mkl handling on windows or use modules like pydiso to do it
-    # for us.
+
     if plat.startswith("win"):
+        # TODO: fix the mkl handling on windows or use modules like pydiso to do it
+        # for us.
         return ""
+    if plat == "emscripten":
+        # mkl is not supported on emscripten
+        return ""
+
     python_dir = os.path.dirname(sys.executable)
     if plat in ['darwin', 'linux2', 'linux']:
         python_dir = os.path.dirname(python_dir)

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -82,8 +82,8 @@ def _find_mkl():
     plat = sys.platform
 
     if plat.startswith("win"):
-        # TODO: fix the mkl handling on windows or use modules like pydiso to do it
-        # for us.
+        # TODO: fix the mkl handling on windows or use modules like pydiso to
+        # do it for us.
         return ""
     if plat == "emscripten":
         # mkl is not supported on emscripten


### PR DESCRIPTION
**Description**

The mkl finding routine only supports a fixed set of `sys.platform` values. This PR adds support for the "emscripten" platform (used by, e.g., try-qutip).

The error was reported by the emscripten-forge package builder for qutip in https://github.com/emscripten-forge/recipes/pull/1475. The build log is at https://github.com/emscripten-forge/recipes/actions/runs/12423612434/job/34687415066?pr=1475 and the relevant portion is:

```
 │ │ │         elif plat in ['linux2', 'linux']:
 │ │ │             ext = ".so"
 │ │ │         else:
 │ │ │ >           raise Exception('Unknown platfrom.')
 │ │ │ E           Exception: Unknown platfrom.
 │ │ │ /lib/python3.11/site-packages/qutip/settings.py:98: Exception
```

**Related issues or PRs**
- https://github.com/emscripten-forge/recipes/pull/1475