### PR TITLE
Fix mcsolve crash with non-normalized mixed initial state (fixes #2880)

### DIFF
--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -448,6 +448,16 @@ class _InitialConditions:
         filtered_states = [(index, weight)
                            for index, (_, weight) in enumerate(state_list)
                            if weight > 0]
+
+        # Normalize weights so they sum to 1, guarding against numerical
+        # errors that could leave the sum < 1 and cause too few trajectories
+        # to be allocated (leading to an IndexError crash).
+        weight_sum = sum(w for _, w in filtered_states)
+        if weight_sum > 0 and abs(weight_sum - 1.0) > 1e-10:
+            filtered_states = [
+                (index, weight / weight_sum)
+                for index, weight in filtered_states
+            ]
         if len(filtered_states) > ntraj_total:
             raise ValueError(f'{ntraj_total} trajectories is not enough for '
                              f'initial mixture of {len(filtered_states)} '

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -656,3 +656,30 @@ def test_mixed_equals_merged(improved_sampling, p):
         sum(merged_result.runs_weights + merged_result.deterministic_weights)
         == pytest.approx(1.)
     )
+
+
+@pytest.mark.parametrize("weights,ntraj", [
+    pytest.param([(0.5, 0.25)], 10, id="sub-unity"),
+    pytest.param([(0.1, 0.05)], 10, id="very-sub-unity"),
+    pytest.param([(0.6, 0.3)], 10, id="slightly-sub-unity"),
+])
+@pytest.mark.parametrize("improved_sampling", [True, False])
+def test_non_normalized_mixed_state(improved_sampling, weights, ntraj):
+    """
+    Regression test for gh-2880: mcsolve should not crash when the weights
+    of the mixed initial state do not sum exactly to 1 (e.g. due to
+    numerical error or user input).
+    """
+    states = [qutip.fock_dm(2, 0), qutip.fock_dm(2, 1)]
+    initial_state = sum(w * s for w, s in zip(weights, states))
+
+    H = qutip.sigmaz()
+    tlist = [0, 1]
+    L = qutip.sigmam()
+
+    solver = qutip.MCSolver(
+        H, [L], options={'improved_sampling': improved_sampling})
+    result = solver.run(initial_state, tlist, ntraj)
+
+    assert result.num_trajectories == ntraj
+    assert len(result.states) == 2  # initial + final


### PR DESCRIPTION
## Problem

`mcsolve` crashes with `IndexError: State id X must be smaller than number of trajectories Y` when a mixed initial state has weights that don't sum exactly to 1.0.

**Reproduction:**
```python
import qutip as qt
import numpy as np
initial_state = 0.5 * qt.fock_dm(2, 0) + 0.25 * qt.fock_dm(2, 1)
qt.mcsolve(qt.sigmaz(), initial_state, np.linspace(0, 1, 100), [qt.sigmam()], ntraj=10)
```

## Root Cause

In `_InitialConditions._minimum_roundoff_ensemble()` (`qutip/solver/multitraj.py:442`), the trajectory allocation algorithm assumes weights sum to exactly 1.0:

```python
guess = int(np.ceil(weight * ntraj_total))  # weight=0.5, ntraj=10 → guess=5
```

With weights `[0.5, 0.25]` (sum=0.75), only 8 trajectories are allocated for 10 requested. The algorithm then tries to access trajectory IDs 8-9, which don't exist → IndexError crash.

## Fix

Normalize filtered weights in `_minimum_roundoff_ensemble()` before trajectory allocation. This is a 4-line change that:
- Only affects the internal allocation algorithm
- No behavior change when weights already sum to 1.0 (normalization divides by 1.0)
- Preserves the original weights in `state_list` for `get_state_and_weight()` correction

## Tests

Added `test_non_normalized_mixed_state` with 3 weight scenarios × 2 `improved_sampling` modes = 6 test cases:
- `sub-unity`: weights sum to 0.75 (exact reproduction)
- `very-sub-unity`: weights sum to 0.15 (extreme case)
- `slightly-sub-unity`: weights sum to 0.9 (near-miss)

## Impact

- **Scope**: Only `_minimum_roundoff_ensemble()` in `multitraj.py`
- **Backward compatibility**: Full — normalized input produces identical results
- **Risk**: Minimal — the fix only triggers when `abs(weight_sum - 1.0) > 1e-10`
