### PR TITLE
Use x86 wheels in build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Verify this is not a dev version
         shell: bash
         run: |
-          python -m pip install wheels/*-cp311-cp311-manylinux*.whl
+          python -m pip install wheels/*-cp311-cp311-manylinux*_x86_64.whl
           python -c 'import qutip; print(qutip.__version__); assert "dev" not in qutip.__version__; assert "+" not in qutip.__version__'
 
       # We built the zipfile for convenience distributing to Windows users on


### PR DESCRIPTION
**Description**
The build action fails trying to install the `aarch64` wheels to confirm the version instead of the `x86` one...

Same commit as #2909 for the release branch.