### PR TITLE
Add tsit5 integrator method

### DIFF
--- a/qutip/solver/integrator/explicit_rk.pxd
+++ b/qutip/solver/integrator/explicit_rk.pxd
@@ -27,6 +27,7 @@ cdef class Explicit_RungeKutta:
     cdef readonly int max_numsteps
     cdef readonly bint interpolate
     cdef readonly object method
+    cdef dict butcher_tableau
 
     # Runge Kutta tableau and info
     cdef int rk_step, rk_extra_step, order, denseout_order

--- a/qutip/solver/integrator/tsit5.py
+++ b/qutip/solver/integrator/tsit5.py
@@ -1,0 +1,68 @@
+"""
+Tsitouras's 5/4 order Runge-Kutta method
+
+Runge–Kutta pairs of order 5(4) satisfying only the first column
+simplifying assumption,
+Ch. Tsitouras,
+Computers & Mathematics with Applications, Vol 62, Issue 2, 770-775
+Jan 2011
+"""
+
+__all__ = ["tsit5_coeff"]
+import numpy as np
+order = 5
+rk_step = 7
+
+a = np.zeros((rk_step, rk_step), dtype=np.float64)
+b = np.zeros(rk_step, dtype=np.float64)
+c = np.zeros(rk_step, dtype=np.float64)
+e = np.zeros(rk_step, dtype=np.float64)
+bi = None
+
+c[0] = 0.
+c[1] = .161
+c[2] = .327
+c[3] = .9
+c[4] = .9800255409045097
+c[5] = 1.
+c[6] = 1.
+
+b[0] =  .09646076681806523
+b[1] =  .01
+b[2] =  .4798896504144996
+b[3] =  1.379008574103742
+b[4] = -3.290069515436081
+b[5] =  2.324710524099774
+b[6] = 0.
+
+e[0] =  .17800110522257773e-2
+e[1] =  .8164344596567463e-3
+e[2] = -.7880878010261994e-2
+e[3] =  .1447110071732629
+e[4] = -.5823571654525552
+e[5] =  .45808210592918686
+e[6] = -1/66
+
+a[1, 0] = c[1]
+
+a[2, 1] = 0.3354806554923570
+a[2, 0] = c[2] - a[2, 1]
+
+a[3, 1] = -6.359448489975075
+a[3, 2] = 4.362295432869581
+a[3, 0] = c[3] - a[3, 2] - a[3, 1]
+
+a[4, 1] = -11.74888356406283
+a[4, 2] = 7.495539342889836
+a[4, 3] = -0.09249506636175525
+a[4, 0] = c[4] - a[4, 3] - a[4, 2] - a[4, 1]
+
+a[5, 1] = -12.92096931784711
+a[5, 2] = 8.159367898576159
+a[5, 3] = -0.071584973281401
+a[5, 4] = -0.02826905039406838
+a[5, 0] = c[5] - a[5, 4] - a[5, 3] - a[5, 2] - a[5, 1]
+
+a[6, :6] = b[:6]
+
+tsit5_coeff = {'order': order, 'a': a, 'b': b, 'c': c, 'e': e, 'bi': bi}

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -153,11 +153,11 @@ def test_krylov(sizes):
 def test_concurent_usage(integrator):
     opt = {'atol':1e-10, 'rtol':1e-7}
 
-    sys1 = qutip.QobjEvo(0.5*qutip.qeye(1))
+    sys1 = qutip.QobjEvo(0.5 * qutip.qeye(1))
     inter1 = integrator(sys1, opt)
     inter1.set_state(0, qutip.basis(1,0).data)
 
-    sys2 = qutip.QobjEvo(-0.5*qutip.qeye(1))
+    sys2 = qutip.QobjEvo(-0.5 * qutip.qeye(1))
     inter2 = integrator(sys2, opt)
     inter2.set_state(0, qutip.basis(1,0).data)
 
@@ -168,14 +168,14 @@ def test_concurent_usage(integrator):
         assert inter2.integrate(t)[1].to_array()[0, 0] == expected2
 
 @pytest.mark.parametrize('integrator',
-    [IntegratorVern7, IntegratorVern9],
-    ids=["vern7", 'vern9']
+    [IntegratorVern7, IntegratorVern9, IntegratorTsit5],
+    ids=["vern7", 'vern9', 'tsit5']
 )
-def test_pickling_vern_methods(integrator):
+def test_pickling_rk_methods(integrator):
     """Test whether VernN methods can be pickled and hence used in multiprocessing"""
     opt = {'atol':1e-10, 'rtol':1e-7}
 
-    sys = qutip.QobjEvo(0.5*qutip.qeye(1))
+    sys = qutip.QobjEvo(0.5 * qutip.qeye(1))
     inter = integrator(sys, opt)
     inter.set_state(0, qutip.basis(1,0).data)
 
@@ -184,8 +184,27 @@ def test_pickling_vern_methods(integrator):
     recreated = pickle.loads(pickled)
     recreated.set_state(0, qutip.basis(1,0).data)
 
-    for t in np.linspace(0,1,6):
+    for t in np.linspace(0, 1, 6):
         expected = pytest.approx(np.exp(t/2), abs=1e-5)
         result1 = inter.integrate(t)[1].to_array()[0, 0]
         result2 = recreated.integrate(t)[1].to_array()[0, 0]
         assert result1 == result2 == expected
+
+@pytest.mark.parametrize('integrator',
+    [IntegratorVern7, IntegratorVern9, IntegratorTsit5],
+    ids=["vern7", 'vern9', 'tsit5']
+)
+def test_rk_options(integrator):
+    """Test whether VernN methods can be pickled and hence used in multiprocessing"""
+    opt = {
+        'atol':1e-10, 'rtol':1e-7, 'interpolate':False, 'first_step':0.5
+    }
+
+    sys = qutip.QobjEvo(qutip.qeye(1))
+    inter = integrator(sys, opt)
+    inter.set_state(0, qutip.basis(1,0).data)
+
+    for t in np.linspace(0, 1, 6):
+        expected = pytest.approx(np.exp(t), abs=1e-5)
+        result1 = inter.integrate(t)[1].to_array()[0, 0]
+        assert result1 == expected


### PR DESCRIPTION
**Description**
Add a new integrator using qutip data as state, tsit5.
The existing vern7, vern9 are high order an require a lot of derivatives and states, which use a lot of RAM.
The tsit5 use 7 steps and about half the memory of vern7.

It could be optimized more: it lack the dense output and one step is repeated. 