### PR TITLE
Fix tests

### DIFF
--- a/qutip/tests/core/test_brtools.py
+++ b/qutip/tests/core/test_brtools.py
@@ -10,9 +10,8 @@ from qutip.core._brtensor import (
 )
 
 
-def _make_rand_data(shape):
-    np.random.seed(11)
-    array = np.random.rand(*shape) + 1j*np.random.rand(*shape)
+def _make_rand_data(shape, rng):
+    array = rng.random(shape) + 1j*rng.random(shape)
     return qutip.data.Dense(array)
 
 
@@ -31,9 +30,9 @@ transform = {
                          ids=['', 'transpose', 'conj', 'dag'])
 def test_matmul_var(datatype, transleft, transright):
     shape = (5, 5)
-    np.random.seed(11)
-    left = qutip.data.to(datatype, _make_rand_data(shape))
-    right = qutip.data.to(datatype, _make_rand_data(shape))
+    rng = np.random.default_rng(seed=11)
+    left = qutip.data.to(datatype, _make_rand_data(shape, rng))
+    right = qutip.data.to(datatype, _make_rand_data(shape, rng))
 
     expected = qutip.data.matmul(
         transform[transleft](left),

--- a/qutip/tests/core/test_environment.py
+++ b/qutip/tests/core/test_environment.py
@@ -804,7 +804,7 @@ class TestBosonicEnvironment:
             reference.spectral_density, T=reference.T, tag="test"
         )
         wlist = np.linspace(-wMax, wMax, 200)
-        fit, info = env.approximate("ps", wlist,Nmax=6)
+        fit, info = env.approximate("ps", wlist, Nmax=6, maxfev=1e5)
 
         assert isinstance(fit, ExponentialBosonicEnvironment)
         assert fit.T == env.T

--- a/qutip/tests/core/test_environment.py
+++ b/qutip/tests/core/test_environment.py
@@ -775,7 +775,7 @@ class TestBosonicEnvironment:
 
     @pytest.mark.parametrize(["reference", "wMax", "tol"], [
         pytest.param(OhmicReference(3, .75, 10, 1), 15, .2, id="Ohmic Example"),
-        pytest.param(UDReference(1, .5, .1, 1), 2, 1e-4, id='UD Example'),
+        pytest.param(UDReference(1, .5, .1, 1), 2, 1e-3, id='UD Example'),
     ])
     def test_fixed_aaa_fit(self, reference, wMax, tol):
         env = BosonicEnvironment.from_spectral_density(
@@ -797,7 +797,7 @@ class TestBosonicEnvironment:
 
     @pytest.mark.parametrize(["reference", "wMax", "tol"], [
         pytest.param(OhmicReference(3, .75, 10, 1), 15, .2, id="DL Example"),
-        pytest.param(UDReference(1, .5, .1, 1), 2, 1e-4, id='UD Example'),
+        pytest.param(UDReference(1, .5, .1, 1), 2, 1e-3, id='UD Example'),
     ])
     def test_fixed_ps_fit(self, reference, wMax, tol):
         env = BosonicEnvironment.from_spectral_density(

--- a/qutip/tests/core/test_environment.py
+++ b/qutip/tests/core/test_environment.py
@@ -532,8 +532,8 @@ class TestBosonicEnvironment:
 
         assert info["Nr"] == 2
         assert info["Ni"] == 2
-        assert info["rmse_real"] < 5e-3
-        assert info["rmse_imag"] < 5e-3
+        assert info["rmse_real"] < 5e-2
+        assert info["rmse_imag"] < 5e-2
         for key in ["fit_time_real", "fit_time_imag",
                     "params_real", "params_imag", "summary"]:
             assert key in info
@@ -551,7 +551,7 @@ class TestBosonicEnvironment:
         )
         tlist = np.linspace(0, tMax, 100)[1:]  # exclude t=0
         fit, info = env.approximate(
-            "cf", tlist, target_rmse=0.01, Nr_max=3, Ni_max=3,
+            "cf", tlist, target_rmse=0.1, Nr_max=3, Ni_max=3,
             full_ansatz=full_ansatz
         )
 
@@ -564,8 +564,8 @@ class TestBosonicEnvironment:
 
         assert info["Nr"] == 1
         assert info["Ni"] == 1
-        assert info["rmse_real"] <= 0.01
-        assert info["rmse_imag"] <= 0.01
+        assert info["rmse_real"] <= 0.1
+        assert info["rmse_imag"] <= 0.1
         for key in ["fit_time_real", "fit_time_imag",
                     "params_real", "params_imag", "summary"]:
             assert key in info
@@ -594,7 +594,7 @@ class TestBosonicEnvironment:
 
         assert info["N"] == 4
         assert info["Nk"] == 1
-        assert info["rmse"] < 5e-3
+        assert info["rmse"] < 5e-2
         for key in ["fit_time", "params", "summary"]:
             assert key in info
 
@@ -611,7 +611,7 @@ class TestBosonicEnvironment:
         )
         wlist = np.linspace(0, wMax, 100)
         fit, info = env.approximate(
-            "sd", wlist, Nk=1, target_rmse=0.01, Nmax=5, **params
+            "sd", wlist, Nk=1, target_rmse=0.1, Nmax=5, **params
         )
 
         assert isinstance(fit, ExponentialBosonicEnvironment)
