### PR TITLE
docs: add guide links from API reference docstrings

### DIFF
--- a/doc/changes/2865.doc
+++ b/doc/changes/2865.doc
@@ -1,0 +1,2 @@
+Add links from the API reference docstrings to the corresponding user guide
+sections for solver, tensor, superoperator, environment, and HEOM APIs.

--- a/doc/guide/dynamics/dynamics-stochastic.rst
+++ b/doc/guide/dynamics/dynamics-stochastic.rst
@@ -73,6 +73,8 @@ the arguments ``'heterodyne=True'`` to :func:`~qutip.solver.stochastic.ssesolve`
 Stochastic Master Equation
 ==========================
 
+.. _sme-solver:
+
 .. Stochastic Master equation
 
 When the initial state of the system is a density matrix :math:`\rho`, the stochastic master equation solver :func:`qutip.stochastic.smesolve` must be used.

--- a/qutip/core/environment.py
+++ b/qutip/core/environment.py
@@ -45,6 +45,9 @@ class BosonicEnvironment(abc.ABC):
     its spectral density and temperature or, equivalently, its power spectrum
     or its two-time auto-correlation function.
 
+    See the Users Guide on :ref:`environments guide` and
+    :ref:`bosonic environments guide` for an introduction and definitions.
+
     Use one of the classmethods :meth:`from_spectral_density`,
     :meth:`from_power_spectrum` or :meth:`from_correlation_function` to
     construct an environment manually from one of these characteristic
@@ -2388,6 +2391,10 @@ class FermionicEnvironment(abc.ABC):
     The fermionic environment of an open quantum system. It is characterized by
     its spectral density, temperature and chemical potential or, equivalently,
     by its power spectra or its two-time auto-correlation functions.
+
+    See the Users Guide on :ref:`environments guide` and
+    :ref:`fermionic environments <fermionic environments guide>` for an
+    introduction and definitions.
 
     This class is included as a counterpart to :class:`BosonicEnvironment`, but
     it currently does not support all features that the bosonic environment

