### PR TITLE
Replace unittest.skipIf with pytest.mark.skipif

### DIFF
--- a/qutip/tests/test_openmp.py
+++ b/qutip/tests/test_openmp.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.testing import assert_equal
-import unittest
+import pytest
 from qutip import *
 from qutip.settings import settings as qset
 # if qset.has_openmp:
@@ -8,7 +8,7 @@ from qutip.settings import settings as qset
 
 
 # @unittest.skipIf(qset.has_openmp == False, 'OPENMP not available.')
-@unittest.skipIf(True, 'OPENMP disabled.')
+@pytest.mark.skipif(True, reason='OPENMP disabled.')
 def test_openmp_spmv():
     "OPENMP : spmvpy_openmp == spmvpy"
     for k in range(100):
@@ -21,7 +21,7 @@ def test_openmp_spmv():
         assert (np.allclose(out, out_openmp, 1e-15))
 
 # @unittest.skipIf(qset.has_openmp == False, 'OPENMP not available.')
-@unittest.skipIf(True, 'OPENMP disabled.')
+@pytest.mark.skipif(True, reason='OPENMP disabled.')
 def test_openmp_mesolve():
     "OPENMP : mesolve"
     N = 100
@@ -66,7 +66,7 @@ def test_openmp_mesolve():
 
 
 # @unittest.skipIf(qset.has_openmp == False, 'OPENMP not available.')
-@unittest.skipIf(True, 'OPENMP disabled.')
+@pytest.mark.skipif(True, reason='OPENMP disabled.')
 def test_openmp_mesolve_td():
     "OPENMP : mesolve (td)"
     N = 100


### PR DESCRIPTION
Currently, tests appear to be failing because of pytest 9 release, which does not support `unittest.skipIf` marker. See https://github.com/pytest-dev/pytest/issues/13895

This might get fixed on pytest's side, but we have only one file where we use `unittest`, so might as well change it