### PR TITLE
Fix isequal_dia for unequal number of diags

### DIFF
--- a/doc/changes/2669.bugfix
+++ b/doc/changes/2669.bugfix
@@ -1,0 +1,1 @@
+Fix equality operators for diagonal format Qobj.

--- a/qutip/core/data/properties.pyx
+++ b/qutip/core/data/properties.pyx
@@ -371,6 +371,18 @@ cpdef bint isequal_dia(Dia A, Dia B, double atol=-1, double rtol=-1):
                         return False
                 ptr_b += size
                 diag_b += 1
+        while diag_a < A.num_diag:
+            for i in range(size):
+                if not _feq(0., ptr_a[i], atol, rtol):
+                    return False
+            ptr_a += size
+            diag_a += 1
+        while diag_b < B.num_diag:
+            for i in range(size):
+                if not _feq(0., ptr_b[i], atol, rtol):
+                    return False
+            ptr_b += size
+            diag_b += 1
     return True
 
 

--- a/qutip/tests/core/data/test_properties.py
+++ b/qutip/tests/core/data/test_properties.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import qutip
 from qutip import data as _data
 from qutip import CoreOptions
 from . import conftest
@@ -243,3 +244,13 @@ class TestIsEqual:
         A = conftest.random_diag(shape, 0.5, False)
         B = clean_dia(A)
         assert _data.isequal(A, B)
+
+    def test_dia_mismatch_structure(self):
+        true_zeros = qutip.qzero(5, dtype="dia")
+        diag_of_zeros = qutip.qdiags([0]*5)
+        id = qutip.qeye(5, dtype="dia")
+        assert true_zeros == diag_of_zeros
+        assert id != diag_of_zeros
+        assert id != true_zeros
+        assert qutip.destroy(3) * qutip.create(3) != qutip.destroy(3)
+        assert qutip.destroy(3) * qutip.create(3) != qutip.create(3)

--- a/qutip/tests/core/data/test_properties.py
+++ b/qutip/tests/core/data/test_properties.py
@@ -252,5 +252,5 @@ class TestIsEqual:
         assert true_zeros == diag_of_zeros
         assert id != diag_of_zeros
         assert id != true_zeros
-        assert qutip.destroy(3) * qutip.create(3) != qutip.destroy(3)
-        assert qutip.destroy(3) * qutip.create(3) != qutip.create(3)
+        assert qutip.destroy(3) + qutip.create(3) != qutip.destroy(3)
+        assert qutip.destroy(3) + qutip.create(3) != qutip.create(3)


### PR DESCRIPTION
**Description**
Fix a bug in `isequal_dia` for case where the number of diagonals doesn't match.

**Related issues or PRs**
Fix #2669