### PR TITLE
Add support for FermionicEnvironment in Bloch RedFieldTensor.

### DIFF
--- a/doc/apidoc/quantumobject.rst
+++ b/doc/apidoc/quantumobject.rst
@@ -85,6 +85,12 @@ Superoperators and Liouvillians
 .. automodule:: qutip.core.superoperator
     :members: operator_to_vector, vector_to_operator, liouvillian, spost, spre, sprepost, lindblad_dissipator
 
+Superoperators and Liouvillians
+-------------------------------
+
+.. automodule:: qutip.core.blochredfield
+    :members: bloch_redfield_tensor, brterm, brcrossterm
+
 Superoperator Representations
 -----------------------------
 

--- a/doc/changes/2628.feature
+++ b/doc/changes/2628.feature
@@ -1,0 +1,1 @@
+Add support for `FermionicEnvironment` in Bloch Redfield tensor and solver.

--- a/doc/guide/dynamics/dynamics-bloch-redfield.rst
+++ b/doc/guide/dynamics/dynamics-bloch-redfield.rst
@@ -81,10 +81,10 @@ This allows us to write master equation in terms of system operators and bath co
     \sum_{\alpha\beta}
     \int_0^\infty d\tau\;
     \left\{
-    g_{\alpha\beta}(\tau) \left[A_\alpha(t)A_\beta(t-\tau)\rho_S(t) - A_\alpha(t-\tau)\rho_S(t)A_\beta(t)\right]
+    g_{\alpha\beta}(\tau) \left[A_\alpha(t)A_\beta(t-\tau)\rho_S(t) - A_\beta(t-\tau)\rho_S(t)A_\alpha(t)\right]
     \right. \nonumber\\
     \left.
-    g_{\alpha\beta}(-\tau) \left[\rho_S(t)A_\alpha(t-\tau)A_\beta(t) - A_\alpha(t)\rho_S(t)A_\beta(t-\tau)\right]
+    g_{\alpha\beta}(-\tau) \left[\rho_S(t)A_\alpha(t-\tau)A_\beta(t) - A_\beta(t)\rho_S(t)A_\beta(t-\alpha)\right]
     \right\},
 
 where :math:`g_{\alpha\beta}(\tau) = {\rm Tr}_B\left[B_\alpha(t)B_\beta(t-\tau)\rho_B\right] = \left<B_\alpha(\tau)B_\beta(0)\right>`,
@@ -107,7 +107,7 @@ corresponding the eigenstate :math:`\left|m\right>`, we obtain in matrix form in
     g_{\alpha\beta}(\tau)
     \left[\delta_{bd}\sum_nA^\alpha_{an}A^\beta_{nc}e^{i\omega_{cn}\tau}
     -
-    A^\alpha_{ac} A^\beta_{db} e^{i\omega_{ca}\tau}
+    A^\beta_{ac} A^\alpha_{db} e^{i\omega_{ca}\tau}
     \right]
     \right. \nonumber\\
     &+
@@ -115,7 +115,7 @@ corresponding the eigenstate :math:`\left|m\right>`, we obtain in matrix form in
     g_{\alpha\beta}(-\tau)
     \left[\delta_{ac}\sum_n A^\alpha_{dn}A^\beta_{nb} e^{i\omega_{nd}\tau}
     -
-    A^\alpha_{ac}A^\beta_{db}e^{i\omega_{bd}\tau}
+    A^\beta_{ac}A^\alpha_{db}e^{i\omega_{bd}\tau}
     \right]
     \right\} \rho_{cd}(t),
     \nonumber\\
@@ -149,20 +149,20 @@ where
     \left\{
     \delta_{bd}\sum_nA^\alpha_{an}A^\beta_{nc}S_{\alpha\beta}(\omega_{cn})
     -
-    A^\alpha_{ac} A^\beta_{db} S_{\alpha\beta}(\omega_{ca})
+    A^\beta_{ac} A^\alpha_{db} S_{\alpha\beta}(\omega_{ca})
     \right. \nonumber\\
     +
     \left.
     \delta_{ac}\sum_n A^\alpha_{dn}A^\beta_{nb} S_{\alpha\beta}(\omega_{dn})
     -
-    A^\alpha_{ac}A^\beta_{db} S_{\alpha\beta}(\omega_{db})
+    A^\beta_{ac}A^\alpha_{db} S_{\alpha\beta}(\omega_{db})
     \right\},
 
 is the Bloch-Redfield tensor.
 
 The Bloch-Redfield master equation in the form Eq. :eq:`br-final` is suitable for numerical implementation. The input parameters are the system Hamiltonian :math:`H`, the system operators through which the environment couples to the system :math:`A_\alpha`, and the noise-power spectrum :math:`S_{\alpha\beta}(\omega)` associated with each system-environment interaction term.
 
