### PR TITLE
Add debug logs to runge kutta integrator

### DIFF
--- a/qutip/solver/integrator/explicit_rk.pxd
+++ b/qutip/solver/integrator/explicit_rk.pxd
@@ -2,6 +2,7 @@
 from qutip.core.data cimport Data
 from qutip.core.cy.qobjevo cimport QobjEvo
 
+
 cpdef enum Status:
     AT_FRONT = 2
     INTERPOLATED = 1
@@ -10,6 +11,28 @@ cpdef enum Status:
     DT_UNDERFLOW = -2
     OUTSIDE_RANGE = -3
     NOT_INITIATED = -4
+
+
+cdef class RKStats:
+    cdef int loglevel, rk_step, rk_extra_step
+    cdef int num_step_total, num_step_failed, num_step_success
+    cdef int num_interpolation_step, num_interpolation_preparation
+    cdef int num_derr_computation
+
+    cdef double max_sucess_dt, min_sucess_dt, avg_sucess_dt
+    cdef double max_failed_dt, min_failed_dt, avg_failed_dt
+    cdef double max_sucess_error, min_sucess_error, avg_sucess_error
+    cdef double max_failed_error, min_failed_error, avg_failed_error
+    cdef double max_sucess_safe_dt, min_sucess_safe_dt, avg_sucess_safe_dt
+    cdef double max_failed_safe_dt, min_failed_safe_dt, avg_failed_safe_dt
+    cdef dict full_step_data
+
+    cdef void log_success_step(self, double t, double dt, double error, double safe_dt)
+    cdef void log_failed_step(self, double t, double dt, double error, double safe_dt)
+    cdef void log_step(self, double t, double dt, double error, double safe_dt)
+    cdef void increment_interpolation_step(self)
+    cdef void increment_interpolation_preparation(self)
+
 
 cdef class Explicit_RungeKutta:
     cdef QobjEvo qevo
@@ -21,6 +44,7 @@ cdef class Explicit_RungeKutta:
     cdef double _t, _t_prev, _t_front
     cdef Status _status
     cdef dict status_messages
+    cdef RKStats statistics
 
     # options: set in init
     cdef readonly double rtol, atol, first_step, min_step, max_step

--- a/qutip/solver/integrator/qutip_integrator.py
+++ b/qutip/solver/integrator/qutip_integrator.py
@@ -57,6 +57,7 @@ class IntegratorVern7(Integrator):
         'min_step': 0,
         'interpolate': True,
         'allow_sparse': False,
+        'loglevel': 0,
     }
     support_time_dependant = True
     supports_blackbox = True
@@ -103,6 +104,9 @@ class IntegratorVern7(Integrator):
         if self._ode_solver.successful():
             return
         raise IntegratorException(self._ode_solver.status_message())
+
+    def get_statistics(self):
+        return self._ode_solver.get_statistics()
 
     @property
     def options(self):
@@ -166,6 +170,7 @@ class IntegratorVern9(IntegratorVern7):
         'min_step': 0,
         'interpolate': True,
         'allow_sparse': False,
+        'loglevel': 0,
     }
     method = 'vern9'
     tableau = vern9_coeff
@@ -196,6 +201,7 @@ class IntegratorTsit5(IntegratorVern7):
         'min_step': 0,
         'interpolate': True,
         'allow_sparse': False,
+        'loglevel': 0,
     }
     method = 'tsit5'
     tableau = tsit5_coeff


### PR DESCRIPTION
**Description**

Add some logging tools for runge kutta integrator.
I don't know if it's useful for users and did not make any formal interface, but can be useful to debug issues such as the side effect of #2726. So I am putting it here as a draft to see if there is some interest.

Usage:
```
solver = qt.MESolver(H, c_ops, options={"method": "vern7", "loglevel": 1})
res = solver.run(rho0, tlist, e_ops=e_ops)
stats = solver._integrator.get_statistics()
```
With the option `loglevel: 1`, average are obtained:
```
stats = {'num_step_total': 133,
 'num_step_failed': 6,
 'num_step_success': 127,
 'num_interpolation_step': 300,
 'num_interpolation_preparation': 118,
 'num_derr_computation': 2038,
 'max_sucess_dt': 0.515096572114642,
 'max_failed_dt': 0.5262419454101978,
 'max_sucess_error': 0.974917769187816,
 'max_failed_error': 7.62518679277136,
 'max_sucess_safe_dt': 0.974917769187816,
 'max_failed_safe_dt': 0.39151296890187265,
 'min_sucess_dt': 0.05156953618470823,
 'min_failed_dt': 0.07591298171654884,
 'min_sucess_error': 0.1296423787087295,
 'min_failed_error': 1.096222411627917,
 'min_sucess_safe_dt': 0.1296423787087295,
 'min_failed_safe_dt': 0.05300016828715936,
 'avg_sucess_dt': 0.237014727053706,
 'avg_sucess_error': 0.37556749310832205,
 'avg_sucess_safe_dt': 0.24259736305725754,
 'avg_failed_dt': 0.371498106208543,
 'avg_failed_error': 3.0062483012547627,
 'avg_failed_safe_dt': 0.3077467924640786}
```

With the option `loglevel: 2`, information for each steps is available:
```
plt.plot(stats["times"], stats["step_lenghts"])
plt.show()
plt.plot(stats["times"], stats["errors"])
plt.ylim(0, 1.5)
```
<img width="547" height="413" alt="download" src="https://github.com/user-attachments/assets/7f12289f-7926-4500-bc90-d25e3a14a109" />

<img width="547" height="413" alt="download" src="https://github.com/user-attachments/assets/7adea6fd-77ff-4db2-bf60-a255b8615681" />

