### PR TITLE
Bugfix dimensions.Compound.remove

### DIFF
--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -678,9 +678,11 @@ class Compound(Space):
         new_spaces = []
         for space in self.spaces:
             n_indices = len(space.flat())
-            idx_space = [i for i in idx if i < n_indices]
-            idx = [i-n_indices for i in idx if i >= n_indices]
-            new_space = space.remove(idx_space)
+            if 0 <= idx < n_indices:
+                pass
+            else:
+                new_spaces.append(space)
+            idx -= n_indices
         if new_spaces:
             return Compound(*new_spaces)
         return Field()


### PR DESCRIPTION
I just came across this in `dimensions.py`. The current code looks definitely wrong. In the docstring it says
```Space([2, 3, 4]).remove(1) == Space([2, 4])```
but currently
``Space([2, 3, 4]).remove(1)``
gives an error because the argument is not a list, and
``Space([2, 3, 4]).remove([1])``
gives an error as well.

I am not sure if this is even used anywhere, but I have tried to fix it.