### PR TITLE
Change `default_dtype` initial value

### DIFF
--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -150,11 +150,11 @@ class CoreOptions(QutipOptions):
           is exactly ``f(t, args)`` then ``dict`` is used. Otherwise
           ``pythonic`` is used.
 
-    default_dtype : Nonetype, str, type {"core"}
+    default_dtype : str, type {"core"}
         The specified data type will be used as output for different qutip
         functions determined by the "default_dtype_scope" options. Any
         data-layer known to ``qutip.data.to`` is accepted. The default `core``,
-        refert to any format available in the qutip qutip package and
+        refers to any format available in the qutip package and
         functions will default to a sensible data type.
 
     default_dtype_scope : str {"creation"}


### PR DESCRIPTION
**Description**
Change the initial value for `default_dtype`.
It was originally `None`, but that is not supported for `default_dtype_scope` other than `"creation"`.
So changing both options could causes error depending on which was applied first...

This change it for the group `"core"`: Dense, CSR and Dia.
So it's exactly the same default behaviour, but changing `default_dtype_scope` alone will not raise error.

Discussed in #2719
