### PR TITLE
OhmicEnvironment without mpmath

### DIFF
--- a/doc/changes/2859.misc
+++ b/doc/changes/2859.misc
@@ -1,0 +1,1 @@
+Add fallback for missing mpmath module for OhmicEnvironment

--- a/qutip/core/environment.py
+++ b/qutip/core/environment.py
@@ -26,6 +26,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 from scipy.linalg import eigvalsh
 from scipy.interpolate import CubicSpline
+import scipy.special
 
 try:
     from mpmath import mp
@@ -1614,8 +1615,6 @@ class OhmicEnvironment(BosonicEnvironment):
         J(\omega)
         = \alpha \frac{\omega^s}{\omega_c^{s-1}} e^{-\omega / \omega_c} .
 
-    This class requires the `mpmath` module to be installed.
-
     Parameters
     ----------
     T : float
@@ -1642,11 +1641,6 @@ class OhmicEnvironment(BosonicEnvironment):
         self.alpha = alpha
         self.wc = wc
         self.s = s
-
-        if _mpmath_available is False:
-            warnings.warn(
-                "The mpmath module is required for some operations on "
-                "Ohmic environments, but it is not installed.")
 
     def spectral_density(self, w: float | ArrayLike) -> (float | ArrayLike):
         r"""
@@ -1712,6 +1706,13 @@ class OhmicEnvironment(BosonicEnvironment):
         t : array_like or float
             The time at which to evaluate the correlation function.
         """
+        if _mpmath_available:
+            zeta = mp.zeta
+            gamma = mp.gamma
+        else:
+            gamma = scipy.special.gamma
+            from qutip.utilities import zeta
+
         t = np.asarray(t, dtype=float)
         t_was_array = t.ndim > 0
         if not t_was_array:
@@ -1719,18 +1720,18 @@ class OhmicEnvironment(BosonicEnvironment):
 
         if self.T != 0:
             corr = (self.alpha * self.wc ** (1 - self.s) / np.pi
-                    * mp.gamma(self.s + 1) * self.T ** (self.s + 1))
+                    * gamma(self.s + 1) * self.T ** (self.s + 1))
             z1_u = ((1 + self.wc / self.T - 1j * self.wc * t)
                     / (self.wc / self.T))
             z2_u = (1 + 1j * self.wc * t) / (self.wc / self.T)
             result = np.asarray(
-                [corr * (mp.zeta(self.s + 1, u1) + mp.zeta(self.s + 1, u2))
+                [corr * (zeta(self.s + 1, u1) + zeta(self.s + 1, u2))
                  for u1, u2 in zip(z1_u, z2_u)],
                 dtype=np.cdouble
             )
         else:
             corr = (self.alpha * self.wc**2 / np.pi
-                    * mp.gamma(self.s + 1)
+                    * gamma(self.s + 1)
                     * (1 + 1j * self.wc * t) ** (-self.s - 1))
             result = np.asarray(corr, dtype=np.cdouble)
 

--- a/qutip/tests/test_utilities.py
+++ b/qutip/tests/test_utilities.py
@@ -127,12 +127,13 @@ def test_zeta():
     mpmath = pytest.importorskip("mpmath")
     N = 100
     s_list = np.random.rand(N) + 1.0001
-    q_list = np.random.lognormal(size=N)
+    # could randomly fail if q is an integer <=0
+    q_list = (np.random.rand(N) - 0.5) * 10
     for s, q in zip(s_list, q_list):
         assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-14)
 
     s_list = np.random.rand(N) + 1.0001
-    q_list = np.random.lognormal(size=N) + np.random.lognormal(size=N) * 1j
+    q_list = (np.random.rand(N) - 0.5) * 10 + np.random.randn(N) * 10j
     for s, q in zip(s_list, q_list):
         assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-14)
 
@@ -140,7 +141,7 @@ def test_zeta():
         1 + (np.random.lognormal(size=N) + 1e-6)
         * np.exp((np.random.rand(N) - 0.5) * 1j * np.pi)
     )  # Real part > 1.000001
-    q_list = np.random.lognormal(size=N) + np.random.lognormal(size=N)* 1j
+    q_list = (np.random.rand(N) - 0.5) * 10 + np.random.randn(N) * 10j
     for s, q in zip(s_list, q_list):
         assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-14)
 

--- a/qutip/tests/test_utilities.py
+++ b/qutip/tests/test_utilities.py
@@ -123,6 +123,28 @@ def test_cpu_count(monkeypatch):
     assert new_ncpus >= 1
 
 
