### PR TITLE
Add Result.plot_expect for visualisation

### DIFF
--- a/qutip/solver/result.py
+++ b/qutip/solver/result.py
@@ -8,6 +8,12 @@ from ..core.numpy_backend import np
 from numpy.typing import ArrayLike
 from ..core import Qobj, QobjEvo, expect
 
+try:
+    import matplotlib.pyplot as plt
+    mpl_available = True
+except:
+    mpl_available = False
+
 __all__ = ["Result"]
 
 
@@ -367,6 +373,30 @@ class Result(_BaseResult):
     @property
     def expect(self) -> list[ArrayLike]:
         return [np.array(e_op) for e_op in self.e_data.values()]
+
+    @property
+    def plot_expect(self):
+        """
+        Optional dependency matplotlib is REQUIRED.
+        Look at the expectation value from evolution. Return a graph displaying 
+        the time evolution of the expectation of each op. 
+        The plt.close function prevents the figure from being displayed twice 
+        in a Jupyter notebook cell.
+        """
+        if not self.times:
+            raise ValueError("This is not a result after evolution.")
+        if not mpl_available:
+            raise ImportError(
+                "matplotlib is required for plot_expect. Please install it.")
+        labels = list(self.e_data.keys())
+        fig, ax = plt.subplots()
+        for _, (label, values) in enumerate(zip(labels, self.expect)):
+            ax.plot(self.times, values, label=label)
+            ax.set_xlabel('Time')
+            ax.set_ylabel('Expectation Value')
+        ax.legend()
+        plt.close(fig)
+        return fig, ax
 
     @property
     def final_state(self) -> Qobj:

--- a/qutip/tests/solver/test_results.py
+++ b/qutip/tests/solver/test_results.py
@@ -5,6 +5,8 @@ import qutip
 from qutip.solver.result import Result
 from qutip.solver.multitrajresult import MultiTrajResult, McResult, NmmcResult
 
+mpl = pytest.importorskip("matplotlib")
+plt = pytest.importorskip("matplotlib.pyplot")
 
 def fill_options(**kwargs):
     return {
@@ -166,6 +168,20 @@ class TestResult:
 def e_op_num(t, state):
     """ An e_ops function that returns the ground state occupation. """
     return state.dag() @ qutip.num(5) @ state
+
+@pytest.mark.parametrize('n_of_e_ops', [(1), (2), (3)])
+def test_plot_expect(n_of_e_ops):
+    H = qutip.sigmaz() + 0.3 * qutip.sigmay()
+    e_ops = [qutip.sigmax(), qutip.sigmay(), qutip.sigmaz()]
+    times = np.linspace(0, 10, 100)
+    psi0 = (qutip.basis(2, 0) + qutip.basis(2, 1)).unit()
+    result = qutip.mesolve(H, psi0, times, e_ops=e_ops[:n_of_e_ops])
+
+    fig, ax = result.plot_expect
+    plt.close()
+
+    assert isinstance(fig, mpl.figure.Figure)
+    assert isinstance(ax, mpl.axes._axes.Axes)
 
 
 class TestMultiTrajResult:


### PR DESCRIPTION
**Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to QuTiP Development](https://qutip.readthedocs.io/en/stable/development/contributing.html)
- [x] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
- [x] Please add tests to cover your changes if applicable.
- [ ] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-tutorials). Feel free to ask if you are not sure.
- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](https://qutip.readthedocs.io/en/stable/development/contributing.html#changelog-generation) for more information).

Delete this checklist after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.

**Description**
A new property `plot_expect` is added to the [solver.Result](https://qutip.readthedocs.io/en/stable/guide/dynamics/dynamics-data.html) class for the visualisation of  expectation values from time evolution. The corresponding pytests are created. \
Instead of using matplotlib directly to draw time evolution figure([example](https://qutip.readthedocs.io/en/stable/guide/dynamics/dynamics-master.html)), now we can use `fig, ax = result.plot_expect`. 


**Related issues or PRs**
This PR contributes to #2617.

**Additonal Comments**
- Feel free to make comments on current implementation of `Result.plot_expect`.
- The documentation has not been updated yet. I am not sure how to modify the content displayed on the website https://qutip.readthedocs.io/en/stable/guide/.
- More options for `mcsolve` results are not implemented.
