### PR TITLE
Fix small typo in sesolve.py

### DIFF
--- a/doc/changes/2677.doc
+++ b/doc/changes/2677.doc
@@ -1,0 +1,1 @@
+Fix small typo in docstring for `sesolve`.

--- a/qutip/solver/sesolve.py
+++ b/qutip/solver/sesolve.py
@@ -102,7 +102,7 @@ def sesolve(
           | Maximum number of (internally defined) steps allowed in one ``tlist``
             step.
         - | max_step : float
-          | Maximum lenght of one internal step. When using pulses, it should be
+          | Maximum length of one internal step. When using pulses, it should be
             less than half the width of the thinnest pulse.
 
         Other options could be supported depending on the integration method,


### PR DESCRIPTION
**Description**
Fix small typo in docstring for `sesolve`.

**Related issues or PRs**
N/A