-To simplify the numerical implementation we assume that :math:`A_\alpha` are Hermitian and that cross-correlations between different environment operators vanish, so that the final expression for the Bloch-Redfield tensor that is implemented in QuTiP is
+To simplify the numerical implementation we often assume that :math:`A_\alpha` are Hermitian and that cross-correlations between different environment operators vanish, resulting in
 
 .. math::
    :label: br-tensor
@@ -190,8 +190,8 @@ Bloch-Redfield master equation in QuTiP
 In QuTiP, Eq. :eq:`br-final` can be calculated using the function :func:`.bloch_redfield_tensor`.
 It takes two mandatory arguments: The system Hamiltonian :math:`H`, a nested list of operator
 :math:`A_\alpha`, spectral density functions :math:`S_\alpha(\omega)` pairs that characterize the coupling between system and bath.
-The spectral density functions are Python callback functions that takes the (angular) frequency as a single argument.
-Each term of Eq. :eq:`br-tensor` can be called using :func:`.brterm`.
+The spectral density functions are best given using `QuTiP's Environment <environments guide>`_, but Python callback functions that takes the (angular) frequency as a single argument are also accepted.
+It is possible to also get each term of Eq. :eq:`br-tensor` directly using :func:`.brterm`.
 This function take only a single operator a_op and spectral response function.
 
 To illustrate how to calculate the Bloch-Redfield tensor, let's consider a two-level atom
@@ -324,10 +324,10 @@ Simulating Fermionic interactions
 =================================
 
 Previously, we assumed that the interaction operators :math:`A_\alpha` were hermitian.
-However to simulate fermionic bath, we must consider system-bath interaction in the form :math:`H_I = \sum_\alpha A^\dagger_\alpha \otimes B_\alpha + A_\alpha \otimes B^\dagger_\alpha`.
+However for fermionic bath, we must consider system-bath interaction in the form :math:`H_I = \sum_\alpha A^\dagger_\alpha \otimes B_\alpha + A_\alpha \otimes B^\dagger_\alpha`.
 
-In QuTiP, to simutate such system, :class:`.FermionicEnvironment` can be used as the spectra.
-Otherwise the function :func:`.brcrossterm` can build a single term of the :math:`\alpha, \beta` sum of Eq. :eq:`br-nonmarkovian-form-five` allowing custom complex baths.
+In QuTiP, to create such system, :class:`.FermionicEnvironment` can be used as the spectra in :func:`.bloch_redfield_tensor`.
+The function :func:`.brcrossterm` can build a single term of the sum over :math:`\alpha, \beta` of Eq. :eq:`br-nonmarkovian-form-five` allowing custom complex baths.
 
 
 .. _td-bloch-redfield:

--- a/doc/guide/dynamics/dynamics-bloch-redfield.rst
+++ b/doc/guide/dynamics/dynamics-bloch-redfield.rst
@@ -187,11 +187,12 @@ Bloch-Redfield master equation in QuTiP
 =======================================
 
 
-
-In QuTiP, the Bloch-Redfield tensor Eq. :eq:`br-tensor` can be calculated using the function :func:`.bloch_redfield_tensor`.
+In QuTiP, Eq. :eq:`br-final` can be calculated using the function :func:`.bloch_redfield_tensor`.
 It takes two mandatory arguments: The system Hamiltonian :math:`H`, a nested list of operator
 :math:`A_\alpha`, spectral density functions :math:`S_\alpha(\omega)` pairs that characterize the coupling between system and bath.
 The spectral density functions are Python callback functions that takes the (angular) frequency as a single argument.
