### PR TITLE
Fix missing core.tensor members in docs

### DIFF
--- a/doc/apidoc/quantumobject.rst
+++ b/doc/apidoc/quantumobject.rst
@@ -71,7 +71,7 @@ Tensor
 ------
 
 .. automodule:: qutip.core.tensor
-    :members: tensor, super_tensor, composite, tensor_contract
+    :members: tensor, super_tensor, composite, tensor_swap, tensor_contract, expand_operator
 
 .. automodule:: qutip.core.qobj
     :members: ptrace

--- a/doc/changes/2775.bugfix
+++ b/doc/changes/2775.bugfix
@@ -1,0 +1,1 @@
+Fix mssing binding of docstrings of tensor_swap and expand_operator into APIdoc

--- a/doc/changes/2775.bugfix
+++ b/doc/changes/2775.bugfix
@@ -1,1 +1,1 @@
-Fix mssing binding of docstrings of tensor_swap and expand_operator into APIdoc
+Fix missing binding of docstrings of tensor_swap and expand_operator into APIdoc

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -455,19 +455,20 @@ def expand_operator(
     targets: int,
     dtype: LayerType = None
 ) -> QobjOrQobjEvo:
-    """
-    Expand an operator to one that acts on a system with desired dimensions.
-    e.g.
-    ```
-    expand_operator(oper, [2, 3, 4, 5], 2) ==
-        tensor(qeye(2), qeye(3), oper, qeye(5))
-    expand_operator(tensor(oper1, oper2), [2, 3, 4, 5], [2, 0]) ==
-        tensor(oper2, qeye(3), oper1, qeye(5))
-    ```
+    """Expand an operator to one that acts on a system with desired dimensions.
+
+    Example
+
+    .. code-block:: python
+
+        expand_operator(oper, [2, 3, 4, 5], 2) ==
+            tensor(qeye(2), qeye(3), oper, qeye(5))
+        expand_operator(tensor(oper1, oper2), [2, 3, 4, 5], [2, 0]) ==
+            tensor(oper2, qeye(3), oper1, qeye(5))
 
     Parameters
     ----------
-    oper : :class:`.Qobj`
+    oper : Qobj
         An operator that act on the subsystem, has to be an operator and the
         dimension matches the tensored dims Hilbert space
         e.g. oper.dims = ``[[2, 3], [2, 3]]``
@@ -477,13 +478,13 @@ def expand_operator(
     targets : int or list of int
         The indices of subspace that are acted on.
     dtype : str, optional
-        Data type of the output :class:`.Qobj`. By default it uses the data
+        Data type of the output Qobj. By default it uses the data
         type specified in settings. If no data type is specified
         in settings it uses the ``CSR`` data type.
 
     Returns
     -------
-    expanded_oper : :class:`.Qobj`
+    expanded_oper : Qobj
         The expanded operator acting on a system with the desired dimension.
     """
     oper._dims._require_pure_dims("expand operator")

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -198,7 +198,7 @@ def composite(*args: Qobj | QobjEvo) -> QobjEvo: ...
 
 def composite(*args):
     """
-    Given two or more operators, kets or bras, returns the Qobj
+    Given two or more operators, kets or bras, returns the :class:`.Qobj`
     corresponding to a composite system over each argument.
     For ordinary operators and vectors, this is the tensor product,
     while for superoperators and vectorized operators, this is
@@ -268,7 +268,7 @@ def _tensor_contract_dense(arr, *pairs):
 
 
 def tensor_swap(q_oper: Qobj, *pairs: tuple[int, int]) -> Qobj:
-    """Transposes one or more pairs of indices of a Qobj.
+    """Transposes one or more pairs of indices of a :class:`.Qobj`.
 
     .. note::
 
@@ -277,7 +277,7 @@ def tensor_swap(q_oper: Qobj, *pairs: tuple[int, int]) -> Qobj:
 
     Parameters
     ----------
-    q_oper : Qobj
+    q_oper : :class:`.Qobj`
         Operator to swap dims.
 
     pairs : tuple
@@ -288,8 +288,9 @@ def tensor_swap(q_oper: Qobj, *pairs: tuple[int, int]) -> Qobj:
     Returns
     -------
 
-    sqobj : Qobj
-        The original Qobj with all named index pairs swapped with each other
+    sqobj : :class:`.Qobj`
+        The original :class:`.Qobj` with all named index pairs swapped with
+        each other
     """
     q_oper._dims._require_pure_dims("tensor swap")
     dims = q_oper.dims
@@ -322,7 +323,7 @@ def tensor_contract(qobj: Qobj, *pairs: tuple[int, int]) -> Qobj:
 
     Parameters
     ----------
-    qobj: Qobj
+    qobj: :class:`.Qobj`
         Operator to contract subspaces on.
 
     pairs : tuple
@@ -333,8 +334,8 @@ def tensor_contract(qobj: Qobj, *pairs: tuple[int, int]) -> Qobj:
     Returns
     -------
 
-    cqobj : Qobj
-        The original Qobj with all named index pairs contracted
+    cqobj : :class:`.Qobj`
+        The original :class:`.Qobj` with all named index pairs contracted
         away.
 
     """
@@ -468,7 +469,7 @@ def expand_operator(
 
     Parameters
     ----------
-    oper : Qobj
+    oper : :class:`.Qobj`
         An operator that act on the subsystem, has to be an operator and the
         dimension matches the tensored dims Hilbert space
         e.g. oper.dims = ``[[2, 3], [2, 3]]``
@@ -478,13 +479,13 @@ def expand_operator(
     targets : int or list of int
         The indices of subspace that are acted on.
     dtype : str, optional
-        Data type of the output Qobj. By default it uses the data
+        Data type of the output :class:`.Qobj`. By default it uses the data
         type specified in settings. If no data type is specified
         in settings it uses the ``CSR`` data type.
 
     Returns
     -------
-    expanded_oper : Qobj
+    expanded_oper : :class:`.Qobj`
         The expanded operator acting on a system with the desired dimension.
     """
     oper._dims._require_pure_dims("expand operator")


### PR DESCRIPTION
**Description**
The functions `tensor_swap` and `expand_operator` from `qutip.core.tensor` have docstrings and were present in the documentation of QuTiP 4. But they can't be found anymore in QuTiP 5. So, they should be added to the APIdoc, too.

There might be some other functions missing (@nwlambert mentioned some ptrace function).
So, before merging this pull request, it might be beneficial to look for some other missing functions.