### PR TITLE
Bug.pip in test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,11 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           channels: ${{ matrix.condaforge == 1 && 'conda-forge' || 'defaults' }}
-        run: conda install pip
+
+      - name: Install pip
+        if: matrix.os != 'windows-11-arm'
+        shell: bash -l {0}
+        run: conda install pip -y -n test
 
       # TODO remove this once conda supports windows arm
       - uses: actions/setup-python@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,6 +140,7 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           channels: ${{ matrix.condaforge == 1 && 'conda-forge' || 'defaults' }}
+        run: conda install pip
 
       # TODO remove this once conda supports windows arm
       - uses: actions/setup-python@v6
@@ -185,7 +186,7 @@ jobs:
             conda install --channel conda-forge "openmpi>=5.0" mpi4py
           fi
           if [[ "${{ matrix.oldcython }}" ]]; then
-            python -m pip install cython==0.29.36 filelock matplotlib==3.5
+            python -m pip install cython==0.29.36 filelock matplotlib==3.6
           else
             python -m pip install cython filelock
           fi


### PR DESCRIPTION
**Description**
Use conda to install pip in case it's not available with setup-miniconda by default.

Also increased the oldest matplotlib version to match the one we officially support now that we don't support python 3.10.
