### PR TITLE
Fix mcsolve crash with non-normalized mixed initial state

### DIFF
--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -444,10 +444,18 @@ class _InitialConditions:
         Calculate a list ntraj from the given total number, under contraints
         explained above. Algorithm based on https://stackoverflow.com/a/792490
         """
-        # First we throw out zero-weight states
+        # First we throw out zero-weight states and normalize the
+        # remaining weights so they sum to one. This is necessary because
+        # the input density matrix may not be perfectly normalized due to
+        # numerical error. Without normalization, the algorithm can assign
+        # too few trajectories, leading to an IndexError later.
         filtered_states = [(index, weight)
                            for index, (_, weight) in enumerate(state_list)
                            if weight > 0]
+        total_weight = sum(weight for _, weight in filtered_states)
+        if total_weight > 0 and abs(total_weight - 1.0) > 1e-12:
+            filtered_states = [(index, weight / total_weight)
+                               for index, weight in filtered_states]
         if len(filtered_states) > ntraj_total:
             raise ValueError(f'{ntraj_total} trajectories is not enough for '
                              f'initial mixture of {len(filtered_states)} '

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -656,3 +656,15 @@ def test_mixed_equals_merged(improved_sampling, p):
         sum(merged_result.runs_weights + merged_result.deterministic_weights)
         == pytest.approx(1.)
     )
+
+
+def test_mcsolve_non_normalized_mixed_state():
+    """Regression test for issue #2880: mcsolve should handle a mixed
+    initial state whose weights do not sum to exactly one."""
+    initial_state = 0.5 * qutip.fock_dm(2, 0) + 0.25 * qutip.fock_dm(2, 1)
+    result = qutip.mcsolve(
+        qutip.sigmaz(), initial_state,
+        np.linspace(0, 1, 100), [qutip.sigmam()],
+        ntraj=10, options={'progress_bar': False},
+    )
+    assert result.num_trajectories == 10


### PR DESCRIPTION
## Summary

When `mcsolve` receives a density matrix whose eigenvalues do not sum to exactly 1.0 (e.g. `0.5 * fock_dm(2, 0) + 0.25 * fock_dm(2, 1)` has trace 0.75), the `_minimum_roundoff_ensemble` method in `_InitialConditions` allocates fewer trajectories than requested. This happens because the ceil-based initial guesses sum to less than `ntraj_total`, so the trimming loop never runs and the total trajectory count ends up too low. Downstream, this causes an `IndexError` when trajectory IDs exceed the allocated count.

The fix normalizes the weights within `_minimum_roundoff_ensemble` so the distribution algorithm always assigns exactly `ntraj_total` trajectories. A tolerance of `1e-12` avoids unnecessary normalization when weights are already close to 1. The original un-normalized weights are preserved in `state_list` and continue to be used by `get_state_and_weight` for the correction factor, so the physical meaning of the result is unaffected.

Includes a regression test that reproduces the exact scenario from the issue report.

Closes #2880

## Changes

- `qutip/solver/multitraj.py`: Normalize filtered weights in `_minimum_roundoff_ensemble` before trajectory allocation
- `qutip/tests/solver/test_mcsolve.py`: Add `test_mcsolve_non_normalized_mixed_state` regression test