### PR TITLE
Update wigner docstring to clarify x,y axis order

### DIFF
--- a/doc/changes/1532.doc
+++ b/doc/changes/1532.doc
@@ -1,1 +1,1 @@
-Clarified the x and y axis order for the arrays returned by the phase-space functions wigner, qfunc and spin_q_function.
+Clarified the x and y axis order for the arrays returned by the phase-space functions wigner, spin_wigner, qfunc and spin_q_function.

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -985,7 +985,8 @@ def spin_wigner(rho, theta, phi):
     -------
     W, THETA, PHI : 2d-array
         Values representing the spin Wigner function at the values specified
-        by THETA and PHI.
+        by THETA and PHI. The arrays are indexed such that the element [j,k]
+        corresponds to the azimuthal angle ``phi[j]`` and polar angle ``theta[k]``
 
     References
     ----------


### PR DESCRIPTION
**Description**
Updated wigner() function's docstring to reflect x,y axis order in return type.

**Related issues or PRs**
Fixes #1532
