### PR TITLE
allow np.int as targets in expand_operator

### DIFF
--- a/doc/changes/2634.bugfix
+++ b/doc/changes/2634.bugfix
@@ -1,0 +1,1 @@
+Allow np.int as targets in expand_operator

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -424,7 +424,7 @@ def _targets_to_list(targets, oper=None, N=None):
         targets = list(range(len(oper.dims[0])))
     if not hasattr(targets, '__iter__'):
         targets = [targets]
-    if not all([isinstance(t, int) for t in targets]):
+    if not all([isinstance(t, (int, np.integer)) for t in targets]):
         raise TypeError(
             "targets should be "
             "an integer or a list of integer")


### PR DESCRIPTION
Allow `expand_operator()` to work with `np.int`'s as targets, e.g. in `expand_operator(op, dims, np.ravel_multi_index(...))`.
Currently this would raise `"targets should be an integer or a list of integer"`.