### PR TITLE
Fix Bloch sphere view angle updating for animations

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -719,6 +719,10 @@ class Bloch:
 
         if self.axes is None:
             self.axes = _axes3D(self.fig, azim=self.view[0], elev=self.view[1])
+        else:
+            current_azim, current_elev = self.axes.azim, self.axes.elev        
+            if current_azim != self.view[0] or current_elev != self.view[1]:   
+                self.axes.view_init(azim=self.view[0], elev=self.view[1])
 
         # Clearing the axes is horrifically slow and loses a lot of the
         # axes state, but matplotlib doesn't seem to provide a better way


### PR DESCRIPTION
**Description**
Currently, when animating a Bloch sphere with changing view angles, users must recreate the entire Bloch sphere object for each frame because updating attributes like `b.view` doesn't take effect. Through my testing, I found that this wasn't actually that inefficient, but it's definitely inconvenient.

The fix adds logic to check if the view angle has changed and update it using `view_init()` instead of requiring a new Bloch object. It checks current view angle (`self.axes.azim`, `self.axes.elev`) against desired angle (`self.view[0]`, `self.view[1]`) and only updates the view when it has actually changed.

**Related issues or PRs**
Fixes #1106
