### PR TITLE
Skip loky version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,7 +148,7 @@ jobs:
           # Install the extra requirement
           python -m pip install pytest>=5.2 pytest-rerunfailures  # tests
           python -m pip install ipython  # ipython
-          python -m pip install loky tqdm mpmath  # extras
+          python -m pip install loky!=3.5.0 tqdm mpmath  # extras
           python -m pip install "coverage${{ matrix.coverage-requirement }}" chardet
           python -m pip install pytest-cov coveralls pytest-fail-slow
           python -m pip install setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,8 +60,9 @@ ipython =
     ipython
 extras =
     # loky 3.5.0 has a bug with python 3.10 on linux. (joblib/loky#444)
+    # Fixed in 3.5.1
     loky; python_version>='3.11'
-    loky!=3.5.0; python_version<='3.10'  # Hopefully fixed by 3.5.1
+    loky!=3.5.0; python_version<='3.10'
     tqdm
     mpmath
 mpi =

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,9 @@ tests =
 ipython =
     ipython
 extras =
-    loky
+    # loky 3.5.0 has a bug with python 3.10 on linux. (joblib/loky#444)
+    loky; python_version>='3.11'
+    loky!=3.5.0; python_version<='3.10'  # Hopefully fixed by 3.5.1
     tqdm
     mpmath
 mpi =


### PR DESCRIPTION
**Description**
loky 3.5.0, released last week, has a bug on python 3.10, see joblib/loky#444
It will hopefully be fixed soon, but it breaks some tests until then.
I exclude only that exact version for now, expecting 3.5.1 to work.
For the tests, I did not add branching on python version for simplicity. 

If a bugfix release does not fix the issue, I will make a follow up PR.