### PR TITLE
Add support for scipy 1.16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
             # Install mpi4py to test mpi_pmap
             # Should be enough to include this in one of the runs
             includempi: 1
+            pytest-extra-options: "-W ignore:Matrix:scipy.linalg._misc.LinAlgWarning"
 
           - case-name: p310 numpy 1.22
             os: ubuntu-latest
@@ -64,7 +65,7 @@ jobs:
             oldmpl: 1
             pypi: 1
             coveralls: 1
-            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
+            pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\" -W ignore:Matrix:scipy.linalg._misc.LinAlgWarning"
 
           # Python 3.12 and latest numpy
           # Use conda-forge to provide Python 3.11 and latest numpy
@@ -102,6 +103,7 @@ jobs:
             numpy-requirement: ">=2.0.0"
             condaforge: 1
             nomkl: 1
+            pytest-extra-options: "-W ignore:Matrix:scipy.linalg._misc.LinAlgWarning"
 
           - case-name: macos - numpy fallback
             os: macos-13  # Test on intel cpus
@@ -111,6 +113,7 @@ jobs:
             condaforge: 1
             nomkl: 1
             coveralls: 1
+            pytest-extra-options: "-W ignore:Matrix:scipy.linalg._misc.LinAlgWarning"
 
           - case-name: Windows
             os: windows-latest
@@ -118,6 +121,7 @@ jobs:
             numpy-build: ">=2.0.0"
             numpy-requirement: ">=2.0.0"
             pypi: 1
+            pytest-extra-options: "-W ignore:Matrix:scipy.linalg._misc.LinAlgWarning"
 
           - case-name: Windows - numpy fallback
             os: windows-latest

--- a/doc/changes/2711.misc
+++ b/doc/changes/2711.misc
@@ -1,0 +1,1 @@
+Add support for scipy 1.16

