### PR TITLE
Bugfix: ensure CSR matrices are initialized correctly

### DIFF
--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -23,12 +23,14 @@ if parse_version(scipy.version.version) >= parse_version("1.14.0"):
     from scipy.sparse._data import _data_matrix as scipy_data_matrix
     # From scipy 1.14.0, a check that the input is not scalar was added for
     # sparse arrays.
-    scipy_data_matrix = partial(scipy_data_matrix, arg1=(0,))
+    scipy_data_matrix_init = partial(scipy_data_matrix.__init__, arg1=(0,))
 elif parse_version(scipy.version.version) >= parse_version("1.8.0"):
     # The file data was renamed to _data from scipy 1.8.0
     from scipy.sparse._data import _data_matrix as scipy_data_matrix
+    scipy_data_matrix_init = scipy_data_matrix.__init__
 else:
     from scipy.sparse.data import _data_matrix as scipy_data_matrix
+    scipy_data_matrix_init = scipy_data_matrix.__init__
 from scipy.linalg cimport cython_blas as blas
 
 from qutip.core.data cimport base, Dense, Dia
@@ -60,7 +62,7 @@ cdef object _csr_matrix(data, indices, indptr, shape):
     cdef object out = scipy_csr_matrix.__new__(scipy_csr_matrix)
     # `_data_matrix` is the first object in the inheritance chain which
     # doesn't have a really slow __init__.
-    scipy_data_matrix.__init__(out)
+    scipy_data_matrix_init(out)
     out.data = data
     out.indices = indices
     out.indptr = indptr

--- a/qutip/tests/core/data/test_csr.py
+++ b/qutip/tests/core/data/test_csr.py
@@ -152,6 +152,15 @@ class TestClassMethods:
         assert original is not copy
         assert (original.as_scipy() - copy.as_scipy()).nnz == 0
 
+    def test_as_scipy_initializes_correctly(self, data_csr):
+        """
+        Test that the object returned from as_scipy is initialized correctly.
+        If not, there might be some missing attributes.
+        """
+        sci = data_csr.as_scipy()
+        reference = scipy.sparse.csr_matrix((1, 0))
+        assert sci.__dict__.keys() == reference.__dict__.keys()
+
     def test_as_scipy_returns_a_view(self, data_csr):
         """
         Test that modifying the views in the result of as_scipy() also modifies


### PR DESCRIPTION
For scipy version >= 1.14, we are accidentally calling `object.__init__` instead of `scipy.sparse._data._data_matrix.__init__` on CSR matrices created in the data layer.

Fixes #2690