@@ -623,14 +623,14 @@ class TestBosonicEnvironment:
 
         assert info["N"] < 5
         assert info["Nk"] == 1
-        assert info["rmse"] < 0.01
+        assert info["rmse"] < 0.1
         for key in ["fit_time", "params", "summary"]:
             assert key in info
 
     @pytest.mark.parametrize(["reference", "tMax", "N", "tol"], [
         pytest.param(OhmicReference(3, .75, 10, 1),
-                     15, 8, 1e-3, id="Ohmic Example"),
-        pytest.param(UDReference(1, .5, .1, 1), 2, 4, 1e-3, id='UD Example'),
+                     15, 8, 1e-2, id="Ohmic Example"),
+        pytest.param(UDReference(1, .5, .1, 1), 2, 4, 1e-2, id='UD Example'),
     ])
     @pytest.mark.parametrize("separate", [True, False])
     def test_fixed_prony_fit(self, reference, tMax, N, tol, separate):
@@ -665,8 +665,8 @@ class TestBosonicEnvironment:
 
     @pytest.mark.parametrize(["reference", "tMax", "N", "tol"], [
         pytest.param(OhmicReference(3, .75, 10, 1),
-                     15, 8, 1e-3, id="Ohmic Example"),
-        pytest.param(UDReference(1, .5, .1, 1), 2, 4, 1e-3, id='UD Example'),
+                     15, 8, 1e-2, id="Ohmic Example"),
+        pytest.param(UDReference(1, .5, .1, 1), 2, 4, 1e-2, id='UD Example'),
     ])
     @pytest.mark.parametrize("separate", [True, False])
     def test_fixed_esprit_fit(self, reference, tMax, N, tol, separate):
@@ -701,8 +701,8 @@ class TestBosonicEnvironment:
 
     @pytest.mark.parametrize(["reference", "tMax", "N", "tol"], [
         pytest.param(OhmicReference(3, .75, 10, 1),
-                     15, 8, 1e-3, id="Ohmic Example"),
-        pytest.param(UDReference(1, .5, .1, 1), 2, 2, 1e-3, id='UD Example'),
+                     15, 8, 1e-2, id="Ohmic Example"),
+        pytest.param(UDReference(1, .5, .1, 1), 2, 2, 1e-2, id='UD Example'),
     ])
     @pytest.mark.parametrize("separate", [True, False])
     def test_fixed_espira1_fit(self, reference, tMax, N, tol, separate):
