### PR TITLE
Qobj: Deprecate Qobj @ numpy.array

### DIFF
--- a/doc/changes/2829.bugfix
+++ b/doc/changes/2829.bugfix
@@ -1,0 +1,1 @@
+Qobj: Updated __matmul__ to throw deprecation warning for Qobj @ numpy.array operation

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -455,6 +455,13 @@ class Qobj:
 
     def __matmul__(self, other: Qobj) -> Qobj:
         if not isinstance(other, Qobj):
+            warnings.warn(
+                "Support for Qobj @ numpy.array has been deprecated "
+                "and will be removed in qutip 5.4. "
+                "Please use Qobj(A) @ B instead.",
+                DeprecationWarning,
+                stacklevel=2
+            )
             try:
                 other = Qobj(other)
             except TypeError:

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -459,8 +459,7 @@ class Qobj:
                 "Support for Qobj @ numpy.array has been deprecated "
                 "and will be removed in qutip 5.5 or later. "
                 "Please use Qobj(A) @ B instead.",
-                DeprecationWarning,
-                stacklevel=2
+                FutureWarning
             )
             try:
                 other = Qobj(other)

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -457,7 +457,7 @@ class Qobj:
         if isinstance(other, np.ndarray):
             warnings.warn(
                 "Support for Qobj @ numpy.array has been deprecated "
-                "and will be removed in qutip 5.4. "
+                "and will be removed in qutip 5.5 or later. "
                 "Please use Qobj(A) @ B instead.",
                 DeprecationWarning,
                 stacklevel=2

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -454,7 +454,7 @@ class Qobj:
         return self.__mul__(other)
 
     def __matmul__(self, other: Qobj) -> Qobj:
-        if not isinstance(other, Qobj):
+        if isinstance(other, np.ndarray):
             warnings.warn(
                 "Support for Qobj @ numpy.array has been deprecated "
                 "and will be removed in qutip 5.4. "
@@ -464,8 +464,12 @@ class Qobj:
             )
             try:
                 other = Qobj(other)
-            except TypeError:
+            except Exception:
                 return NotImplemented
+
+        if not isinstance(other, Qobj):
+            return NotImplemented
+
         new_dims = self._dims @ other._dims
         if new_dims.type == 'scalar':
             return _data.inner(self._data, other._data)

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -407,17 +407,18 @@ def test_mul_vec(all_qevo):
 def test_matmul(all_qevo):
     "QobjEvo matmul oper"
     mat = np.random.rand(N, N) + 1 + 1j * np.random.rand(N, N)
+    matQobj = Qobj(mat)
     matDense = Qobj(mat).to(_data.Dense)
     matF = Qobj(np.asfortranarray(mat)).to(_data.Dense)
     matCSR = Qobj(mat).to(_data.CSR)
     op = all_qevo
     for t in TESTTIMES:
         Qo1 = op(t)
-        assert_allclose((Qo1 @ mat).full(),
+        assert_allclose((Qo1 @ matQobj).full(),
                         op.matmul(t, matF).full(), atol=1e-14)
-        assert_allclose((Qo1 @ mat).full(),
+        assert_allclose((Qo1 @ matQobj).full(),
                         op.matmul(t, matDense).full(), atol=1e-14)
-        assert_allclose((Qo1 @ mat).full(),
+        assert_allclose((Qo1 @ matQobj).full(),
                         op.matmul(t, matCSR).full(), atol=1e-14)
 
 


### PR DESCRIPTION
**Description**
This PR deprecates `Qobj @ numpy.array` operation.

**Related issues or PRs**
fixes #2547 

**Steps to test**
Code:
```python
import qutip
import numpy as np

A = qutip.Qobj([[0, 1], [1, 0]])
C = np.array([[0, 1], [1, 0]])

print(A @ C)
```

Output:
```shell
/home/mochi/Projects/qutip/temp.py:7: DeprecationWarning: Support for Qobj @ numpy.array has been deprecated and will be removed in qutip 5.4. Please use Qobj(A) @ B instead.
  print(A @ C)
Quantum object: dims=[[2], [2]], shape=(2, 2), type='oper', dtype=Dense, isherm=True
Qobj data =
[[1. 0.]
 [0. 1.]]
```