### PR TITLE
Fix Pauli Y sign in to_chi basis

### DIFF
--- a/qutip/core/superop_reps.py
+++ b/qutip/core/superop_reps.py
@@ -33,7 +33,7 @@ from ..typing import DimensionLike
 _SINGLE_QUBIT_PAULI_BASIS = (
     identity(2).to(_data.CSR),
     sigmax().to(_data.CSR),
-    sigmay().to(_data.CSR),
+    (-sigmay()).to(_data.CSR),
     sigmaz().to(_data.CSR),
 )
 
@@ -53,7 +53,7 @@ def _superpauli_basis(nq=1):
         basis = paulis[0].data
         for pauli in paulis[1:]:
             basis = _data.kron_csr(basis, pauli.data)
-        basis_ket_sci = _data.column_stack_csr(basis).transpose().as_scipy()
+        basis_ket_sci = _data.column_stack_csr(basis).adjoint().as_scipy()
         sci.data[ptr : ptr+ptr_inc] = basis_ket_sci.data
         sci.indices[ptr : ptr+ptr_inc] = basis_ket_sci.indices
         sci.indptr[i] = ptr

--- a/qutip/tests/core/test_superop_reps.py
+++ b/qutip/tests/core/test_superop_reps.py
@@ -114,6 +114,18 @@ class TestSuperopReps:
         with pytest.raises(ValueError, match="must be a square."):
             superpauli_to_super(non_square)
 
+
+
+    def test_superpauli_basis_uses_positive_y_column(self):
+        """
+        Superoperator: Check that the Pauli basis contains the usual Y
+        operator, not its complex conjugate.
+        """
+        y_ket = operator_to_vector(sigmay()).full().ravel()
+        y_column = to_superpauli(sprepost(sigmay(), identity(2))).full()
+
+        np.testing.assert_allclose(y_column[:, 2], y_ket, atol=1e-12)
+
     def test_SuperChoiSuper(self, superoperator):
         """
         Superoperator: Converting superoperator to Choi matrix and back.


### PR DESCRIPTION
This fixes the Pauli-Y sign convention used when building the super-Pauli basis for chi and Pauli-transfer conversions. The basis now keeps the usual Y orientation rather than its complex conjugate, and a focused regression test checks that the Y column matches the vectorized Pauli-Y operator. Verification was attempted with `python3 -m pytest qutip/tests/core/test_superop_reps.py -q -k positive_y_column`; it currently cannot run in this checkout because the local C extension module `qutip.core.data._local_matmul` is not built, and `python3 setup.py build_ext --inplace` is blocked by the installed setuptools validation of the repository's existing license metadata.