--- a/qutip/core/data/expm.py
+++ b/qutip/core/data/expm.py
@@ -133,6 +133,9 @@ logm.add_specialisations([
 def sqrtm_dense(matrix) -> Dense:
     if matrix.shape[0] != matrix.shape[1]:
         raise ValueError("can only compute logarithm square matrix")
+    # As of scipy 1.16.0, it's bugged and overly eager for warning.
+    # Tests filter warnings, and 1.16.1 will fix the bug.
+    # See qutip#2711
     return Dense(scipy.linalg.sqrtm(matrix.as_ndarray()))
 
 

--- a/qutip/tests/core/data/test_dia.py
+++ b/qutip/tests/core/data/test_dia.py
@@ -61,7 +61,7 @@ class TestClassMethods:
         """Test that __init__ can accept a scipy dia matrix."""
         out = dia.Dia(scipy_dia)
         assert out.shape == scipy_dia.shape
-        assert (out.as_scipy() - scipy_dia).nnz == 0
+        assert not np.any((out.as_scipy() != scipy_dia).data)
 
     def test_init_from_tuple(self, scipy_dia):
         """
@@ -71,7 +71,7 @@ class TestClassMethods:
         arg = (scipy_dia.data, scipy_dia.offsets)
         out = dia.Dia(arg, shape=scipy_dia.shape)
         assert out.shape == scipy_dia.shape
-        assert (out.as_scipy() - scipy_dia).nnz == 0
+        assert not np.any((out.as_scipy() != scipy_dia).data)
 
     @pytest.mark.parametrize('d_type', (
         _dtype_complex + _dtype_float + _dtype_int + _dtype_uint
@@ -90,7 +90,7 @@ class TestClassMethods:
         out_scipy = out.as_scipy()
         assert out.shape == scipy_dia.shape
         assert out_scipy.data.dtype == np.complex128
-        assert (out_scipy - scipy_dia).nnz == 0
+        assert not np.any((out_scipy != scipy_dia).data)
 
     @pytest.mark.parametrize(['arg', 'kwargs', 'error'], [
         pytest.param((), {}, ValueError, id="arg 0 tuple"),
@@ -189,7 +189,7 @@ class TestClassMethods:
         """
         data_diag = dia.Dia(scipy_dia)
         assert isinstance(data_diag.as_scipy(), scipy.sparse.dia_matrix)
-        assert (data_diag.as_scipy() - scipy_dia).nnz == 0
+        assert not np.any((data_diag.as_scipy() != scipy_dia).data)
 
     def test_as_scipy_of_uninitialised_is_empty(self, shape):
         ndiag = 0
@@ -243,7 +243,7 @@ class TestFactoryMethods:
         assert isinstance(base, dia.Dia)
         assert base.shape == (dimension, dimension)
         assert sci.nnz == dimension
-        assert (sci - scipy_test).nnz == 0
+        assert not np.any((sci != scipy_test).data)
 
 
     @pytest.mark.parametrize(['diagonals', 'offsets', 'shape'], [

--- a/qutip/tests/core/data/test_dia.py
+++ b/qutip/tests/core/data/test_dia.py
@@ -14,6 +14,13 @@ _dtype_int = ['int32', 'int64']
 _dtype_uint = ['uint32']
 
 
+def _dia_eq(left, right):
+    """
+    left == right for scipy sparse dia_matrix
+    """
+    return not np.any((left != right).data)
+
+
 # Set up some fixtures for automatic parametrisation.
 
 @pytest.fixture(params=[
@@ -61,7 +68,7 @@ class TestClassMethods:
         """Test that __init__ can accept a scipy dia matrix."""
         out = dia.Dia(scipy_dia)
         assert out.shape == scipy_dia.shape
-        assert not np.any((out.as_scipy() != scipy_dia).data)
+        assert _dia_eq(out.as_scipy(), scipy_dia)
 
     def test_init_from_tuple(self, scipy_dia):
         """
@@ -71,7 +78,7 @@ class TestClassMethods:
         arg = (scipy_dia.data, scipy_dia.offsets)
         out = dia.Dia(arg, shape=scipy_dia.shape)
         assert out.shape == scipy_dia.shape
-        assert not np.any((out.as_scipy() != scipy_dia).data)
+        assert _dia_eq(out.as_scipy(), scipy_dia)
 
     @pytest.mark.parametrize('d_type', (
         _dtype_complex + _dtype_float + _dtype_int + _dtype_uint
@@ -90,7 +97,7 @@ class TestClassMethods:
         out_scipy = out.as_scipy()
         assert out.shape == scipy_dia.shape
         assert out_scipy.data.dtype == np.complex128
-        assert not np.any((out_scipy != scipy_dia).data)
+        assert _dia_eq(out_scipy, scipy_dia)
 
     @pytest.mark.parametrize(['arg', 'kwargs', 'error'], [
         pytest.param((), {}, ValueError, id="arg 0 tuple"),
@@ -189,7 +196,7 @@ class TestClassMethods:
         """
         data_diag = dia.Dia(scipy_dia)
         assert isinstance(data_diag.as_scipy(), scipy.sparse.dia_matrix)
-        assert not np.any((data_diag.as_scipy() != scipy_dia).data)
+        assert _dia_eq(data_diag.as_scipy(), scipy_dia)
 
     def test_as_scipy_of_uninitialised_is_empty(self, shape):
         ndiag = 0
@@ -243,7 +250,7 @@ class TestFactoryMethods:
         assert isinstance(base, dia.Dia)
         assert base.shape == (dimension, dimension)
         assert sci.nnz == dimension
-        assert not np.any((sci != scipy_test).data)
+        assert _dia_eq(sci, scipy_test)
 
 
     @pytest.mark.parametrize(['diagonals', 'offsets', 'shape'], [

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,8 @@ zip_safe = False
 python_requires = >=3.10
 install_requires =
     numpy>=1.22
-    scipy>=1.9
+    # A bug in scipy 1.16.0 break `fidelity` skip that exact version.
+    scipy>=1.9,!=1.16.0
     packaging
 setup_requires =
     numpy>=2.0.0


### PR DESCRIPTION
**Description**
Update for scipy 1.16.

2 changes broke our tests:
- Faster dia operations: it does no longer clean the `0` after the operation. So `(dia - dia).nnz` is no longer 0 even if all values are zero. `==` raise a warning so `not any(dia != dia)` it is...
- New `sqrtm`, it raise a warning when the matrix is singular. I just filtered the warnings in the tests, expecting the result to still be right most of the time. But we should see it fail if the result it wrong.