### PR TITLE
Pluging utilities

### DIFF
--- a/qutip/core/data/dispatch.pyx
+++ b/qutip/core/data/dispatch.pyx
@@ -342,27 +342,36 @@ cdef class Dispatcher:
 
         Parameters
         ----------
-        dtype: tuple(type)
-            dtype of the function to register.
-            If all dispatched types are the same, a single entry is sufficient.
-            Otherwise each types should be passed.
+        *dtype: type
+            The data types for each of the dispatched arguments. There should
+            be one for each `Data` input and one for the output if also a
+            `Data` object.
+
+            As a convenience, if the specialisation uses the same data type for
+            all inputs, you can provide the type just once.
 
         Example
         -------
 
-        @func_dispatched.register(new_dtype)
-        def func_new_dtype(A: new_dtype, b: new_dtype) -> new_dtype:
+        @func.register(CSR)
+        def func_new_dtype(A: CSR, b: CSR) -> CSR:
             ...
 
         or
 
-        @func_dispatched.register(new_dtype, Dense, new_dtype)
-        def func_new_dtype(A: new_dtype, b: Dense) -> new_dtype:
+        @func.register(CSR, Dense, CSR)
+        def func_new_dtype(A: CSR, b: Dense) -> CSR:
             ...
 
         """
         if len(dtypes) == 1 and self._n_dispatch > 1:
             dtypes = dtypes * self._n_dispatch
+
+        if len(dtypes) != self._n_dispatch:
+            raise ValueError(
+                f"Dispatcher expects {self._n_dispatch} type arguments,"
+                f" but {len(dtypes)} were given."
+            )
 
         def _register(func):
             self.add_specialisations([dtypes + (func,)])

--- a/qutip/core/data/dispatch.pyx
+++ b/qutip/core/data/dispatch.pyx
@@ -344,7 +344,7 @@ cdef class Dispatcher:
         ----------
         *dtype: type
             The data types for each of the dispatched arguments. There should
-            be one for each `Data` input and one for the output if also a
+            be one for each `Data` input and one for the output if that is also a
             `Data` object.
 
             As a convenience, if the specialisation uses the same data type for

--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -93,6 +93,10 @@ def _set_default_dtype_scope(new_range):
             "'default_dtype_scope' must be one of "
             "'creation', 'missing', 'full'"
         )
+    if new_range != "creation" and settings.core["default_dtype"] is None:
+        raise RuntimeError(
+            "Can't set 'default_dtype_scope' without setting 'default_dtype'"
+        )
     for dispatcher in qutip.core.data.to.dispatchers:
         dispatcher.rebuild_lookup()
 

--- a/qutip/tests/core/data/conftest.py
+++ b/qutip/tests/core/data/conftest.py
@@ -4,7 +4,7 @@ import scipy.sparse
 import qutip
 
 
-def shuffle_indices_scipy_csr(matrix):
+def shuffle_indices_scipy_csr(matrix, gen=None):
     """
     Given a scipy.sparse.csr_matrix, shuffle the indices within each row and
     return a new array.  This should represent the same matrix, but in the less
