### PR TITLE
Non-hermitian matrix mesolve

### DIFF
--- a/doc/changes/2898.feature
+++ b/doc/changes/2898.feature
@@ -1,0 +1,1 @@
+Allow the matrix-form ``mesolve`` (``options={"matrix_form": True}``) to evolve non-Hermitian initial states such as transition matrices ``|i><j|``.

--- a/doc/guide/dynamics/dynamics-master.rst
+++ b/doc/guide/dynamics/dynamics-master.rst
@@ -347,8 +347,3 @@ Or when using :class:`.MESolver` directly:
 The matrix-form solver supports all the same features as the standard solver,
 including time-dependent Hamiltonians and collapse operators, expectation value
 feedback, and most available ODE integrators.
-
-.. note::
-
-   The matrix-form solver requires the input state to be a Hermitian density
-   matrix.

--- a/qutip/core/cy/lindblad_matrix_form.pxd
+++ b/qutip/core/cy/lindblad_matrix_form.pxd
@@ -10,7 +10,7 @@ cdef class LindbladMatrixForm(QobjEvo):
     # When True, exploit Hermiticity of rho to halve the matmul work
     # (drho/dt = A + A.dag()).  When False, compute the full RHS so the
     # solver can handle non-Hermitian states such as |i><j|.
-    cdef public bint assume_hermitian
+    cdef public bint assume_hermitian_state
 
     # Pre-allocated temporary buffer
     cdef Dense _temp_buffer

--- a/qutip/core/cy/lindblad_matrix_form.pxd
+++ b/qutip/core/cy/lindblad_matrix_form.pxd
@@ -7,6 +7,10 @@ cdef class LindbladMatrixForm(QobjEvo):
     cdef public QobjEvo H_nh
     cdef public list c_ops
     cdef public int num_collapse
+    # When True, exploit Hermiticity of rho to halve the matmul work
+    # (drho/dt = A + A.dag()).  When False, compute the full RHS so the
+    # solver can handle non-Hermitian states such as |i><j|.
+    cdef public bint assume_hermitian
 
     # Pre-allocated temporary buffer
     cdef Dense _temp_buffer

--- a/qutip/core/cy/lindblad_matrix_form.pxd
+++ b/qutip/core/cy/lindblad_matrix_form.pxd
@@ -7,9 +7,6 @@ cdef class LindbladMatrixForm(QobjEvo):
     cdef public QobjEvo H_nh
     cdef public list c_ops
     cdef public int num_collapse
-    # When True, exploit Hermiticity of rho to halve the matmul work
-    # (drho/dt = A + A.dag()).  When False, compute the full RHS so the
-    # solver can handle non-Hermitian states such as |i><j|.
     cdef public bint assume_hermitian_state
 
     # Pre-allocated temporary buffer

--- a/qutip/core/cy/lindblad_matrix_form.pyx
+++ b/qutip/core/cy/lindblad_matrix_form.pyx
@@ -56,7 +56,7 @@ cdef class LindbladMatrixForm(QobjEvo):
         Shape of operators (n, n)
     """
 
-    def __init__(self, H, c_ops, *, _H_nh=None):
+    def __init__(self, H, c_ops, *, assume_hermitian=True, _H_nh=None):
         """
         Initialize matrix-form Lindblad system.
 
@@ -66,6 +66,11 @@ cdef class LindbladMatrixForm(QobjEvo):
             Hamiltonian
         c_ops : list of QobjEvo
             Collapse operators
+        assume_hermitian : bool, optional
+            When True (default), the integrand assumes the state ``rho``
+            passed to :meth:`matmul_data` is Hermitian and halves the work
+            by computing ``A + A.dag()``.  Set to False to evolve
+            non-Hermitian states such as transition matrices ``|i><j|``.
         _H_nh : QobjEvo, optional
             Pre-computed non-Hermitian Hamiltonian. If provided, skips the
             H_nh computation. This is used internally for pickling.
@@ -79,6 +84,7 @@ cdef class LindbladMatrixForm(QobjEvo):
 
         self.c_ops = list(c_ops) if c_ops else []
         self.num_collapse = len(self.c_ops)
+        self.assume_hermitian = assume_hermitian
 
         # Use pre-computed H_nh if provided (e.g., from unpickling)
         if _H_nh is not None:
