### PR TITLE
Dep old coeff

### DIFF
--- a/doc/changes/2889.deprecation
+++ b/doc/changes/2889.deprecation
@@ -1,0 +1,1 @@
+Add deprecation warning for dict coefficient format.

--- a/doc/guide/dynamics/dynamics-floquet.rst
+++ b/doc/guide/dynamics/dynamics-floquet.rst
@@ -149,7 +149,7 @@ due that the driving, degenerate quasienergies indicates a "freezing" of the dyn
    >>> args = {'w': omega}
    >>> for idx, A in enumerate(A_vec): # doctest: +SKIP
    >>>   H1 = A / 2.0 * sigmax() # doctest: +SKIP
-   >>>   H = [H0, [H1, lambda t, args: np.sin(args['w'] * t)]] # doctest: +SKIP
+   >>>   H = [H0, [H1, lambda t, w: np.sin(w * t)]] # doctest: +SKIP
    >>>   floquet_basis = FloquetBasis(H, T, args)
    >>>   q_energies[idx,:] = floquet_basis.e_quasi # doctest: +SKIP
    >>> plt.figure() # doctest: +SKIP

--- a/doc/guide/dynamics/dynamics-time.rst
+++ b/doc/guide/dynamics/dynamics-time.rst
@@ -157,14 +157,14 @@ simple Harmonic oscillator with time-varying decay rate
 
     kappa = 0.5
 
-    def col_coeff(t, args):  # coefficient function
+    def col_coeff(t, kappa):  # coefficient function
         return np.sqrt(kappa * np.exp(-t))
 
     N = 10  # number of basis states
     a = destroy(N)
     H = a.dag() * a  # simple HO
     psi0 = basis(N, 9)  # initial state
-    c_ops = [QobjEvo([a, col_coeff])]  # time-dependent collapse term
+    c_ops = [QobjEvo([a, col_coeff], args={"kappa": kappa})]  # time-dependent collapse term
     times = np.linspace(0, 10, 100)
     output = mesolve(H, psi0, times, c_ops, e_ops=[a.dag() * a])
 
@@ -242,8 +242,8 @@ function that make the :obj:`.QobjEvo`. For instance, instead of explicitly writ
 
 .. code-block:: python
 
-    >>> def H1_coeff(t, args):
-    >>>     return args['A'] * np.exp(-(t/args['sigma'])**2)
+    >>> def H1_coeff(t, A, sigma):
+    >>>     return A * np.exp(-(t / sigma)**2)
 
 
 or, new from v5, add the extra parameter directly:
@@ -365,13 +365,35 @@ but QuTiP support multiple formats: ``callable``, ``strings``, ``array``.
 
 **Function coefficients** :
 Use a callable with the signature ``f(t: double, ...) -> double`` as coefficient.
-Any function or method that can be called by ``f(t, args)``, ``f(t, **args)`` is accepted.
-
+The function signature must start with the time and have no positional no other positional arguments:
 
 .. code-block:: python
 
     def coeff(t, A, sigma):
         return A * np.exp(-(t / sigma)**2)
+
+    H = QobjEvo([H0, [H1, coeff]], args=args)
+
+Unused arguments will be filtered. In the previous example, if ``args``
+contained an extra ``w`` key, it would not be passed to the ``coeff`` function,
+allowing mixing function with different signatures in the same QobjEvo.
+If the function has a ``**kwargs``, it will receive all the arguments passed to
+the time dependent operator.
+
+Any callable are supported, this include classes with a __call__ methods or
+bound methods.
+
+.. code-block:: python
+
+    class My_Coeff:
+        def __init__(self):
+            self.num_calls = 0
+
+        def __call__(self, t, A, sigma):
+            self.num_calls += 1
+            if self.num_calls % 100 == 0:
+                print(f"After {self.num_calls} the time is as {t}")
+            return A * np.exp(-(t / sigma)**2)
 
     H = QobjEvo([H0, [H1, coeff]], args=args)
 

--- a/qutip/core/_brtools.pyx
+++ b/qutip/core/_brtools.pyx
@@ -173,7 +173,7 @@ class _eigen_qevo:
         # are flat.
         self.out_dims = [qevo.dims[0], [qevo.shape[1]]]
 
-    def __call__(self, t, args):
+    def __call__(self, t, **args):
         if args is not self.args:
             self.args = args
             self.qevo.arguments(self.args)

