### PR TITLE
Add concurrency limit to action

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -2,6 +2,9 @@ name: Build documentation
 
 on:
   [push, pull_request]
+concurrency:
+  group: doc_${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ name: Tests
 
 on:
     [push, pull_request]
+concurrency:
+    group: test_${{ github.ref }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 defaults:
   run:


### PR DESCRIPTION
**Description**
Github action have a `concurrency` clause that control limit the number of job in a group that can run at once.
In a PR late stage, it is not unusual to make a lot of small commit in quick succession (pep8, towncrier, merge suggestions...).
In these case, usually only the latest run is useful.

This `concurrency` will cancel previous jobs and start the latest one quicker if waiting for resources. 
It's set to not cancel jobs in the master branch, but will force them to run one at a time.