### PR TITLE
Update github action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,9 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           # For the sdist we should be as conservative as possible with our
@@ -90,7 +90,7 @@ jobs:
           zip "$zipfile" -r "$stem"
           rm -r "$stem"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: |
@@ -117,9 +117,9 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           # This is about the build environment, not the released wheel version.
@@ -139,7 +139,7 @@ jobs:
           if [[ ! -z "$OVERRIDE_VERSION" ]]; then echo "$OVERRIDE_VERSION" > VERSION; fi
           python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
@@ -155,7 +155,7 @@ jobs:
 
     steps:
       - name: Download build artifacts to local runner
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: wheels
           merge-multiple: true
@@ -169,7 +169,7 @@ jobs:
           if ! ls wheels/*.tar.gz 1> /dev/null 2>&1; then exit 1; fi
           if ! ls wheels/*.zip 1> /dev/null 2>&1; then exit 1; fi
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           python-version: '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
             pytest-extra-options: "-W ignore:dep_util:DeprecationWarning -W \"ignore:The 'renderer' parameter of do_3d_projection\""
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: conda-incubator/setup-miniconda@v3
         if: matrix.os != 'windows-11-arm'
         # Currently miniconda doesn't support window-11 arms
@@ -296,7 +296,7 @@ jobs:
     name: Verify Towncrier entry added
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,7 +133,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         if: matrix.os != 'windows-11-arm'
         # Currently miniconda doesn't support window-11 arms
         with:

--- a/.github/workflows/tests_env.yml
+++ b/.github/workflows/tests_env.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: 3.11

--- a/.github/workflows/tests_env.yml
+++ b/.github/workflows/tests_env.yml
@@ -25,7 +25,7 @@ jobs:
         repo: [qutip-qip, qutip-jax, qutip-qoc, qutip-qtrl]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true


### PR DESCRIPTION
**Description**
Update major Github action from v4 to v6 and for artifact to v7. v4 actions running on Node 20 which has completed its EOL and won't be supported by Github anymore.

**Related issues or PRs**
None

**AI Tools Usage Disclosure**
None