@@ -101,13 +107,21 @@ cdef class LindbladMatrixForm(QobjEvo):
         """
         Compute ``out += scale * L[rho]`` where L is the Lindblad superoperator.
 
-        Exploits Hermiticity of rho to compute A + A.dag() where:
+        When ``self.assume_hermitian`` is True, exploits Hermiticity of rho
+        by computing A + A.dag() where:
 
         .. math::
 
             A = -i H_{nh} \\rho + \\frac{1}{2} \\sum_i c_i \\rho c_i^\\dagger
 
-        and H_nh = H - (i/2) sum(c_i^dag c_i).
+        Otherwise computes the full RHS:
+
+        .. math::
+
+            \\frac{d\\rho}{dt} = -i (H_{nh} \\rho - \\rho H_{nh}^\\dagger)
+            + \\sum_i c_i \\rho c_i^\\dagger
+
+        with H_nh = H - (i/2) sum(c_i^dag c_i).
 
         Parameters
         ----------
@@ -128,6 +142,8 @@ cdef class LindbladMatrixForm(QobjEvo):
         cdef Dense rho_dense, out_dense, temp_dense
         cdef int i
         cdef int n = rho.shape[0]
+        cdef double complex c_scale
+        cdef QobjEvo c_op
 
         if type(rho) is not Dense:
             raise TypeError(
@@ -152,22 +168,37 @@ cdef class LindbladMatrixForm(QobjEvo):
         temp_dense = <Dense>self._temp_buffer
         temp_dense.fortran = rho_dense.fortran
 
-        # Compute A = -i H_nh @ rho + 0.5 sum(L @ rho @ Ld)
-        # Then drho/dt = A + A.dag()
+        if self.assume_hermitian:
+            # Compute A = -i H_nh @ rho + 0.5 sum(L @ rho @ Ld)
+            # Then drho/dt = A + A.dag()
+            c_scale = 0.5 * scale
 
-        # -i * scale * H_nh @ rho
-        out_dense = self.H_nh.matmul_data(t, rho_dense, out_dense, -1j * scale)
+            # -i * scale * H_nh @ rho
+            out_dense = self.H_nh.matmul_data(t, rho_dense, out_dense,
+                                              -1j * scale)
 
-        # +0.5 * scale * sum(L @ rho @ Ld)
-        cdef QobjEvo c_op
-        for i in range(self.num_collapse):
-            c_op = <QobjEvo>self.c_ops[i]
-            temp_dense = imul_dense(temp_dense, 0)
-            temp_dense = c_op.matmul_data(t, rho_dense, temp_dense, 0.5 * scale)
-            out_dense = c_op.adjoint_rmatmul_data(t, temp_dense, out_dense)
+            # +0.5 * scale * sum(L @ rho @ Ld)
+            for i in range(self.num_collapse):
+                c_op = <QobjEvo>self.c_ops[i]
+                temp_dense = imul_dense(temp_dense, 0)
+                temp_dense = c_op.matmul_data(t, rho_dense, temp_dense, c_scale)
+                out_dense = c_op.adjoint_rmatmul_data(t, temp_dense, out_dense)
 
-        # Add Hermitian conjugate: out += out.dag()
-        out_dense = iadd_adjoint_dense(out_dense, temp_dense)
+            # Add Hermitian conjugate: out += out.dag()
+            out_dense = iadd_adjoint_dense(out_dense, temp_dense)
+        else:
+            # Full non-Hermitian RHS:
+            # -i scale (H_nh @ rho - rho @ H_nh.dag()) + scale sum(L @ rho @ Ld)
+            out_dense = self.H_nh.matmul_data(t, rho_dense, out_dense,
+                                              -1j * scale)
+            out_dense = self.H_nh.adjoint_rmatmul_data(t, rho_dense, out_dense,
+                                                       1j * scale)
+
+            for i in range(self.num_collapse):
+                c_op = <QobjEvo>self.c_ops[i]
+                temp_dense = imul_dense(temp_dense, 0)
+                temp_dense = c_op.matmul_data(t, rho_dense, temp_dense, scale)
+                out_dense = c_op.adjoint_rmatmul_data(t, temp_dense, out_dense)
 
         return out_dense
 
@@ -221,7 +252,9 @@ cdef class LindbladMatrixForm(QobjEvo):
         recomputing it on unpickle.
         """
         return (
-            partial(LindbladMatrixForm, _H_nh=self.H_nh),
+            partial(LindbladMatrixForm,
+                    assume_hermitian=self.assume_hermitian,
+                    _H_nh=self.H_nh),
             (self.H_nh, self.c_ops)
         )
 