@@ -16,11 +16,13 @@ def shuffle_indices_scipy_csr(matrix):
     general, we attempt to shuffle, and if this returns the same order as
     before, we just reverse it to ensure it's different.
     """
+    if gen is None:
+        gen = np.random.default_rng()
     out = matrix.copy()
     for row in range(out.shape[0]):
         ptr = (out.indptr[row], out.indptr[row + 1])
         if ptr[1] - ptr[0] > 1:
-            order = np.argsort(np.random.rand(ptr[1] - ptr[0]))
+            order = np.argsort(gen.uniform(size=(ptr[1] - ptr[0])))
             # If sorted, reverse it.
             order = np.flip(order) if np.all(order[:-1] < order[1:]) else order
             out.indices[ptr[0]:ptr[1]] = out.indices[ptr[0]:ptr[1]][order]
@@ -28,14 +30,16 @@ def shuffle_indices_scipy_csr(matrix):
     return out
 
 
-def random_scipy_dia(shape, density, sort=False):
+def random_scipy_dia(shape, density, sort=False, gen=None):
     """
     Generate a random scipy dia matrix with the given shape, density.
     """
+    if gen is None:
+        gen = np.random.default_rng()
     num_diag = int(density * (shape[0] + shape[1] - 1)) or 1
     offsets = []
     data = []
-    diags = np.random.choice(
+    diags = gen.choice(
         np.arange(-shape[0] + 1, shape[1]),
         num_diag,
         replace=False
@@ -46,7 +50,8 @@ def random_scipy_dia(shape, density, sort=False):
             shape[0], shape[1], shape[0] + diag, shape[1] - diag
         )
         data.append(
-            np.random.rand(num_elements) + 1j*np.random.rand(num_elements)
+            gen.uniform(size=num_elements)
+            + 1j * gen.uniform(size=num_elements)
         )
     if sort:
         order = np.argsort(offsets)
@@ -55,44 +60,48 @@ def random_scipy_dia(shape, density, sort=False):
     return scipy.sparse.diags(data, offsets, shape=shape).todia()
 
 
-def random_scipy_csr(shape, density, sorted_):
+def random_scipy_csr(shape, density, sorted_, gen=None):
     """
     Generate a random scipy CSR matrix with the given shape, nnz density, and
     with indices that are either sorted or unsorted.  The nnz elements will
     always be at least one.
     """
+    if gen is None:
+        gen = np.random.default_rng()
     nnz = int(shape[0] * shape[1] * density) or 1
-    data = np.random.rand(nnz) + 1j*np.random.rand(nnz)
-    rows = np.random.choice(np.arange(shape[0]), nnz)
-    cols = np.random.choice(np.arange(shape[1]), nnz)
+    data = gen.uniform(size=nnz) + 1j * gen.uniform(size=nnz)
+    rows = gen.choice(np.arange(shape[0]), nnz)
+    cols = gen.choice(np.arange(shape[1]), nnz)
     sci = scipy.sparse.coo_matrix((data, (rows, cols)), shape=shape).tocsr()
     if not sorted_:
-        sci = shuffle_indices_scipy_csr(sci)
+        sci = shuffle_indices_scipy_csr(sci, gen)
     return sci
 
 
-def random_numpy_dense(shape, fortran):
+def random_numpy_dense(shape, fortran, gen=None):
     """Generate a random numpy dense matrix with the given shape."""
-    out = np.random.rand(*shape) + 1j*np.random.rand(*shape)
+    if gen is None:
+        gen = np.random.default_rng()
+    out = gen.uniform(size=shape) + 1j * gen.uniform(size=shape)
     if fortran:
         out = np.asfortranarray(out)
     return out
 
 
-def random_csr(shape, density, sorted_):
+def random_csr(shape, density, sorted_, gen=None):
     """
     Generate a random qutip CSR matrix with the given shape, nnz density, and
     with indices that are either sorted or unsorted.  The nnz elements will
     always be at least one (use data.csr.zeros otherwise).
     """
-    return qutip.core.data.CSR(random_scipy_csr(shape, density, sorted_))
+    return qutip.core.data.CSR(random_scipy_csr(shape, density, sorted_, gen))
 
 
-def random_dense(shape, fortran):
+def random_dense(shape, fortran, gen=None):
     """Generate a random qutip Dense matrix of the given shape."""
-    return qutip.core.data.Dense(random_numpy_dense(shape, fortran))
+    return qutip.core.data.Dense(random_numpy_dense(shape, fortran, gen))
 
 
-def random_diag(shape, density, sort=False):
+def random_diag(shape, density, sort=False, gen=None):
     """Generate a random qutip Dia matrix of the given shape and density"""
-    return qutip.core.data.Dia(random_scipy_dia(shape, density, sort))
+    return qutip.core.data.Dia(random_scipy_dia(shape, density, sort, gen))

--- a/qutip/tests/core/data/conftest.py
+++ b/qutip/tests/core/data/conftest.py
@@ -93,15 +93,25 @@ def random_csr(shape, density, sorted_, gen=None):
     Generate a random qutip CSR matrix with the given shape, nnz density, and
     with indices that are either sorted or unsorted.  The nnz elements will
     always be at least one (use data.csr.zeros otherwise).
+
+    An optional numpy random generator can be passed.
     """
     return qutip.core.data.CSR(random_scipy_csr(shape, density, sorted_, gen))
 
 
 def random_dense(shape, fortran, gen=None):
