### PR TITLE
Ensure the first state of Result is consitant.

### DIFF
--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -195,7 +195,10 @@ class Solver:
             e_ops, self.options,
             solver=self.name, stats=stats,
         )
-        results.add(tlist[0], self._restore_state(_data0, copy=False))
+        results.add(
+            tlist[0],
+            self._restore_state(self._integrator.get_state()[1], copy=False)
+        )
         stats['preparation time'] += time() - _time_start
 
         progress_bar = progress_bars[self.options['progress_bar']](


### PR DESCRIPTION
**Description**
Change it so the the first state of the evolution in solvers take the same path as the others.
If the integrator modify the state in some way the first state was not.

The `adams` method only support dense, so if the initial state passed was a jax/cupy/cudensity one. The result would have the first state in the previous format and the other in as `Dense`. The opposite happening when using jax's or cudensity's integrator with initial state as `Dense`.