--- a/qutip/core/coefficient.py
+++ b/qutip/core/coefficient.py
@@ -84,9 +84,11 @@ def coefficient(
     For function based coefficients, the function signature must be either:
 
     * ``f(t, ...)`` where the other arguments are supplied as ordinary
-      "pythonic" arguments (e.g. ``f(t, w, a=5)``)
+      "pythonic" arguments (e.g. ``f(t, w, a=5)``) or keyword arguments
+      (e.g. ``f(t, w, **args)``)
     * ``f(t, args)`` where the arguments are supplied in a "dict" named
       ``args``
+      This format is deprecated, to be remove in QuTiP 5.5.
 
     By default the signature style is controlled by the
     ``qutip.settings.core["function_coefficient_style"]`` setting, but it
@@ -622,7 +624,7 @@ def compile_code(code, file_name, parsed, c_opt):
             qutip_root = Path(__file__).resolve().parents[2]
 
             ext_modules = cythonize(
-                coeff_file, force=True, build_dir=c_opt['build_dir'], 
+                coeff_file, force=True, build_dir=c_opt['build_dir'],
                 include_path=[str(qutip_root)]
             )
             setup(ext_modules=ext_modules)

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -67,19 +67,16 @@ def coefficient_function_parameters(func, style=None):
             # if the signature is exactly f(t, args), then assume parameters
             # are supplied in an argument dictionary
             style = "dict"
-            warnings.warn(
-                "From QuTiP 5.5, signature detection of time-depend QobjEvo "
-                "will be removed. All python function passed to coefficient "
-                "and QobjEvo will expect to be pythonic: use the signature "
-                "'f(t, **args)'.\n"
-                "To use v4's signature (f(t, args: dict)) manually passing "
-                "the keyword 'function_style' will be required: \n"
-                "    QobjEvo(..., function_style='dict') \n"
-                "    coefficient(..., function_style='dict')",
-                FutureWarning
-            )
         else:
             style = "pythonic"
+    if style == "dict":
+        warnings.warn(
+            "The signature f(t, args) is deprecated and will be removed in "
+            "QuTiP 5.5. Please update your function to the pythonic signature "
+            "f(t, **kwargs) to maintain compatibility.",
+            FutureWarning
+        )
+
     if style == "dict" or f_has_kw:
         # f might accept any parameter
         f_parameters = None

--- a/qutip/core/cy/coefficient.pyx
+++ b/qutip/core/cy/coefficient.pyx
@@ -5,6 +5,7 @@ import inspect
 import pickle
 import typing
 import scipy
+import warnings
 from scipy.interpolate import make_interp_spline
 import numpy as np
 cimport numpy as cnp
@@ -66,6 +67,17 @@ def coefficient_function_parameters(func, style=None):
             # if the signature is exactly f(t, args), then assume parameters
             # are supplied in an argument dictionary
             style = "dict"
+            warnings.warn(
+                "From QuTiP 5.5, signature detection of time-depend QobjEvo "
+                "will be removed. All python function passed to coefficient "
+                "and QobjEvo will expect to be pythonic: use the signature "
+                "'f(t, **args)'.\n"
+                "To use v4's signature (f(t, args: dict)) manually passing "
+                "the keyword 'function_style' will be required: \n"
+                "    QobjEvo(..., function_style='dict') \n"
+                "    coefficient(..., function_style='dict')",
+                FutureWarning
+            )
         else:
             style = "pythonic"
     if style == "dict" or f_has_kw:

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -270,6 +270,7 @@ cdef class QobjEvo:
             out = _EvoElement(
                 op[0].copy() if copy else op[0],
                 coefficient(op[1], tlist=tlist, args=args, order=order,
+                            function_style=function_style,
                             boundary_conditions=boundary_conditions)
             )
             qobj = op[0]

--- a/qutip/core/cy/qobjevo.pyx
+++ b/qutip/core/cy/qobjevo.pyx
@@ -128,8 +128,8 @@ cdef class QobjEvo:
 
     .. code-block::
 
-        def f(t, args):
-            return qutip.qeye(N) * np.exp(args['w'] * t)
+        def f(t, w):
+            return qutip.qeye(N) * np.exp(w * t)
 
         QobjEvo(f, args={'w': 1j})
 
@@ -150,8 +150,8 @@ cdef class QobjEvo:
 
     .. code-block::
 
-        def f1_t(t, args):
-            return np.exp(-1j * t * args["w1"])
+        def f1_t(t, w1):
+            return np.exp(-1j * t * w1)
 
         QobjEvo([[H1, f1_t]], args={"w1": 1.})
 

--- a/qutip/core/options.py
+++ b/qutip/core/options.py
@@ -140,6 +140,7 @@ class CoreOptions(QutipOptions):
         - "pythonic": the signature should be ``f(t, ...)`` where ``t``
           is the time and the ``...`` are the remaining arguments passed
           directly into the function. E.g. ``f(t, w, b=5)``.
+          Keyword arguments are supported: ``f(t, **args)``.
 
         - "dict": the signature shoule be ``f(t, args)`` where ``t`` is
           the time and ``args`` is a dict containing the remaining arguments.
@@ -149,6 +150,9 @@ class CoreOptions(QutipOptions):
           on the signature of the supplied function. If the function signature
           is exactly ``f(t, args)`` then ``dict`` is used. Otherwise
           ``pythonic`` is used.
+
+        From QuTiP 5.5, this options will be removed and only pythonic
+        siganture will be supported.
 
     default_dtype : str, type {"core"}
         The specified data type will be used as output for different qutip

--- a/qutip/solver/propagator.py
+++ b/qutip/solver/propagator.py
@@ -40,9 +40,7 @@ def propagator_piecewise(
     Parameters
     ----------
     H : :obj:`.QobjEvo`
-        Time-dependent Hamiltonian or Liouvillian. Must be callable with
-        signature ``H(t, args)`` that returns the constant operator valid at
-        time ``t``.
+        Time-dependent Hamiltonian or Liouvillian.
 
     tlist : list of float
         List of times at which to evaluate the propagator.

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -10,6 +10,9 @@ from qutip.core.coefficient import (coefficient, norm, conj, const,
                                     WARN_MISSING_MODULE,
                                     )
 
+pytest.mark.filterwarnings(
+    "ignore:The signature f\(t, args\) is deprecated:FutureWarning"
+)
 
 # Ensure the latest version is tested
 clean_compiled_coefficient(True)
@@ -489,3 +492,10 @@ def test_coefficient_parallel(map_func):
     for coeff in coeffs:
         assert isinstance(coeff, Coefficient)
         _assert_eq_over_interval(coeff, expected)
+
+
+def test_warning():
+    with pytest.warns(FutureWarning, match="The signature"):
+        coeff = coefficient(f_qtv4, args={"w":1})
+
+    assert isinstance(coeff, Coefficient)

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -10,10 +10,6 @@ from qutip.core.coefficient import (coefficient, norm, conj, const,
                                     WARN_MISSING_MODULE,
                                     )
 
-pytest.mark.filterwarnings(
-    "ignore:The signature f(t, args) is deprecated:FutureWarning"
-)
-
 # Ensure the latest version is tested
 clean_compiled_coefficient(True)
 
@@ -120,6 +116,7 @@ def coeff_generator(style, func):
     pytest.param("exp(w * t * pi)", {'args': args},
                  1e-10, id="string")
 ])
