### PR TITLE
Fix micro python version in 3.12 fallback test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,14 +64,14 @@ jobs:
           # Use conda-forge to provide Python 3.11 and latest numpy
           - case-name: p312, numpy fallback
             os: ubuntu-latest
-            python-version: "3.12.9"
+            python-version: "3.12"
             numpy-requirement: ">=1.26,<1.27"
             scipy-requirement: ">=1.11,<1.12"
             condaforge: 1
             oldmpl: 1
             # Install mpi4py to test mpi_pmap
             # Should be enough to include this in one of the runs
-            includempi: 1
+            # includempi: 1
             coveralls: 1
 
           # Python 3.10, no mkl, scipy 1.9, numpy 1.23
@@ -88,6 +88,7 @@ jobs:
             oldmpl: 1
             nomkl: 1
             coveralls: 1
+            includempi: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
           # Mac

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
           # Use conda-forge to provide Python 3.11 and latest numpy
           - case-name: p312, numpy fallback
             os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.12.9"
             numpy-requirement: ">=1.26,<1.27"
             scipy-requirement: ">=1.11,<1.12"
             condaforge: 1


### PR DESCRIPTION
**Description**
One of the tests is failing, timing out after finishing the tests:

```
(48156 durations < 1s hidden.  Use -vv to show these durations.)
========== 16036 passed, 103 skipped, 6 xfailed in 1160.36s (0:19:20) ==========
Error: The action 'Run tests' has timed out after 60 minutes.
```

It's happening after merging dysolve and python 3.12.10 being release.
This is to test if the python release had an impact.