--- a/qutip/core/cy/lindblad_matrix_form.pyx
+++ b/qutip/core/cy/lindblad_matrix_form.pyx
@@ -56,7 +56,7 @@ cdef class LindbladMatrixForm(QobjEvo):
         Shape of operators (n, n)
     """
 
-    def __init__(self, H, c_ops, *, assume_hermitian=True, _H_nh=None):
+    def __init__(self, H, c_ops, *, assume_hermitian_state=True, _H_nh=None):
         """
         Initialize matrix-form Lindblad system.
 
@@ -66,7 +66,7 @@ cdef class LindbladMatrixForm(QobjEvo):
             Hamiltonian
         c_ops : list of QobjEvo
             Collapse operators
-        assume_hermitian : bool, optional
+        assume_hermitian_state : bool, optional
             When True (default), the integrand assumes the state ``rho``
             passed to :meth:`matmul_data` is Hermitian and halves the work
             by computing ``A + A.dag()``.  Set to False to evolve
@@ -84,7 +84,7 @@ cdef class LindbladMatrixForm(QobjEvo):
 
         self.c_ops = list(c_ops) if c_ops else []
         self.num_collapse = len(self.c_ops)
-        self.assume_hermitian = assume_hermitian
+        self.assume_hermitian_state = assume_hermitian_state
 
         # Use pre-computed H_nh if provided (e.g., from unpickling)
         if _H_nh is not None:
@@ -107,7 +107,7 @@ cdef class LindbladMatrixForm(QobjEvo):
         """
         Compute ``out += scale * L[rho]`` where L is the Lindblad superoperator.
 
-        When ``self.assume_hermitian`` is True, exploits Hermiticity of rho
+        When ``self.assume_hermitian_state`` is True, exploits Hermiticity of rho
         by computing A + A.dag() where:
 
         .. math::
@@ -168,7 +168,7 @@ cdef class LindbladMatrixForm(QobjEvo):
         temp_dense = <Dense>self._temp_buffer
         temp_dense.fortran = rho_dense.fortran
 
-        if self.assume_hermitian:
+        if self.assume_hermitian_state:
             # Compute A = -i H_nh @ rho + 0.5 sum(L @ rho @ Ld)
             # Then drho/dt = A + A.dag()
             c_scale = 0.5 * scale
@@ -253,7 +253,7 @@ cdef class LindbladMatrixForm(QobjEvo):
         """
         return (
             partial(LindbladMatrixForm,
-                    assume_hermitian=self.assume_hermitian,
+                    assume_hermitian_state=self.assume_hermitian_state,
                     _H_nh=self.H_nh),
             (self.H_nh, self.c_ops)
         )

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -252,12 +252,12 @@ class MESolver(SESolver):
         Solver.__init__(self, rhs, options=options)
 
     def _prepare_state(self, state):
-        # Kets skip this check: ket2dm (in super) always produces a
-        # Hermitian dm.  Only explicit dm inputs need validation.
-        if not self._vectorize_state and state.isoper and not state.isherm:
-            raise ValueError(
-                "matrix_form=True requires a Hermitian density matrix"
-            )
+        # In matrix_form mode the integrand has a fast path that assumes rho
+        # is Hermitian (drho/dt = A + A.dag()).  Kets always become a
+        # Hermitian dm via ket2dm, so only explicit dm inputs can deviate;
+        # detect that and switch the integrand to the full-RHS branch.
+        if not self._vectorize_state and state.isoper:
+            self.rhs.assume_hermitian = bool(state.isherm)
         return super()._prepare_state(state)
 
     def _initialize_stats(self):

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -257,7 +257,7 @@ class MESolver(SESolver):
         # Hermitian dm via ket2dm, so only explicit dm inputs can deviate;
         # detect that and switch the integrand to the full-RHS branch.
         if not self._vectorize_state and state.isoper:
