### PR TITLE
Creating operator from dense ket.proj return CSR when appropriate

### DIFF
--- a/doc/changes/2700.misc
+++ b/doc/changes/2700.misc
@@ -1,0 +1,1 @@
+Creating operator from dense ket.proj return CSR when appropriate

--- a/qutip/core/data/convert.pyx
+++ b/qutip/core/data/convert.pyx
@@ -15,6 +15,7 @@ initialisation of the `data` module.
 # even in a simple interactive QuTiP session, and it all adds up.
 
 import numbers
+from typing import Literal
 from collections import namedtuple
 import numpy as np
 from scipy.sparse import dok_matrix, csgraph
@@ -552,7 +553,15 @@ to = _to()
 create = _create()
 
 
-def _parse_default_dtype(provided, sparcity):
+def _parse_default_dtype(
+    provided : type | str,
+    sparcity : Literal["dense", "sparse", "diagonal"],
+):
+    """
+    Find the best dtype for Qobj creation functions.
+    Take in to accound the settings, user ``provided`` dtype and
+    resulting object ``sparcity``.
+    """
     from qutip import settings
     if provided is None:
         provided = settings.core["default_dtype"] or "core"

--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -965,16 +965,15 @@ cpdef Dia matmul_outer_dia_dense_sparse(Data left, Data right, double complex sc
 
 cpdef Data matmul_outer_dense_Data(Dense left, Dense right, double complex scale=1):
     out_type = settings.core["default_dtype"]
-    if out_type is None:
-        out_density = (
-            dense.nnz(left) * 1.0 / left.shape[0]
-            * dense.nnz(right) * 1.0 / right.shape[1]
-        )
-        if out_density < 0.3:
-            out_type = CSR
-        else:
-            out_type = Dense
-    return matmul(left, right, dtype=out_type)
+    out_density = (
+        dense.nnz(left) * 1.0 / left.shape[0]
+        * dense.nnz(right) * 1.0 / right.shape[1]
+    )
+    if out_density < 0.3 and out_type is not Dense:
+        return matmul(left, right, dtype=CSR)
+    else:
+        return matmul(left, right, dtype=Dense)
+
 
 
 cpdef Data matmul_outer_Data(Data left, Data right, double complex scale=1):

--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -964,12 +964,11 @@ cpdef Dia matmul_outer_dia_dense_sparse(Data left, Data right, double complex sc
 
 
 cpdef Data matmul_outer_dense_Data(Dense left, Dense right, double complex scale=1):
-    out_type = settings.core["default_dtype"]
     out_density = (
         dense.nnz(left) * 1.0 / left.shape[0]
         * dense.nnz(right) * 1.0 / right.shape[1]
     )
-    if out_density < 0.3 and out_type is not Dense:
+    if out_density < 0.3:
         return matmul(left, right, dtype=CSR)
     else:
         return matmul(left, right, dtype=Dense)

--- a/qutip/core/data/project.pyx
+++ b/qutip/core/data/project.pyx
@@ -3,7 +3,6 @@
 
 from libc.string cimport memcpy, memset
 
-from qutip.settings import settings
 from qutip.core.data.base cimport idxint
 from qutip.core.data cimport csr, dense, Dense, dia, Dia, Data
 from qutip.core.data.csr cimport CSR
@@ -103,9 +102,8 @@ cpdef Data project_dense_data(Dense state):
 
     If the projection output would be less than 30% full, return a CSR matrix.
     """
-    out_type = settings.core["default_dtype"]
     out_density = dense.nnz(state) * 1.0 / state.shape[0]
-    if out_density < 0.55 and out_type is not Dense:
+    if out_density < 0.55:
         return project_csr(_to(CSR, state))
     else:
         return _project_dense(state)

--- a/qutip/tests/core/data/test_mathematics.py
+++ b/qutip/tests/core/data/test_mathematics.py
@@ -1025,7 +1025,7 @@ class TestProject(UnaryOpMixin):
     specialisations = [
         pytest.param(data.project_csr, CSR, CSR),
         pytest.param(data.project_dia, Dia, Dia),
-        pytest.param(data.project_dense, Dense, Dense),
+        pytest.param(data.project_dense_data, Dense, Data),
     ]
 
 

--- a/qutip/tests/core/data/test_operators.py
+++ b/qutip/tests/core/data/test_operators.py
@@ -67,3 +67,14 @@ def test_data_eq_operator(type_left, type_right):
 
     assert left != mat
     assert numpy.all(left != mat.full())
+
+
+def test_oper_from_ketbra():
+    ket = qutip.basis(2)
+    bra = qutip.basis(2).dag()
+    assert (ket @ bra).dtype is _data.CSR
+    assert (ket.proj()).dtype is _data.CSR
+
+    ket2 = qutip.coherent(2, 1)
+    assert (ket2 @ bra).dtype is _data.Dense
+    assert (ket2.proj()).dtype is _data.Dense

--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 from qutip import (
-    mesolve, liouvillian, QobjEvo, spre, spost,
+    mesolve, liouvillian, QobjEvo, spre, spost, CoreOptions,
     destroy, coherent, qeye, fock_dm, num, basis
 )
 from qutip.solver.stochastic import smesolve, ssesolve, SMESolver, SSESolver
@@ -545,10 +545,13 @@ def test_merge_results(store_measurement, keep_runs_results):
     result_merged = result1 + result2
     assert len(result_merged.seeds) == 15
     if store_measurement:
-        assert (
-            result_merged.average_states[0] ==
-            (initial_state1.proj() + 2 * initial_state2.proj()).unit()
-        )
+        with CoreOptions(atol=2e-8):
+            # In the numpy 1.X test, this fail with the defautl atol=1e-12
+            # One operation is computed in single precision?
+            assert (
+                result_merged.average_states[0] ==
+                (initial_state1.proj() + 2 * initial_state2.proj()).unit()
+            )
     np.testing.assert_allclose(result_merged.average_expect[0][0], 1)
     np.testing.assert_allclose(result_merged.average_expect[1], 2/3)
 


### PR DESCRIPTION
**Description**
We made it so `|ket><bra|` return a sparse when appropriate, but `basis(10, 2).proj()` would still return a dense matrix...
This update `proj` to match the matmul behavior and add a test.

Ideally, this should be the dispatcher that can choose the appropriate output type so we don't have to do the same in qutip-jax etc. 