-    """Generate a random qutip Dense matrix of the given shape."""
+    """
+    Generate a random qutip Dense matrix of the given shape.
+
+    An optional numpy random generator can be passed.
+    """
     return qutip.core.data.Dense(random_numpy_dense(shape, fortran, gen))
 
 
 def random_diag(shape, density, sort=False, gen=None):
-    """Generate a random qutip Dia matrix of the given shape and density"""
+    """
+    Generate a random qutip Dia matrix of the given shape and density.
+
+    An optional numpy random generator can be passed.
+    """
     return qutip.core.data.Dia(random_scipy_dia(shape, density, sort, gen))

--- a/qutip/tests/core/data/conftest.py
+++ b/qutip/tests/core/data/conftest.py
@@ -15,6 +15,9 @@ def shuffle_indices_scipy_csr(matrix, gen=None):
     If there is at most one value per row, there is no unsorted order.  In
     general, we attempt to shuffle, and if this returns the same order as
     before, we just reverse it to ensure it's different.
+
+    An optional numpy random generator can be passed as `gen`.
+    If not provided one will be created.
     """
     if gen is None:
         gen = np.random.default_rng()
@@ -33,6 +36,9 @@ def shuffle_indices_scipy_csr(matrix, gen=None):
 def random_scipy_dia(shape, density, sort=False, gen=None):
     """
     Generate a random scipy dia matrix with the given shape, density.
+
+    An optional numpy random generator can be passed as `gen`.
+    If not provided one will be created.
     """
     if gen is None:
         gen = np.random.default_rng()
@@ -65,6 +71,9 @@ def random_scipy_csr(shape, density, sorted_, gen=None):
     Generate a random scipy CSR matrix with the given shape, nnz density, and
     with indices that are either sorted or unsorted.  The nnz elements will
     always be at least one.
+
+    An optional numpy random generator can be passed as `gen`.
+    If not provided one will be created.
     """
     if gen is None:
         gen = np.random.default_rng()
@@ -79,7 +88,12 @@ def random_scipy_csr(shape, density, sorted_, gen=None):
 
 
 def random_numpy_dense(shape, fortran, gen=None):
-    """Generate a random numpy dense matrix with the given shape."""
+    """
+    Generate a random numpy dense matrix with the given shape.
+
+    An optional numpy random generator can be passed as `gen`.
+    If not provided one will be created.
+    """
     if gen is None:
         gen = np.random.default_rng()
     out = gen.uniform(size=shape) + 1j * gen.uniform(size=shape)
@@ -94,7 +108,8 @@ def random_csr(shape, density, sorted_, gen=None):
     with indices that are either sorted or unsorted.  The nnz elements will
     always be at least one (use data.csr.zeros otherwise).
 
-    An optional numpy random generator can be passed.
+    An optional numpy random generator can be passed as `gen`.
+    If not provided one will be created.
     """
     return qutip.core.data.CSR(random_scipy_csr(shape, density, sorted_, gen))
 
@@ -103,7 +118,8 @@ def random_dense(shape, fortran, gen=None):
     """
     Generate a random qutip Dense matrix of the given shape.
 
