### PR TITLE
Deprecate make_sphere() in Bloch class in favor of render()

### DIFF
--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -675,9 +675,17 @@ class Bloch:
 
     def make_sphere(self):
         """
-        Plots Bloch sphere and data sets.
+        Deprecated: Use render() instead.
         """
-        self.render()
+        import warnings
+
+        warnings.warn(
+            "make_sphere() is deprecated and will be removed in QuTiP 5.0. "
+            "Use render() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.render()
 
     def run_from_ipython(self):
         try:


### PR DESCRIPTION
### Summary
Deprecated the `make_sphere()` method in the Bloch class as it duplicates the functionality of `render()`.

### Changes
- Added a `DeprecationWarning` to `make_sphere()`
- Updated docstring to indicate deprecation
- Ensured backward compatibility by internally calling `render()`

### Rationale
Both `make_sphere()` and `render()` perform identical operations. Deprecating `make_sphere()` simplifies the API and avoids redundancy.

### Future Work
`make_sphere()` can be removed in QuTiP 5.0.

### Notes
No breaking changes introduced.