### PR TITLE
Minor fixes to CI buildwheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Check wheels
         run: |
           ls -R wheels
-          if ! [[ $(ls wheels/*.whl | wc -l) == 20 ]]; then exit 1; fi
+          if ! [[ $(ls wheels/*.whl | wc -l) == 24 ]]; then exit 1; fi
           if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
           if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,8 +114,6 @@ jobs:
       # Python 3.10+, so we skip those:
       CIBW_SKIP: "*-musllinux* *-manylinux_i686 *-win32"
       # Force recent version of manylinux
-      # manylinux2014 no longer supported by scipy and numpy
-      CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:

--- a/doc/changes/2883.misc
+++ b/doc/changes/2883.misc
@@ -1,0 +1,3 @@
+Update manylinux-x86_64-image from manylinux2014 to manylinux_2_28.
+Update build-frontend to build from pip. This allows to use custom build frontends like uv in the future.
+Update wheel number from 20 to 24 while deploying.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,10 +78,8 @@ full = [
 packages = { find = { include = ["qutip*"] } }
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
-# Change in future version to "build"
-build-frontend = "pip"
+manylinux-x86_64-image = "manylinux_2_28"
+build-frontend = "build"
 
 [tool.towncrier]
 directory = "doc/changes"


### PR DESCRIPTION
**Description**
Changes:
- Update wheel number from 20 to 24, based on the changes in #2855 
- Update `manylinux-x86_64-image` from `manylinux2014` to `manylinux_2_28`.
- Update `build-frontend` to `build` from `pip`. This allows to generate sdist which pip does not.

**Related issues or PRs**
None
