### PR TITLE
Direct product

### DIFF
--- a/qutip/core/__init__.py
+++ b/qutip/core/__init__.py
@@ -2,6 +2,8 @@ from .options import *
 from .coefficient import *
 from .qobj import *
 from .cy.qobjevo import *
+from .direct_sum import *
+
 from .environment import *
 from .expect import *
 from .tensor import *

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -816,6 +816,8 @@ cdef class QobjEvo:
         qobjs = []
         coeffs = []
         for element in coeff_elements:
+            if _data.iszero(element.data(0)):
+                continue
             for i, qobj in enumerate(qobjs):
                 if element.qobj(0) == qobj:
                     coeffs[i] = coeffs[i] + element._coefficient
@@ -834,6 +836,7 @@ cdef class QobjEvo:
         Constant parts, (:obj:`.Qobj` without :obj:`Coefficient`) will be
         summed.
         Pairs ``[Qobj, Coefficient]`` with the same :obj:`.Qobj` are merged.
+        Pairs ``[Qobj, Coefficient]`` with zero :obj:`.Qobj` are discarded.
 
         Example:
         ``[[sigmax(), f1], [sigmax(), f2]] -> [[sigmax(), f1+f2]]``

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -723,6 +723,7 @@ cdef class QobjEvo:
         res.elements = [element.linear_map(Qobj.dag, True)
                         for element in res.elements]
         res._dims = Dimensions(res._dims[0], res._dims[1])
+        res.shape = (res.shape[1], res.shape[0])
         return res
 
     def to(self, data_type):

--- a/qutip/core/data/__init__.py
+++ b/qutip/core/data/__init__.py
@@ -8,6 +8,7 @@ from .base import Data
 
 from .add import *
 from .adjoint import *
+from .concat import *
 from .constant import *
 from .eigen import *
 from .expect import *

--- a/qutip/core/data/__init__.py
+++ b/qutip/core/data/__init__.py
@@ -8,7 +8,7 @@ from .base import Data
 
 from .add import *
 from .adjoint import *
-from .concat import *
+from .block_operations import *
 from .constant import *
 from .eigen import *
 from .expect import *

--- a/qutip/core/data/block_operations.py
+++ b/qutip/core/data/block_operations.py
@@ -25,13 +25,13 @@ def _to_array(data: Data | numpy.ndarray) -> numpy.ndarray:
 
 def concat_data(
     data_array: list[list[Data | numpy.ndarray]],
-    _skip_checks: bool = False
+    _skip_check: bool = False
 ) -> Dense:
     """
     Concatenates blocks of data into a block matrix
     """
 
-    if not _skip_checks:
+    if not _skip_check:
         if len(data_array) == 0 or len(data_array[0]) == 0:
             _invalid_shapes()
 

--- a/qutip/core/data/concat.py
+++ b/qutip/core/data/concat.py
@@ -1,0 +1,44 @@
+from .base import Data
+from .csr import CSR
+from .dense import Dense
+
+import numpy
+
+
+__all__ = [
+    'concat_data',
+]
+
+
+
+def _invalid_shapes():
+    raise ValueError(
+        "The given blocks have incompatible shapes and cannot be concatenated."
+    )
+
+
+def concat_data(data_array: list[list[Data]]) -> Dense:
+    """
+    TODO: docstring
+    """
+
+    if len(data_array) == 0 or len(data_array[0]) == 0:
+        _invalid_shapes()
+
+    column_widths = [data.shape[1] for data in data_array[0]]
+    for row in data_array:
+        if len(row) != len(column_widths):
+            _invalid_shapes()
+
+        row_height = row[0].shape[0]
+        for data, column_width in zip(row, column_widths):
+            if data.shape != (column_width, row_height):
+                _invalid_shapes()
+
+    nd_arrays = [[data.to_array() for data in row] for row in data_array]
+    return Dense(numpy.block(nd_arrays), copy=False)
+
+
+# TODO other dtypes
+def concat_csr(data_array: list[list[CSR]]) -> CSR:
+    ...

--- a/qutip/core/data/concat.py
+++ b/qutip/core/data/concat.py
@@ -6,7 +6,7 @@ import numpy
 
 
 __all__ = [
-    'concat_data', 'slice_dense', 'slice',
+    'concat_data', 'slice_dense', 'slice', 'zeropad_dense', 'zeropad'
 ]
 
 