-            self.rhs.assume_hermitian = state.isherm
+            self.rhs.assume_hermitian_state = state.isherm
         return super()._prepare_state(state)
 
     def _initialize_stats(self):

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -257,7 +257,7 @@ class MESolver(SESolver):
         # Hermitian dm via ket2dm, so only explicit dm inputs can deviate;
         # detect that and switch the integrand to the full-RHS branch.
         if not self._vectorize_state and state.isoper:
-            self.rhs.assume_hermitian = bool(state.isherm)
+            self.rhs.assume_hermitian = state.isherm
         return super()._prepare_state(state)
 
     def _initialize_stats(self):

--- a/qutip/tests/solver/test_lindblad_matrix_form.py
+++ b/qutip/tests/solver/test_lindblad_matrix_form.py
@@ -135,3 +135,79 @@ class TestLindbladMatrixFormProperties:
                 drho_matrix_qobj.full(), drho_super.full(), atol=1e-10,
                 err_msg=f"Failed at t={t}",
             )
+
+    @pytest.mark.parametrize("case", [
+        pytest.param({
+            'N': 6,
+            'H': qutip.num(6),
+            'c_ops': [np.sqrt(0.1) * qutip.destroy(6)],
+        }, id='simple_decay'),
+        pytest.param({
+            'N': 6,
+            'H': [qutip.num(6),
+                  [qutip.create(6) + qutip.destroy(6), 'cos(t)']],
+            'c_ops': [np.sqrt(0.05) * qutip.destroy(6)],
+        }, id='driven_system'),
+        pytest.param({
+            'N': 5,
+            'H': qutip.rand_herm(5, seed=11),
+            'c_ops': [
+                np.sqrt(0.1) * qutip.destroy(5),
+                np.sqrt(0.05) * qutip.create(5),
+            ],
+        }, id='multiple_collapse'),
+    ])
+    def test_lindblad_matrix_form_non_hermitian_rho(self, case):
+        """
+        Non-Hermitian rho (e.g. transition matrix |i><j|) must agree with
+        the Liouvillian superoperator when assume_hermitian=False.
+        """
+        N = case['N']
+        H = case['H']
+        c_ops = case['c_ops']
+
+        # |0><N-1| — explicitly non-Hermitian
+        rho0 = qutip.basis(N, 0) * qutip.basis(N, N - 1).dag()
+        rho_dense = dense.Dense(rho0.data.to_array(), copy=False)
+        rho_vec = qutip.operator_to_vector(rho0)
+
+        rhs_matrix = LindbladMatrixForm(
+            QobjEvo(H), [QobjEvo(c) for c in c_ops],
+            assume_hermitian=False,
+        )
+        L = qutip.liouvillian(QobjEvo(H), [QobjEvo(c) for c in c_ops])
+
+        for t in [0.0, 0.5, 1.0, 2.0]:
+            drho_matrix = rhs_matrix.matmul_data(t, rho_dense)
+
+            drho_super_vec = L(t) * rho_vec
+            drho_super = qutip.vector_to_operator(drho_super_vec)
+
+            assert_allclose(
+                drho_matrix.to_array(), drho_super.full(), atol=1e-10,
+                err_msg=f"Failed at t={t}",
+            )
+
+    def test_assume_hermitian_default_rejects_nonhermitian(self):
+        """
+        With the default assume_hermitian=True, the integrand returns a
+        Hermitian-symmetrized result, which is *wrong* for a non-Hermitian
+        rho.  This test pins down that mismatch so the flag is required to
+        opt in to non-Hermitian evolution.
+        """
+        N = 4
+        H = qutip.num(N)
+        c_ops = [np.sqrt(0.1) * qutip.destroy(N)]
+        rho0 = qutip.basis(N, 0) * qutip.basis(N, 1).dag()
+        rho_dense = dense.Dense(rho0.data.to_array(), copy=False)
+        rho_vec = qutip.operator_to_vector(rho0)
+
+        rhs_default = LindbladMatrixForm(
+            QobjEvo(H), [QobjEvo(c) for c in c_ops]
+        )
+        L = qutip.liouvillian(QobjEvo(H), [QobjEvo(c) for c in c_ops])
+
+        drho_default = rhs_default.matmul_data(0.0, rho_dense).to_array()
+        drho_super = qutip.vector_to_operator(L(0.0) * rho_vec).full()
+        # Default branch (assumes Hermitian rho) must NOT match for |0><1|
+        assert not np.allclose(drho_default, drho_super, atol=1e-10)

