### PR TITLE
Update cibuildwheel version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           # cibuildwheel does the heavy lifting for us. >=3 is needed for
           # python 3.14.
-          python -m pip install 'cibuildwheel==3.2.*'
+          python -m pip install 'cibuildwheel==3.3.*'
 
       - name: Build wheels
         shell: bash


### PR DESCRIPTION
**Description**
cibuildwheel 3.2 default to multilinux2014, which is no longer supported by numpy and scipy.
Both update the cibuildwheel version and choose the latest multilinux image.