### PR TITLE
Update openmpi version used in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,9 @@ jobs:
             numpy-build: ">=2.0.0"
             numpy-requirement: ">=2.0.0"
             pypi: 1
+            # Install mpi4py to test mpi_pmap
+            # Should be enough to include this in one of the runs
+            includempi: 1
 
           - case-name: p310 numpy 1.22
             os: ubuntu-latest
@@ -69,9 +72,6 @@ jobs:
             scipy-requirement: ">=1.11,<1.12"
             condaforge: 1
             oldmpl: 1
-            # Install mpi4py to test mpi_pmap
-            # Should be enough to include this in one of the runs
-            includempi: 1
             coveralls: 1
 
           # Python 3.10, no mkl, scipy 1.9, numpy 1.23
@@ -169,8 +169,10 @@ jobs:
             conda install "${{ matrix.conda-extra-pkgs }}"
           fi
           if [[ "${{ matrix.includempi }}" ]]; then
-            # Use openmpi because mpich causes problems. Note, environment variable names change in v5
-            conda install "openmpi<5" mpi4py
+            # Both mpich and openmpi version 4 have caused problems in the past
+            # so we use openmpi version 5. Openmpi 5 and python 3.13-compatible
+            # version of mpi4py are currently only available on conda-forge:
+            conda install --channel conda-forge "openmpi>=5.0" mpi4py
           fi
           if [[ "${{ matrix.oldcython }}" ]]; then
             python -m pip install cython==0.29.36 filelock matplotlib==3.5
@@ -233,7 +235,10 @@ jobs:
             # By default, the max. number of allowed worker processes in openmpi is
             # (number of physical cpu cores) - 1.
             # We only have 2 physical cores, but we want to test mpi_pmap with 2 workers.
-            export OMPI_MCA_rmaps_base_oversubscribe=true
+            # For OpenMPI <= 4:
+            # export OMPI_MCA_rmaps_base_oversubscribe=true
+            # For OpenMPI >= 5:
+            export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
           fi
           pytest -Werror --strict-config --strict-markers --fail-slow=300 --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip --cov-report= --color=yes ${{ matrix.pytest-extra-options }} qutip/tests
           # Above flags are:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -240,6 +240,11 @@ If any failures or errors occur, please check that you have installed all of the
 See the next section on how to check the installed versions of the QuTiP dependencies.
 If these tests still fail, then head on over to the `QuTiP Discussion Board <https://groups.google.com/g/qutip>`_ or `the GitHub issues page <https://github.com/qutip/qutip/issues>`_ and post a message detailing your particular issue.
 
+If the ``mpi4py`` module is installed, the test suide will also run a set of tests checking the MPI capabilities of QuTiP.
+If the MPI backend on your system is not configured correctly, these tests may sometimes cause the test suite to crash or hang.
+Please make sure that you are using the latest versions of ``mpi4py`` and the MPI backend.
+If the tests still crash or hang, try running pytest with the ``-s`` option to display any potential error or warning messages from the MPI backend.
+
 .. _install-about:
 
 Checking Version Information


### PR DESCRIPTION
We are including the MPI tests in only one of the test runs. I am changing that to be the one with the latest python and numpy (which it was always supposed to be, but it didn't get updated when python 3.13 came out). I am also changing openmpi, which was pinned to `<5` due to dependency issues, to the latest version.

This gets rid of some warning messages, and it seems to fix the problem with the test timing out. I still do not know exactly what caused that problem, but I am fine if things are working with the latest openmpi / mpi4py versions.