### PR TITLE
Improve test tolerance to lower random failures rate

### DIFF
--- a/qutip/tests/core/test_eigenstates.py
+++ b/qutip/tests/core/test_eigenstates.py
@@ -78,7 +78,7 @@ def random_hamiltonian(request):
     eigen = None
     dist = "fill"
     if dimensions == [3, 3, 3]:
-        eigen = [0, 1, 1] * 9
+        eigen = [1, 2, 3] * 9
         dist = "eigen"
     return qutip.rand_herm(dimensions, distribution=dist, eigenvalues=eigen)
 

--- a/qutip/tests/solver/test_stochastic.py
+++ b/qutip/tests/solver/test_stochastic.py
@@ -464,7 +464,7 @@ def test_run_from_experiment_open(method, heterodyne):
     a = destroy(N)
     sc_ops = [a, a.dag() * 0.1]
     psi0 = basis(N, N-1)
-    tlist = np.linspace(0, 1, 251)
+    tlist = np.linspace(0, 0.5, 501)
     options = {
         "store_measurement": "start",
         "dt": tlist[1],

--- a/qutip/tests/test_utilities.py
+++ b/qutip/tests/test_utilities.py
@@ -125,25 +125,29 @@ def test_cpu_count(monkeypatch):
 
 def test_zeta():
     mpmath = pytest.importorskip("mpmath")
-    N = 100
+    N = 50
     s_list = np.random.rand(N) + 1.0001
     # could randomly fail if q is an integer <=0
-    q_list = (np.random.rand(N) - 0.5) * 10
+    q_list = (np.random.rand(N) + 0.05) * 10
     for s, q in zip(s_list, q_list):
-        assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-14)
+        assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-12)
 
-    s_list = np.random.rand(N) + 1.0001
+    q_list = (np.random.rand(N) * 0.9 - .95 - np.random.randint(10))
+    for s, q in zip(s_list, q_list):
+        assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-12)
+
+    s_list = np.random.rand(N) + 1.001
     q_list = (np.random.rand(N) - 0.5) * 10 + np.random.randn(N) * 10j
     for s, q in zip(s_list, q_list):
-        assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-14)
+        assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-12)
 
     s_list = (
         1 + (np.random.lognormal(size=N) + 1e-6)
-        * np.exp((np.random.rand(N) - 0.5) * 1j * np.pi)
+        * np.exp((np.random.rand(N) * 0.8 - 0.4) * 1j * np.pi)
     )  # Real part > 1.000001
-    q_list = (np.random.rand(N) - 0.5) * 10 + np.random.randn(N) * 10j
+    q_list = (np.random.rand(N) + 0.1) * 10 + np.random.randn(N) * 10j
     for s, q in zip(s_list, q_list):
-        assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-14)
+        assert utils.zeta(s, q) == pytest.approx(mpmath.zeta(s, q), rel=1e-12)
 
 
 class TestFitting:


### PR DESCRIPTION
**Description**
Improve test tolerances to reduce random failures in tests:
- `test_satisfy_eigenvalue_equation`: The sparse solver had trouble converging on degenerate `0` Eigenvalues.
  The error could happen with `scipy.sparse.linalg.eigh` directly, with it not finding the desired eigenvalues or error around 1e-6 instead of machine precision. 
  Avoiding `0` eigenvalues avoid the issue.
- `test_run_from_experiment_open`: decrease the step length make it stable enough for the tests. The error is of order `dt` and can accumulate quickly.
- `test_fsesolve_fallback`: Not fixed, unable to reproduce the error...
- `test_zeta`: I tested it more than in the original PR and 1e-14 tolerance was too tight. I loosened the tolerance and also keep input farther from hard to converge cases.

fix #2876
