### PR TITLE
Add doc notes to sigmam and sigmap

### DIFF
--- a/doc/changes/2862.doc
+++ b/doc/changes/2862.doc
@@ -1,0 +1,1 @@
+Add doc notes to sigmam and sigmap

--- a/qutip/core/operators.py
+++ b/qutip/core/operators.py
@@ -357,6 +357,11 @@ def sigmap(*, dtype: LayerType = None) -> Qobj:
         Storage representation. Any data-layer known to ``qutip.data.to`` is
         accepted.
 
+    Notes
+    -----
+    Equivalent to :func:`.create` when acting on a qubit defined by
+    :func:`.basis`.
+
     Examples
     --------
     >>> sigmap() # doctest: +SKIP
@@ -379,6 +384,11 @@ def sigmam(*, dtype: LayerType = None) -> Qobj:
     dtype : type or str, optional
         Storage representation. Any data-layer known to ``qutip.data.to`` is
         accepted.
+
+    Notes
+    -----
+    Equivalent to :func:`.destroy` when acting on a qubit defined by
+    :func:`.basis`.
 
     Examples
     --------


### PR DESCRIPTION

- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](https://qutip.readthedocs.io/en/stable/development/contributing.html#changelog-generation) for more information).

**Description**
Add doc notes for sigmax and sigmap operators.

**Related issues or PRs**
Fix #2494