@@ -737,8 +737,8 @@ class TestBosonicEnvironment:
 
     @pytest.mark.parametrize(["reference", "tMax", "N", "tol"], [
         pytest.param(OhmicReference(3, .75, 10, 1),
-                     15, 8, 1e-3, id="Ohmic Example"),
-        pytest.param(UDReference(1, .5, .1, 1), 2, 2, 1e-3, id='UD Example'),
+                     15, 8, 1e-2, id="Ohmic Example"),
+        pytest.param(UDReference(1, .5, .1, 1), 2, 2, 1e-2, id='UD Example'),
     ])
     @pytest.mark.parametrize("separate", [True, False])
     def test_fixed_espira2_fit(self, reference, tMax, N, tol, separate):

--- a/qutip/tests/solver/test_results.py
+++ b/qutip/tests/solver/test_results.py
@@ -283,6 +283,7 @@ class TestMultiTrajResult:
         for i, (s1, s2) in enumerate(zip(m_res.average_states, result_trace)):
             assert s1 == s2 * qutip.fock_dm(10, i)
 
+    @pytest.mark.flaky(reruns=2)
     @pytest.mark.parametrize('keep_runs_results', [True, False])
     @pytest.mark.parametrize('include_no_jump', [True, False])
     @pytest.mark.parametrize(["e_ops", "results"], [

--- a/qutip/tests/solver/test_results.py
+++ b/qutip/tests/solver/test_results.py
@@ -400,6 +400,7 @@ class TestMultiTrajResult:
         if keep_runs_results:
             assert "Trajectories saved." in repr
 
+    @pytest.mark.flaky(reruns=2)
     @pytest.mark.parametrize('keep_runs_results1', [True, False])
     @pytest.mark.parametrize('keep_runs_results2', [True, False])
     def test_merge_result(self, keep_runs_results1, keep_runs_results2):

--- a/qutip/tests/test_mkl.py
+++ b/qutip/tests/test_mkl.py
@@ -19,8 +19,8 @@ class Test_spsolve:
                            [1, 0, 1],
                            [0, 0, 1]])
         As = scipy.sparse.csr_matrix(Adense)
-        np.random.seed(1234)
-        x = np.random.randn(3)
+        rng = np.random.default_rng(seed=1234)
+        x = rng.standard_normal(3)
         b = As * x
         x2 = mkl_spsolve(As, b, verbose=True)
         np.testing.assert_allclose(x, x2)

--- a/qutip/utilities.py
+++ b/qutip/utilities.py
@@ -490,7 +490,7 @@ def _rmse(fun, xdata, ydata, params):
     if (yhat == ydata).all():
         return 0
     return (
-        np.sqrt(np.mean((yhat - ydata) ** 2) / len(ydata))
+        np.sqrt(np.mean(np.abs(yhat - ydata) ** 2))
         / (np.max(ydata) - np.min(ydata))
     )
 


### PR DESCRIPTION
Fixes two current problems with the tests:

1. Running `loky_pmap` and later `mpi_pmap` in the same session causes python to hang on exit. I have tracked the problem down to `loky` creating two "resource tracker" subprocesses that are never shut down. If I manually stop these subprocesses before calling `mpi_pmap`, the deadlock does not happen. Generally, I recommend not to use both loky and MPI in the same program, but to fix the problem with the test run, I added code to `mpi_pmap` to stop these resource trackers if they are running.
2. A few tests were calling `np.random.seed`, making it so that all randomness in all tests afterwards would also be determined by that seed. For example, in #2751, it happened that a flaky test (`TestMultiTrajResult::test_merge_result`) would now always fail. I have removed all calls to `np.random.seed` and I have marked the mentioned test as flaky.

When fixing the test of the fitting utilities, I noticed that the calculation of the root mean square error in the fitting routines was wrong. I have also fixed that, and then needed to adjust some tolerances.