### PR TITLE
Apply tidyup options in `csr.from_dense`

### DIFF
--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -597,14 +597,19 @@ cpdef CSR from_dense(Dense matrix):
     cdef CSR out = empty(matrix.shape[0], matrix.shape[1],
                          matrix.shape[0]*matrix.shape[1])
     cdef size_t row, col, ptr_in, ptr_out=0, row_stride, col_stride
+    cdef double atol = 0
+    cdef double complex value
     row_stride = 1 if matrix.fortran else matrix.shape[1]
     col_stride = matrix.shape[0] if matrix.fortran else 1
     out.row_index[0] = 0
+    if settings.core["auto_tidyup"]:
+        atol = settings.core["auto_tidyup_atol"]**2
     for row in range(matrix.shape[0]):
         ptr_in = row_stride * row
         for col in range(matrix.shape[1]):
-            if matrix.data[ptr_in] != 0:
-                out.data[ptr_out] = matrix.data[ptr_in]
+            value = matrix.data[ptr_in]
+            if value.real**2 + value.imag**2 > atol:
+                out.data[ptr_out] = value
                 out.col_index[ptr_out] = col
                 ptr_out += 1
             ptr_in += col_stride

--- a/qutip/tests/core/data/test_convert.py
+++ b/qutip/tests/core/data/test_convert.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from scipy import sparse
-from qutip import data
+from qutip import data, CoreOptions
 from .test_mathematics import UnaryOpMixin
 
 
@@ -103,3 +103,15 @@ class TestConvert(UnaryOpMixin):
         pytest.param(data.dia.from_dense, data.Dense, data.Dia),
         pytest.param(data.dia.from_csr, data.CSR, data.Dia),
     ]
+
+def test_tidyup_on_convert():
+    mat = data.Dense([[0.1, 1, 1e-15, 0]])
+    with CoreOptions(auto_tidyup=False):
+        csr_mat = data.csr.from_dense(mat)
+        assert data.csr.nnz(csr_mat) == 3
+    with CoreOptions(auto_tidyup=True, auto_tidyup_atol=1e-13):
+        csr_mat = data.csr.from_dense(mat)
+        assert data.csr.nnz(csr_mat) == 2
+    with CoreOptions(auto_tidyup=True, auto_tidyup_atol=0.5):
+        csr_mat = data.csr.from_dense(mat)
+        assert data.csr.nnz(csr_mat) == 1


### PR DESCRIPTION
**Description**
Conversion from csr to dense keeps all non strictly `0` entries.
This could cause strange result: `oper.expm().to("csr")` would not round, but `oper.expm(dtype="csr")` would.

With this change, the `auto_tidyup` options is used to round off small values.
The default for `auto_tidyup_atol` is `1e-14` to 0.