### PR TITLE
Force dense state in solver

### DIFF
--- a/qutip/solver/integrator/qutip_integrator.py
+++ b/qutip/solver/integrator/qutip_integrator.py
@@ -56,7 +56,6 @@ class IntegratorVern7(Integrator):
         'max_step': 0,
         'min_step': 0,
         'interpolate': True,
-        'allow_sparse': False,
     }
     support_time_dependant = True
     supports_blackbox = True
@@ -64,13 +63,9 @@ class IntegratorVern7(Integrator):
     tableau = vern7_coeff
 
     def _prepare(self):
-        options = {
-            k: v for k, v in self.options.items()
-            if k != 'allow_sparse'
-        }
         self._ode_solver = Explicit_RungeKutta(
             self.system, self.tableau,
-            **options
+            **self.options
         )
         self.name = self.method
 
@@ -79,14 +74,7 @@ class IntegratorVern7(Integrator):
         return self._ode_solver.t, state.copy() if copy else state
 
     def set_state(self, t, state):
-        if (
-            not self.options["allow_sparse"]
-            and isinstance(state, (_data.CSR, _data.Dia))
-        ):
-            state = _data.to(_data.Dense, state)
-        else:
-            state = state.copy()
-        self._ode_solver.set_initial_value(state, t)
+        self._ode_solver.set_initial_value(state.copy(), t)
         self._is_set = True
 
     def integrate(self, t, copy=True):
@@ -131,9 +119,6 @@ class IntegratorVern7(Integrator):
 
         interpolate : bool, default: True
             Whether to use interpolation step, faster most of the time.
-
-        allow_sparse : bool, default: False
-            Whether to use sparse state for the evolution. Usually much slower.
         """
         return self._options
 
@@ -165,7 +150,6 @@ class IntegratorVern9(IntegratorVern7):
         'max_step': 0,
         'min_step': 0,
         'interpolate': True,
-        'allow_sparse': False,
     }
     method = 'vern9'
     tableau = vern9_coeff
@@ -195,7 +179,6 @@ class IntegratorTsit5(IntegratorVern7):
         'max_step': 0,
         'min_step': 0,
         'interpolate': True,
-        'allow_sparse': False,
     }
     method = 'tsit5'
     tableau = tsit5_coeff

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -15,6 +15,7 @@ from .integrator import Integrator
 from ..ui.progressbar import progress_bars
 from ._feedback import _ExpectFeedback
 from ..typing import EopsLike
+from ..core import data as _data
 from time import time
 import warnings
 import numpy as np
@@ -84,6 +85,12 @@ class Solver:
         """
         if self.rhs.issuper and state.isket:
             state = ket2dm(state)
+
+        if not state.dtype.sparcity() == "dense":
+            # Add an option to support sparse data?
+            # States almost never stays sparse, so it's usually **very** slow.
+            dtype = _data._parse_default_dtype(None, "dense")
+            state = state.to(dtype)
 
         if (
             self.rhs.dims[1] != state.dims[0]


### PR DESCRIPTION
**Description**
In 5.2, we made it easier to get the right data type for operator by ensuring operators created from ket are sparse:
`basis(n) @ basis(n).dag()` and `basis(n).proj()` now return sparse matrix. 
Before it would default to dense, which would surprise users and slow down their simulation.

But, sparse density matrix as state in solvers has the same negative impact on computation time...
All our integrators converted the state to dense, but stochastic integrators did not...

I set it so `_prepare_state` in the solver does the conversion to dense (not the Dense class, but any dense format of any sub project).

**Related issues or PRs**
fix #2733 
