### PR TITLE
Add linux, windows arm64 to wheels build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # mac has 2 chipsets that need different build.
-        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
+        # Each os has two instruction set (x86, arm) that needs different build.
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest]
     env:
       # Set up wheels matrix.  This is CPython 3.10--3.14 for all OS targets.
       CIBW_BUILD: "cp3{10,11,12,13,14}-*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,8 +108,8 @@ jobs:
         # Each os has two instruction set (x86, arm) that needs different build.
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-latest]
     env:
-      # Set up wheels matrix.  This is CPython 3.10--3.14 for all OS targets.
-      CIBW_BUILD: "cp3{10,11,12,13,14}-*"
+      # Set up wheels matrix.  This is CPython 3.11--3.14 for all OS targets.
+      CIBW_BUILD: "cp3{11,12,13,14}-*"
       # Numpy and SciPy do not supply wheels for i686 or win32 for
       # Python 3.10+, so we skip those:
       CIBW_SKIP: "*-musllinux* *-manylinux_i686 *-win32"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,16 @@ jobs:
             # Should be enough to include this in one of the runs
             includempi: 1
 
+          - case-name: p314 ubuntu arm
+            os: ubuntu-24.04-arm
+            python-version: "3.14"
+            numpy-build: ">=2.2.0"
+            numpy-requirement: ">=2.2.0"
+            pypi: 1
+            # Install mpi4py to test mpi_pmap
+            # Should be enough to include this in one of the runs
+            includempi: 1
+
           - case-name: p312, numpy fallback
             os: ubuntu-latest
             python-version: "3.12"
@@ -87,6 +97,7 @@ jobs:
             pypi: 1
             coveralls: 1
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
+
           # Mac
           # Mac has issues with MKL since september 2022.
           - case-name: macos
@@ -110,7 +121,7 @@ jobs:
             pytest-extra-options: "-W ignore:Matrix:scipy.linalg._misc.LinAlgWarning"
 
           - case-name: Windows
-            os: windows-latest
+            os: windows-11-arm
             python-version: "3.14"
             numpy-build: ">=2.0.0"
             numpy-requirement: ">=2.0.0"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,6 +145,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
+        if: matrix.os != 'windows-11-arm'
+        # Currently miniconda doesn't support window-11 arms
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -218,8 +220,13 @@ jobs:
           fi
 
       - name: Package information
+        shell: bash
         run: |
-          conda list
+          if [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
+            pip list
+          else
+            conda list
+          fi
           python -c "import qutip; qutip.about()"
           python -c "import qutip; print(qutip.settings)"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,6 +152,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: ${{ matrix.condaforge == 1 && 'conda-forge' || 'defaults' }}
 
+      # TODO remove this once conda supports windows arm
+      - uses: actions/setup-python@v6
+        if: matrix.os == 'windows-11-arm'
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Install QuTiP and dependencies
         # In the run, first we handle any special cases.  We do this in bash
         # rather than in the GitHub Actions file directly, because bash gives us

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -220,7 +220,6 @@ jobs:
           fi
 
       - name: Package information
-        shell: bash
         run: |
           if [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
             pip list

--- a/doc/changes/2855.feature
+++ b/doc/changes/2855.feature
@@ -1,0 +1,1 @@
+Add ubuntu-24-arm64, windows-11-arm64 to wheels build target


### PR DESCRIPTION
**Description**
Add ubuntu-24.04-arm, windows-11-arm as wheels build targets.

For reference:
https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

**Related issues or PRs**
Fixes #2832