+Each term of Eq. :eq:`br-tensor` can be called using :func:`.brterm`.
+This function take only a single operator a_op and spectral response function.
 
 To illustrate how to calculate the Bloch-Redfield tensor, let's consider a two-level atom
 
@@ -316,6 +317,18 @@ where the resulting `output` is an instance of the class :class:`.Result`.
 
     will simulate the same example as above without the secular approximation.
     Note that using the non-secular version may lead to negativity issues.
+
+.. _br-fermion:
+
+Simulating Fermionic interactions
+=================================
+
+Previously, we assumed that the interaction operators :math:`A_\alpha` were hermitian.
+However to simulate fermionic bath, we must consider system-bath interaction in the form :math:`H_I = \sum_\alpha A^\dagger_\alpha \otimes B_\alpha + A_\alpha \otimes B^\dagger_\alpha`.
+
+In QuTiP, to simutate such system, :class:`.FermionicEnvironment` can be used as the spectra.
+Otherwise the function :func:`.brcrossterm` can build a single term of the :math:`\alpha, \beta` sum of Eq. :eq:`br-nonmarkovian-form-five` allowing custom complex baths.
+
 
 .. _td-bloch-redfield:
 

--- a/qutip/core/_brtensor.pyx
+++ b/qutip/core/_brtensor.pyx
@@ -228,6 +228,7 @@ cdef class _BlochRedfieldElement(_BaseElement):
         self.tensortype = {
             'sparse': SPARSE,
             'dense': DENSE,
+            'matrix': DATA,
             'data': DATA
         }[dtype]
 
@@ -472,8 +473,9 @@ cdef class _BlochRedfieldCrossElement(_BlochRedfieldElement):
 
         dtype = dtype or ('dense' if sec_cutoff >= np.inf else 'sparse')
         self.tensortype = {
-            'sparse': DATA,
+            'sparse': DENSE,  # TODO write the dense version.
             'dense': DENSE,
+            'matrix': DATA,
             'data': DATA
         }[dtype]
 

