### PR TITLE
Optimize solvers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -223,7 +223,6 @@ jobs:
         # to see if something hung.
         timeout-minutes: 60
         run: |
-          export MKL_VERBOSE=2
           if [[ -n "${{ matrix.openmp }}" ]]; then
             # Force OpenMP runs to use more threads, even if there aren't
             # actually that many CPUs.  We have to check any dispatch code is

--- a/doc/changes/2643.misc
+++ b/doc/changes/2643.misc
@@ -1,0 +1,1 @@
+Change default ode method for mcsolve

--- a/qutip/core/expect.py
+++ b/qutip/core/expect.py
@@ -79,7 +79,7 @@ def _single_qobj_expect(oper, state):
     """
     if not oper.isoper or not (state.isket or state.isoper):
         raise TypeError('invalid operand types')
-    if oper.dims[1] != state.dims[0]:
+    if oper._dims[1] != state._dims[0]:
         msg = (
             "incompatible dimensions "
             + str(oper.dims[1]) + " and " + str(state.dims[0])

--- a/qutip/solver/integrator/explicit_rk.pyx
+++ b/qutip/solver/integrator/explicit_rk.pyx
@@ -302,6 +302,7 @@ cdef class Explicit_RungeKutta:
                 self._status = Status.INTERPOLATED
             self._y = self._interpolate_step(t, self._y)
             self._t = t
+            return
 
         self._status = Status.NORMAL
 

--- a/qutip/solver/integrator/explicit_rk.pyx
+++ b/qutip/solver/integrator/explicit_rk.pyx
@@ -221,7 +221,8 @@ cdef class Explicit_RungeKutta:
         self._norm_front = self._norm_prev
 
         #prepare the buffers
-        for i in range(len(self.k), self.rk_extra_step):
+        self.k = []
+        for i in range(self.rk_extra_step):
             self.k.append(self._y.copy())
         self._y_temp = self._y.copy()
         self._y_front = self._y.copy()

--- a/qutip/solver/integrator/qutip_integrator.py
+++ b/qutip/solver/integrator/qutip_integrator.py
@@ -31,15 +31,20 @@ class IntegratorVern7(Integrator):
         'max_step': 0,
         'min_step': 0,
         'interpolate': True,
+        'allow_sparse': False,
     }
     support_time_dependant = True
     supports_blackbox = True
     method = 'vern7'
 
     def _prepare(self):
+        options = {
+            k: v for k, v in self.options.items()
+            if k != 'allow_sparse'
+        }
         self._ode_solver = Explicit_RungeKutta(
             self.system, method=self.method,
-            **self.options
+            **options
         )
         self.name = self.method
 
@@ -48,7 +53,14 @@ class IntegratorVern7(Integrator):
         return self._ode_solver.t, state.copy() if copy else state
 
     def set_state(self, t, state):
-        self._ode_solver.set_initial_value(state.copy(), t)
+        if (
+            not self.options["allow_sparse"]
+            and isinstance(state, (_data.CSR, _data.Dia))
+        ):
+            state = _data.to(_data.Dense, state)
+        else:
+            state = state.copy()
+        self._ode_solver.set_initial_value(state, t)
         self._is_set = True
 
     def integrate(self, t, copy=True):
@@ -93,6 +105,9 @@ class IntegratorVern7(Integrator):
 
         interpolate : bool, default: True
             Whether to use interpolation step, faster most of the time.
+
+        allow_sparse : bool, default: False
+            Whether to use sparse state for the evolution. Usually much slower.
         """
         return self._options
 
@@ -124,6 +139,7 @@ class IntegratorVern9(IntegratorVern7):
         'max_step': 0,
         'min_step': 0,
         'interpolate': True,
+        'allow_sparse': False,
     }
     method = 'vern9'
 
@@ -171,7 +187,9 @@ class IntegratorDiag(Integrator):
         return self.integrate(t, copy=copy)
 
     def get_state(self, copy=True):
-        return self._t, _data.matmul(self.U, _data.dense.Dense(self._y))
+        return self._t, _data.matmul(
+            self.U, _data.dense.fast_from_numpy(self._y)
+        )
 
     def set_state(self, t, state0):
         self._t = t

--- a/qutip/solver/integrator/scipy_integrator.py
+++ b/qutip/solver/integrator/scipy_integrator.py
@@ -87,11 +87,11 @@ class IntegratorScipyAdams(Integrator):
         t = self._ode_solver.t
         if self._mat_state:
             state = _data.column_unstack_dense(
-                _data.dense.Dense(self._ode_solver._y, copy=copy),
+                _data.dense.fast_from_numpy(self._ode_solver._y),
                 self._size,
                 inplace=True)
         else:
-            state = _data.dense.Dense(self._ode_solver._y, copy=copy)
+            state = _data.dense.fast_from_numpy(self._ode_solver._y)
         return t, state
 
     def _check_handle(self):
@@ -283,13 +283,16 @@ class IntegratorScipyDop853(Integrator):
         t = self._ode_solver.t
         if self._mat_state:
             state = _data.column_unstack_dense(
-                _data.dense.Dense(self._ode_solver._y.view(np.complex128),
-                                  copy=copy),
+                _data.dense.fast_from_numpy(
+                    self._ode_solver._y.view(np.complex128)
+                ),
                 self._size,
                 inplace=True)
         else:
