### PR TITLE
Update shape in qobjevo dag/trans

### DIFF
--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -708,6 +708,7 @@ cdef class QobjEvo:
         res.elements = [element.linear_map(Qobj.trans)
                         for element in res.elements]
         res._dims = Dimensions(res._dims[0], res._dims[1])
+        res.shape = res._dims.shape
         return res
 
     def conj(self):
@@ -723,6 +724,7 @@ cdef class QobjEvo:
         res.elements = [element.linear_map(Qobj.dag, True)
                         for element in res.elements]
         res._dims = Dimensions(res._dims[0], res._dims[1])
+        res.shape = res._dims.shape
         return res
 
     def to(self, data_type):

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -318,6 +318,9 @@ def test_unary_ket(unary_op):
         as_qevo = transformed(t)
         as_qobj = unary_op(obj(t))
         assert transformed._dims == as_qevo._dims
+        assert transformed._dims == as_qobj._dims
+        assert transformed.shape == as_qobj.shape
+        assert transformed.shape == as_qevo.shape
         _assert_qobj_almost_eq(as_qevo, as_qobj)
 
 
@@ -493,7 +496,7 @@ def test_QobjEvo_step_coeff():
     "QobjEvo step interpolation"
     coeff1 = np.random.rand(6)
     coeff2 = np.random.rand(6) + np.random.rand(6) * 1.j
-    # uniform t
+    # uniform t_dims =
     tlist = np.array([2, 3, 4, 5, 6, 7], dtype=float)
     qobjevo = QobjEvo([[sigmaz(), coeff1], [sigmax(), coeff2]],
                       tlist=tlist, order=0)


### PR DESCRIPTION
**Description**
There is a bug in `QobjEvo.dag` and `QobjEvo.trans`, where the shape was not updated, only the dims and data.
The Qobj created when calling the function would have the right shape, so it was missed in the tests.

