### PR TITLE
Improve test tolerance to lower random failures rate [part 2]

### DIFF
--- a/doc/changes/2913.misc
+++ b/doc/changes/2913.misc
@@ -1,1 +1,1 @@
-Making initial kets generation safer against very small values in order to make Floquet solver tests with randomization more stable.
+Tightens the absolute tolerance of ``sesolve`` by one order of magnitude in order to make Floquet solver tests with randomized inputs more robust.

--- a/doc/changes/2913.misc
+++ b/doc/changes/2913.misc
@@ -1,0 +1,1 @@
+Making initial kets generation safer against very small values in order to make Floquet solver tests with randomization more stable.

--- a/qutip/tests/solver/test_floquet.py
+++ b/qutip/tests/solver/test_floquet.py
@@ -334,16 +334,9 @@ class TestFloquet:
             assert (min(abs(Xs - Xpm_m1)) < 1e-4)
             idx += 1
 
-def safe_rand_ket(N, min_weight=1e-2):
-    while True:
-        psi = rand_ket(N)
-        weights = np.abs(psi.full().flatten())**2
-        if np.min(weights) > min_weight:
-            return psi
-
 def test_fsesolve_fallback():
     H = [sigmaz(), lambda t: np.sin(t * 2 * np.pi)]
-    psi0 = safe_rand_ket(2)
+    psi0 = rand_ket(2)
     ffstate = fmmesolve(H, psi0, [0, 1], T=1.).final_state
-    fstate = sesolve(H, psi0, [0, 1]).final_state
+    fstate = sesolve(H, psi0, [0, 1], options={"atol": 1e-9}).final_state
     assert (ffstate - fstate).norm() < 1e-5

--- a/qutip/tests/solver/test_floquet.py
+++ b/qutip/tests/solver/test_floquet.py
@@ -334,10 +334,16 @@ class TestFloquet:
             assert (min(abs(Xs - Xpm_m1)) < 1e-4)
             idx += 1
 
+def safe_rand_ket(N, min_weight=1e-4):
+    while True:
+        psi = rand_ket(N)
+        weights = np.abs(psi.full().flatten())**2
+        if np.min(weights) > min_weight:
+            return psi
 
 def test_fsesolve_fallback():
     H = [sigmaz(), lambda t: np.sin(t * 2 * np.pi)]
-    psi0 = rand_ket(2)
+    psi0 = safe_rand_ket(2)
     ffstate = fmmesolve(H, psi0, [0, 1], T=1.).final_state
     fstate = sesolve(H, psi0, [0, 1]).final_state
     assert (ffstate - fstate).norm() < 1e-5

--- a/qutip/tests/solver/test_floquet.py
+++ b/qutip/tests/solver/test_floquet.py
@@ -334,7 +334,7 @@ class TestFloquet:
             assert (min(abs(Xs - Xpm_m1)) < 1e-4)
             idx += 1
 
-def safe_rand_ket(N, min_weight=1e-4):
+def safe_rand_ket(N, min_weight=1e-2):
     while True:
         psi = rand_ket(N)
         weights = np.abs(psi.full().flatten())**2


### PR DESCRIPTION
**Description**
This is the continuation of addressing #2876, started by @Ericgig  in #2890. 

Upon repeating `test_fsesolve_fallback` > 2000-3000 times, I managed to reproduce the error occasionally occurring in the test workflows.
(`pytest qutip/tests/solver/test_floquet.py::test_fsesolve_fallback --count=2000`)

The only source of randomness in the test is in the initial ket generation, so I had a look at an example of its value upon the test's failure:

```
Quantum object: dims=[[2], [1]], shape=(2, 1), type='ket', dtype=Dense
Qobj data =
[[ 0.43238738+0.90113114j]
 [-0.02923969-0.01220112j]]
```
As we see, the second value is very small in magnitude. 

When multiplying matrices to get inner products in [to_floquet_basis](https://github.com/qutip/qutip/blob/master/qutip/solver/floquet.py#L280), such tiny values may lead to cancelling out larger complex values.

Knowing we want to keep randomness in tests, I'd suggest constraining it a bit to make the test stabler. We could introduce a "minimum weight" for the coefficients of a vector, for example. 

I experimented with minimum weight values and found out the following:
`1e-4` makes it a bit too loose -> for ~5000 tests, there are 1-2 failed tests. Without constraining weights, there are 2-3 failed tests per 5000. There is no significant difference between having a guard on weights and not having one. 

Going much higher in the number of trials doesn't increase the average number of failed tests significantly, though. 
**Proposal**
Based on the observed failure rate when doing local repeated runs, I believe `1e-2` should do well as a weight constraint (with the latter, I didn't get any error per 10K test runs). With this, we still cover a significant amount of initial kets, but make errors even more unlikely than they are now. 

**Related issues or PRs**
Fix #2876

**AI Tools Usage Disclosure**
Claude Sonnet 4.7 was used to analyze the Floquet solver codebase and find an exact place where catastrophic cancellation may occur if the initial density matrix/ket contains too small values.
