### PR TITLE
ENH: restore OpenMP configuration surface

### DIFF
--- a/doc/changes/1904.feature
+++ b/doc/changes/1904.feature
@@ -1,0 +1,1 @@
+Restores OpenMP support controls by re-enabling the build flag (``--with-openmp``/``CI_QUTIP_WITH_OPENMP``), exposing ``settings.has_openmp`` detection, and adding ``CoreOptions(use_openmp=..., openmp_thresh=...)`` toggles for runtime configuration.

--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -134,6 +134,12 @@ class CoreOptions(QutipOptions):
         ``auto_tidyup`` parameter above) and the default value of ``atol`` used
         in :meth:`Qobj.tidyup`.
 
+    use_openmp : bool [True]
+        Enable OpenMP-enabled kernels when they are available.
+
+    openmp_thresh : int [10000]
+        Minimum matrix size threshold before OpenMP kernels should be used.
+
     function_coefficient_style : str {"auto"}
         The signature expected by function coefficients. The options are:
 
@@ -185,6 +191,10 @@ class CoreOptions(QutipOptions):
         "rtol": 1e-12,
         # use auto tidyup absolute tolerance
         "auto_tidyup_atol": 1e-14,
+        # Enable OpenMP kernels when available.
+        "use_openmp": True,
+        # Minimum size threshold for OpenMP kernels.
+        "openmp_thresh": 10000,
         # signature style expected by function coefficients
         "function_coefficient_style": "auto",
         # Default Qobj dtype for Qobj create function
@@ -217,6 +227,9 @@ class CoreOptions(QutipOptions):
     ) -> float: ...
 
     @overload
+    def __getitem__(self, key: Literal["openmp_thresh"]) -> int: ...
+
+    @overload
     def __getitem__(
         self, key: Literal["function_coefficient_style", "default_dtype_scope"]
     ) -> str: ...
@@ -239,6 +252,9 @@ class CoreOptions(QutipOptions):
     def __setitem__(
         self, key: Literal["atol", "rtol", "auto_tidyup_atol"], value: float
     ) -> None: ...
+
+    @overload
+    def __setitem__(self, key: Literal["openmp_thresh"], value: int) -> None: ...
 
     @overload
     def __setitem__(

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -4,6 +4,7 @@ tidyup functionality, etc.
 """
 import os
 import sys
+import importlib.util
 from ctypes import cdll, CDLL
 import platform
 from glob import glob
@@ -184,6 +185,7 @@ class Settings:
         self._debug = False
         self._log_handler = "default"
         self._colorblind_safe = False
+        self._has_openmp_cache = None
 
     @property
     def has_mkl(self) -> bool:
@@ -304,10 +306,21 @@ class Settings:
         return os.access(self.coeffroot, os.W_OK)
 
     @property
+    def has_openmp(self) -> bool:
+        """Whether OpenMP support is available in the installed extensions."""
+        if self._has_openmp_cache is None:
+            # We detect OpenMP support by checking if the OpenMP Cython module
+            # was built and is importable in this installation.
+            self._has_openmp_cache = (
+                importlib.util.find_spec("qutip.core.cy.openmp.parfuncs")
+                is not None
+            )
+        return self._has_openmp_cache
+
+    @property
     def _has_openmp(self) -> bool:
-        return False
-        # We keep this as a reminder for when openmp is restored: see Pull #652
-        # os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
+        # Backward-compatible alias for internal legacy call-sites.
+        return self.has_openmp
 
     @property
     def idxint_size(self) -> int:

--- a/qutip/tests/core/test_options.py
+++ b/qutip/tests/core/test_options.py
@@ -87,3 +87,13 @@ class TestNumpyBackend:
     def test_getattr_jax(self):
         with CoreOptions(numpy_backend=mock_jax):
             assert np.sum([1, 2, 3]) == "jax_sum"
+
+
+class TestOpenMPOptions:
+    def test_has_openmp_is_boolean(self):
+        assert isinstance(settings.has_openmp, bool)
+
+    def test_openmp_core_options_roundtrip(self):
+        with CoreOptions(use_openmp=False, openmp_thresh=123):
+            assert settings.core["use_openmp"] is False
+            assert settings.core["openmp_thresh"] == 123

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def process_options():
             Is this a release build (True) or a local development build (False)
         'openmp': bool
             Should we build our OpenMP extensions and attempt to link in OpenMP
-            libraries? (Not supported in this version.)
+            libraries?
         'cflags': list of str
             Flags to be passed to the C++ compiler.
         'ldflags': list of str
@@ -88,8 +88,7 @@ def _determine_user_arguments(options):
             --wheel \
             --config-setting="--global-option=--with-openmp"
     """
-    # options = _parse_bool_user_argument(options, 'openmp')
-    options['openmp'] = False  # Not supported yet
+    options = _parse_bool_user_argument(options, 'openmp')
     options = _parse_bool_user_argument(options, 'idxint_64')
     return options
 


### PR DESCRIPTION
**Description**
This PR restores the OpenMP configuration surface for QuTiP by re-enabling OpenMP controls that were effectively disabled.

**Related issues or PRs**
Fixes #1904