+@pytest.mark.filterwarnings("ignore:The signature:FutureWarning")
 def test_CoeffCreationCall(base, kwargs, tol):
     opt = CompilationOptions(recompile=True)
     expected = lambda t: np.exp(1j * t * np.pi)
@@ -137,6 +134,7 @@ def test_CoeffCreationCall(base, kwargs, tol):
     pytest.param("exp(w * t * pi)", {'args': args},
                  1e-10, id="string")
 ])
+@pytest.mark.filterwarnings("ignore:The signature:FutureWarning")
 def test_CoeffCallArgs(base, kwargs, tol):
     w = np.e + 0.5j
     expected = lambda t: np.exp(w * t * np.pi)
@@ -150,6 +148,7 @@ def test_CoeffCallArgs(base, kwargs, tol):
     pytest.param(h_qtv4, 1e-10, id="func_qutip_v4"),
     pytest.param("a + b + t", 1e-10, id="string")
 ])
+@pytest.mark.filterwarnings("ignore:The signature:FutureWarning")
 def test_CoeffCallArguments(base, tol):
     # Partial args update
     args = {"a": 1, "b": 1}

--- a/qutip/tests/core/test_coefficient.py
+++ b/qutip/tests/core/test_coefficient.py
@@ -11,7 +11,7 @@ from qutip.core.coefficient import (coefficient, norm, conj, const,
                                     )
 
 pytest.mark.filterwarnings(
-    "ignore:The signature f\(t, args\) is deprecated:FutureWarning"
+    "ignore:The signature f(t, args) is deprecated:FutureWarning"
 )
 
 # Ensure the latest version is tested