-            state = _data.dense.Dense(self._ode_solver._y.view(np.complex128),
-                                      copy=copy)
+            state = _data.dense.fast_from_numpy(
+                self._ode_solver._y.view(np.complex128)
+            )
+            state = state.copy() if copy else state
         return t, state
 
     def set_state(self, t, state0):

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -864,8 +864,8 @@ class MCSolver(MultiTrajSolver):
             Maximum number of tries to find the collapse.
 
         norm_min_step: float, default: 0.10
-            Minimum step used when finding the collapse time, given as a fraction
-            of the search interval. Must be between 0 and 0.5.
+            Minimum step used when finding the collapse time, given as a
+            fraction of the search interval. Must be between 0 and 0.5.
             A small non-zero value can help avoid the worst cases of
             convergence at the cost of increased average steps required to find
             the collapse.

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -655,9 +655,11 @@ class NonMarkovianMCSolver(MCSolver):
             Maximum number of tries to find the collapse.
 
         norm_min_step: float, default: 0.0
-            Minimum split used when finding jump location.
-            A small non-zero value can help avoid the worst cases convergence
-            when finding jumb at the cost of increased average steps.
+            Minimum step used when finding the collapse time, given as a
+            fraction of the search interval. Must be between 0 and 0.5.
+            A small non-zero value can help avoid the worst cases of
+            convergence at the cost of increased average steps required to find
+            the collapse.
 
         improved_sampling: Bool, default: False
             Whether to use the improved sampling algorithm

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -370,6 +370,7 @@ class NonMarkovianMCSolver(MCSolver):
         "norm_steps": 5,
         "norm_t_tol": 1e-6,
         "norm_tol": 1e-4,
+        "norm_min_step": 0.0,
         "improved_sampling": False,
         "completeness_rtol": 1e-5,
         "completeness_atol": 1e-8,
@@ -652,6 +653,11 @@ class NonMarkovianMCSolver(MCSolver):
 
         norm_steps: int, default: 5
             Maximum number of tries to find the collapse.
+
+        norm_min_step: float, default: 0.0
+            Minimum split used when finding jump location.
+            A small non-zero value can help avoid the worst cases convergence
+            when finding jumb at the cost of increased average steps.
 
         improved_sampling: Bool, default: False
             Whether to use the improved sampling algorithm

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -93,8 +93,11 @@ class _BaseResult:
             options_copy._feedback = None
         self.options = options_copy
         # Almost all integrators already return a copy that is safe to use.
-        self._integrator_return_not_copy = options.get("method", None) in [
-            "vern7", "vern9"
+        self._integrator_return_copy = options.get("method", None) in [
+            "adams", "lsoda", "bdf", "dop853", "diag",
+            "euler", "platen", "explicit1.5",
+            "milstein", "pred_corr", "taylor1.5",
+            "milstein_imp", "taylor1.5_imp", "rouchon",
         ]
 
     def _e_ops_to_dict(self, e_ops):
@@ -331,7 +334,7 @@ class Result(_BaseResult):
 
         if (
             self._state_processors_require_copy
-            and self._integrator_return_not_copy
+            and not self._integrator_return_copy
         ):
             state = self._pre_copy(state)
 

--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -92,6 +92,10 @@ class _BaseResult:
         if hasattr(options_copy, "_feedback"):
             options_copy._feedback = None
         self.options = options_copy
+        # Almost all integrators already return a copy that is safe to use.
+        self._integrator_return_not_copy = options.get("method", None) in [
+            "vern7", "vern9"
+        ]
 
     def _e_ops_to_dict(self, e_ops):
         """Convert the supplied e_ops to a dictionary of Eop instances."""
@@ -325,7 +329,10 @@ class Result(_BaseResult):
         """
         self.times.append(t)
 
-        if self._state_processors_require_copy:
+        if (
+            self._state_processors_require_copy
+            and self._integrator_return_not_copy
+        ):
             state = self._pre_copy(state)
 
         for op in self._state_processors:

--- a/qutip/tests/solver/test_results.py
+++ b/qutip/tests/solver/test_results.py
@@ -109,7 +109,7 @@ class TestResult:
                 np.testing.assert_allclose(e_op_call_values, results[k])
 
     def test_add_processor(self):
-        res = Result([], fill_options(store_states=False))
+        res = Result([], fill_options(store_states=False, method="vern7"))
         a = []
         b = []
         states = [{"t": 0}, {"t": 1}]


### PR DESCRIPTION
**Description**
Benchmarks for QuantumToolbox showed that the difference between us and them was particularly bad for `mcsolve`.
After some looking around, the `adams` method is bad with quantum jumps. It's an ODE method that remembers previous steps and accelerate. Being reset at each jumps is slow when there are a lot of them. Using runge-kutta methods (`vern7`, `dop853`, ...) are therefore more appropriate for mcsolve and I changed the default.

I also checked code that took more time than expected:

- I removed extra copies of the state.
- `np.cumsum` used to look at which jump happen took as much time as a ODE step. Pure python is faster.
- Comparing list format dims is slow.

Overall, mcsolve is 20% faster with the same method, 3x with the change of method for the benchmark used for QuantumToolbox paper, but this is quite problem dependant. 