--- a/qutip/core/superoperator.py
+++ b/qutip/core/superoperator.py
@@ -56,6 +56,9 @@ def liouvillian(
     """Assembles the Liouvillian superoperator from a Hamiltonian
     and a ``list`` of collapse operators.
 
+    See the Users Guide on :ref:`master-master` and :ref:`super` for
+    background on Liouvillian and superoperator formalisms.
+
     Parameters
     ----------
     H : Qobj or QobjEvo, optional
@@ -167,6 +170,9 @@ def lindblad_dissipator(
     Lindblad dissipator (generalized) for a single pair of collapse operators
     (a, b), or for a single collapse operator (a) when b is not specified:
 
+    See the Users Guide on :ref:`master-master` and :ref:`super` for
+    background on Lindblad and superoperator notation.
+
     .. math::
 
         \\mathcal{D}[a,b]\\rho = a \\rho b^\\dagger -
@@ -233,6 +239,9 @@ def operator_to_vector(op: Qobj) -> Qobj:
     The passed object should have a ``Qobj.type`` of 'oper' or 'super'; this
     function is not designed for general-purpose matrix reshaping.
 
+    See the Users Guide on :ref:`super` for an introduction and worked
+    examples.
+
     Parameters
     ----------
     op : Qobj or QobjEvo
@@ -259,6 +268,9 @@ def vector_to_operator(op: Qobj) -> Qobj:
     Create a matrix representation given a quantum operator in vector form.
     The passed object should have a ``Qobj.type`` of 'operator-ket'; this
     function is not designed for general-purpose matrix reshaping.
+
+    See the Users Guide on :ref:`super` for an introduction and worked
+    examples.
 
     Parameters
     ----------
@@ -355,6 +367,9 @@ def spost(A: AnyQobj) -> AnyQobj:
     """
     Superoperator formed from post-multiplication by operator A
 
+    See the Users Guide on :ref:`super` for an introduction and worked
+    examples.
+
     Parameters
     ----------
     A : Qobj or QobjEvo
@@ -384,6 +399,9 @@ def spost(A: AnyQobj) -> AnyQobj:
 @_map_over_compound_operators
 def spre(A: AnyQobj) -> AnyQobj:
     """Superoperator formed from pre-multiplication by operator A.
+
+    See the Users Guide on :ref:`super` for an introduction and worked
+    examples.
 
     Parameters
     ----------
@@ -421,6 +439,9 @@ def sprepost(A, B):
     """
     Superoperator formed from pre-multiplication by A and post-multiplication
     by B.
+
+    See the Users Guide on :ref:`super` for an introduction and worked
+    examples.
 
     Parameters
     ----------

--- a/qutip/core/tensor.py
+++ b/qutip/core/tensor.py
@@ -42,6 +42,9 @@ def tensor(*args: Qobj | QobjEvo) -> QobjEvo: ...
 def tensor(*args: Qobj | QobjEvo) -> Qobj | QobjEvo:
     """Calculates the tensor product of input operators.
 
+    See the Users Guide on :ref:`tensor-products` for an introduction and
+    worked examples.
+
     Parameters
     ----------
     args : array_like
@@ -127,6 +130,9 @@ def super_tensor(*args: Qobj | QobjEvo) -> Qobj | QobjEvo:
     Calculate the tensor product of input superoperators, by tensoring together
     the underlying Hilbert spaces on which each vectorized operator acts.
 
+    See the Users Guide on :ref:`super` for an introduction and worked
+    examples.
+
     Parameters
     ----------
     args : array_like
@@ -209,6 +215,9 @@ def composite(*args):
     are assumed to be unitaries, and are promoted using ``to_super``,
     while kets and bras are promoted by taking their projectors and
     using ``operator_to_vector(ket2dm(arg))``.
+
+    See the Users Guide on :ref:`tensor-products` and :ref:`super` for
+    related examples of tensor products and Liouville-space composition.
     """
     import qutip.core.superop_reps
     # First step will be to ensure everything is a Qobj at all.
@@ -314,6 +323,9 @@ def tensor_swap(q_oper: Qobj, *pairs: tuple[int, int]) -> Qobj:
 
 def tensor_contract(qobj: Qobj, *pairs: tuple[int, int]) -> Qobj:
     """Contracts a qobj along one or more index pairs.
+
+    See the Users Guide on :ref:`super` for worked examples of reshaping and
+    contracting operators in Liouville space.
 
     .. note::
 

--- a/qutip/solver/brmesolve.py
+++ b/qutip/solver/brmesolve.py
@@ -43,6 +43,9 @@ def brmesolve(
     their associated spectral functions, as well as possible Lindblad collapse
     operators.
 
+    See the Users Guide on :ref:`bloch-redfield-qutip` for an introduction and
+    worked examples.
+
     Parameters
     ----------
     H : :obj:`.Qobj`, :obj:`.QobjEvo`
@@ -229,6 +232,9 @@ class BRSolver(Solver):
     """
     Bloch Redfield equation evolution of a density matrix for a given
     Hamiltonian and set of bath coupling operators.
+
+    See the Users Guide on :ref:`bloch-redfield-qutip` for an introduction and
+    worked examples.
 
     Parameters
     ----------

--- a/qutip/solver/floquet.py
+++ b/qutip/solver/floquet.py
@@ -547,6 +547,9 @@ def fsesolve(
     """
     Solve the Schrodinger equation using the Floquet formalism.
 
+    See the Users Guide on :ref:`floquet-unitary` for an introduction and
+    worked examples.
+
     Parameters
     ----------
     H : :obj:`.Qobj`, :obj:`.QobjEvo`, :obj:`.QobjEvo` compatible format.
@@ -650,6 +653,9 @@ def fmmesolve(
  ) -> "FloquetResult":
     """
     Solve the dynamics for the system using the Floquet-Markov master equation.
+
+    See the Users Guide on :ref:`floquet-dissipative` for an introduction and
+    worked examples.
 
     Parameters
     ----------
@@ -830,6 +836,9 @@ class FMESolver(MESolver):
 
     .. note ::
         Operators (``c_ops`` and ``e_ops``) are in the laboratory basis.
+
+    See the Users Guide on :ref:`floquet-dissipative` for an introduction and
+    worked examples.
 
     Parameters
     ----------

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -441,6 +441,9 @@ def heomsolve(
     using :class:`HEOMSolver` directly to avoid having to continually
     reconstruct the equation hierarchy for every evolution.
 
+    See the Users Guide on :ref:`heom` for an introduction and worked
+    examples.
+
     Parameters
     ----------
     H : :obj:`.Qobj`, :obj:`.QobjEvo`
@@ -573,6 +576,9 @@ class HEOMSolver(Solver):
 
     Each bath must be either bosonic or fermionic, but bosonic and fermionic
     baths can be mixed.
+
+    See the Users Guide on :ref:`heom` for an introduction and worked
+    examples.
 
     Parameters
     ----------

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -44,6 +44,9 @@ def mcsolve(
     given Hamiltonian and sets of collapse operators. Options for the
     underlying ODE solver are given by the Options class.
 
+    See the Users Guide on :ref:`monte-qutip` for an introduction and worked
+    examples.
+
     Parameters
     ----------
     H : :class:`.Qobj`, :class:`.QobjEvo`, ``list``, callable.
@@ -434,6 +437,9 @@ class MCSolver(MultiTrajSolver):
     Monte Carlo Solver of a state vector :math:`|\psi \rangle` for a
     given Hamiltonian and sets of collapse operators. Options for the
     underlying ODE solver are given by the Options class.
+
+    See the Users Guide on :ref:`monte-qutip` for an introduction and worked
+    examples.
 
     Parameters
     ----------

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -56,6 +56,10 @@ def mesolve(
     This allows the solution of master equations that are not in standard
     Lindblad form.
 
+    See the Users Guide on :ref:`master-master` and
+    :ref:`master-matrix-form` for an introduction, worked examples, and
+    matrix-form usage.
+
     **Time-dependent operators**
 
     For time-dependent problems, ``H`` and ``c_ops`` can be a :obj:`.QobjEvo`
@@ -188,6 +192,10 @@ class MESolver(SESolver):
     will be treated as direct contributions to the total system Liouvillian.
     This allows the solution of master equations that are not in standard
     Lindblad form.
+
+    See the Users Guide on :ref:`master-master` and
+    :ref:`master-matrix-form` for an introduction, worked examples, and
+    matrix-form usage.
 
     Parameters
     ----------

--- a/qutip/solver/nm_mcsolve.py
+++ b/qutip/solver/nm_mcsolve.py
@@ -57,6 +57,9 @@ def nm_mcsolve(
     to allow for negative rates. Options for the underlying ODE solver are
     given by the Options class.
 
+    See the Users Guide on :ref:`monte-nonmarkov` for an introduction and
+    worked examples.
+
     Parameters
     ----------
     H : :class:`.Qobj`, :class:`.QobjEvo`, ``list``, callable.
@@ -333,6 +336,9 @@ class NonMarkovianMCSolver(MCSolver):
     negative. The ``c_ops`` parameter of :class:`.MCSolver` is replaced by
     an ``ops_and_rates`` parameter to allow for negative rates. Options for the
     underlying ODE solver are given by the Options class.
+
+    See the Users Guide on :ref:`monte-nonmarkov` for an introduction and
+    worked examples.
 
     Parameters
     ----------

--- a/qutip/solver/sesolve.py
+++ b/qutip/solver/sesolve.py
@@ -47,6 +47,9 @@ def sesolve(
     does not use any return values. e_ops cannot be used in conjunction
     with solving the Schrodinger operator equation
 
+    See the Users Guide on :ref:`master-unitary` for an introduction and
+    worked examples.
+
     **Time-dependent operators**
 
     For time-dependent problems, ``H`` and ``c_ops`` can be a :obj:`.QobjEvo`
@@ -131,6 +134,9 @@ class SESolver(Solver):
     """
     Schrodinger equation evolution of a state vector or unitary matrix
     for a given Hamiltonian.
+
+    See the Users Guide on :ref:`master-unitary` for an introduction and
+    worked examples.
 
     Parameters
     ----------

--- a/qutip/solver/stochastic.py
+++ b/qutip/solver/stochastic.py
@@ -329,6 +329,10 @@ def smesolve(
     """
     Solve stochastic master equation.
 
+    See the Users Guide on
+    :ref:`the stochastic master equation section <sme-solver>` for an
+    introduction and worked examples.
+
     Parameters
     ----------
     H : :obj:`.Qobj`, :obj:`.QobjEvo`, :obj:`.QobjEvo` compatible format.
@@ -473,6 +477,10 @@ def ssesolve(
 ) -> StochasticResult:
     """
     Solve stochastic Schrodinger equation.
+
+    See the Users Guide on
+    :ref:`the stochastic Schrodinger equation section <sse-solver>` for an
+    introduction and worked examples.
 
     Parameters
     ----------
@@ -1045,6 +1053,10 @@ class SMESolver(StochasticSolver):
     r"""
     Stochastic Master Equation Solver.
 
+    See the Users Guide on
+    :ref:`the stochastic master equation section <sme-solver>` for an
+    introduction and worked examples.
+
     Parameters
     ----------
     H : :obj:`.Qobj`, :obj:`.QobjEvo`, :obj:`.QobjEvo` compatible format.
@@ -1084,6 +1096,10 @@ class SMESolver(StochasticSolver):
 class SSESolver(StochasticSolver):
     r"""
     Stochastic Schrodinger Equation Solver.
+
+    See the Users Guide on
+    :ref:`the stochastic Schrodinger equation section <sse-solver>` for an
+    introduction and worked examples.
 
     Parameters
     ----------


### PR DESCRIPTION
**Description**
Add guide references to the public API docstrings surfaced in the solver, quantumobject, environments, and HEOM API reference pages. This links the API docs back to the relevant user-guide sections and adds an explicit label for the stochastic master equation section.

Validated with a focused Sphinx HTML build of the affected API and guide pages.

**Related issues or PRs**
Fixes #2854