### PR TITLE
Fix color ordering for single points in Bloch sphere. Fixes issue #2681

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -874,8 +874,12 @@ class Bloch:
 
             if self._inner_point_color[k] is not None:
                 color = self._inner_point_color[k]
+                if isinstance(color, list) and len(color) > 1:
+                    color = [color[i] for i in indperm]
             elif self.point_color is not None:
                 color = self.point_color
+                if isinstance(color, list) and len(color) > 1:
+                    color = [color[i] for i in indperm]
             elif style in ['s', 'l']:
                 color = [self.point_default_color[
                     k % len(self.point_default_color)


### PR DESCRIPTION
**Description**
When choosing the color for points to be plotted on a Bloch sphere, there are 2 options that are broken:

1. By modifying `Bloch.point_color` directly. Note: code description seems to suggest this is deprecated, but the [docs](https://qutip.readthedocs.io/en/stable/guide/guide-bloch.html#configuring-the-bloch-sphere) seem to suggest it is still supported.
2. By passing a list of colours when calling `Bloch.add_points`.

In both of these cases, the order of points will get sorted by `indperm`, but the colours will not, leading to a mismatch.

For example,
```py
from qutip import Bloch

x = [1, 0.5, 0, -0.5, -1]
y = [0, 0, 0, 0, 0]
z = [0, 0, 0, 0, 0]

b = Bloch()
b.add_points([x, y, z], colors=['red', 'orange', 'yellow', 'cyan', 'blue'])
b.show()
```
and
```py
from qutip import Bloch

x = [1, 0.5, 0, -0.5, -1]
y = [0, 0, 0, 0, 0]
z = [0, 0, 0, 0, 0]

b = Bloch()
b.point_color=list(['red', 'orange', 'yellow', 'cyan', 'blue'])
b.add_points([
    x,
    y,
    z
])
b.show()
```
previously both did not work, and both cases are now fixed.

**Related issues or PRs**
Fixes #2681 