+def test_zeta():
+    mpmath = pytest.importorskip("mpmath")
+    N = 100
+    s_list = np.random.rand(N) + 1.0001
+    q_list = np.random.lognormal(size=N)
+    for s, q in zip(s_list, q_list):
+        assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-14)
+
+    s_list = np.random.rand(N) + 1.0001
+    q_list = np.random.lognormal(size=N) + np.random.lognormal(size=N) * 1j
+    for s, q in zip(s_list, q_list):
+        assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-14)
+
+    s_list = (
+        1 + (np.random.lognormal(size=N) + 1e-6)
+        * np.exp((np.random.rand(N) - 0.5) * 1j * np.pi)
+    )  # Real part > 1.000001
+    q_list = np.random.lognormal(size=N) + np.random.lognormal(size=N)* 1j
+    for s, q in zip(s_list, q_list):
+        assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-14)
+
+
 class TestFitting:
     rng = np.random.default_rng(seed=42)
 

--- a/qutip/utilities.py
+++ b/qutip/utilities.py
@@ -15,6 +15,7 @@ from numpy.typing import ArrayLike
 from scipy.optimize import curve_fit
 from scipy.linalg import hankel, lstsq, eigvals, svd, eig
 from scipy.fft import fft
+from scipy.special import bernoulli, factorial
 
 
 def n_thermal(w, w_th):
@@ -345,6 +346,63 @@ def _version2int(version_string):
     return sum([int(d if len(d) > 0 else 0) * (100 ** (3 - n))
                 for n, d in enumerate(str_list[:3])])
 
+
+# -----------------------------------------------------------------------------
+#  special function
+# -----------------------------------------------------------------------------
+
+# Scipy does not support complex `q`
+def zeta(s, q, N=20, M=15):
+    """
+    Evaluates the Hurwitz zeta function for complex s and q using the
+    Euler-Maclaurin summation formula.
+
+    zeta(s, q) = sum(1 / (k + q)**s for k in range(inf))
+
+    Parameters
+    ----------
+    s : complex
+        The exponent. Cannot be 1.
+    q : complex
+        The shift parameter (q in standard notation).
+    N : int, default: 20
+        Number of direct terms to sum before the asymptotic expansion.
+    M : int, default: 15
+        Number of Bernoulli terms for the tail approximation.
+
+    Note
+    ----
+    Only tested for s.real > 1.
+    """
+    if np.isclose(s, 1.0):
+        raise ValueError("The Hurwitz zeta function has a pole at x = 1.")
+
+    # Direct Summation of the first N terms
+    # sum_{k=0}^{N} (k + q)^(-s)
+    direct_sum = sum((k + q)**-s for k in range(N + 1))
+
+    # Integral term: int_N^\inf (k + q)^(-s) dk
+    a = N + 1 + q
+    integral_term = (a**(1 - s)) / (s - 1)
+
+    # Boundary term: 1/2 * f(0)
+    half_term = 0.5 * (a**-s)
+
+    # Bernoulli series terms
+    B = bernoulli(2 * M)
+    bernoulli_sum = 0
+    factor = 1.0
+
+    for j in range(1, M + 1):
+        if j == 1:
+            factor = s
+        else:
+            factor *= (s + 2*j - 3) * (s + 2*j - 2)
+
+        term = (B[2*j] / factorial(2*j)) * factor * (a**(-s - 2*j + 1))
+        bernoulli_sum += term
+
+    return direct_sum + integral_term + half_term + bernoulli_sum
 
 # -----------------------------------------------------------------------------
 # Fitting utilities

--- a/qutip/utilities.py
+++ b/qutip/utilities.py
@@ -367,6 +367,7 @@ def zeta(s, q, N=20, M=15):
         The shift parameter (q in standard notation).
     N : int, default: 20
         Number of direct terms to sum before the asymptotic expansion.
+        When ``q.real < 0``, should be larger than ``-q``.
     M : int, default: 15
         Number of Bernoulli terms for the tail approximation.
 
@@ -374,6 +375,7 @@ def zeta(s, q, N=20, M=15):
     ----
     Only tested for s.real > 1.
     """
+    q = np.complex128(q)
     if np.isclose(s, 1.0):
         raise ValueError("The Hurwitz zeta function has a pole at x = 1.")
 


### PR DESCRIPTION
**Description**
`mpmath` is only needed for one function `zeta` that is not available for complex number in scipy. An efficient equation to implement it is available on [wikipedia](https://en.wikipedia.org/wiki/Euler%E2%80%93Maclaurin_formula#Examples).

This implementation is not as robust as mpmath's when s is smaller than 1, but works well in the range needed for OhmicEnvironment.


