### PR TITLE
Use slots to speed up numpy_backend

### DIFF
--- a/qutip/core/numpy_backend.py
+++ b/qutip/core/numpy_backend.py
@@ -2,8 +2,46 @@ from ..settings import settings
 
 
 class NumpyBackend:
+    __slots__ = (
+        "_qt_np",
+        "abs",
+        "angle",
+        "arccos",
+        "array",
+        "ceil",
+        "conj",
+        "cos",
+        "cumsum",
+        "diff",
+        "e",
+        "histogram",
+        "imag",
+        "inf",
+        "inner",
+        "linalg",
+        "log",
+        "log2",
+        "max",
+        "maximum",
+        "ones",
+        "pi",
+        "prod",
+        "real",
+        "searchsorted",
+        "sin",
+        "sort",
+        "sqrt",
+        "sum",
+        "where",
+        "zeros",
+        "zeros_like",
+    )
+
     def _qutip_setting_backend(self, np):
         self._qt_np = np
+        for slot in self.__slots__:
+            if slot != "_qt_np":
+                setattr(self, slot, getattr(np, slot))
 
     def __getattr__(self, name):
         return getattr(self._qt_np, name)

--- a/qutip/tests/core/test_options.py
+++ b/qutip/tests/core/test_options.py
@@ -1,14 +1,21 @@
 import pytest
 import numpy
-from unittest.mock import Mock
 
 import qutip
 from qutip.core.numpy_backend import np
 from qutip import CoreOptions, settings
 
+
 # Mocking JAX to demonstrate backend switching
-mock_jax = Mock
-mock_jax.sum = Mock(return_value="jax_sum")
+class Mock_JAX:
+    def sum(*a, **kw):
+        return "jax_sum"
+
+    def __getattr__(self, _):
+        return "other"
+
+
+mock_jax = Mock_JAX()
 mock_np = numpy
 
 


### PR DESCRIPTION
**Description**
Speed up the numpy backend class using `__slots__` as proposed by Simon in #2509.