### PR TITLE
Update build python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # between 13 and 14, mac changed from intel chip to apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        # mac has 2 chipsets that need different build.
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
     env:
       # Set up wheels matrix.  This is CPython 3.10--3.14 for all OS targets.
       CIBW_BUILD: "cp3{10,11,12,13,14}-*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
             pytest-extra-options: "-W ignore:Matrix:scipy.linalg._misc.LinAlgWarning"
 
           - case-name: macos - numpy fallback
-            os: macos-13  # Test on intel cpus
+            os: macos-15-intel  # Test on intel cpus
             python-version: "3.11"
             numpy-build: ">=2.0.0"
             numpy-requirement: ">=1.25,<1.26"


### PR DESCRIPTION
**Description**
When updating the build action for 3.14, I updated the runner python version, but forgot it in one place leading to an error just before uploading the wheels to pypi...

I already force merged this on the qutip-5.2.X branch for the release.