### PR TITLE
Allow all function to work with `auto_real_casting=False`

### DIFF
--- a/qutip/core/expect.py
+++ b/qutip/core/expect.py
@@ -1,12 +1,11 @@
 __all__ = ['expect', 'variance']
 
-import numpy as np
 from typing import overload, Sequence
 
 from .qobj import Qobj
 from . import data as _data
 from ..settings import settings
-
+from ..core.numpy_backend import np
 
 @overload
 def expect(oper: Qobj, state: Qobj) -> complex: ...
@@ -66,7 +65,11 @@ def expect(oper, state):
 
     elif isinstance(state, Sequence):
         dtype = np.complex128
-        if oper.isherm and all(op.isherm or op.isket for op in state):
+        if (
+            oper.isherm
+            and all(op.isherm or op.isket for op in state)
+            and settings.core["auto_real_casting"]
+        ):
             dtype = np.float64
         return np.array([_single_qobj_expect(oper, x) for x in state],
                         dtype=dtype)

--- a/qutip/measurement.py
+++ b/qutip/measurement.py
@@ -93,7 +93,7 @@ def _measurement_statistics_povm_dm(density_mat, ops, tol=None):
     Parameters
     ----------
     state : :class:`.Qobj` (density matrix)
-        The ket or density matrix specifying the state to measure.
+        The density matrix specifying the state to measure.
 
     ops : list of :class:`.Qobj`
         List of measurement operators :math:`M_i` (specifying a POVM s.t.
@@ -122,6 +122,11 @@ def _measurement_statistics_povm_dm(density_mat, ops, tol=None):
     for i, op in enumerate(ops):
         st = op * density_mat * op.dag()
         p = st.tr()
+        if np.iscomplexobj(p):
+            if np.abs(np.imag(p)) > tol:
+                raise TypeError("Not defined for non-hermitian density matrix")
+            p = np.real(p)
+
         if p >= tol:
             collapsed_states.append(st/p)
             probabilities.append(p)
@@ -236,6 +241,10 @@ def measurement_statistics_observable(state, op, tol=None):
         for j in present_group:
             projector += eigenstates[j].proj()
         probability = expect(projector, state)
+        if np.iscomplexobj(probability):
+            if np.abs(np.imag(probability)) > tol:
+                raise TypeError("Not defined for non-hermitian density matrix")
+            probability = np.real(probability)
 
         if probability >= tol:
             probabilities.append(probability)

--- a/qutip/solver/steadystate.py
+++ b/qutip/solver/steadystate.py
@@ -307,7 +307,7 @@ def _steadystate_expm(L, rho=None, propagator_tol=1e-5, propagator_T=10, **kw):
     while niter < max_iter:
         rho_next = prop(rho)
         rho_next = (rho_next + rho_next.dag()) / (2 * rho_next.tr())
-        if hilbert_dist(rho_next, rho) <= propagator_tol:
+        if np.real(hilbert_dist(rho_next, rho)) <= propagator_tol:
             return rho_next
         rho = rho_next
         prop = prop @ prop

--- a/qutip/solver/stochastic.py
+++ b/qutip/solver/stochastic.py
@@ -21,6 +21,7 @@ from ..core import data as _data
 from .solver_base import _solver_deprecation
 from ._feedback import _QobjFeedback, _DataFeedback, _WienerFeedback
 from ..typing import QobjEvoLike, EopsLike
+from ..settings import settings
 
 
 class StochasticTrajResult(Result):
@@ -821,6 +822,10 @@ class StochasticSolver(MultiTrajSolver):
         dt = tlist[1] - tlist[0]
         if not np.allclose(dt, np.diff(tlist)):
             raise ValueError("tlist must be evenly spaced.")
+        if np.iscomplexobj(noise):
+            if np.any(np.abs(np.imag(noise)) > settings.core["atol"]):
+                raise TypeError("noise must be real.")
+            noise = np.real(noise)
         generator = PreSetWiener(
             noise, tlist, len(self.rhs.sc_ops), self.heterodyne, measurement
         )

--- a/qutip/tests/core/test_expect.py
+++ b/qutip/tests/core/test_expect.py
@@ -166,3 +166,10 @@ def test_no_real_casting(monkeypatch):
     assert isinstance(qutip.expect(sz, sz), float)
     with qutip.CoreOptions(auto_real_casting=False):
         assert isinstance(qutip.expect(sz, sz), complex)
+
+
+def test_no_real_casting_multiple_states(monkeypatch):
+    sz = qutip.sigmaz() # the choice of the matrix does not matter
+    assert isinstance(qutip.expect(sz, [sz])[0], float)
+    with qutip.CoreOptions(auto_real_casting=False):
+        assert isinstance(qutip.expect(sz, [sz])[0], complex)

--- a/qutip/tests/solver/test_steadystate.py
+++ b/qutip/tests/solver/test_steadystate.py
@@ -86,7 +86,8 @@ def test_exact_solution_for_simple_methods(method, kwargs):
     # with high accuracy for a small Liouvillian requiring correct weighting.
     H = qutip.identity(2)
     c_ops = [qutip.sigmam(), 1e-5 * qutip.sigmap()]
-    rho_ss = qutip.steadystate(H, c_ops, method=method, **kwargs)
+    with qutip.CoreOptions(auto_real_casting=False):
+        rho_ss = qutip.steadystate(H, c_ops, method=method, **kwargs)
     expected_rho_ss = np.array([
         [1.e-10+0.j, 0.e+00-0.j],
         [0.e+00-0.j, 1.e+00+0.j],

--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -442,14 +442,16 @@ def test_run_from_experiment_close(method, heterodyne):
         "store_states": True,
         "method": method,
     }
-    solver = SSESolver(H, sc_ops, heterodyne, options=options)
-    res_forward = solver.run(psi0, tlist, 1, e_ops=[H])
-    res_backward = solver.run_from_experiment(
-        psi0, tlist, res_forward.dW[0], e_ops=[H]
-    )
-    res_measure = solver.run_from_experiment(
-        psi0, tlist, res_forward.measurement[0], e_ops=[H], measurement=True
-    )
+    with CoreOptions(auto_real_casting=False):
+        solver = SSESolver(H, sc_ops, heterodyne, options=options)
+        res_forward = solver.run(psi0, tlist, 1, e_ops=[H])
+        res_backward = solver.run_from_experiment(
+            psi0, tlist, res_forward.dW[0], e_ops=[H]
+        )
+        res_measure = solver.run_from_experiment(
+            psi0, tlist, res_forward.measurement[0],
+            e_ops=[H], measurement=True
+        )
 
     np.testing.assert_allclose(
         res_backward.measurement, res_forward.measurement[0], atol=1e-10

--- a/qutip/tests/test_measurement.py
+++ b/qutip/tests/test_measurement.py
@@ -4,7 +4,7 @@ import pytest
 from math import sqrt
 from qutip import (
     Qobj, basis, ket2dm, sigmax, sigmay, sigmaz, identity, num, tensor,
-    rand_ket
+    rand_ket, CoreOptions
 )
 from qutip.measurement import (
     measure_povm, measurement_statistics_povm, measure_observable,
@@ -325,3 +325,31 @@ def test_povm():
 
     _, probabilities = measurement_statistics_povm(dm2, M)
     np.testing.assert_allclose(probabilities, [0.293, 0, 0.707], atol=0.001)
+
+
+def test_measurement_povm_no_casting():
+    coeff = (sqrt(2) / (1 + sqrt(2)))
+
+    E_1 = coeff * ket2dm(basis(2, 1))
+    E_2 = coeff * ket2dm((basis(2, 0) - basis(2, 1))/(sqrt(2)))
+    E_3 = identity(2) - E_1 - E_2
+    M = [E_1.sqrtm(), E_2.sqrtm(), E_3.sqrtm()]
+
+    dm = (basis(2, 0) + basis(2, 1)).proj() / 2
+
+    *_, probabilities_real = measurement_statistics_povm(dm, M)
+    with CoreOptions(auto_real_casting=False):
+        *_, probabilities_cplx = measurement_statistics_povm(dm, M)
+
+    assert np.allclose(probabilities_real, probabilities_cplx)
+
+
+def test_measurement_observable_no_casting():
+    M = (sqrt(2) / (1 + sqrt(2))) * ket2dm(basis(2, 1)).sqrtm()
+    dm = (basis(2, 0) + basis(2, 1)).proj() / 2
+
+    *_, probabilities_real = measurement_statistics_observable(dm, M)
+    with CoreOptions(auto_real_casting=False):
+        *_, probabilities_cplx = measurement_statistics_observable(dm, M)
+
+    assert np.allclose(probabilities_real, probabilities_cplx)


### PR DESCRIPTION
**Description**
We have the options `auto_real_casting` that control the casting to real in expect for hermitian operators.
It's is useful for plug-in with auto-differentiation, but it was not fully tested and broke some functionalities.
I ran the full test without auto casting and fixed the issues:

- `expect` with multiple state would fails when trying to return an array.
- In measurement, complex probability would cause errors.
- stochastic measurement output would be complex and not usable in `run_from_experiment`.
- Steadystate `"propagator"` method convergence would break.


