### PR TITLE
Correct type hint for __mul__ of Qobj

### DIFF
--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -413,7 +413,7 @@ class Qobj:
     def __rsub__(self, other: Qobj | complex) -> Qobj:
         return self.__neg__().__add__(other)
 
-    def __mul__(self, other: complex) -> Qobj:
+    def __mul__(self, other: Qobj | complex) -> Qobj:
         """
         If other is a Qobj, we dispatch to __matmul__. If not, we
         check that other is a valid complex scalar, i.e., we can do


### PR DESCRIPTION
**Description**
Correct the type hint of `__mul__` of the `Qobj` so that type checking is also correct for multiplying two `Qobj`s.

**Changelog**
Improve type hint of the `__mul__` method of `Qobj` (#2749, by hbeukers)