--- a/qutip/tests/core/test_direct_sum.py
+++ b/qutip/tests/core/test_direct_sum.py
@@ -15,7 +15,7 @@ from numbers import Number
 import numpy as np
 
 
-def _ramp(t, args):
+def _ramp(t):
     return t
 
 

--- a/qutip/tests/core/test_qobjevo.py
+++ b/qutip/tests/core/test_qobjevo.py
@@ -26,12 +26,12 @@ class Pseudo_qevo:
 
     def array(self):
         tlist = np.linspace(0, 10, 10001)
-        coeff = self.func(tlist, self.args)
+        coeff = self.func(tlist, **self.args)
         return ([self.cte, [self.qobj, coeff]], {}, tlist)
 
     def logarray(self):
         tlist = np.logspace(-3, 1, 10001)
-        coeff = self.func(tlist, self.args)
+        coeff = self.func(tlist, **self.args)
         return ([self.cte, [self.qobj, coeff]], {}, tlist)
 
     def func_coeff(self):
@@ -43,9 +43,9 @@ class Pseudo_qevo:
     def func_call(self):
         return (self.__call__, self.args)
 
-    def __call__(self, t, args={}):
+    def __call__(self, t, **args):
         args = args or self.args
-        return self.cte + self.qobj * self.func(t, args)
+        return self.cte + self.qobj * self.func(t, **args)
 
     def __getitem__(self, which):
         return getattr(self, which)()
@@ -60,12 +60,12 @@ args = {'w1': 1, "w2": 2}
 TESTTIMES = np.linspace(0.001, 1.0, 10)
 
 
-def _real(t, args):
-    return np.sin(t*args['w1'])
+def _real(t, w1, **kw):
+    return np.sin(t * w1)
 
 
-def _cplx(t, args):
-    return np.exp(1j*t*args['w2'])
+def _cplx(t, w2, **kw):
+    return np.exp(1j * t * w2)
 
 
 real_qevo = Pseudo_qevo(
@@ -189,7 +189,7 @@ def test_QobjEvo_repr():
                          ['func_coeff', 'string', 'array', 'logarray'])
 def test_product_coeff(pseudo_qevo, coeff_type):
     # test creation of QobjEvo with Qobj * Coefficient
-    # Skip pure func: QobjEvo(f(t, args) -> Qobj)
+    # Skip pure func: QobjEvo(f(t, **args) -> Qobj)
     base = pseudo_qevo[coeff_type]
     cte, [qobj, coeff] = base[0]
     args = base[1] if len(base) >= 2 else {}
@@ -331,8 +331,8 @@ def test_args(pseudo_qevo, args_coeff_type):
     args = {'w1': 3, "w2": 3}
 
     for t in TESTTIMES:
-        _assert_qobj_almost_eq(obj(t, args), pseudo_qevo(t, args))
-        _assert_qobj_almost_eq(obj(t, **args), pseudo_qevo(t, args))
+        _assert_qobj_almost_eq(obj(t, args), pseudo_qevo(t, **args))
+        _assert_qobj_almost_eq(obj(t, **args), pseudo_qevo(t, **args))
 
     # Did it modify original args
     _assert_qobjevo_equivalent(obj, pseudo_qevo)
@@ -340,13 +340,13 @@ def test_args(pseudo_qevo, args_coeff_type):
     obj.arguments(args)
     _assert_qobjevo_different(obj, pseudo_qevo)
     for t in TESTTIMES:
-        _assert_qobj_almost_eq(obj(t), pseudo_qevo(t, args))
+        _assert_qobj_almost_eq(obj(t), pseudo_qevo(t, **args))
 
     args = {'w1': 4, "w2": 4}
     obj.arguments(**args)
     _assert_qobjevo_different(obj, pseudo_qevo)
     for t in TESTTIMES:
-        _assert_qobj_almost_eq(obj(t), pseudo_qevo(t, args))
+        _assert_qobj_almost_eq(obj(t), pseudo_qevo(t, **args))
 
 
 def test_copy_side_effects(all_qevo):

