### PR TITLE
Use less the sparse eigen solver

### DIFF
--- a/qutip/core/data/eigen.py
+++ b/qutip/core/data/eigen.py
@@ -337,7 +337,6 @@ eigs.__doc__ =\
         order of the eigenvalues.
     """
 eigs.add_specialisations([
-    (CSR, eigs_csr),
     (Dense, eigs_dense),
 ], _defer=True)
 

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1563,7 +1563,8 @@ class Qobj:
         -----
         The sparse eigensolver is much slower than the dense version.
         Use sparse only if memory requirements demand it.
-
+        It is designed to compute only a few eigenvalues and can give wrong
+        results when all eigenvalues are asked.
         """
         if isinstance(self.data, _data.CSR) and sparse:
             evals, evecs = _data.eigs_csr(self.data,
@@ -1678,13 +1679,6 @@ class Qobj:
             Eigenvalue for the ground state of quantum operator.
         eigvec : :class:`.Qobj`
             Eigenket for the ground state of quantum operator.
-
-        Notes
-        -----
-        The sparse eigensolver is much slower than the dense version.
-        Use sparse only if memory requirements demand it.
-        It is designed to compute only a few eigenvalues and can give wrong
-        results when all eigenvalues are asked.
         """
         eigvals = 2 if safe else 1
         evals, evecs = self.eigenstates(sparse=sparse, eigvals=eigvals,

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -1630,7 +1630,8 @@ class Qobj:
         -----
         The sparse eigensolver is much slower than the dense version.
         Use sparse only if memory requirements demand it.
-
+        It is designed to compute only a few eigenvalues and can give wrong
+        results when all eigenvalues are asked.
         """
         # TODO: consider another way of handling the dispatch here.
         if isinstance(self.data, _data.CSR) and sparse:
@@ -1682,6 +1683,8 @@ class Qobj:
         -----
         The sparse eigensolver is much slower than the dense version.
         Use sparse only if memory requirements demand it.
+        It is designed to compute only a few eigenvalues and can give wrong
+        results when all eigenvalues are asked.
         """
         eigvals = 2 if safe else 1
         evals, evecs = self.eigenstates(sparse=sparse, eigvals=eigvals,

--- a/qutip/tests/core/test_eigen.py
+++ b/qutip/tests/core/test_eigen.py
@@ -35,8 +35,9 @@ def test_eigen_known_oper(sparse, dtype):
 @pytest.mark.parametrize("order", ['low', 'high'])
 def test_eigen_rand_oper(rand, sparse, dtype, order):
     H = rand(10, dtype=dtype)
-    spvals, spvecs = H.eigenstates(sparse=sparse, sort=order)
-    sp_energies = H.eigenenergies(sparse=sparse, sort=order)
+    eigvals = 5 if sparse else 0
+    spvals, spvecs = H.eigenstates(sparse=sparse, sort=order, eigvals=eigvals)
+    sp_energies = H.eigenenergies(sparse=sparse, sort=order, eigvals=eigvals)
     if order == 'low':
         assert np.all(np.diff(spvals).real >= 0)
     else:
@@ -58,7 +59,7 @@ def test_eigen_rand_oper(rand, sparse, dtype, order):
 @pytest.mark.parametrize("N", [1, 5, 8, 9])
 def test_FewState(rand, sparse, dtype, order, N):
     H = rand(10, dtype=dtype)
-    all_spvals = H.eigenenergies(sparse=sparse, sort=order)
+    all_spvals = H.eigenenergies(sort=order)
     spvals, spvecs = H.eigenstates(sparse=sparse, sort=order, eigvals=N)
     assert np.allclose(all_spvals[:N], spvals)
     is_eigen_set(H, spvals, spvecs)
@@ -81,7 +82,7 @@ def test_FewState(rand, sparse, dtype, order, N):
 @pytest.mark.parametrize("N", [1, 5, 8, 9])
 def test_ValsOnly(rand, sparse, dtype, order, N):
     H = rand(10, dtype=dtype)
-    all_spvals = H.eigenenergies(sparse=sparse, sort=order)
+    all_spvals = H.eigenenergies(sort=order)
     spvals = H.eigenenergies(sparse=sparse, sort=order, eigvals=N)
     assert np.allclose(all_spvals[:N], spvals)
     if order == 'low':
@@ -97,7 +98,7 @@ def test_ValsOnly(rand, sparse, dtype, order, N):
 ])
 def test_eigen_small(sparse, dtype):
     H = (qutip.sigmax() + qutip.sigmaz()).to(dtype)
-    all_spvals = H.eigenenergies(sparse=sparse)
+    all_spvals = H.eigenenergies()
     spvals, spvecs = H.eigenstates(sparse=sparse, eigvals=1)
     assert np.abs(all_spvals[0] - spvals[0]) <= 1e-14
     is_eigen_set(H, spvals, spvecs)

--- a/qutip/tests/core/test_eigenstates.py
+++ b/qutip/tests/core/test_eigenstates.py
@@ -87,7 +87,10 @@ def random_hamiltonian(request):
 @pytest.mark.parametrize('dtype', ['csr', 'dense'])
 def test_satisfy_eigenvalue_equation(random_hamiltonian, sparse, dtype):
     random_hamiltonian = random_hamiltonian.to(dtype)
-    eigenvalues, eigenstates = random_hamiltonian.eigenstates(sparse=sparse)
+    eigvals = 3 if sparse else 0
+    eigenvalues, eigenstates = random_hamiltonian.eigenstates(
+        sparse=sparse, eigvals=eigvals
+    )
     for eigenvalue, eigenstate in zip(eigenvalues, eigenstates):
         np.testing.assert_allclose((random_hamiltonian * eigenstate).full(),
                                    (eigenvalue * eigenstate).full(),


### PR DESCRIPTION
**Description**
The sparse eigen solver got more finicky since it was updated with last scipy version.
It makes our tests randomly fails quite often:
https://github.com/qutip/qutip/actions/runs/13191102536/job/36824098439?pr=2628
https://github.com/qutip/qutip/actions/runs/13169799701/job/36757919548?pr=2626
https://github.com/qutip/qutip/actions/runs/13151403307/job/36699388137#step:7:14687

We use it wrong as it was never meant to be used to compute all eigen values / vector as once.
We call scipy sparse solver twice and stitch the result together but it's not perfect (#1998).

This change the tests so we use the sparse solver mostly for a limited number of eigen states and make it clean in the docstring.
Also remove `eigs_csr` from the dispatched function. It can be still be used with `Qobj.eigenstates`, but it will not be used without an explicit `sparse` parameter.

