### PR TITLE
plot expect function added to result object

### DIFF
--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -7,6 +7,7 @@ from typing import TypedDict, Any, Callable
 from ..core.numpy_backend import np
 from numpy.typing import ArrayLike
 from ..core import Qobj, QobjEvo, expect
+import matplotlib.pyplot as plt
 
 __all__ = ["Result"]
 
@@ -295,6 +296,42 @@ class Result(_BaseResult):
         altogether if a copy is not necessary.
         """
         return state.copy()
+
+    def plot_expect(self, labels=None, title=None, show=True):
+        """
+        Plot expectation values stored in the result object.
+
+        Parameters:
+        -----------
+        labels : list of str, optional
+            Labels for the expectation values.
+            If None, keys from e_ops dictionary are used.
+        title : str, optional
+            Title of the plot. If None, a default title is used.
+        show : bool, optional
+            If True, the plot is displayed immediately.
+        """
+        if not hasattr(self, 'expect'):
+            raise AttributeError(
+                "No expectation values found in the result object.")
+
+        if labels is None:
+            if hasattr(self, 'e_ops') and isinstance(self.e_ops, dict):
+                labels = list(self.e_ops.keys())
+            else:
+                labels = [f'Expectation {i}' for i in range(len(self.expect))]
+
+        plt.figure()
+        for i, (label, values) in enumerate(zip(labels, self.expect)):
+            plt.plot(self.times, values, label=label)
+
+        plt.xlabel('Time')
+        plt.ylabel('Expectation Value')
+        plt.title(title if title else 'Expectation Values')
+        plt.legend()
+
+        if show:
+            plt.show()
 
     def add(self, t, state):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cython>=0.29.20
 numpy>=1.22
 scipy>=1.8
 packaging
+matplotlib


### PR DESCRIPTION
**Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.

- [X] Please read [Contributing to QuTiP Development](http://qutip.org/docs/latest/development/contributing.html)
- [X] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
- [ ] Please add tests to cover your changes if applicable.
- [ ] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-tutorials). Feel free to ask if you are not sure.
- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](http://qutip.org/docs/latest/development/contributing.html#changelog-generation) for more information).

Delete this checklist after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.

**Description**

The given PR adds the plot_expect function to the result class, plotting the required expectation values of `e_ops`. 

**Related issues or PRs**

The PR contributes to #2617.

**Additonal Comments**

- Additional options are such as options for mcsolve results or plotting photocurrent are yet to be added.
- This maybe added in another PR, or in the same PR, once the current changes are approved.
- Not sure on whether I need to create another function or add some extra parameters in the plot_expect to implement the additonal requirements.