--- a/qutip/core/_brtensor.pyx
+++ b/qutip/core/_brtensor.pyx
@@ -355,8 +355,8 @@ cpdef Data _br_cterm_data(Data A, Data B, double[:, ::1] spectrum,
     S = _data.to(cls, _data.mul(_data.Dense(spectrum), 0.5))
     I = _data.identity[cls](nrows)
 
-    P1 = _data.kron(_data.multiply(A, _data.transpose(S)), _data.transpose(B))
-    P2 = _data.kron(A, _data.transpose(_data.multiply(B, S)))
+    P1 = _data.kron(_data.multiply(B, _data.transpose(S)), _data.transpose(A))
+    P2 = _data.kron(B, _data.transpose(_data.multiply(A, S)))
     P3 = _data.kron(I, _data.transpose(_data.matmul(_data.multiply(A, S), B)))
     P4 = _data.kron(_data.matmul(A, _data.multiply(B, _data.transpose(S))), I)
 
@@ -425,8 +425,8 @@ cpdef Dense _br_cterm_dense(Data A, Data B, double[:, ::1] spectrum,
             for c in range(nrows):
                 for d in range(nrows):
                     if fabs(skew[a, b] - skew[c, d]) < cutoff:
-                        elem = A_mat[a, c] * B_mat[d, b]
-                        elem *= (spectrum[c, a] + spectrum[d, b])
+                        elem = B_mat[a, c] * A_mat[d, b] * spectrum[d, b]
+                        elem += B_mat[a, c] * A_mat[d, b] * spectrum[c, a]
                         if a == c:
                             elem = elem - ac_term[d, b]
                         if b == d:

--- a/qutip/core/_brtools.pyx
+++ b/qutip/core/_brtools.pyx
@@ -4,6 +4,7 @@ from libc.float cimport DBL_MAX
 
 cimport numpy as cnp
 import numpy as np
+import warnings
 
 cimport cython
 
@@ -191,13 +192,18 @@ cdef class _EigenBasisTransform:
         Hermitian operator for which to compute the eigenbasis.
 
     sparse : bool [False]
-        Whether to use sparse solver for eigen decomposition.
+        Deprecated
     """
     def __init__(self, QobjEvo oper, bint sparse=False):
         if oper.dims[0] != oper.dims[1]:
             raise ValueError
         if type(oper(0).data) in (_data.CSR, _data.Dia) and not sparse:
             oper = oper.to(Dense)
+        elif type(oper(0).data) in (_data.CSR, _data.Dia) and sparse:
+            warnings.warn(
+                "Sparse Eigen solver is unstable and will be removed",
+                DeprecationWarning
+            )
         self.oper = oper
         self.isconstant = oper.isconstant
         self.size = oper.shape[0]

--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -125,12 +125,12 @@ def bloch_redfield_tensor(
                 # TODO: Check if plus / minus are right.
                 R += brcrossterm(
                     H_transform, a_op, a_op.dag(),
-                    spectra.power_spectrum_minus, sec_cutoff, True,
+                    lambda w: spectra.power_spectrum_plus(-w), sec_cutoff, True,
                     br_computation_method=br_computation_method
                 )
                 R += brcrossterm(
                     H_transform, a_op.dag(), a_op,
-                    spectra.power_spectrum_plus, sec_cutoff, True,
+                    spectra.power_spectrum_minus, sec_cutoff, True,
                     br_computation_method=br_computation_method
                 )
             else:

--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -294,7 +294,7 @@ def brcrossterm(
     sec_cutoff: float = 0.1,
     fock_basis: bool = False,
     sparse_eigensolver: bool = False,
-    br_computation_method: str = 'data',
+    br_computation_method: str = 'sparse',
 ) -> Qobj: ...
 
 @overload
@@ -306,7 +306,7 @@ def brcrossterm(
     sec_cutoff: float = 0.1,
     fock_basis: bool = False,
     sparse_eigensolver: bool = False,
-    br_computation_method: str = 'data',
+    br_computation_method: str = 'sparse',
 ) -> QobjEvo: ...
 
 def brcrossterm(
@@ -317,7 +317,7 @@ def brcrossterm(
     sec_cutoff: float = 0.1,
     fock_basis: bool = False,
     sparse_eigensolver: bool = False,
-    br_computation_method: str = 'data',
+    br_computation_method: str = 'sparse',
 ) -> Qobj | QobjEvo:
     """
     Calculates the contribution of one coupling operator to the Bloch-Redfield
@@ -359,10 +359,11 @@ def brcrossterm(
     sparse_eigensolver : bool {False}
         Whether to use the sparse eigensolver on the Hamiltonian.
 
-    br_computation_method : ['dense', 'matrix']
+    br_computation_method : ['dense', 'sparse', 'matrix']
         How computation for the tensor is made.
-        With 'dense', the secular cutoff is checked first and only
-        elements within the approximation are computed and stored in an array.
+        With 'dense' or 'sparse', the secular cutoff is checked first and only
+        elements within the approximation are computed and stored in an
+        (sparse) array.
         With 'matrix', the tensor is build using matrix operation and the
         secular cutoff is applied at the end.
 

--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -100,10 +100,13 @@ def bloch_redfield_tensor(
     sparse_eigensolver : bool {False}
         Whether to use the sparse eigensolver
 
-    br_computation_method : ['sparse', 'dense', 'data']
+    br_computation_method : ['sparse', 'dense', 'matrix']
         How computation for the tensor is made.
-        Using "dense" numpy array, coo "sparse" matrix or qutip's "data" class.
-        With a cutoff 'sparse' is usually the most efficient.
+        With 'dense' or 'sparse', the secular cutoff is checked first and only
+        elements within the approximation are computed and stored in an
+        (sparse) array.
+        With 'matrix', the tensor is build using matrix operation and the
+        secular cutoff is applied at the end.
 
     Returns
     -------
@@ -229,10 +232,13 @@ def brterm(
     sparse_eigensolver : bool {False}
         Whether to use the sparse eigensolver on the Hamiltonian.
 
-    br_computation_method : ['sparse', 'dense', 'data']
+    br_computation_method : ['sparse', 'dense', 'matrix']
         How computation for the tensor is made.
-        Using "dense" numpy array, coo "sparse" matrix or qutip's "data" class.
-        With a cutoff 'sparse' is usually the most efficient.
+        With 'dense' or 'sparse', the secular cutoff is checked first and only
+        elements within the approximation are computed and stored in an
+        (sparse) array.
+        With 'matrix', the tensor is build using matrix operation and the
+        secular cutoff is applied at the end.
 
     Returns
     -------
@@ -353,9 +359,12 @@ def brcrossterm(
     sparse_eigensolver : bool {False}
         Whether to use the sparse eigensolver on the Hamiltonian.
 
-    br_computation_method : ['dense', 'data']
+    br_computation_method : ['dense', 'matrix']
         How computation for the tensor is made.
-        Using "dense" numpy array or qutip's "data" class.
+        With 'dense', the secular cutoff is checked first and only
+        elements within the approximation are computed and stored in an array.
+        With 'matrix', the tensor is build using matrix operation and the
+        secular cutoff is applied at the end.
 
     Returns
     -------

--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -104,7 +104,7 @@ def bloch_redfield_tensor(
         basis.
 
     sparse_eigensolver : bool {False}
-        Whether to use the sparse eigensolver
+        Deprecated
 
     br_computation_method : ['sparse', 'dense', 'matrix']
         How computation for the tensor is made.
@@ -123,7 +123,7 @@ def bloch_redfield_tensor(
         column.
     """
     R = liouvillian(H, c_ops)
-    H_transform = _EigenBasisTransform(QobjEvo(H), sparse_eigensolver)
+    H_transform = _EigenBasisTransform(QobjEvo(H), sparse=sparse_eigensolver)
 
     if fock_basis:
         for (a_op, spectra) in a_ops:
@@ -234,7 +234,7 @@ def brterm(
         basis.
 
     sparse_eigensolver : bool {False}
-        Whether to use the sparse eigensolver on the Hamiltonian.
+        Deprecated
 
     br_computation_method : ['sparse', 'dense', 'matrix']
         How computation for the tensor is made.
@@ -361,7 +361,7 @@ def brcrossterm(
         basis.
 
     sparse_eigensolver : bool {False}
-        Whether to use the sparse eigensolver on the Hamiltonian.
+        Deprecated
 
     br_computation_method : ['dense', 'sparse', 'matrix']
         How computation for the tensor is made.

--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -151,7 +151,7 @@ def bloch_redfield_tensor(
                 # TODO: double check plus / minus ...
                 R += brcrossterm(
                     H_transform, a_op, a_op.dag(),
-                    spectra.power_spectrum_plus, sec_cutoff, False,
+                    lambda w: spectra.power_spectrum_plus(-w), sec_cutoff, False,
                     br_computation_method=br_computation_method
                 )[0]
                 R += brcrossterm(

--- a/qutip/core/blochredfield.py
+++ b/qutip/core/blochredfield.py
@@ -72,13 +72,16 @@ def bloch_redfield_tensor(
         a_op : :class:`qutip.Qobj`, :class:`qutip.QobjEvo`
             The operator coupling to the environment. Must be hermitian.
 
-        spectra : :obj:`.Coefficient`, func, str
+        spectra : :obj:`.Coefficient`, func, str, Environment
             The corresponding bath spectra.
-            Can be a :obj:`.Coefficient` using an 'w' args, a function of the
-            frequency or a string. The :class:`SpectraCoefficient` can be used
-            for array based coefficient.
-            The spectra can depend on ``t`` if the corresponding
-            ``a_op`` is a :obj:`.QobjEvo`.
+            Bath can be provided as :class:`.BosonicEnvironment`,
+            :class:`.FermionicEnvironment` or power spectra function. These can
+            be a :obj:`.Coefficient`, function or string. For coefficient, the
+            frequency is passed as the 'w' args. The
+            :class:`SpectraCoefficient` can be used for array based
+            coefficient.
+
+            The spectra can depend on ``t`` if ``a_op`` is a :obj:`.QobjEvo`.
 
         Example:
 
@@ -212,18 +215,22 @@ def brterm(
     a_op : :class:`qutip.Qobj`, :class:`qutip.QobjEvo`
         The operator coupling to the environment. Expected to be hermitian.
 
-    spectra : :obj:`.Coefficient`, func, str
+    spectra : :obj:`.Coefficient`, func, str, Environment
         The corresponding bath spectra.
-        Can be a :obj:`.Coefficient` using an 'w' args, a function of the
-        frequency or a string. The :class:`SpectraCoefficient` can be used for
-        array based coefficient.
-        The spectra can depend on ``t`` if the corresponding
-        ``a_op`` is a :obj:`.QobjEvo`.
+        Bath can be provided as :class:`.BosonicEnvironment`,
+        :class:`.FermionicEnvironment` or power spectra function. These can be
+        a :obj:`.Coefficient`, function or string. For coefficient, the
+        frequency is passed as the 'w' args. The :class:`SpectraCoefficient`
+        can be used for array based coefficient.
+
+        The spectra can depend on ``t`` if ``a_op`` is a :obj:`.QobjEvo`.
 
         Example:
 
             coefficient('w>0', args={"w": 0})
             SpectraCoefficient(coefficient(array, tlist=...))
+            lambda w: (w > 0) * 1.
+            BosonicEnvironment(...)
 
     sec_cutoff : float {0.1}
         Cutoff for secular approximation. Use ``-1`` if secular approximation
@@ -339,18 +346,22 @@ def brcrossterm(
     b_op : :class:`qutip.Qobj`, :class:`qutip.QobjEvo`
         The operator coupling to the environment.
 
-    spectra : :obj:`.Coefficient`, func, str
+    spectra : :obj:`.Coefficient`, func, str, Environment
         The corresponding bath spectra.
-        Can be a :obj:`.Coefficient` using an 'w' args, a function of the
-        frequency or a string. The :class:`SpectraCoefficient` can be used for
-        array based coefficient.
-        The spectra can depend on ``t`` if the corresponding
-        ``a_op`` is a :obj:`.QobjEvo`.
+        Bath can be provided as :class:`.BosonicEnvironment`,
+        :class:`.FermionicEnvironment` or power spectra function. These can be
+        a :obj:`.Coefficient`, function or string. For coefficient, the
+        frequency is passed as the 'w' args. The :class:`SpectraCoefficient`
+        can be used for array based coefficient.
+
+        The spectra can depend on ``t`` if ``a_op`` is a :obj:`.QobjEvo`.
 
         Example:
 
             coefficient('w>0', args={"w": 0})
             SpectraCoefficient(coefficient(array, tlist=...))
+            lambda w: (w > 0) * 1.
+            BosonicEnvironment(...)
 
     sec_cutoff : float {0.1}
         Cutoff for secular approximation. Use ``-1`` if secular approximation

--- a/qutip/core/environment.py
+++ b/qutip/core/environment.py
@@ -19,7 +19,7 @@ __all__ = ['BosonicEnvironment',
 import abc
 import enum
 from time import time
-from typing import Any, Callable, Literal, Sequence, overload
+from typing import Any, Callable, Literal, Sequence, overload, Union
 import warnings
 
 import numpy as np
@@ -2743,3 +2743,6 @@ class ExponentialFermionicEnvironment(FermionicEnvironment):
                 )
 
         return S.item() if w.ndim == 0 else S
+
+
+Environment = Union[BosonicEnvironment, FermionicEnvironment]

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -143,8 +143,6 @@ def brmesolve(
             array. With 'matrix', the tensor is build using matrix operation
             and the secular cutoff is applied at the end.
             With a cutoff 'sparse' is usually the most efficient.
-        - | sparse_eigensolver : bool {False}
-            Whether to use the sparse eigensolver
         - | method : str ["adams", "bdf", "lsoda", "dop853", "vern9", etc.]
             Which differential equation integration method to use.
         - | atol, rtol : float
@@ -288,7 +286,6 @@ class BRSolver(Solver):
         "normalize_output": False,
         'method': 'adams',
         'tensor_type': 'sparse',
-        'sparse_eigensolver': False,
     }
     _avail_integrators = {}
 
@@ -355,7 +352,7 @@ class BRSolver(Solver):
             *self._system,
             fock_basis=True,
             sec_cutoff=self.sec_cutoff,
-            sparse_eigensolver=self.options['sparse_eigensolver'],
+            sparse_eigensolver=False,
             br_computation_method=self.options['tensor_type']
         )
         self._init_rhs_time = time() - _time_start
@@ -391,9 +388,6 @@ class BRSolver(Solver):
             Which data type to use when computing the brtensor.
             With a cutoff 'sparse' is usually the most efficient.
 
-        sparse_eigensolver: bool, default: False
-            Whether to use the sparse eigensolver
-
         method: str, default: "adams"
             Which ODE integrator methods are supported.
         """
@@ -405,9 +399,7 @@ class BRSolver(Solver):
 
     def _apply_options(self, keys):
         need_new_rhs = self.rhs is not None and not self.rhs.isconstant
-        need_new_rhs &= (
-            'sparse_eigensolver' in keys or 'tensor_type' in keys
-        )
+        need_new_rhs &= 'tensor_type' in keys
         if need_new_rhs:
             self.rhs = self._prepare_rhs()
 

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -137,8 +137,11 @@ def brmesolve(
             if not installed. Empty string or False will disable the bar.
         - | progress_kwargs : dict
           | kwargs to pass to the progress_bar. Qutip's bars use `chunk_size`.
-        - | tensor_type : str ['sparse', 'dense', 'data']
-          | Which data type to use when computing the brtensor.
+        - | computation_type : str ['sparse', 'dense', 'matrix']
+          | With 'dense', the secular cutoff is checked first and only
+            elements within the approximation are computed and stored in an
+            array. With 'matrix', the tensor is build using matrix operation
+            and the secular cutoff is applied at the end.
             With a cutoff 'sparse' is usually the most efficient.
         - | sparse_eigensolver : bool {False}
             Whether to use the sparse eigensolver

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -63,21 +63,24 @@ def brmesolve(
         a_op : :obj:`.Qobj`, :obj:`.QobjEvo`, :obj:`.QobjEvo` compatible format
             The operator coupling to the environment. Must be hermitian.
 
-        spectra : :obj:`.Coefficient`, str, func
-            The corresponding bath spectral responce.
-            Can be a `Coefficient` using an 'w' args, a function of the
-            frequence or a string. Coefficient build from a numpy array are
-            understood as a function of ``w`` instead of ``t``. Function are
-            expected to be of the signature ``f(w)`` or ``f(t, w, **args)``.
+        spectra : :obj:`.Coefficient`, str, func, Environment
+            The corresponding bath spectra.
+            Bath can be provided as :class:`.BosonicEnvironment`, 
+            :class:`.FermionicEnvironment` or power spectra function.  These
+            can be a :obj:`.Coefficient`, function or string. For coefficient,
+            the frequency is passed as the 'w' args. The
+            :class:`SpectraCoefficient` can be used for array based
+            coefficient.
 
-            The spectra function can depend on ``t`` if the corresponding
-            ``a_op`` is a :obj:`.QobjEvo`.
+            The spectra can depend on ``t`` if the corresponding ``a_op`` is a
+            :obj:`.QobjEvo`.
 
         Example:
 
         .. code-block::
 
             a_ops = [
+                (a+a.dag(), BosonicEnvironment(...)),
                 (a+a.dag(), ('w>0', args={"w": 0})),
                 (QobjEvo(a+a.dag()), 'w > exp(-t)'),
                 ([[b+b.dag(), lambda t: ...]], lambda w: ...)),

--- a/qutip/tests/core/test_brtools.py
+++ b/qutip/tests/core/test_brtools.py
@@ -141,7 +141,7 @@ def test_eigen_transform_super_ops():
 
 @pytest.mark.parametrize('func',
                          [_br_term_dense, _br_term_sparse, _br_term_data],
-                         ids=['dense', 'sparse', 'data'])
+                         ids=['dense', 'sparse', 'matrix'])
 def test_br_term_linbblad_comp(func):
     N = 5
     a = qutip.destroy(N) + qutip.destroy(N)**2 / 2
@@ -224,7 +224,7 @@ def test_td_brterm(cutoff):
 
 
 @pytest.mark.parametrize(
-    'func', [_br_term_sparse, _br_term_data], ids=['sparse', 'data']
+    'func', [_br_term_sparse, _br_term_data], ids=['sparse', 'matrix']
 )
 @pytest.mark.parametrize('cutoff', [0, 0.1, 1, 3, -1])
 def test_br_term_format(func, cutoff):
@@ -241,7 +241,7 @@ def test_br_term_format(func, cutoff):
 
 
 @pytest.mark.parametrize(
-    'func', [_br_cterm_dense, _br_cterm_data], ids=['dense', 'data']
+    'func', [_br_cterm_dense, _br_cterm_data], ids=['dense', 'matrix']
 )
 @pytest.mark.parametrize('cutoff', [0, 0.1, 1, 3, -1])
 def test_brcrossterm_direct(func, cutoff):

--- a/qutip/tests/core/test_brtools.py
+++ b/qutip/tests/core/test_brtools.py
@@ -44,12 +44,11 @@ def test_matmul_var(datatype, transleft, transright):
     np.testing.assert_allclose(computed, expected, rtol=1e-14)
 
 
-@pytest.mark.parametrize('sparse', [False, True], ids=['Dense', 'Sparse'])
-def test_eigen_transform(sparse):
+def test_eigen_transform():
     a = qutip.destroy(5)
     f = lambda t: t
     op = qutip.QobjEvo([a*a.dag(), [a+a.dag(), f]])
-    eigenT = _EigenBasisTransform(op, sparse=sparse)
+    eigenT = _EigenBasisTransform(op)
     evecs_qevo = eigenT.as_Qobj()
 
     for t in [0, 1, 1.5]:

--- a/qutip/tests/core/test_brtools.py
+++ b/qutip/tests/core/test_brtools.py
@@ -5,7 +5,7 @@ from qutip.core._brtools import matmul_var_data, _EigenBasisTransform
 from qutip.core.blochredfield import brterm, bloch_redfield_tensor, brcrossterm
 from qutip.core._brtensor import (
     _br_term_dense, _br_term_sparse, _br_term_data,
-    _br_cterm_dense, _br_cterm_data,
+    _br_cterm_dense, _br_cterm_sparse, _br_cterm_data,
     _BlochRedfieldElement
 )
 
@@ -241,7 +241,9 @@ def test_br_term_format(func, cutoff):
 
 
 @pytest.mark.parametrize(
-    'func', [_br_cterm_dense, _br_cterm_data], ids=['dense', 'matrix']
+    'func',
+    [_br_cterm_dense, _br_cterm_data, _br_cterm_sparse],
+    ids=['dense', 'matrix', 'sparse']
 )
 @pytest.mark.parametrize('cutoff', [0, 0.1, 1, 3, -1])
 def test_brcrossterm_direct(func, cutoff):
@@ -272,6 +274,10 @@ def test_brcrossterm_comp(cutoff):
         a.data, a.dag().data, spectrum, skew, cutoff
     ).to_array()
     np.testing.assert_allclose(computed, expected, rtol=1e-14, atol=1e-14)
+    expected = _br_cterm_sparse(
+        a.data, a.dag().data, spectrum, skew, cutoff
+    ).to_array()
+    np.testing.assert_allclose(computed, expected, rtol=1e-14, atol=1e-14)
 
 
 def test_bloch_redfield_tensor_fermionbath():
@@ -282,7 +288,7 @@ def test_bloch_redfield_tensor_fermionbath():
 
     R_split = qutip.liouvillian(H)
     R_split += brcrossterm(
-        H, A, A.dag(), w, fock_basis=True
+        H, A, A.dag(), env.power_spectrum_minus, fock_basis=True
     )
     R_split += brcrossterm(
         H, A.dag(), A, lambda w: env.power_spectrum_plus(-w), fock_basis=True


### PR DESCRIPTION
**Description**
- Add support for `FermionicEnvironment` in Bloch `brmesolve`, `BRSolver` and `bloch_redfield_tensor`.
- Any environment are valid spectra for the above function.
- Add a new function: `brcrossterm`, compute cross term in equation (6) of our [guide](https://qutip.readthedocs.io/en/latest/guide/dynamics/dynamics-bloch-redfield.html).
- Improve documentation for the `br_dtype` parameter in `bloch_redfield_tensor`.
- Fix the equations in the documentation.

An example of fermion environment in the guide could be good.