--- a/qutip/tests/core/test_superoper.py
+++ b/qutip/tests/core/test_superoper.py
@@ -6,7 +6,7 @@ from qutip.core import data as _data
 import pytest
 
 
-def f(t, args):
+def f(t):
     return t * (1 - 0.5j)
 
 

--- a/qutip/tests/solver/test_correlation.py
+++ b/qutip/tests/solver/test_correlation.py
@@ -103,16 +103,15 @@ def _n_correlation(times, n):
                      for t in range(times.shape[0])])
 
 
-def _coefficient_function(t, args):
-    t_off, tp = args['t_off'], args['tp']
-    return np.exp(-(t-t_off)*(t-t_off) / (2*tp*tp))
+def _coefficient_function(t, t_off, tp, **kw):
+    return np.exp(-(t - t_off) * (t - t_off) / (2 * tp * tp))
 
 
 _coefficient_string = "exp(-(t-t_off)**2 / (2 * tp*tp))"
 
 
-def _h_qobj_function(t, args):
-    return args['H0'] * _coefficient_function(t, args)
+def _h_qobj_function(t, H0, **args):
+    return H0 * _coefficient_function(t, **args)
 
 
 # 2LS and 3LS stand for two- and three-level system respectively.
@@ -142,7 +141,7 @@ def _2ls_g2_0(H, c_ops):
 
 @pytest.fixture(params=[
     pytest.param(_coefficient_string, id="string"),
-    pytest.param(_coefficient_function(_2ls_times, _2ls_args), id="numpy"),
+    pytest.param(_coefficient_function(_2ls_times, **_2ls_args), id="numpy"),
     pytest.param(_coefficient_function, id="function"),
 ])
 def dependence_2ls(request):
@@ -171,7 +170,9 @@ class TestTimeDependence:
     @pytest.mark.slow
     @pytest.mark.parametrize("dependence_3ls", [
         pytest.param(_coefficient_string, id="string"),
-        pytest.param(_coefficient_function(_3ls_times, _3ls_args), id="numpy"),
+        pytest.param(
+            _coefficient_function(_3ls_times, **_3ls_args), id="numpy"
+        ),
         pytest.param(_coefficient_function, id="function"),
     ])
     def test_coefficient_c_ops_3ls(self, dependence_3ls):

--- a/qutip/tests/solver/test_floquet.py
+++ b/qutip/tests/solver/test_floquet.py
@@ -81,7 +81,7 @@ class TestFloquet:
         H0 = - eps0 / 2.0 * sigmaz() - delta / 2.0 * sigmax()
         H1 = A / 2.0 * sigmax()
         args = {'w': omega}
-        H = [H0, [H1, lambda t, args: np.sin(args['w'] * t)]]
+        H = [H0, [H1, lambda t, w: np.sin(w * t)]]
         e_ops = [num(2)]
         gamma1 = 0
 

--- a/qutip/tests/solver/test_lindblad_matrix_form.py
+++ b/qutip/tests/solver/test_lindblad_matrix_form.py
@@ -31,7 +31,7 @@ class TestLindbladMatrixFormInit:
         N = 10
         H0 = qutip.num(N)
         H1 = 0.1 * qutip.create(N)
-        H_td = [H0, [H1, lambda t, args: np.cos(t)]]
+        H_td = [H0, [H1, lambda t: np.cos(t)]]
         c_ops = [np.sqrt(0.1) * qutip.destroy(N)]
 
         rhs = LindbladMatrixForm(QobjEvo(H_td), [QobjEvo(c) for c in c_ops])

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -5,12 +5,12 @@ from copy import copy
 from qutip.solver.mcsolve import mcsolve, MCSolver
 
 
-def _return_constant(t, args):
-    return args['constant']
+def _return_constant(t, constant):
+    return constant
 
 
-def _return_decay(t, args):
-    return args['constant'] * np.exp(-args['rate'] * t)
+def _return_decay(t, constant, rate):
+    return constant * np.exp(-rate * t)
 
 
 class callable_qobj:
@@ -18,9 +18,9 @@ class callable_qobj:
         self.oper = oper
         self.coeff = coeff
 
-    def __call__(self, t, args):
+    def __call__(self, t, **args):
         if self.coeff is not None:
-            return self.oper * self.coeff(t, args)
+            return self.oper * self.coeff(t, **args)
         return self.oper
 
 