-    An optional numpy random generator can be passed.
+    An optional numpy random generator can be passed as `gen`.
+    If not provided one will be created.
     """
     return qutip.core.data.Dense(random_numpy_dense(shape, fortran, gen))
 
@@ -112,6 +128,7 @@ def random_diag(shape, density, sort=False, gen=None):
     """
     Generate a random qutip Dia matrix of the given shape and density.
 
-    An optional numpy random generator can be passed.
+    An optional numpy random generator can be passed as `gen`.
+    If not provided one will be created.
     """
     return qutip.core.data.Dia(random_scipy_dia(shape, density, sort, gen))

--- a/qutip/tests/core/data/test_dispatch.py
+++ b/qutip/tests/core/data/test_dispatch.py
@@ -124,7 +124,7 @@ def test_register_wrong_number_of_types():
         return "Dense"
 
     dispatched = Dispatcher(func_dense, ("left", "right"), False)
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError) as exc:
         @dispatched.register(_data.CSR, _data.Dense, _data.Dia)
         def func_too_many(left, right):
             pass

--- a/qutip/tests/core/data/test_dispatch.py
+++ b/qutip/tests/core/data/test_dispatch.py
@@ -119,6 +119,20 @@ def test_register():
     assert dispatched[_data.Dia, _data.CSR] is func_dia_csr
 
 
+def test_register_wrong_number_of_types():
+    def func_dense(left, right, /):
+        return "Dense"
+
+    dispatched = Dispatcher(func_dense, ("left", "right"), False)
+    with pytest.raises(ValueError) as err:
+        @dispatched.register(_data.CSR, _data.Dense, _data.Dia)
+        def func_too_many(left, right):
+            pass
+
+    assert str(exc.value) == (
+        "Dispatcher expects 2 type arguments, but 3 were given."
+    )
+
 def test_Data_low_priority_one_dispatch():
     class func():
         __name__ = "dummy name"

--- a/qutip/tests/core/data/test_dispatch.py
+++ b/qutip/tests/core/data/test_dispatch.py
@@ -97,6 +97,28 @@ def test_build_full(specialisation, output):
                         assert isinstance(out, out_dtype)
 
 
+def test_register():
+    def func_dense(left, right):
+        return "Dense"
+
+    dispatched = Dispatcher(func_dense, ("mat",), False)
+    dispatched.add_specialisations([
+        (_data.Dense, _data.Dense, func_dense),
+    ])
+
+    @dispatched.register(_data.CSR)
+    def func_csr(left, right):
+        return "CSR"
+
+    @dispatched.register(_data.Dia, _data.CSR)
+    def func_dia_csr(left, right):
+        return "Dia", "CSR"
+
+    assert dispatched[_data.Dense, _data.Dense] is func_dense
+    assert dispatched[_data.CSR, _data.CSR] is func_csr
+    assert dispatched[_data.Dia, _data.CSR] is func_dia_csr
+
+
 def test_Data_low_priority_one_dispatch():
     class func():
         __name__ = "dummy name"

--- a/qutip/tests/core/data/test_dispatch.py
+++ b/qutip/tests/core/data/test_dispatch.py
@@ -98,10 +98,10 @@ def test_build_full(specialisation, output):
 
 
 def test_register():
-    def func_dense(left, right):
+    def func_dense(left, right, /):
         return "Dense"
 
-    dispatched = Dispatcher(func_dense, ("mat",), False)
+    dispatched = Dispatcher(func_dense, ("left", "right"), False)
     dispatched.add_specialisations([
         (_data.Dense, _data.Dense, func_dense),
     ])


### PR DESCRIPTION
**Description**
- Add `Dispatcher.register` a decorator for adding specialization.
- Add random generator input in random operator generators. 
  Not used here, but can be used to make the mathematics test reproductive.
- Add error message when settings `default_dtype_scope` without `default_dtype`.
- Fix `_group_specialisation` repr using removed group name. 