@@ -80,4 +80,30 @@ slice = _Dispatcher(
 slice.__doc__ = """TODO"""
 slice.add_specialisations([
     (Data, Dense, slice_dense),
+], _defer=True)
+
+
+def zeropad_dense(data: Data,
+                  before: int, after: int,
+                  above: int, below: int) -> Dense:
+    array = data.to_array()
+    padded = numpy.pad(array, ((above, below), (before, after)))
+    return Dense(padded, copy=True)
+
+zeropad = _Dispatcher(
+    _inspect.Signature([
+        _inspect.Parameter('data', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('before', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('after', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('above', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('below', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    ]),
+    name='zeropad',
+    module=__name__,
+    inputs=('data',),
+    out=True,
+)
+zeropad.__doc__ = """TODO"""
+zeropad.add_specialisations([
+    (Data, Dense, zeropad_dense),
 ], _defer=True)

--- a/qutip/core/data/concat.py
+++ b/qutip/core/data/concat.py
@@ -6,7 +6,7 @@ import numpy
 
 
 __all__ = [
-    'concat_data',
+    'concat_data', 'slice_dense', 'slice',
 ]
 
 
@@ -53,3 +53,31 @@ def concat_data(
 # TODO other dtypes
 def concat_csr(data_array: list[list[CSR]]) -> CSR:
     ...
+
+
+def slice_dense(data: Data,
+                row_start: int, row_stop: int,
+                col_start: int, col_stop: int) -> Dense:
+    array = data.to_array()
+    return Dense(array[row_start:row_stop, col_start:col_stop], copy=True)
+
+from .dispatch import Dispatcher as _Dispatcher
+import inspect as _inspect
+
+slice = _Dispatcher(
+    _inspect.Signature([
+        _inspect.Parameter('data', _inspect.Parameter.POSITIONAL_ONLY),
+        _inspect.Parameter('row_start', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('row_stop', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('col_start', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        _inspect.Parameter('col_stop', _inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    ]),
+    name='slice',
+    module=__name__,
+    inputs=('data',),
+    out=True,
+)
+slice.__doc__ = """TODO"""
+slice.add_specialisations([
+    (Data, Dense, slice_dense),
+], _defer=True)

--- a/qutip/core/data/concat.py
+++ b/qutip/core/data/concat.py
@@ -23,28 +23,31 @@ def _to_array(data: Data | numpy.ndarray) -> numpy.ndarray:
         return data.to_array()
     return data
 
-def concat_data(data_array: list[list[Data | numpy.ndarray]]) -> Dense:
+def concat_data(
+    data_array: list[list[Data | numpy.ndarray]],
+    _skip_checks: bool = False
+) -> Dense:
     """
     TODO: docstring
     """
 
-    if len(data_array) == 0 or len(data_array[0]) == 0:
-        _invalid_shapes()
-
-    column_widths = [data.shape[1] for data in data_array[0]]
-    for row in data_array:
-        if len(row) != len(column_widths):
+    if not _skip_checks:
+        if len(data_array) == 0 or len(data_array[0]) == 0:
             _invalid_shapes()
 
-        row_height = row[0].shape[0]
-        for data, column_width in zip(row, column_widths):
-            if data.shape != (row_height, column_width):
-                print(data.shape, column_width, row_height)
+        column_widths = [data.shape[1] for data in data_array[0]]
+        for row in data_array:
+            if len(row) != len(column_widths):
                 _invalid_shapes()
 
+            row_height = row[0].shape[0]
+            for data, column_width in zip(row, column_widths):
+                if data.shape != (row_height, column_width):
+                    _invalid_shapes()
+
     nd_arrays = [[_to_array(data) for data in row] for row in data_array]
-    return Dense(numpy.block(nd_arrays), copy=None)  # only copy if numpy
-                                                     # cannot avoid copying
+    return Dense(numpy.block(nd_arrays), copy=None)
+    # copy=None means: only copy if numpy cannot avoid copying
 
 
 # TODO other dtypes

--- a/qutip/core/data/concat.py
+++ b/qutip/core/data/concat.py
@@ -13,11 +13,17 @@ __all__ = [
 
 def _invalid_shapes():
     raise ValueError(
-        "The given blocks have incompatible shapes and cannot be concatenated."
+        "The given matrices have incompatible shapes and cannot be"
+        " concatenated."
     )
 
 
-def concat_data(data_array: list[list[Data]]) -> Dense:
+def _to_array(data: Data | numpy.ndarray) -> numpy.ndarray:
+    if isinstance(data, Data):
+        return data.to_array()
+    return data
+
+def concat_data(data_array: list[list[Data | numpy.ndarray]]) -> Dense:
     """
     TODO: docstring
     """
@@ -32,11 +38,13 @@ def concat_data(data_array: list[list[Data]]) -> Dense:
 
         row_height = row[0].shape[0]
         for data, column_width in zip(row, column_widths):
-            if data.shape != (column_width, row_height):
+            if data.shape != (row_height, column_width):
+                print(data.shape, column_width, row_height)
                 _invalid_shapes()
 
-    nd_arrays = [[data.to_array() for data in row] for row in data_array]
-    return Dense(numpy.block(nd_arrays), copy=False)
+    nd_arrays = [[_to_array(data) for data in row] for row in data_array]
+    return Dense(numpy.block(nd_arrays), copy=None)  # only copy if numpy
+                                                     # cannot avoid copying
 
 
 # TODO other dtypes

--- a/qutip/core/direct_sum.py
+++ b/qutip/core/direct_sum.py
@@ -1,5 +1,7 @@
+from .dimensions import Dimensions, Field, Space
 from .qobj import Qobj
 from . import data as _data
+from .. import settings
 
 from numbers import Number
 
@@ -13,6 +15,11 @@ def _is_like_qobj(qobj):
 
 def _qobj_data(qobj):
     return qobj.data if isinstance(qobj, Qobj) else np.array([[qobj]])
+
+def _qobj_dims(qobj):
+    return (
+        qobj._dims if isinstance(qobj, Qobj) else Dimensions(Field(), Field())
+    )
 
 def _is_like_ket(qobj):
     return (
@@ -68,9 +75,119 @@ def direct_sum(qobjs: list[Qobj | float] | list[list[Qobj | float]]) -> Qobj:
         raise ValueError("No Qobjs provided for direct sum.")
 
     linear = _is_like_qobj(qobjs[0])
+    if not linear and len(qobjs[0]) == 0:
+        raise ValueError("No Qobjs provided for direct sum.")
+    if not linear and not all(len(row) == len(qobjs[0]) for row in qobjs):
+        raise ValueError("Matrix of Qobjs in direct sum must be square.")
 
     if linear and all(_is_like_ket(qobj) for qobj in qobjs):
-        out_data = _data.concat_data([[_qobj_data(qobj)] for qobj in qobjs])
-        return Qobj(out_data, copy=False)
+        if not settings.core['auto_tidyup_dims']:
+            scalar_dim = _qobj_dims(qobjs[0]).from_
+            scalar_dims_match = all(
+                _qobj_dims(qobj).from_ == scalar_dim for qobj in qobjs
+            )
+            if not scalar_dims_match:
+                raise ValueError("Scalar dimensions do not match in"
+                                 " direct sum of vectors.")
+        else:
+            scalar_dim = Field()
+        vector_dim = SumSpace([_qobj_dims(qobj).to_ for qobj in qobjs])
+
+        out_data = _data.concat_data([[_qobj_data(qobj)] for qobj in qobjs],
+                                     _skip_checks=True)
+        return Qobj(out_data,
+                    dims=Dimensions(scalar_dim, vector_dim),
+                    copy=False)
+
+    if linear and all(_is_like_bra(qobj) for qobj in qobjs):
+        if not settings.core['auto_tidyup_dims']:
+            scalar_dim = _qobj_dims(qobjs[0]).to_
+            scalar_dims_match = all(
+                _qobj_dims(qobj).to_ == scalar_dim for qobj in qobjs
+            )
+            if not scalar_dims_match:
+                raise ValueError("Scalar dimensions do not match in"
+                                 " direct sum of covectors.")
+        else:
+            scalar_dim = Field()
+        vector_dim = SumSpace([_qobj_dims(qobj).from_ for qobj in qobjs])
+
+        out_data = _data.concat_data([[_qobj_data(qobj) for qobj in qobjs]],
+                                     _skip_checks=True)
+        return Qobj(out_data,
+                    dims=Dimensions(vector_dim, scalar_dim),
+                    copy=False)
+
+    if not linear and all(_is_like_oper(qobj)
+                          for row in qobjs for qobj in row):
+        from_dim = [_qobj_dims(qobj).from_ for qobj in qobjs[0]]
+        to_dim = [_qobj_dims(row[0]).to_ for row in qobjs]
+        dims_match = all(
+            _qobj_dims(qobj).from_ == from_dim[col_index]
+            and _qobj_dims(qobj).to_ == to_dim[row_index]
+            for row_index, row in enumerate(qobjs)
+            for col_index, qobj in enumerate(row)
+        )
+        if not dims_match:
+            raise ValueError("Mismatching dimensions in"
+                             " direct sum of operators.")
+
+        out_data = _data.concat_data(
+            [[_qobj_data(qobj) for qobj in row] for row in qobjs],
+            _skip_checks=True
+        )
+        return Qobj(out_data,
+                    dims=Dimensions(SumSpace(from_dim), SumSpace(to_dim)),
+                    copy=False)
 
     raise NotImplementedError
+
+
+class SumSpace(Space):
+    _stored_dims = {}
+
+    def __init__(self, spaces: list[Space]):
+        self.spaces = spaces
+        dim = sum(space.size for space in spaces)
+        super().__init__(dim)
+        self._pure_dims = False
+
+    def __eq__(self, other) -> bool:
+        return self is other or (
+            type(other) is type(self) and
+            self.spaces == other.spaces
+        )
+
+    def __hash__(self):
+        return hash(self.spaces)
+
+    def __repr__(self) -> str:
+        parts_rep = ", ".join(repr(space) for space in self.spaces)
+        return f"Sum({parts_rep})"
+
+    def as_list(self) -> tuple[list[int]]:
+        return tuple(space.as_list() for space in self.spaces)
+
+    def dims2idx(self, dims: list[int]) -> int:
+        raise NotImplementedError()
+
+    def idx2dims(self, idx: int) -> list[int]:
+        raise NotImplementedError()
+
+    def step(self) -> list[int]:
+        raise NotImplementedError()
+
+    def flat(self) -> list[int]:
+        raise NotImplementedError()
+
+    def remove(self, idx: int):
+        raise NotImplementedError()
+
+    def replace(self, idx: int, new: int) -> "Space":
+        raise NotImplementedError()
+
+    def replace_superrep(self, super_rep: str) -> "Space":
+        raise NotImplementedError()
+
+    def scalar_like(self) -> "Space":
+        raise NotImplementedError()

--- a/qutip/core/direct_sum.py
+++ b/qutip/core/direct_sum.py
@@ -10,7 +10,7 @@ from typing import overload, Union
 
 import numpy as np
 
-__all__ = ['direct_sum', 'component']
+__all__ = ['direct_sum', 'component', 'set_component']
 
 
 QobjLike = Union[Number, Qobj, QobjEvo]
@@ -86,6 +86,10 @@ def direct_sum(
     ...
 
 def direct_sum(qobjs):
+    """
+    Takes a list or matrix of Qobjs and makes them into a single Qobj with
+    block-matrix elements.
+    """
     if len(qobjs) == 0:
         raise ValueError("No Qobjs provided for direct sum.")
 
@@ -139,22 +143,21 @@ def direct_sum(qobjs):
 
     # Handle QobjEvos. We have to pull them out and handle them separately.
     qobjevos = []
-    for row_index, row in enumerate(qobjs):
-        for col_index, qobj in enumerate(row):
+    for to_index, row in enumerate(qobjs):
+        for from_index, qobj in enumerate(row):
             if isinstance(qobj, QobjEvo):
-                qobjs[row_index][col_index] = qzero_like(qobj)
+                # remove from `qobjs` ...
+                qobjs[to_index][from_index] = qzero_like(qobj)
 
-                dim_before = sum(from_dim[i].size for i in range(col_index))
-                dim_after = sum(from_dim[i].size
-                                for i in range(col_index + 1, len(from_dim)))
-                dim_above = sum(to_dim[i].size for i in range(row_index))
-                dim_below = sum(to_dim[i].size
-                                for i in range(row_index + 1, len(to_dim)))
-                zeropad_args = (dim_before, dim_after, dim_above, dim_below)
-                blow_up = qobj.linear_map(
-                    lambda x: Qobj(_data.zeropad(x.data, *zeropad_args),
-                                   dims=out_dims, copy=False)
+                # ... but embed component in big matrix and add to qobjevos
+                zeroes_like_sum = Qobj(
+                    _data.zeros[qobj.dtype](*out_dims.shape),
+                    dims=out_dims, copy=False
                 )
+                blow_up = qobj.linear_map(
+                    lambda x: set_component(
+                        zeroes_like_sum, x, to_index, from_index
+                    ))
                 qobjevos.append(blow_up)
 
     out_data = _data.concat_data(
@@ -165,94 +168,119 @@ def direct_sum(qobjs):
     return sum(qobjevos, start=result)
 
 
-def _check_index(given, min, max):
+@overload
+def component(sum_qobj: Qobj, *index: int) -> Qobj:
+    ...
+
+@overload
+def component(sum_qobj: QobjEvo, *index: int) -> Qobj | QobjEvo:
+    ...
+
+def component(sum_qobj, *index):
+    """
+    Extracts component at index from qobj which is a direct sum.
+    """
+    if isinstance(sum_qobj, QobjEvo):
+        result = sum_qobj.linear_map(lambda x: component(x, *index))
+        result.compress()
+        return result(0) if result.isconstant else result
+
+    to_index, from_index = _check_component_index(sum_qobj, index)
+    (component_to, to_data_start, to_data_stop,
+     component_from, from_data_start, from_data_stop) =\
+        _component_info(sum_qobj, to_index, from_index)
+
+    out_data = _data.slice(sum_qobj.data,
+                           to_data_start, to_data_stop,
+                           from_data_start, from_data_stop)
+    return Qobj(
+        out_data, dims=Dimensions(component_from, component_to), copy=False
+    )
+
+
+@overload
+def set_component(
+    sum_qobj: Qobj, component: Qobj, *index: int
+) -> Qobj:
+    ...
+
+@overload
+def set_component(
+    sum_qobj: Qobj | QobjEvo, component: Qobj | QobjEvo, *index: int
+) -> QobjEvo:
+    ...
+
+def set_component(sum_qobj, component, *index):
+    """
+    Sets the component of the direct sum qobjs at the given index.
+    """
+    if isinstance(sum_qobj, QobjEvo) or isinstance(component, QobjEvo):
+        raise NotImplementedError()
+
+    to_index, from_index = _check_component_index(sum_qobj, index)
+    (component_to, to_data_start, _, component_from, from_data_start, _) =\
+        _component_info(sum_qobj, to_index, from_index)
+
+    if (
+        component._dims.to_ != component_to
+        or component._dims.from_ != component_from
+    ):
+        raise ValueError("Canot set component of direct sum:"
+                         " dimension mismatch.")
+
+    out_data = _data.insert(sum_qobj.data, component.data,
+                            to_data_start, from_data_start)
+    return Qobj(out_data, dims=sum_qobj._dims, copy=False)
+
+
+def _check_bounds(given, min, max):
     if not (min <= given < max):
         raise ValueError(f"Index ({given}) out of bounds ({min}, {max-1})"
                           " for component of direct sum.")
 
-@overload
-def component(qobj: Qobj, *index: int) -> Qobj:
-    ...
-
-@overload
-def component(qobj: QobjEvo, *index: int) -> Qobj | QobjEvo:
-    ...
-
-def component(qobj, *index):
-    if isinstance(qobj, QobjEvo):
-        result = qobj.linear_map(lambda x: component(x, *index))
-        result.compress()
-        return result(0) if result.isconstant else result
-
-    is_to_sum = isinstance(qobj._dims.to_, SumSpace)
-    is_from_sum = isinstance(qobj._dims.from_, SumSpace)
+def _check_component_index(sum_qobj, index):
+    is_to_sum = isinstance(sum_qobj._dims.to_, SumSpace)
+    is_from_sum = isinstance(sum_qobj._dims.from_, SumSpace)
     if not is_to_sum and not is_from_sum:
-        if index == [0] or index == [0, 0]:
-            return qobj
         raise ValueError("Qobj is not a direct sum.")
 
     if is_to_sum and is_from_sum:
         if len(index) != 2:
             raise ValueError("Invalid number of indices provided for component"
                              " of direct sum (two indices required).")
-        to_index, from_index = index
-        _check_index(to_index, 0, len(qobj._dims.to_.spaces))
-        _check_index(from_index, 0, len(qobj._dims.from_.spaces))
-        to_data_start = qobj._dims.to_._space_cumdims[to_index]
-        to_data_stop = qobj._dims.to_._space_cumdims[to_index + 1]
-        from_data_start = qobj._dims.from_._space_cumdims[from_index]
-        from_data_stop = qobj._dims.from_._space_cumdims[from_index + 1]
+    else:
+        if len(index) == 1 and is_to_sum:
+            index = (index[0], 0)
+        elif len(index) == 1 and is_from_sum:
+            index = (0, index[0])
+        if len(index) != 2:
+            raise ValueError("Invalid number of indices provided for component"
+                             " of direct sum (one ortwo indices required).")
 
-        out_data = _data.slice(qobj.data,
-                               to_data_start, to_data_stop,
-                               from_data_start, from_data_stop)
-        return Qobj(out_data,
-                    dims=Dimensions(qobj._dims.from_.spaces[from_index],
-                                    qobj._dims.to_.spaces[to_index]),
-                    copy=False)
+    return index
 
-    if len(index) == 2:
-        to_index, from_index = index
-        if not is_to_sum:
-            _check_index(to_index, 0, 1)
-            index = [from_index]
-        else:
-            _check_index(from_index, 0, 1)
-            index = [to_index]
+def _component_info(sum_qobj, to_index, from_index):
+    if isinstance(sum_qobj._dims.to_, SumSpace):
+        _check_bounds(to_index, 0, len(sum_qobj._dims.to_.spaces))
+        component_to = sum_qobj._dims.to_.spaces[to_index]
+        to_data_start = sum_qobj._dims.to_._space_cumdims[to_index]
+        to_data_stop = sum_qobj._dims.to_._space_cumdims[to_index + 1]
+    else:
+        _check_bounds(to_index, 0, 1)
+        component_to = sum_qobj._dims.to_
+        to_data_start = 0
+        to_data_stop = sum_qobj._dims.to_.size
 
-    if len(index) != 1:
-        raise ValueError("Invalid number of indices provided for component"
-                         " of direct sum (one or two indices required).")
-
-    if is_to_sum:
-        to_index, = index
-        _check_index(to_index, 0, len(qobj._dims.to_.spaces))
-        to_data_start = qobj._dims.to_._space_cumdims[to_index]
-        to_data_stop = qobj._dims.to_._space_cumdims[to_index + 1]
+    if isinstance(sum_qobj._dims.from_, SumSpace):
+        _check_bounds(from_index, 0, len(sum_qobj._dims.from_.spaces))
+        component_from = sum_qobj._dims.from_.spaces[from_index]
+        from_data_start = sum_qobj._dims.from_._space_cumdims[from_index]
+        from_data_stop = sum_qobj._dims.from_._space_cumdims[from_index + 1]
+    else:
+        _check_bounds(from_index, 0, 1)
+        component_from = sum_qobj._dims.from_
         from_data_start = 0
-        from_data_stop = qobj._dims.from_.size
+        from_data_stop = sum_qobj._dims.from_.size
 
-        out_data = _data.slice(qobj.data,
-                               to_data_start, to_data_stop,
-                               from_data_start, from_data_stop)
-        result = Qobj(out_data,
-                      dims=Dimensions(qobj._dims.from_,
-                                      qobj._dims.to_.spaces[to_index]),
-                      copy=False)
-        return result
-
-    from_index, = index
-    _check_index(from_index, 0, len(qobj._dims.from_.spaces))
-    to_data_start = 0
-    to_data_stop = qobj._dims.to_.size
-    from_data_start = qobj._dims.from_._space_cumdims[from_index]
-    from_data_stop = qobj._dims.from_._space_cumdims[from_index + 1]
-
-    out_data = _data.slice(qobj.data,
-                           to_data_start, to_data_stop,
-                           from_data_start, from_data_stop)
-    result = Qobj(out_data,
-                  dims=Dimensions(qobj._dims.from_.spaces[from_index],
-                                  qobj._dims.to_),
-                  copy=False)
-    return result
+    return (component_to, to_data_start, to_data_stop,
+            component_from, from_data_start, from_data_stop)

--- a/qutip/core/direct_sum.py
+++ b/qutip/core/direct_sum.py
@@ -90,130 +90,66 @@ def direct_sum(qobjs: list[Qobj | float] | list[list[Qobj | float]]) -> Qobj:
         raise ValueError("Matrix of Qobjs in direct sum must be square.")
 
     if linear and all(_is_like_ket(qobj) for qobj in qobjs):
-        if not settings.core['auto_tidyup_dims']:
-            scalar_dim = _qobj_dims(qobjs[0]).from_
-            scalar_dims_match = all(
-                _qobj_dims(qobj).from_ == scalar_dim for qobj in qobjs
-            )
-            if not scalar_dims_match:
-                raise ValueError("Scalar dimensions do not match in"
-                                 " direct sum of vectors.")
-        else:
-            scalar_dim = Field()
-        vector_dim = SumSpace([_qobj_dims(qobj).to_ for qobj in qobjs])
-
-        out_data = _data.concat_data([[_qobj_data(qobj)] for qobj in qobjs],
-                                     _skip_checks=True)
-        return Qobj(out_data,
-                    dims=Dimensions(scalar_dim, vector_dim),
-                    copy=False)
-
-    if linear and all(_is_like_bra(qobj) for qobj in qobjs):
-        if not settings.core['auto_tidyup_dims']:
-            scalar_dim = _qobj_dims(qobjs[0]).to_
-            scalar_dims_match = all(
-                _qobj_dims(qobj).to_ == scalar_dim for qobj in qobjs
-            )
-            if not scalar_dims_match:
-                raise ValueError("Scalar dimensions do not match in"
-                                 " direct sum of covectors.")
-        else:
-            scalar_dim = Field()
-        vector_dim = SumSpace([_qobj_dims(qobj).from_ for qobj in qobjs])
-
-        out_data = _data.concat_data([[_qobj_data(qobj) for qobj in qobjs]],
-                                     _skip_checks=True)
-        return Qobj(out_data,
-                    dims=Dimensions(vector_dim, scalar_dim),
-                    copy=False)
-
-    if linear and all(_is_like_operator_ket(qobj) for qobj in qobjs):
-        oper_as_opket = [False] * len(qobjs)
-        for index, qobj in enumerate(qobjs):
+        qobjs = [[qobj] for qobj in qobjs]
+    elif linear and all(_is_like_operator_ket(qobj) for qobj in qobjs):
+        # for convenience, we call operator_to_vector on operators provided
+        # in matrix form
+        def _ensure_vector(qobj):
             if isinstance(qobj, Qobj) and qobj.type == 'oper':
-                oper_as_opket[index] = True
-                qobjs[index] = operator_to_vector(qobj)
-
-        if not settings.core['auto_tidyup_dims']:
-            scalar_dim = _qobj_dims(qobjs[0]).from_
-            scalar_dims_match = all(
-                _qobj_dims(qobj).from_ == scalar_dim for qobj in qobjs
-            )
-            if not scalar_dims_match:
-                raise ValueError("Scalar dimensions do not match in"
-                                 " direct sum of operator-kets.")
-        else:
-            scalar_dim = Field()
-        vector_dim = SumSpace([_qobj_dims(qobj).to_ for qobj in qobjs],
-                              oper_as_opket)
-
-        out_data = _data.concat_data([[_qobj_data(qobj)] for qobj in qobjs],
-                                     _skip_checks=True)
-        return Qobj(out_data,
-                    dims=Dimensions(scalar_dim, vector_dim),
-                    copy=False)
-
-    if linear and all(_is_like_operator_bra(qobj) for qobj in qobjs):
-        oper_as_opket = [False] * len(qobjs)
-        for index, qobj in enumerate(qobjs):
+                return operator_to_vector(qobj)
+            return qobj
+        qobjs = [[_ensure_vector(qobj)] for qobj in qobjs]
+    elif linear and all(_is_like_bra(qobj) for qobj in qobjs):
+        qobjs = [[qobj for qobj in qobjs]]
+    elif linear and all(_is_like_operator_bra(qobj) for qobj in qobjs):
+        # for convenience, we call operator_to_vector on operators provided
+        # in matrix form
+        def _ensure_vector(qobj):
             if isinstance(qobj, Qobj) and qobj.type == 'oper':
-                oper_as_opket[index] = True
-                qobjs[index] = operator_to_vector(qobj).dag()
+                return operator_to_vector(qobj).dag()
+            return qobj
+        qobjs = [[_ensure_vector(qobj) for qobj in qobjs]]
+    elif linear:
+        raise ValueError("Invalid combination of Qobj types"
+                         " for direct sum.")
+    else:
+        allsuper = all(_is_like_super(qobj) for row in qobjs for qobj in row)
+        alloper = all(_is_like_oper(qobj) for row in qobjs for qobj in row)
+        if not (allsuper or alloper):
+            raise ValueError("Invalid combination of Qobj types"
+                             " for direct sum.")
 
-        if not settings.core['auto_tidyup_dims']:
-            scalar_dim = _qobj_dims(qobjs[0]).to_
-            scalar_dims_match = all(
-                _qobj_dims(qobj).to_ == scalar_dim for qobj in qobjs
-            )
-            if not scalar_dims_match:
-                raise ValueError("Scalar dimensions do not match in"
-                                 " direct sum of covectors.")
-        else:
-            scalar_dim = Field()
-        vector_dim = SumSpace([_qobj_dims(qobj).from_ for qobj in qobjs],
-                              oper_as_opket)
+    from_dim = [_qobj_dims(qobj).from_ for qobj in qobjs[0]]
+    to_dim = [_qobj_dims(row[0]).to_ for row in qobjs]
+    dims_match = all(
+        _qobj_dims(qobj).from_ == from_dim[col_index]
+        and _qobj_dims(qobj).to_ == to_dim[row_index]
+        for row_index, row in enumerate(qobjs)
+        for col_index, qobj in enumerate(row)
+    )
+    if not dims_match:
+        raise ValueError("Mismatching dimensions in direct sum of operators.")
 
-        out_data = _data.concat_data([[_qobj_data(qobj) for qobj in qobjs]],
-                                     _skip_checks=True)
-        return Qobj(out_data,
-                    dims=Dimensions(vector_dim, scalar_dim),
-                    copy=False)
-
-    allsuper = all(_is_like_super(qobj) for row in qobjs for qobj in row)
-    alloper = all(_is_like_oper(qobj) for row in qobjs for qobj in row)
-    if allsuper and any(not _is_like_scalar(qobj) and qobj.superrep != 'super'
-                        for row in qobjs for qobj in row):
-        raise ValueError("Direct sums only accept superoperators"
-                         " in super representation.")
-
-    if not linear and (allsuper or alloper):
-        from_dim = [_qobj_dims(qobj).from_ for qobj in qobjs[0]]
-        to_dim = [_qobj_dims(row[0]).to_ for row in qobjs]
-        dims_match = all(
-            _qobj_dims(qobj).from_ == from_dim[col_index]
-            and _qobj_dims(qobj).to_ == to_dim[row_index]
-            for row_index, row in enumerate(qobjs)
-            for col_index, qobj in enumerate(row)
-        )
-        if not dims_match:
-            raise ValueError("Mismatching dimensions in"
-                             " direct sum of operators.")
-
-        out_data = _data.concat_data(
-            [[_qobj_data(qobj) for qobj in row] for row in qobjs],
-            _skip_checks=True
-        )
-        return Qobj(out_data,
-                    dims=Dimensions(SumSpace(from_dim), SumSpace(to_dim)),
-                    copy=False)
-
-    raise ValueError("Invalid combination of Qobj types for direct sum.")
+    out_data = _data.concat_data(
+        [[_qobj_data(qobj) for qobj in row] for row in qobjs],
+        _skip_checks=True
+    )
+    return Qobj(out_data,
+                dims=Dimensions(SumSpace(*from_dim), SumSpace(*to_dim)),
+                copy=False)
 
 
-def component(qobj: Qobj, *index: list[int]) -> Qobj:
+def _check_index(given, min, max):
+    if not (min <= given < max):
+        raise ValueError(f"Index ({given}) out of bounds ({min}, {max-1})"
+                          " for component of direct sum.")
+
+def component(qobj: Qobj, *index: int) -> Qobj:
     is_to_sum = isinstance(qobj._dims.to_, SumSpace)
     is_from_sum = isinstance(qobj._dims.from_, SumSpace)
     if not is_to_sum and not is_from_sum:
+        if index == [0] or index == [0, 0]:
+            return qobj
         raise ValueError("Qobj is not a direct sum.")
 
     if is_to_sum and is_from_sum:
@@ -221,6 +157,8 @@ def component(qobj: Qobj, *index: list[int]) -> Qobj:
             raise ValueError("Invalid number of indices provided for component"
                              " of direct sum (two indices required).")
         to_index, from_index = index
+        _check_index(to_index, 0, len(qobj._dims.to_.spaces))
+        _check_index(from_index, 0, len(qobj._dims.from_.spaces))
         to_data_start = qobj._dims.to_._space_cumdims[to_index]
         to_data_stop = qobj._dims.to_._space_cumdims[to_index + 1]
         from_data_start = qobj._dims.from_._space_cumdims[from_index]
@@ -234,12 +172,22 @@ def component(qobj: Qobj, *index: list[int]) -> Qobj:
                                     qobj._dims.to_.spaces[to_index]),
                     copy=False)
 
+    if len(index) == 2:
+        to_index, from_index = index
+        if not is_to_sum:
+            _check_index(to_index, 0, 1)
+            index = [from_index]
+        else:
+            _check_index(from_index, 0, 1)
+            index = [to_index]
+
     if len(index) != 1:
         raise ValueError("Invalid number of indices provided for component"
-                         " of direct sum (one index required).")
+                         " of direct sum (one or two indices required).")
 
     if is_to_sum:
         to_index, = index
+        _check_index(to_index, 0, len(qobj._dims.to_.spaces))
         to_data_start = qobj._dims.to_._space_cumdims[to_index]
         to_data_stop = qobj._dims.to_._space_cumdims[to_index + 1]
         from_data_start = 0
@@ -252,11 +200,10 @@ def component(qobj: Qobj, *index: list[int]) -> Qobj:
                       dims=Dimensions(qobj._dims.from_,
                                       qobj._dims.to_.spaces[to_index]),
                       copy=False)
-        if qobj._dims.to_._oper_as_opket[to_index]:
-            return vector_to_operator(result)
         return result
 
     from_index, = index
+    _check_index(from_index, 0, len(qobj._dims.from_.spaces))
     to_data_start = 0
     to_data_stop = qobj._dims.to_.size
     from_data_start = qobj._dims.from_._space_cumdims[from_index]
@@ -269,6 +216,4 @@ def component(qobj: Qobj, *index: list[int]) -> Qobj:
                   dims=Dimensions(qobj._dims.from_.spaces[from_index],
                                   qobj._dims.to_),
                   copy=False)
-    if qobj._dims.from_._oper_as_opket[from_index]:
-        return vector_to_operator(result.dag())
     return result

--- a/qutip/core/direct_sum.py
+++ b/qutip/core/direct_sum.py
@@ -1,0 +1,76 @@
+from .qobj import Qobj
+from . import data as _data
+
+from numbers import Number
+
+import numpy as np
+
+__all__ = ['direct_sum']
+
+
+def _is_like_qobj(qobj):
+    return isinstance(qobj, Number) or isinstance(qobj, Qobj)
+
+def _qobj_data(qobj):
+    return qobj.data if isinstance(qobj, Qobj) else np.array([[qobj]])
+
+def _is_like_ket(qobj):
+    return (
+        isinstance(qobj, Number)
+        or (
+            isinstance(qobj, Qobj)
+            and qobj.type in ['scalar', 'ket']
+        ))
+
+def _is_like_bra(qobj):
+    return (
+        isinstance(qobj, Number)
+        or (
+            isinstance(qobj, Qobj)
+            and qobj.type in ['scalar', 'bra']
+        ))
+
+def _is_like_oper(qobj):
+    return (
+        isinstance(qobj, Number)
+        or (
+            isinstance(qobj, Qobj)
+            and qobj.type in ['scalar', 'oper', 'ket', 'bra']
+        ))
+
+def _is_like_operator_ket(qobj):
+    return (
+        isinstance(qobj, Number)
+        or (
+            isinstance(qobj, Qobj)
+            and qobj.type in ['scalar', 'oper', 'operator-ket']
+        ))
+
+def _is_like_operator_bra(qobj):
+    return (
+        isinstance(qobj, Number)
+        or (
+            isinstance(qobj, Qobj)
+            and qobj.type in ['scalar', 'oper', 'operator-bra']
+        ))
+
+def _is_like_super(qobj):
+    return (
+        isinstance(qobj, Number)
+        or (
+            isinstance(qobj, Qobj)
+            and qobj.type in ['scalar', 'super',
+                              'operator-ket', 'operator-bra']
+        ))
+
+def direct_sum(qobjs: list[Qobj | float] | list[list[Qobj | float]]) -> Qobj:
+    if len(qobjs) == 0:
+        raise ValueError("No Qobjs provided for direct sum.")
+
+    linear = _is_like_qobj(qobjs[0])
+
+    if linear and all(_is_like_ket(qobj) for qobj in qobjs):
+        out_data = _data.concat_data([[_qobj_data(qobj)] for qobj in qobjs])
+        return Qobj(out_data, copy=False)
+
+    raise NotImplementedError

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -11,13 +11,14 @@ import numpy as np
 from functools import partial
 from typing import TypeVar, overload
 
+from .direct_sum import component, direct_sum
 from .operators import qeye
 from .qobj import Qobj
 from .cy.qobjevo import QobjEvo
 from .superoperator import operator_to_vector, reshuffle
 from .dimensions import (
     flatten, enumerate_flat, unflatten, deep_remove, dims_to_tensor_shape,
-    dims_idxs_to_tensor_idxs
+    dims_idxs_to_tensor_idxs, SumSpace
 )
 from . import data as _data
 from .. import settings
@@ -64,6 +65,12 @@ shape = [4, 4], type = oper, isHerm = True
      [ 1.+0.j  0.+0.j  0.+0.j  0.+0.j]]
     """
     from .cy.qobjevo import QobjEvo
+
+    if any(isinstance(q._dims.from_, SumSpace)
+           or isinstance(q._dims.to_, SumSpace)
+           for q in args):
+        return _tensor_of_sum(*args)
+
     if not args:
         raise TypeError("Requires at least one input argument")
     if len(args) == 1 and isinstance(args[0], (Qobj, QobjEvo)):
@@ -114,6 +121,32 @@ shape = [4, 4], type = oper, isHerm = True
                 isherm=isherm,
                 isunitary=isunitary,
                 copy=False)
+
+def _tensor_of_sum(*args):
+    sum_index = -1
+    for index, q in enumerate(args):
+        if (isinstance(q._dims.from_, SumSpace)
+                or isinstance(q._dims.to_, SumSpace)):
+            if sum_index == -1:
+                sum_index = index
+                nrows = len(q._dims.from_.spaces)
+                ncols = len(q._dims.to_.spaces)
+            else:
+                # It would not be too difficult to implement
+                # but it seems very niche
+                raise NotImplementedError(
+                    "Tensor involving more than one direct sum is not"
+                    " implemented. Please raise an issue on Github if you"
+                    " require it."
+                )
+
+    args_before = args[:sum_index]
+    sum_qobj = args[sum_index]
+    args_after = args[(sum_index+1):]
+    return direct_sum(
+        [[tensor(*args_before, component(sum_qobj, row, col), *args_after)
+          for col in range(ncols)] for row in range(nrows)]
+    )
 
 
 @overload

--- a/qutip/typing.py
+++ b/qutip/typing.py
@@ -44,7 +44,8 @@ QobjEvoLike = Union["Qobj", "QobjEvo", ElementType, Sequence[ElementType]]
 LayerType = Union[str, type]
 
 
-SpaceLike = Union[int, list[int], list[list[int]], "Space"]
+SpaceLike = Union[int, list[int], list[list[int]], "Space",
+                  tuple[Union[list[int], list[list[int]]], ...]]
 
 
 DimensionLike = Union[


### PR DESCRIPTION
Support for direct sums (aka direct products) natively in qutip. Work in progress, closes #2384

**Why**

* This is a natural way to think about coupled differential equations. We are solving coupled DEs in the HEOM solver and in the QOC-GOAT algorithm. Currently, this requires manual data-layer manipulations (HEOM) or some trickery (GOAT). The HEOM solver only works with CSR dtype for that reason. These things could be more easily expressed with direct sums.
It might also be useful in the future when we are talking about parallelizing simulations of coupled DEs on clusters...
* It might be useful for educators? I remember my quantum mechanics lectures put quite some time into explaining how a composite system of two spins is the same as the sum of a triplet and a singlet ($\mathcal H_{1/2} \otimes \mathcal H_{1/2} = \mathcal H_0 \oplus \mathcal H_1$).

**Implementation**

This adds three functions:
1. `direct_sum` takes a list or matrix of `Qobj`, concatenates their data into a block vector or matrix, and returns it as a single `Qobj`. The dimensions of the result keep track of its block structure.
2. `component` extracts a constituent block from a `Qobj` that is a direct sum.
3. `set_component` replaces a constituent block in a `Qobj` that is a direct sum.

All of this should already be functional for regular operators / kets / bras and superoperators / operator-kets / operator-bras as well as for regular Qobj and for QobjEvo. Regular and superoperators are not allowed to be mixed.

In the dimensions, the direct sum is indicated as a tuple `()` of the dimensions of the blocks. The sum is always the outermost part of the dimensions and always flattened.

**Todo**

* The data layer functions currently only support `Dense` and are not cythonized. I would need help with the cython part.
* Need to make sure direct sums work together with all other qutip functions. For example, I have implemented tensor of direct sums (which is done componentwise), but not yet partial trace (also componentwise).
* Update HEOM and QOC.
* Testing and documentation required.

**Examples**

`direct_sum` tries to combine `Qobj` with different types in a way that makes sense:
```python
In [2]: qt.direct_sum([
   ...:     [qt.sigmax(),          qt.basis(2, 0)],
   ...:     [qt.basis(2, 1).dag(), 42            ]
   ...: ])
Out[2]:
Quantum object: dims=[([2], [1]), ([2], [1])], shape=(3, 3), type='oper', dtype=Dense, isherm=False
Qobj data =
[[ 0.  1.  1.]
 [ 1.  0.  0.]
 [ 0.  1. 42.]]
```

To solve the coupled equations $\dot \rho_1 = \mathcal L \rho_1$ and $\dot \rho_2 = \mathcal L \rho_2 + \mathcal L' \rho_1$, we can combine the initial conditions and the liouvillians and then use `mesolve`:
```python
rho_ini = qt.direct_sum([rho1_ini, rho2_ini])
liou = qt.direct_sum([[liou1, 0 * liou2], [liou2, liou1]])
res = qt.mesolve(liou, rho_ini, np.linspace(0, 10, 100))
```