@@ -649,7 +649,7 @@ def test_mixed_equals_merged(improved_sampling, p):
     assert isinstance(mixed_result.ntraj_per_initial_state, list)
     assert mixed_result.ntraj_per_initial_state == ntraj
     assert (
-        sum(mixed_result.runs_weights + mixed_result.deterministic_weights) 
+        sum(mixed_result.runs_weights + mixed_result.deterministic_weights)
         == pytest.approx(1.)
     )
     assert (

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -34,11 +34,11 @@ class TestMESolveDecay:
     ada = a.dag() * a
 
     @pytest.fixture(params=[
-        pytest.param([ada, lambda t, args: 1], id='Hlist_func'),
+        pytest.param([ada, lambda t: 1], id='Hlist_func'),
         pytest.param([ada, '1'], id='Hlist_str'),
         pytest.param([ada, np.ones_like(tlist)], id='Hlist_array'),
         pytest.param(qutip.QobjEvo([ada, '1']), id='HQobjEvo'),
-        pytest.param(lambda t, args: qutip.create(10) * qutip.destroy(10),
+        pytest.param(lambda t: qutip.create(10) * qutip.destroy(10),
                      id='func'),
     ])
     def H(self, request):
@@ -47,10 +47,9 @@ class TestMESolveDecay:
     @pytest.fixture(params=[
         pytest.param(np.sqrt(kappa) * a,
                      id='const'),
-        pytest.param(lambda t, args: (np.sqrt(args['kappa'])
-                                      * qutip.destroy(10)),
+        pytest.param(lambda t, kappa: (np.sqrt(kappa) * qutip.destroy(10)),
                      id='func'),
-        pytest.param([a, lambda t, args: np.sqrt(args['kappa'])],
+        pytest.param([a, lambda t, kappa: np.sqrt(kappa)],
                      id='list_func'),
         pytest.param([a, 'sqrt(kappa)'],
                      id='list_str'),
@@ -63,7 +62,7 @@ class TestMESolveDecay:
         return request.param
 
     @pytest.fixture(params=[
-        pytest.param([a, lambda t, args: np.sqrt(args['kappa'] * np.exp(-t))],
+        pytest.param([a, lambda t, kappa: np.sqrt(kappa * np.exp(-t))],
                   id='list_func'),
         pytest.param([a, 'sqrt(kappa * exp(-t))'],
                   id='list_str'),
@@ -72,9 +71,10 @@ class TestMESolveDecay:
         pytest.param(qutip.QobjEvo([a, 'sqrt(kappa * exp(-t))'],
                           args={'kappa': kappa}),
                   id='QobjEvo'),
-        pytest.param(lambda t, args: (np.sqrt(args['kappa'] * np.exp(-t)) *
-                                      qutip.destroy(10)),
-                     id='func'),
+        pytest.param(
+            lambda t, kappa: np.sqrt(kappa * np.exp(-t)) * qutip.destroy(10),
+            id='func'
+        ),
     ])
     def c_ops(self, request):
         return request.param
@@ -648,7 +648,7 @@ class TestMESolveStepFuncCoeff:
     # than multi-step methods (adams, qutip 4's default)
     options = {"method": "dop853", "nsteps": 1e8, "progress_bar": None}
 
-    def python_coeff(self, t, args):
+    def python_coeff(self, t):
         if t < np.pi/2:
             return 1.
         else:
@@ -890,7 +890,7 @@ class TestMESolveMatrixForm:
     def test_matrix_form_vs_superop_with_collapse(self):
         """
         Test matrix_form vs superop with collapse operators and various options.
-        
+
         This test exercises non-default solver options to ensure they are
         processed correctly by both solver forms.
         """

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -135,12 +135,12 @@ def _assert_functions_equal(f1, f2):
     np.testing.assert_allclose(values1, values2)
 
 
-def _return_constant(t, args):
-    return args['constant']
+def _return_constant(t, constant):
+    return constant
 
 
-def _return_decay(t, args):
-    return args['constant'] * np.exp(-args['rate'] * t)
+def _return_decay(t, constant, rate):
+    return constant * np.exp(-rate * t)
 
 
 class callable_qobj:
@@ -148,9 +148,9 @@ class callable_qobj:
         self.oper = oper
         self.coeff = coeff
 
-    def __call__(self, t, args):
+    def __call__(self, t, **args):
         if self.coeff is not None:
-            return self.oper * self.coeff(t, args)
+            return self.oper * self.coeff(t, **args)
         return self.oper
 
 
@@ -678,8 +678,8 @@ def test_NonMarkovianMCSolver_stepping():
 
 
 # Defined in module-scope so it's pickleable.
-def _dynamic(t, args):
-    return 0 if args["collapse"] else 1
+def _dynamic(t, collapse):
+    return 0 if collapse else 1
 
 
 @pytest.mark.xfail(reason="current limitation of NonMarkovianMCSolver")

--- a/qutip/tests/solver/test_propagator.py
+++ b/qutip/tests/solver/test_propagator.py
@@ -193,7 +193,7 @@ def testPropPiecewiseConst():
     H0 = qutip.sigmaz()
     H1 = qutip.sigmax()
 
-    def H_func(t, args):
+    def H_func(t):
         return H0 if t < 0.5 else H1
 
     U = propagator(H_func, 2, piecewise_t=[0.5])
@@ -204,7 +204,7 @@ def testPropPiecewiseConst():
 def testPropPiecewiseConstantH():
     H0 = qutip.sigmaz()
 
-    def H_func(t, args):
+    def H_func(t):
         return H0
 
     U = propagator(H_func, 2, piecewise_t=[0.5, 1.0])
@@ -217,7 +217,7 @@ def testPropPiecewiseSingleCop():
     H1 = qutip.sigmax()
     a = destroy(2)
 
-    def H_func(t, args):
+    def H_func(t):
         return H0 if t < 1.0 else H1
 
     U = propagator(H_func, 2, piecewise_t=[1.0], c_ops=a)
@@ -230,7 +230,7 @@ def testPropPiecewiseListCops():
     H1 = qutip.sigmax()
     a = destroy(2)
 
-    def H_func(t, args):
+    def H_func(t):
         return H0 if t < 0.75 else H1
 
     kappa = 0.1
@@ -249,7 +249,7 @@ def testPropPiecewiseSuperoperator():
     L0 = liouvillian(H0, [a])
     L1 = liouvillian(H1, [a])
 
-    def L_func(t, args):
+    def L_func(t):
         return L0 if t < 1.0 else L1
 
     U = propagator(L_func, 2, piecewise_t=[1.0])
@@ -264,7 +264,7 @@ def testPropPiecewiseMultipleTimes():
     H1 = qutip.sigmax()
     H2 = qutip.sigmay()
 
-    def H_func(t, args):
+    def H_func(t):
         if t < 0.5:
             return H0
         elif t < 1.5:
@@ -287,7 +287,7 @@ def testPropPiecewiseListOutput():
     H2 = qutip.sigmay()
     H3 = qutip.sigmaz() + qutip.sigmax()
 
-    def H_func(t, args):
+    def H_func(t):
         if t < 0.5:
             return H0
         elif t < 1.0:
@@ -311,11 +311,11 @@ def testPropPiecewiseBoundaryConsistency():
     H1 = qutip.sigmax()
 
     # Function with <= at boundary
-    def H_func_leq(t, args):
+    def H_func_leq(t):
         return H0 if t <= 1.0 else H1
 
     # Function with < at boundary
-    def H_func_lt(t, args):
+    def H_func_lt(t):
         return H0 if t < 1.0 else H1
 
     U_leq = propagator(H_func_leq, 2.0, piecewise_t=[1.0])
@@ -329,11 +329,11 @@ def testPropPiecewiseTimeDependentCops():
     H1 = qutip.sigmax()
     a = destroy(2)
 
-    def H_func(t, args):
+    def H_func(t):
         return H0 if t < 1.0 else H1
 
     # Time-dependent collapse operators (piecewise constant)
-    def c_func(t, args):
+    def c_func(t):
         kappa = 0.1 if t < 1.0 else 0.2
         return np.sqrt(kappa) * a
 
@@ -350,7 +350,7 @@ def testPropPiecewiseUniformGrid(n_points):
     H0 = qutip.sigmaz()
     H1 = qutip.sigmax()
 
-    def H_func(t, args):
+    def H_func(t):
         return H0 if t < 1.0 else H1
 
     tlist = np.linspace(0, 2.0, n_points)
@@ -369,7 +369,7 @@ def testPropPiecewiseCachingOptimization(n_points):
     """verify exponential caching reduces expm calls"""
     H0 = qutip.sigmaz()
 
-    def H_func(t, args):
+    def H_func(t):
         return H0
 
     original_expm = qutip.Qobj.expm

--- a/qutip/tests/solver/test_scattering.py
+++ b/qutip/tests/solver/test_scattering.py
@@ -32,9 +32,9 @@ class TestScattering:
         tlist = np.geomspace(gamma, 10 * gamma, 40) - gamma
         # Define TLS Hamiltonian
         H0S = w0 * create(2) * destroy(2)
-        H1S1 = lambda t, args: \
+        H1S1 = lambda t: \
             RabiFreq * 1j * np.exp(-1j * w0 * t) * (t < pulseLength)
-        H1S2 = lambda t, args: \
+        H1S2 = lambda t: \
             RabiFreq * -1j * np.exp(1j * w0 * t) * (t < pulseLength)
         Htls = [H0S, [sm.dag(), H1S1], [sm, H1S2]]
         # Run the test
@@ -59,9 +59,9 @@ class TestScattering:
         tlist = np.linspace(0, 1 / gamma, T)
         # Define TLS Hamiltonian
         H0S = w0 * create(2) * destroy(2)
-        H1S1 = lambda t, args: \
+        H1S1 = lambda t: \
             RabiFreq * 1j * np.exp(-1j * w0 * t) * (t < pulseLength)
-        H1S2 = lambda t, args: \
+        H1S2 = lambda t: \
             RabiFreq * -1j * np.exp(1j * w0 * t) * (t < pulseLength)
         Htls = [H0S, [sm.dag(), H1S1], [sm, H1S2]]
         # Run the test
@@ -82,7 +82,7 @@ class TestScattering:
         psi0 = basis(2, 0)
         tlist = np.geomspace(gamma, 10 * gamma, 40) - gamma
         # Define TLS Hamiltonian with rotating frame transformation
-        Htls = [[sm.dag() + sm, lambda t, args: RabiFreq * (t < pulseLength)]]
+        Htls = [[sm.dag() + sm, lambda t: RabiFreq * (t < pulseLength)]]
         # Run the test
         c_ops = [sm]
         c_ops_split = [sm / np.sqrt(2), sm / np.sqrt(2)]

--- a/qutip/tests/solver/test_sesolve.py
+++ b/qutip/tests/solver/test_sesolve.py
@@ -37,7 +37,7 @@ class TestSeSolve():
         pytest.param(lambda t, alpha: (np.pi * qutip.sigmax()
                                        * np.exp(-alpha * t)),
                      _analytic, id='func_H'),
-        pytest.param([[H1, lambda t, args: np.exp(-args['alpha'] * t)]],
+        pytest.param([[H1, lambda t, alpha: np.exp(-alpha * t)]],
                      _analytic, id='list_func_H'),
         pytest.param([[H1, 'exp(-alpha*t)']],
                      _analytic, id='list_str_H'),
@@ -166,8 +166,8 @@ class TestSeSolve():
              np.cos(w_a * t) * np.pi * qutip.sigmax()
          ), {'a':a, 'w_a':w_a}, id='func_H'),
          pytest.param([
-             [H0, lambda t, args: args['a']*t],
-             [H1, lambda t, args: np.cos(args['w_a']*t)]
+             [H0, lambda t, a: a * t],
+             [H1, lambda t, w_a: np.cos(w_a * t)]
          ], {'a':a, 'w_a':w_a}, id='list_func_H'),
          pytest.param([H0, [H1, 'cos(w_a*t)']], {'w_a':w_a}, id='list_str_H'),
     ])

--- a/qutip/tests/solver/test_steadystate.py
+++ b/qutip/tests/solver/test_steadystate.py
@@ -223,7 +223,7 @@ def test_steadystate_fourier(sparse):
 
     H = 0.5 * w_c * sz
 
-    H_t = [H, [sx, lambda t, args: args["A_l"] * np.cos(args["w_l"] * t)]]
+    H_t = [H, [sx, lambda t, **args: args["A_l"] * np.cos(args["w_l"] * t)]]
 
     psi0 = qutip.basis(2, 0)
 


### PR DESCRIPTION
**Description**
Add deprecation warnings for the old coefficient function format `f(t, args)`.
Also remove it's usage from test and documentation.

It's still used in tutorial so we will need to update those.