### PR TITLE
Fix expected wheel number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Check wheels
         run: |
           ls -R wheels
-          if ! [[ $(ls wheels/*.whl | wc -l) == 16 ]]; then exit 1; fi
+          if ! [[ $(ls wheels/*.whl | wc -l) == 20 ]]; then exit 1; fi
           if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
           if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
 


### PR DESCRIPTION
**Description**
Hot fix for 5.2.2 release.

The new py3.14 wheels are seen as extra and stopping the upload to pypi.