--- a/qutip/tests/solver/test_lindblad_matrix_form.py
+++ b/qutip/tests/solver/test_lindblad_matrix_form.py
@@ -143,7 +143,7 @@ class TestLindbladMatrixFormProperties:
     def test_lindblad_matrix_form_non_hermitian_rho(self, case):
         """
         Non-Hermitian rho (e.g. transition matrix |i><j|) must agree with
-        the Liouvillian superoperator when assume_hermitian=False.
+        the Liouvillian superoperator when assume_hermitian_state=False.
         """
         N = case['N']
         H = case['H']
@@ -156,7 +156,7 @@ class TestLindbladMatrixFormProperties:
 
         rhs_matrix = LindbladMatrixForm(
             QobjEvo(H), [QobjEvo(c) for c in c_ops],
-            assume_hermitian=False,
+            assume_hermitian_state=False,
         )
         L = qutip.liouvillian(QobjEvo(H), [QobjEvo(c) for c in c_ops])
 

--- a/qutip/tests/solver/test_lindblad_matrix_form.py
+++ b/qutip/tests/solver/test_lindblad_matrix_form.py
@@ -68,39 +68,42 @@ class TestLindbladMatrixFormInit:
             assert H_nh_actual == H_nh_expected
 
 
+_LINDBLAD_CASES = [
+    pytest.param({
+        'N': 10,
+        'H': qutip.num(10),
+        'c_ops': [np.sqrt(0.1) * qutip.destroy(10)],
+    }, id='simple_decay'),
+    pytest.param({
+        'N': 8,
+        'H': [qutip.num(8),
+              [qutip.create(8) + qutip.destroy(8), 'cos(t)']],
+        'c_ops': [np.sqrt(0.05) * qutip.destroy(8)],
+    }, id='driven_system'),
+    pytest.param({
+        'N': 6,
+        'H': qutip.rand_herm(6, seed=42),
+        'c_ops': [
+            np.sqrt(0.1) * qutip.destroy(6),
+            np.sqrt(0.05) * qutip.create(6),
+            np.sqrt(0.02) * qutip.qeye(6),
+        ],
+    }, id='multiple_collapse'),
+    pytest.param({
+        'N': 8,
+        'H': qutip.num(8),
+        'c_ops': [[np.sqrt(0.1) * qutip.destroy(8), 'exp(-0.1*t)']],
+    }, id='time_dependent_collapse'),
+]
+
+
 class TestLindbladMatrixFormProperties:
     """
     Property tests for LindbladMatrixForm correctness with different
     operator types.
     """
 
-    @pytest.mark.parametrize("case", [
-        pytest.param({
-            'N': 10,
-            'H': qutip.num(10),
-            'c_ops': [np.sqrt(0.1) * qutip.destroy(10)],
-        }, id='simple_decay'),
-        pytest.param({
-            'N': 8,
-            'H': [qutip.num(8),
-                  [qutip.create(8) + qutip.destroy(8), 'cos(t)']],
-            'c_ops': [np.sqrt(0.05) * qutip.destroy(8)],
-        }, id='driven_system'),
-        pytest.param({
-            'N': 6,
-            'H': qutip.rand_herm(6, seed=42),
-            'c_ops': [
-                np.sqrt(0.1) * qutip.destroy(6),
-                np.sqrt(0.05) * qutip.create(6),
-                np.sqrt(0.02) * qutip.qeye(6),
-            ],
-        }, id='multiple_collapse'),
-        pytest.param({
-            'N': 8,
-            'H': qutip.num(8),
-            'c_ops': [[np.sqrt(0.1) * qutip.destroy(8), 'exp(-0.1*t)']],
-        }, id='time_dependent_collapse'),
-    ])
+    @pytest.mark.parametrize("case", _LINDBLAD_CASES)
     def test_lindblad_matrix_form_vs_superoperator(self, case):
         """
         Compare LindbladMatrixForm against time-dependent Liouvillian
@@ -136,27 +139,7 @@ class TestLindbladMatrixFormProperties:
                 err_msg=f"Failed at t={t}",
             )
 
-    @pytest.mark.parametrize("case", [
-        pytest.param({
-            'N': 6,
-            'H': qutip.num(6),
-            'c_ops': [np.sqrt(0.1) * qutip.destroy(6)],
-        }, id='simple_decay'),
-        pytest.param({
-            'N': 6,
-            'H': [qutip.num(6),
-                  [qutip.create(6) + qutip.destroy(6), 'cos(t)']],
-            'c_ops': [np.sqrt(0.05) * qutip.destroy(6)],
-        }, id='driven_system'),
-        pytest.param({
-            'N': 5,
-            'H': qutip.rand_herm(5, seed=11),
-            'c_ops': [
-                np.sqrt(0.1) * qutip.destroy(5),
-                np.sqrt(0.05) * qutip.create(5),
-            ],
-        }, id='multiple_collapse'),
-    ])
+    @pytest.mark.parametrize("case", _LINDBLAD_CASES)
     def test_lindblad_matrix_form_non_hermitian_rho(self, case):
         """
         Non-Hermitian rho (e.g. transition matrix |i><j|) must agree with
