### PR TITLE
Safer metadata import for older python

### DIFF
--- a/qutip/about.py
+++ b/qutip/about.py
@@ -5,7 +5,7 @@ __all__ = ['about']
 
 import sys
 import os
-import importlib
+import importlib.metadata
 import platform
 import numpy
 import scipy


### PR DESCRIPTION
**Description**
In older version of python `importlib`'s `metadata` must be imported directly.