@@ -187,27 +170,3 @@ class TestLindbladMatrixFormProperties:
                 drho_matrix.to_array(), drho_super.full(), atol=1e-10,
                 err_msg=f"Failed at t={t}",
             )
-
-    def test_assume_hermitian_default_rejects_nonhermitian(self):
-        """
-        With the default assume_hermitian=True, the integrand returns a
-        Hermitian-symmetrized result, which is *wrong* for a non-Hermitian
-        rho.  This test pins down that mismatch so the flag is required to
-        opt in to non-Hermitian evolution.
-        """
-        N = 4
-        H = qutip.num(N)
-        c_ops = [np.sqrt(0.1) * qutip.destroy(N)]
-        rho0 = qutip.basis(N, 0) * qutip.basis(N, 1).dag()
-        rho_dense = dense.Dense(rho0.data.to_array(), copy=False)
-        rho_vec = qutip.operator_to_vector(rho0)
-
-        rhs_default = LindbladMatrixForm(
-            QobjEvo(H), [QobjEvo(c) for c in c_ops]
-        )
-        L = qutip.liouvillian(QobjEvo(H), [QobjEvo(c) for c in c_ops])
-
-        drho_default = rhs_default.matmul_data(0.0, rho_dense).to_array()
-        drho_super = qutip.vector_to_operator(L(0.0) * rho_vec).full()
-        # Default branch (assumes Hermitian rho) must NOT match for |0><1|
-        assert not np.allclose(drho_default, drho_super, atol=1e-10)

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -177,6 +177,28 @@ class TestMESolveDecay:
                                      (1.0 - np.exp(-self.tlist)))
         np.testing.assert_allclose(actual_answer, expt, atol=me_error)
 
+    def testME_NonHermRho_matrix_form(self):
+        "mesolve: matrix_form solver evolves a non-Hermitian transition matrix"
+        # rho0 = |0><1| — explicitly non-Hermitian
+        rho0 = (qutip.basis(self.N, 0)
+                * qutip.basis(self.N, 1).dag())
+        H = self.ada
+        c_op_list = [np.sqrt(self.kappa) * self.a]
+
+        tlist = np.linspace(0, 5, 51)
+        options_super = {"progress_bar": None, "matrix_form": False}
+        options_matrix = {"progress_bar": None, "matrix_form": True}
+
+        out_super = mesolve(H, rho0, tlist, c_op_list,
+                            options=options_super)
+        out_matrix = mesolve(H, rho0, tlist, c_op_list,
+                             options=options_matrix)
+
+        for s_super, s_matrix in zip(out_super.states, out_matrix.states):
+            np.testing.assert_allclose(
+                s_matrix.full(), s_super.full(), atol=1e-7,
+            )
+
     def testME_TDH_longTDDecay(self, H, c_ops):
         "mesolve: time-dependence as function list"
         me_error = 2e-5


### PR DESCRIPTION
**Description**
Adds a path through the matrix-form ME solver for non-hermitian "states", for use when computing process matrices and such.

**Related issues or PRs**
Following up on #2811.

**AI Tools Usage Disclosure**
Claude Code with Opus 4.7 was used to plan, implement, test, and review this PR under human guidance and with additional human review.
