### PR TITLE
Add `Integrator` entry point and developper documentation

### DIFF
--- a/doc/changes/2196.doc
+++ b/doc/changes/2196.doc
@@ -1,0 +1,1 @@
+Add integrator developer documentation

--- a/doc/changes/2196.feature
+++ b/doc/changes/2196.feature
@@ -1,0 +1,1 @@
+Allows QuTiP's integrator to support callable derivative instead of only QobjEvo.

--- a/doc/internals/index.rst
+++ b/doc/internals/index.rst
@@ -19,3 +19,4 @@ collection of `example notebooks`_.
 
    quantum-objects
    data-layer/index
+   solver/index

--- a/doc/internals/solver/index.rst
+++ b/doc/internals/solver/index.rst
@@ -1,0 +1,68 @@
+.. _solver_internals:
+
+Quantum Solvers and Integrators Architecture
+############################################
+
+The solver framework in QuTiP is responsible for simulating the time-evolution of quantum systems.
+Built directly on top of the core data layer,
+the architecture enforces a separation of concerns between physical equations and numerical solvers.
+
+This document serves as an overview of the internal architecture of QuTiP's solvers,
+guiding core developers and contributors on how the system is structured,
+how data flows through it, and how to extend it.
+
+
+Core Architecture and Separation of Concerns
+============================================
+
+The framework decouples physical models from their numerical integration backends, dividing
+tasks between two primary base classes:
+
+1. **The Physics Layer (:class:`Solver`)**: This layer represents the physical equation
+   governing the system's dynamics. Each distinct quantum equation—such as the Schrödinger
+   equation, Lindblad Master Equation, or Bloch-Redfield equations—maps to a unique
+   subclass inheriting from the abstract base :class:`Solver` class (e.g., :class:`SESolver`,
+   :class:`MESolver`, :class:`BRSolver`). The solver class is responsible for setting up
+   the system operators and defining the physical derivative.
+
+2. **The Numerical Layer (:class:`Integrator`)**: This layer handles the low-level
+   numerical implementation of Ordinary Differential Equations (ODEs) or Stochastic
+   Differential Equations (SDEs). The solver communicates the physical state and derivative
+   rules down to the :class:`Integrator`. The selection of which numerical scheme to run
+   is entirely dictated by the solver's configuration options through the ``"method"`` parameter.
+
+Generally, integrators are general-purpose ODE solvers. However, to maximize performance,
+certain integrators are specialized to specific physical representations,
+where the boundary between physical assumptions and numerical routines is intentionally blended.
+
+
+User-Facing Interfaces vs. Internal Infrastructure
+==================================================
+
+To maintain an intuitive user experience, QuTiP hides internal architectural complexity
+behind high-level functional wrappers:
+
+- Functions such as :func:`sesolve` or :func:`mesolve` serve as convenience entry points for the end user.
+  In a single call, these helper functions instantiate the appropriate underlying :class:`Solver` class,
+  run the evolution, and return a completed results container.
+- Multiple functional entry points can map back to the same physical equations.
+  For instance, :func:`sesolve`, :func:`fsesolve`, and :func:`krylovsolve`
+  all represent closed-system Schrödinger dynamics, using :class:`SESolver` but different integrators.
+- End users typically interact exclusively with top-level functions or the core :class:`Solver` class interface.
+  The numerical :class:`Integrator` and the configuration parsing via :class:`SolverOptions` operate silently under the hood.
+  Once execution concludes, the resulting :class:`Result` instance is returned
+  to the user and expected to be used as a read-only data container.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Sections
+
+   terminology
+   .. motivation
+   .. solver
+   integrator
+   .. integrator_stochastic
+   .. result
+   .. solveroptions
+   .. feedback

--- a/doc/internals/solver/index.rst
+++ b/doc/internals/solver/index.rst
@@ -59,10 +59,13 @@ behind high-level functional wrappers:
    :caption: Sections
 
    terminology
-   .. motivation
-   .. solver
    integrator
-   .. integrator_stochastic
-   .. result
-   .. solveroptions
-   .. feedback
+
+..
+  Sections to add later:
+  motivation
+  solver
+  integrator_stochastic
+  result
+  solveroptions
+  feedback

--- a/doc/internals/solver/index.rst
+++ b/doc/internals/solver/index.rst
@@ -5,7 +5,7 @@ Quantum Solvers and Integrators Architecture
 
 The solver framework in QuTiP is responsible for simulating the time-evolution of quantum systems.
 Built directly on top of the core data layer,
-the architecture enforces a separation of concerns between physical equations and numerical solvers.
+the architecture enforces a separation of concerns between physical model and numerical solvers.
 
 This document serves as an overview of the internal architecture of QuTiP's solvers,
 guiding core developers and contributors on how the system is structured,
@@ -31,7 +31,7 @@ tasks between two primary base classes:
    rules down to the :class:`Integrator`. The selection of which numerical scheme to run
    is entirely dictated by the solver's configuration options through the ``"method"`` parameter.
 
-Generally, integrators are general-purpose ODE solvers. However, to maximize performance,
+Usually, integrators are general-purpose ODE solvers. However, to maximize performance,
 certain integrators are specialized to specific physical representations,
 where the boundary between physical assumptions and numerical routines is intentionally blended.
 

--- a/doc/internals/solver/integrator.rst
+++ b/doc/internals/solver/integrator.rst
@@ -107,14 +107,14 @@ Derivative Format
 
 While ordinary ODE interfaces strictly expect functions to represent the right-hand side (RHS),
 quantum solvers in QuTiP can profit from alternative formats.
-Every integrator exposes an :attr:`RHS_format` class attribute string that dictates
+Every integrator exposes an :attr:`rhs_format` class attribute string that dictates
 the type of RHS object required during initialization:
 
 * **"callable"**: The integrator expects a function matching the signature
-  ``rhs(t: float, state: Data) -> Data``. This is the default for most ODE methods.
-  For specific Cython-backed ODE implementations, if the passed function is a method of
-  :class:`QobjEvo`, it will bypass standard Python overhead and hook directly into the
-  Cython bindings of ``QobjEvo.matmul`` using a ``RHS`` object.
+  ``rhs(t: float, state: Data) -> Data`` returning the derivative of the `state` at time `t`.
+  This is the default for most ODE methods. For specific Cython-backed ODE implementations,
+  if the passed function is the method of :meth:`QobjEvo.matmul_data`, it will bypass standard
+  Python overhead and hook directly into the Cython bindings of ``QobjEvo.matmul`` using a ``RHS`` object.
 * **"matrix"**: The integrator accepts a complex matrix formatted as a
   :class:`qutip.core.data.Data` object, solving the linear matrix differential equation
   $\frac{dX}{dt} = \text{RHS} \times X$.
@@ -134,7 +134,7 @@ Every subclass inheriting from :class:`Integrator` must define the following cla
    by the numerical backend along with their default values.
    Upon instantiation, this is copied to an instance-level ``options`` dictionary.
 
-.. attribute:: RHS_format
+.. attribute:: rhs_format
 
    A string identifier defining the expected structural format of the Right-Hand Side (RHS)
    derivative function (e.g., ``"callable"``, ``"matrix"``, or ``"solver"``).
@@ -160,7 +160,7 @@ Let's build a simple linear step integrator that updates the current state by ad
     from qutip.solver.integrator import Integrator
 
     class LinearStepODE(Integrator):
-        RHS_format = "callable"
+        rhs_format = "callable"
         name = "Simple Linear Step"
         method = "linear"
         # An integrator may also define `integrator_options` here. If the attribute is not set,
@@ -220,9 +220,9 @@ derivative added directly into the existing ``out`` object. The function is
 permitted to reuse, modify, or overwrite the ``out`` container as needed.
 This pattern eliminates the considerable overhead of frequent memory allocations
 and deallocations inside tight numerical integration loops. The returned object
-does not need to the same as the ``out`` input if immutable or otherwise not reusable.
+does not need to the same as the ``out`` input if it's immutable or otherwise not reusable.
 
-These specialized integrators are marked as ``RHS_format="callable"``.
+These specialized integrators are marked as ``rhs_format="callable"``.
 Internally, they rely on the ``RHS`` helper class.
 This class acts as an interface layer that safely wraps an ordinary,
 out-of-place python derivative function and transforms it into one that behaves

--- a/doc/internals/solver/integrator.rst
+++ b/doc/internals/solver/integrator.rst
@@ -110,11 +110,11 @@ quantum equation in QuTiP can profit from alternative formats.
 Every integrator exposes an :attr:`RHS_format` class attribute string that dictates
 the type of RHS object required during initialization:
 
-* **"callable"**: The integrator expects a function matching the signature ``rhs(t, Data) -> Data``
-  or ``rhs(t, Data, out=Data)``. This is the default for most ODE methods.
+* **"callable"**: The integrator expects a function matching the signature
+  ``rhs(t: float, state: Data) -> Data``. This is the default for most ODE methods.
   For specific Cython-backed ODE implementations, if the passed function is a method of
   :class:`QobjEvo`, it will bypass standard Python overhead and hook directly into the
-  Cython bindings of ``QobjEvo.matmul``.
+  Cython bindings of ``QobjEvo.matmul`` using a ``RHS`` object.
 * **"matrix"**: The integrator accepts a complex matrix formatted as a
   :class:`qutip.core.data.Data` object, solving the linear matrix differential equation
   $\frac{dX}{dt} = \text{RHS} \times X$.
@@ -205,3 +205,46 @@ register it using the solver class's target method:
 Once added, the method is immediately accessible via the high-level functional
 wrappers by configuring the options map (e.g., ``options={"method": "linear"}``).
 Registering the class with the parent :class:`Solver` base class makes it globally available to all solvers except stochastic solver.
+
+
+The RHS class
+-------------
+To optimize performance, certain Cython-backed integrators reuse memory when
+computing derivatives by supporting an in-place functional signature:
+
+.. code-block:: python
+
+    rhs(t: float, state: Data, out: Data) -> Data
+
+In this paradigm, the operation should be interpreted as returning the computed
+derivative added directly into the existing ``out`` object. The function is
+permitted to reuse, modify, or overwrite the ``out`` container as needed.
+This pattern eliminates the considerable overhead of frequent memory allocations
+and deallocations inside tight numerical integration loops. The returned object
+does not need to the same as the ``out`` input if immutable or otherwise not reusable.
+
+These specialized integrators are marked as ``RHS_format="callable"``.
+Internally, they rely on the ``RHS`` helper class.
+This class acts as an interface layer that safely wraps an ordinary,
+out-of-place python derivative function and transforms it into one that behaves
+correctly when subjected to in-place calls.
+
+Within the QuTiP's solver, physical derivatives are usually
+computed via :meth:`QobjEvo.matmul_data`. The integrators automatically detects
+that method and bind directly to the low-level Cython implementation with
+in-place support.
+
+If you are providing a custom Python callable, you must explicitly wrap your
+function inside an ``RHS`` instance to leverage in-place performance optimizations:
+
+
+.. code-block:: python
+
+    from qutip.solver.integrator._rhs import RHS
+
+    def custom_diff(t, state, out):
+        # Perform in-place operations directly on the 'out' data object
+        out += ...
+        return out
+
+    derivative = RHS(custom_diff, inplace=True)

--- a/doc/internals/solver/integrator.rst
+++ b/doc/internals/solver/integrator.rst
@@ -1,0 +1,207 @@
+.. _integrator_internal:
+
+Integrator Architecture and Design
+##################################
+
+The numerical solution of differential equations is a cornerstone of QuTiP's
+time-evolution solvers. Because different quantum systems present varying behaviours,
+no single numerical algorithm is optimal for all scenarios.
+
+The :class:`Integrator` framework provides a unified, backend-agnostic interface
+that wraps external Ordinary Differential Equation (ODE) libraries. This design
+allows solvers to select routines from multiple distinct libraries through a single,
+interchangeable class.
+
+
+Motivation
+==========
+
+While Python packages like SciPy offer a robust collection of integration routines,
+they present several architectural limitations when applied directly to quantum dynamics:
+
+* **Inconsistent API Interfaces**: Across SciPy, interfaces vary drastically
+  (e.g., the older :class:`scipy.integrate.ode` vs. the modern :meth:`scipy.integrate.solve_ivp`),
+  and some legacy algorithms do not natively support complex numbers without manual
+  splitting into real and imaginary parts.
+* **Hardware Limitations**: Standard SciPy integration routines are strictly
+  bound to CPU execution, preventing seamless acceleration via GPUs or distributed architectures.
+* **Specialized Quantum Algorithms**: Certain high-performance routines tailored
+  for quantum mechanics —such as Krylov subspace methods or custom unitary propagators—
+  are too domain-specific to be included in general-purpose mathematical libraries.
+
+The :class:`Integrator` class resolves these challenges by abstracting numerical backends
+into an interchangeable component, ensuring that switching from a SciPy Fortran solver to
+a GPU-accelerated backend requires only changing a configuration string.
+
+
+Core Design
+===========
+
+The abstract base class :class:`Integrator` serves as the common template for all
+numerical integration backends.
+
+Deterministic Time-Evolution
+----------------------------
+For standard solvers, the integrator acts sequentially. Given an initial time $t_0$
+and an initial state vector or density matrix, it propagates the state forward to
+requested target times. This behaviour is governed by four core methods:
+
+* :meth:`set_state(t, state)`: Configures the initial conditions of the
+  integrator, seeding it with the starting time and the state array.
+* :meth:`get_state()`: Returns the current internal numerical state of the integration
+  loop as a tuple of ``(t, state)``.
+* :meth:`integrate(t)`: Steps the numerical solver explicitly to the target time ``t``
+  using the internal state configuration.
+* :meth:`run(tlist)`: A generator method that yields successive ``(t, state)`` tuples at
+  each timestamp specified in the user-provided array ``tlist``.
+
+.. note::
+   The output state returned by :meth:`get_state`, :meth:`integrate`, and :meth:`run`
+   is consistently packed as a tuple: ``(t, state)``.
+
+.. note::
+   All inputs and outputs for states are handled as :class:`qutip.core.data.Data` objects.
+   However, an integrator is permitted to change the underlying representation format
+   internally during evolution.
+
+   For example, SciPy-based integrators utilize NumPy arrays internally; they will
+   automatically convert an incoming initial state from its initial storage type
+   to a dense format during setup, and will subsequently return only dense states.
+
+Monte Carlo Trajectories
+------------------------
+To support Quantum Monte Carlo simulations (:func:`mcsolve`), integrators must provide
+hook interfaces capable of handling non-continuous, conditional integration steps:
+
+* :meth:`mcstep(t)`: Governs evolution inside stochastic loops.
+  Unlike standard integration, :meth:`mcstep` must safely handle non-increasing time targets
+  or backtrack queries (inside the last step range) to assist the parent solver
+  in isolating the exact physical moment a quantum collapse event occurs.
+
+For historical reasons, QuTiP delegates the root-finding search for a collapse to the
+high-level :class:`MCSolver` loop rather than relying on native ODE "event" triggers.
+This design has the advantage of allowing QuTiP to wrap external ODE packages
+that lack native event-detection features, guaranteeing consistent behavior across all
+ODE providers.
+
+
+Configuration and State Resetting
+=================================
+
+Numerical routines depend on parameters (such as tolerance limits
+``atol``/``rtol``, step limits ``nsteps``, etc.) that must be tuned to achieve
+optimal efficiency. These parameters are configurable by the developer or end
+user via the ``options`` attribute passed down to the integrator instance.
+The ``Integrator.options`` attribute operates as a live dictionary containing
+the configuration state.
+
+Because used libraries maintain internal state for their ODE solvers,
+modifying values within the ``options`` dictionary does not always take effect immediately.
+Activating the newly assigned options requires an explicit call to :meth:`reset()`.
+This tears down the active backend instance and restarts it with the new options
+while preserving the active state and time.
+
+
+Derivative Format
+=================
+
+While ordinary ODE interfaces strictly expect functions to represent the right-hand side (RHS),
+quantum equation in QuTiP can profit from alternative formats.
+Every integrator exposes an :attr:`RHS_format` class attribute string that dictates
+the type of RHS object required during initialization:
+
+* **"callable"**: The integrator expects a function matching the signature ``rhs(t, Data) -> Data``
+  or ``rhs(t, Data, out=Data)``. This is the default for most ODE methods.
+  For specific Cython-backed ODE implementations, if the passed function is a method of
+  :class:`QobjEvo`, it will bypass standard Python overhead and hook directly into the
+  Cython bindings of ``QobjEvo.matmul``.
+* **"matrix"**: The integrator accepts a complex matrix formatted as a
+  :class:`qutip.core.data.Data` object, solving the linear matrix differential equation
+  $\frac{dX}{dt} = \text{RHS} \times X$.
+* **"solver"**: The integrator takes the parent :class:`Solver` instance that instantiated it
+  and builds the RHS internally. This is reserved for specialized integration methods that
+  deliberately blend the underlying quantum physics with the numerical method.
+
+
+Class Attributes Reference
+==========================
+
+Every subclass inheriting from :class:`Integrator` must define the following class-level attributes:
+
+.. attribute:: integrator_options
+
+   A class-level dictionary defining the comprehensive set of configuration keys supported
+   by the numerical backend along with their default values.
+   Upon instantiation, this is copied to an instance-level ``options`` dictionary.
+
+.. attribute:: RHS_format
+
+   A string identifier defining the expected structural format of the Right-Hand Side (RHS)
+   derivative function (e.g., ``"callable"``, ``"matrix"``, or ``"solver"``).
+
+.. attribute:: name
+
+   A descriptive, human-readable string representation of the algorithm
+   (e.g., ``"SciPy zvode Adams solver"``) used primarily for populating metadata
+   inside the final :class:`Result` container.
+
+.. attribute:: method
+
+   A unique short-string identifier key (e.g., ``"adams"`` or ``"bdf"``) registered
+   with the solver directory, mapping the option selections directly to the underlying
+   class implementation.
+
+
+Creating New Integrators
+========================
+
+To implement a custom numerical backend, create a subclass derived from :class:`Integrator`.
+At a minimum, your class must override :meth:`integrate`, :meth:`set_state`, :meth:`get_state`,
+and either :meth:`__init__` or :meth:`_prepare`:
+
+.. code-block:: python
+
+    from qutip.solver.integrator import Integrator
+
+    class LinearStepODE(Integrator):
+        RHS_format = "callable"
+        name = "Simple Linear Step"
+        method = "linear"
+        # Uses default empty dict if no specialized integrator_options are defined
+
+        def _prepare(self):
+            # __init__ automatically prepares the local options dict,
+            # stores the rhs in self.derivative, and initializes self._is_set to False.
+            # Apply option here!
+            # This will be called from __init__ and reset.
+            pass
+
+        def set_state(self, t, state):
+            self.t = t
+            self.state = state
+            self._is_set = True
+
+        def integrate(self, t):
+            # Basic Euler step example
+            self.state = self.state + (t - self.t) * self.derivative(self.t, self.state)
+            self.t = t
+
+        def get_state(self):
+            return self.t, self.state
+
+The base :class:`Integrator` class automatically provides default implementations for
+the :meth:`run` :meth:`reset` and :meth:`mcstep` methods
+(though the fallback version of :meth:`mcstep` can be very inefficient).
+
+To expose your custom integrator to a specific physical solver,
+register it using the solver class's target method:
+
+.. code-block:: python
+
+    from qutip.solver import SESolver
+
+    SESolver.add_integrator(LinearStepODE, "linear")
+
+Once added, the method is immediately accessible via the high-level functional
+wrappers by configuring the options map (e.g., ``options={"method": "linear"}``).
+Registering the class with the parent :class:`Solver` base class makes it globally available to all solvers except stochastic solver.

--- a/doc/internals/solver/integrator.rst
+++ b/doc/internals/solver/integrator.rst
@@ -145,12 +145,6 @@ Every subclass inheriting from :class:`Integrator` must define the following cla
    (e.g., ``"SciPy zvode Adams solver"``) used primarily for populating metadata
    inside the final :class:`Result` container.
 
-.. attribute:: method
-
-   A unique short-string identifier key (e.g., ``"adams"`` or ``"bdf"``) registered
-   with the solver directory, mapping the option selections directly to the underlying
-   class implementation.
-
 
 Creating New Integrators
 ========================

--- a/doc/internals/solver/integrator.rst
+++ b/doc/internals/solver/integrator.rst
@@ -8,7 +8,7 @@ time-evolution solvers. Because different quantum systems present varying behavi
 no single numerical algorithm is optimal for all scenarios.
 
 The :class:`Integrator` framework provides a unified, backend-agnostic interface
-that wraps external Ordinary Differential Equation (ODE) libraries. This design
+that wraps external or custom Ordinary Differential Equation (ODE) libraries. This design
 allows solvers to select routines from multiple distinct libraries through a single,
 interchangeable class.
 
@@ -106,7 +106,7 @@ Derivative Format
 =================
 
 While ordinary ODE interfaces strictly expect functions to represent the right-hand side (RHS),
-quantum equation in QuTiP can profit from alternative formats.
+quantum solvers in QuTiP can profit from alternative formats.
 Every integrator exposes an :attr:`RHS_format` class attribute string that dictates
 the type of RHS object required during initialization:
 
@@ -153,6 +153,8 @@ To implement a custom numerical backend, create a subclass derived from :class:`
 At a minimum, your class must override :meth:`integrate`, :meth:`set_state`, :meth:`get_state`,
 and either :meth:`__init__` or :meth:`_prepare`:
 
+Let's build a simple linear step integrator that updates the current state by adding `dt * derivative(t, state)`. This integrator won't provide very accurate results, but it will nicely illustrate what's required.
+
 .. code-block:: python
 
     from qutip.solver.integrator import Integrator
@@ -161,12 +163,14 @@ and either :meth:`__init__` or :meth:`_prepare`:
         RHS_format = "callable"
         name = "Simple Linear Step"
         method = "linear"
-        # Uses default empty dict if no specialized integrator_options are defined
+        # An integrator may also define `integrator_options` here. If the attribute is not set,
+        # a default empty dict is assumed, indicating that their are not special options for
+        # this integrator.
 
         def _prepare(self):
             # __init__ automatically prepares the local options dict,
             # stores the rhs in self.derivative, and initializes self._is_set to False.
-            # Apply option here!
+            # Apply any specialized options here!
             # This will be called from __init__ and reset.
             pass
 
@@ -198,6 +202,7 @@ register it using the solver class's target method:
 
 Once added, the method is immediately accessible via the high-level functional
 wrappers by configuring the options map (e.g., ``options={"method": "linear"}``).
+
 Registering the class with the parent :class:`Solver` base class makes it globally available to all solvers except stochastic solver.
 
 
@@ -224,7 +229,7 @@ out-of-place python derivative function and transforms it into one that behaves
 correctly when subjected to in-place calls.
 
 Within the QuTiP's solver, physical derivatives are usually
-computed via :meth:`QobjEvo.matmul_data`. The integrators automatically detects
+computed via :meth:`QobjEvo.matmul_data`. The integrators automatically detect
 that method and bind directly to the low-level Cython implementation with
 in-place support.
 

--- a/doc/internals/solver/terminology.rst
+++ b/doc/internals/solver/terminology.rst
@@ -1,0 +1,47 @@
+Terminology
+===========
+
+This is a short terminology glossary for the solver and related classes.
+See the rest of the guide for more in depth information.
+
+Quantum system
+  Set of operator and physical parameters that are used to build the equation
+  solved by the solver. Common components are the Hamiltonian, collapse operators,
+  bath coupling operators and environment information.
+
+method
+  Name of the integration method used for the evolution. Can refer to ODE or
+  SODE integration algorithm, depending on the solver.
+
+ODE
+  Ordinary Differential Equation:
+
+    $$ dX/dt = f(t, X) $$
+
+SDE
+  Stochastic Differential Equation:
+
+    $$ dX = f(t, X) dt + \Sum_i g_i(t, X) dW_i $$
+
+  with $dW_i$ independent gaussian noise.
+
+RHS, right hand side.
+  Equation to solve with ODE, right-hand side of $ dX/dt = f(t, X) $.
+
+Feedback
+  General term for non-linear equation. Having the quantum system depend on the
+  state. For example, having the Hamiltonian depend on the density matrix:
+  $H(t, \rho)$. Different :class:`Solver` can support different types of Feedback.
+
+Deterministic, non-deterministic
+  Whether randomness is used in the evolution. deterministic evolution will always
+  result in the same results (up to numerical precision). Whereas non-deterministic
+  will give different results each time.
+
+Stochastic
+  In general, stochastic has a similar meaning as non-deterministic, but in our context, it usually refer to the Stochastic solver: using SDE with gaussian noise.
+  The monte carlo solver, as deterministic evolution between random jumps, it is non-deterministic, but not included in Stochastic in most case of this section.
+
+Trajectory
+  Single run of a non-deterministic evolution. For example, an evolution of
+  :class:`MCSolver` with it's own unique jumps timing.

--- a/doc/internals/solver/terminology.rst
+++ b/doc/internals/solver/terminology.rst
@@ -6,41 +6,39 @@ Terminology
 This is a short terminology glossary for the solver and related classes.
 See the rest of the guide for more in depth information.
 
-.. glossary::
-
-  Quantum system
+Quantum system
     Set of operators and physical parameters used to build the dynamic equations.
     Common components are the Hamiltonian, collapse or jump operators,
     bath coupling operators and environment/spectral noise configurations.
 
-  method
+method
     The identifier string used to select the numerical integration technique for a time-evolution run.
     Can refer to ODE or SDE integration algorithm, depending on the solver.
 
-  ODE
+ODE
     Ordinary Differential Equation.
 
       $$ \frac{dX}{dt} = f(t, X) $$
 
-  SDE
+SDE
     Stochastic Differential Equation:
 
       $$ dX = f(t, X) dt + \sum_i g_i(t, X) dW_i $$
 
     where $dW_i$ represent independent Wiener processes modeling Gaussian white noise.
 
-  RHS
+RHS
     Right-Hand Side
     The representation describing the derivative in a differential equation
     (i.e., the $f(t, X)$ term in an ODE).
 
-  Feedback
+Feedback
     The term we use for quantum dynamics where the underlying quantum system parameters
     depend explicitly on the instantaneous state of the system, introducing a form of non-linearity.
     For example, when its Hamiltonian depends on the expectation value of an operator or the state itself: $H = H(t, \rho)$.
     Different :class:`Solver` provide can provide different feedback format.
 
-  Deterministic / Non-deterministic
+Deterministic / Non-deterministic
     A categorization based on whether randomness is involved in the time-evolution.
     * Deterministic evolution algorithms (like standard master equations or Schrödinger equations)
       always yield identical results (up to numerical imprecision) across separate
@@ -48,7 +46,7 @@ See the rest of the guide for more in depth information.
     * Non-deterministic evolution introduces pseudo-random variables,
       yielding structurally unique trajectories on successive invocations.
 
-  Stochastic
+Stochastic
     While broadly synonymous with non-deterministic behavior, in this section,
     "stochastic" specifically denotes simulations driven by true Stochastic Differential Equations (SDEs)
     containing Gaussian noise channels (e.g., :class:`SMESolver`).
@@ -56,7 +54,7 @@ See the rest of the guide for more in depth information.
     random quantum jumps, their trajectories are piecewise-deterministic and are typically
     excluded when discussing "stochastic evolution" within this architecture framework.
 
-  Trajectory
+Trajectory
     A single, continuous realization of a non-deterministic quantum evolution process.
     For instance, an individual run of a Monte Carlo simulation contains a unique
     sequence of jump events and timings that defines one distinct trajectory.

--- a/doc/internals/solver/terminology.rst
+++ b/doc/internals/solver/terminology.rst
@@ -41,10 +41,11 @@ Feedback
 Deterministic / Non-deterministic
     A categorization based on whether randomness is involved in the time-evolution.
     * Deterministic evolution algorithms (like standard master equations or Schrödinger equations)
-      always yield identical results (up to numerical imprecision) across separate
-      runs given identical initial conditions.
+    | always yield identical results (up to numerical imprecision) across separate
+    | runs given identical initial conditions.
+
     * Non-deterministic evolution introduces pseudo-random variables,
-      yielding structurally unique trajectories on successive invocations.
+    | yielding structurally unique trajectories on successive invocations.
 
 Stochastic
     While broadly synonymous with non-deterministic behavior, in this section,

--- a/doc/internals/solver/terminology.rst
+++ b/doc/internals/solver/terminology.rst
@@ -40,12 +40,12 @@ Feedback
 
 Deterministic / Non-deterministic
     A categorization based on whether randomness is involved in the time-evolution.
-    * Deterministic evolution algorithms (like standard master equations or Schrödinger equations)
-    | always yield identical results (up to numerical imprecision) across separate
-    | runs given identical initial conditions.
 
+    * Deterministic evolution algorithms (like standard master equations or Schrödinger equations)
+      always yield identical results (up to numerical imprecision) across separate
+      runs given identical initial conditions.
     * Non-deterministic evolution introduces pseudo-random variables,
-    | yielding structurally unique trajectories on successive invocations.
+      yielding structurally unique trajectories on successive invocations.
 
 Stochastic
     While broadly synonymous with non-deterministic behavior, in this section,

--- a/doc/internals/solver/terminology.rst
+++ b/doc/internals/solver/terminology.rst
@@ -13,7 +13,7 @@ Quantum system
 
 method
     The identifier string used to select the numerical integration technique for a time-evolution run.
-    Can refer to ODE or SDE integration algorithm, depending on the solver.
+    May refer to an ODE or SDE integration algorithm, depending on the solver.
 
 ODE
     Ordinary Differential Equation.
@@ -25,10 +25,10 @@ SDE
 
       $$ dX = f(t, X) dt + \sum_i g_i(t, X) dW_i $$
 
-    where $dW_i$ represent independent Wiener processes modeling Gaussian white noise.
+    where $dW_i$ represents an independent Wiener processes modeling Gaussian white noise.
 
 RHS
-    Right-Hand Side
+    Right-Hand Side.
     The representation describing the derivative in a differential equation
     (i.e., the $f(t, X)$ term in an ODE).
 
@@ -36,7 +36,7 @@ Feedback
     The term we use for quantum dynamics where the underlying quantum system parameters
     depend explicitly on the instantaneous state of the system, introducing a form of non-linearity.
     For example, when its Hamiltonian depends on the expectation value of an operator or the state itself: $H = H(t, \rho)$.
-    Different :class:`Solver` provide can provide different feedback format.
+    Different :class:`Solver` sub-classes may provide different feedback formats.
 
 Deterministic / Non-deterministic
     A categorization based on whether randomness is involved in the time-evolution.
@@ -53,7 +53,7 @@ Stochastic
     containing Gaussian noise channels (e.g., :class:`SMESolver`).
     Conversely, while Monte Carlo simulations (:class:`MCSolver`) are non-deterministic due to discrete,
     random quantum jumps, their trajectories are piecewise-deterministic and are typically
-    excluded when discussing "stochastic evolution" within this architecture framework.
+    excluded when discussing "stochastic evolution".
 
 Trajectory
     A single, continuous realization of a non-deterministic quantum evolution process.

--- a/doc/internals/solver/terminology.rst
+++ b/doc/internals/solver/terminology.rst
@@ -1,47 +1,62 @@
+.. _solver_terminology:
+
 Terminology
 ===========
 
 This is a short terminology glossary for the solver and related classes.
 See the rest of the guide for more in depth information.
 
-Quantum system
-  Set of operator and physical parameters that are used to build the equation
-  solved by the solver. Common components are the Hamiltonian, collapse operators,
-  bath coupling operators and environment information.
+.. glossary::
 
-method
-  Name of the integration method used for the evolution. Can refer to ODE or
-  SODE integration algorithm, depending on the solver.
+  Quantum system
+    Set of operators and physical parameters used to build the dynamic equations.
+    Common components are the Hamiltonian, collapse or jump operators,
+    bath coupling operators and environment/spectral noise configurations.
 
-ODE
-  Ordinary Differential Equation:
+  method
+    The identifier string used to select the numerical integration technique for a time-evolution run.
+    Can refer to ODE or SDE integration algorithm, depending on the solver.
 
-    $$ dX/dt = f(t, X) $$
+  ODE
+    Ordinary Differential Equation.
 
-SDE
-  Stochastic Differential Equation:
+      $$ \frac{dX}{dt} = f(t, X) $$
 
-    $$ dX = f(t, X) dt + \Sum_i g_i(t, X) dW_i $$
+  SDE
+    Stochastic Differential Equation:
 
-  with $dW_i$ independent gaussian noise.
+      $$ dX = f(t, X) dt + \sum_i g_i(t, X) dW_i $$
 
-RHS, right hand side.
-  Equation to solve with ODE, right-hand side of $ dX/dt = f(t, X) $.
+    where $dW_i$ represent independent Wiener processes modeling Gaussian white noise.
 
-Feedback
-  General term for non-linear equation. Having the quantum system depend on the
-  state. For example, having the Hamiltonian depend on the density matrix:
-  $H(t, \rho)$. Different :class:`Solver` can support different types of Feedback.
+  RHS
+    Right-Hand Side
+    The representation describing the derivative in a differential equation
+    (i.e., the $f(t, X)$ term in an ODE).
 
-Deterministic, non-deterministic
-  Whether randomness is used in the evolution. deterministic evolution will always
-  result in the same results (up to numerical precision). Whereas non-deterministic
-  will give different results each time.
+  Feedback
+    The term we use for quantum dynamics where the underlying quantum system parameters
+    depend explicitly on the instantaneous state of the system, introducing a form of non-linearity.
+    For example, when its Hamiltonian depends on the expectation value of an operator or the state itself: $H = H(t, \rho)$.
+    Different :class:`Solver` provide can provide different feedback format.
 
-Stochastic
-  In general, stochastic has a similar meaning as non-deterministic, but in our context, it usually refer to the Stochastic solver: using SDE with gaussian noise.
-  The monte carlo solver, as deterministic evolution between random jumps, it is non-deterministic, but not included in Stochastic in most case of this section.
+  Deterministic / Non-deterministic
+    A categorization based on whether randomness is involved in the time-evolution.
+    * Deterministic evolution algorithms (like standard master equations or Schrödinger equations)
+      always yield identical results (up to numerical imprecision) across separate
+      runs given identical initial conditions.
+    * Non-deterministic evolution introduces pseudo-random variables,
+      yielding structurally unique trajectories on successive invocations.
 
-Trajectory
-  Single run of a non-deterministic evolution. For example, an evolution of
-  :class:`MCSolver` with it's own unique jumps timing.
+  Stochastic
+    While broadly synonymous with non-deterministic behavior, in this section,
+    "stochastic" specifically denotes simulations driven by true Stochastic Differential Equations (SDEs)
+    containing Gaussian noise channels (e.g., :class:`SMESolver`).
+    Conversely, while Monte Carlo simulations (:class:`MCSolver`) are non-deterministic due to discrete,
+    random quantum jumps, their trajectories are piecewise-deterministic and are typically
+    excluded when discussing "stochastic evolution" within this architecture framework.
+
+  Trajectory
+    A single, continuous realization of a non-deterministic quantum evolution process.
+    For instance, an individual run of a Monte Carlo simulation contains a unique
+    sequence of jump events and timings that defines one distinct trajectory.

--- a/qutip/solver/integrator/_rhs.pxd
+++ b/qutip/solver/integrator/_rhs.pxd
@@ -1,0 +1,10 @@
+#cython: language_level=3
+from qutip.core.data cimport Data
+from qutip.core.cy.qobjevo cimport QobjEvo
+
+
+cdef class RHS:
+    cdef object derivative
+    cdef QobjEvo qevo
+    cdef bint inplace, qevo_derr
+    cdef Data apply(self, double t, Data state, Data out=*)

--- a/qutip/solver/integrator/_rhs.pyx
+++ b/qutip/solver/integrator/_rhs.pyx
@@ -44,7 +44,7 @@ cdef class RHS:
     """
     def __init__(
         self,
-        derivative: Callable[[float, Data], Data] | QobjEvo,
+        derivative: Callable[[float, Data], Data] | Callable[[float, Data, Data], Data] | QobjEvo,
         inplace: bool=False
     ):
         self.derivative = derivative

--- a/qutip/solver/integrator/_rhs.pyx
+++ b/qutip/solver/integrator/_rhs.pyx
@@ -49,8 +49,8 @@ cdef class RHS:
         self.derivative = derivative
         self.inplace = inplace
         self.qevo_derr = False
-        if derivative.__func__ is QobjEvo.matmul_data:
-            self.qevo = derivative
+        if getattr(derivative, "__func__", None) is (<object> QobjEvo).matmul_data:
+            self.qevo = derivative.__self__
             self.qevo_derr = True
 
     def __call__(self, t: float, state: Data):
@@ -69,7 +69,7 @@ cdef class RHS:
         if self.inplace:
             if out is None:
                 out = zeros_like(state)
-            self.derivative(t, state, out)
+            out = self.derivative(t, state, out)
         elif out is not None:
             out = iadd(self.derivative(t, state), out)
         else:

--- a/qutip/solver/integrator/_rhs.pyx
+++ b/qutip/solver/integrator/_rhs.pyx
@@ -35,17 +35,17 @@ cdef class RHS:
     derivative: Callable[[float, Data, ...], Data] | QobjEvo
         Function to integrate.
         Can be either a QobjEvo where QobjEvo @ state is the derivative or
-        a callable. This function can be both inplace or not.
+        a callable. This function may be either inplace or not.
 
     inplace: bool
-        If ``derivative`` is a callable, whether that function take the output
-        inplace or not.
+        When ``derivative`` is a callable, whether the function supplied takes the output
+        argument in-place or not.
 
     """
     def __init__(
         self,
         derivative: Callable[[float, Data], Data] | Callable[[float, Data, Data], Data] | QobjEvo,
-        inplace: bool=False
+        inplace: bool=False,
     ):
         self.derivative = derivative
         self.inplace = inplace

--- a/qutip/solver/integrator/_rhs.pyx
+++ b/qutip/solver/integrator/_rhs.pyx
@@ -65,6 +65,12 @@ cdef class RHS:
     cdef Data apply(self, double t, Data state, Data out=None):
         """
         Cython interface for the derivative function.
+
+        Notes
+        -----
+        When out is passed, the derivative is added to it.
+        In most cases, the derivative by itself is desired, in those case, it
+        is needed to zero the output buffer before using this function.
         """
         if self.qevo_derr:
             return self.qevo.matmul_data(t, state, out=out)

--- a/qutip/solver/integrator/_rhs.pyx
+++ b/qutip/solver/integrator/_rhs.pyx
@@ -32,7 +32,7 @@ cdef class RHS:
 
     Parameters
     ----------
-    derivative: Callable[[float, _data.Data, ...], _data.Data] | QobjEvo
+    derivative: Callable[[float, Data, ...], Data] | QobjEvo
         Function to integrate.
         Can be either a QobjEvo where QobjEvo @ state is the derivative or
         a callable. This function can be both inplace or not.
@@ -44,7 +44,7 @@ cdef class RHS:
     """
     def __init__(
         self,
-        derivative: Callable[[float, _data.Data], _data.Data] | QobjEvo,
+        derivative: Callable[[float, Data], Data] | QobjEvo,
         inplace: bool=False
     ):
         self.derivative = derivative

--- a/qutip/solver/integrator/_rhs.pyx
+++ b/qutip/solver/integrator/_rhs.pyx
@@ -4,6 +4,7 @@ from qutip.core.data cimport Data
 from qutip.core.cy.qobjevo cimport QobjEvo
 from qutip.core.data.constant import zeros_like
 from qutip.core.data.add import iadd
+from collections.abc import Callable
 
 # Migrating integrator from supporting QobjEvo (matmul) only, to functions
 # with signature:

--- a/qutip/solver/integrator/_rhs.pyx
+++ b/qutip/solver/integrator/_rhs.pyx
@@ -49,9 +49,7 @@ cdef class RHS:
         self.derivative = derivative
         self.inplace = inplace
         self.qevo_derr = False
-        if isinstance(getattr(derivative, "__self__", None), QobjEvo):
-            derivative = derivative.__self__
-        if isinstance(derivative, QobjEvo):
+        if derivative.__func__ is QobjEvo.matmul_data:
             self.qevo = derivative
             self.qevo_derr = True
 

--- a/qutip/solver/integrator/_rhs.pyx
+++ b/qutip/solver/integrator/_rhs.pyx
@@ -49,7 +49,10 @@ cdef class RHS:
         self.derivative = derivative
         self.inplace = inplace
         self.qevo_derr = False
-        if getattr(derivative, "__func__", None) is (<object> QobjEvo).matmul_data:
+        if (
+            isinstance(getattr(derivative, "__self__", None), QobjEvo)
+            and getattr(derivative.__self__, "matmul_data", None) == derivative
+        ):
             self.qevo = derivative.__self__
             self.qevo_derr = True
 

--- a/qutip/solver/integrator/_rhs.pyx
+++ b/qutip/solver/integrator/_rhs.pyx
@@ -1,0 +1,79 @@
+#cython: language_level=3
+
+from qutip.core.data cimport Data
+from qutip.core.cy.qobjevo cimport QobjEvo
+from qutip.core.data.constant import zeros_like
+from qutip.core.data.add import iadd
+
+# Migrating integrator from supporting QobjEvo (matmul) only, to functions
+# with signature:
+#
+#     (double t, Data state) -> Data dstate or
+#     (double t, Data state, Data dstate)
+#
+# - Keep fast cython access to `QobjEvo.matmul_data`
+# - Ensure support for both inplace and not python function.
+#
+
+
+__all__ = ["RHS"]
+
+
+cdef class RHS:
+    """
+    Container for the derivative function in qutip's cython integrator.
+
+    When it's a python callable, wrap it and add inplace support.
+
+    When it's a bound method of QobjEvo: bind the ``QobjEvo.matmul_data``
+    cython call directly as the derivative.
+    **This ignore the exact method used.**
+
+    Parameters
+    ----------
+    derivative: Callable[[float, _data.Data, ...], _data.Data] | QobjEvo
+        Function to integrate.
+        Can be either a QobjEvo where QobjEvo @ state is the derivative or
+        a callable. This function can be both inplace or not.
+
+    inplace: bool
+        If ``derivative`` is a callable, whether that function take the output
+        inplace or not.
+
+    """
+    def __init__(
+        self,
+        derivative: Callable[[float, _data.Data], _data.Data] | QobjEvo,
+        inplace: bool=False
+    ):
+        self.derivative = derivative
+        self.inplace = inplace
+        self.qevo_derr = False
+        if isinstance(getattr(derivative, "__self__", None), QobjEvo):
+            derivative = derivative.__self__
+        if isinstance(derivative, QobjEvo):
+            self.qevo = derivative
+            self.qevo_derr = True
+
+    def __call__(self, t: float, state: Data):
+        """
+        Apply the derivative function
+        """
+        return self.apply(t, state)
+
+    cdef Data apply(self, double t, Data state, Data out=None):
+        """
+        Cython interface for the derivative function.
+        """
+        if self.qevo_derr:
+            return self.qevo.matmul_data(t, state, out=out)
+
+        if self.inplace:
+            if out is None:
+                out = zeros_like(state)
+            self.derivative(t, state, out)
+        elif out is not None:
+            out = iadd(self.derivative(t, state), out)
+        else:
+            out = self.derivative(t, state)
+        return out

--- a/qutip/solver/integrator/_rhs.pyx
+++ b/qutip/solver/integrator/_rhs.pyx
@@ -26,9 +26,8 @@ cdef class RHS:
 
     When it's a python callable, wrap it and add inplace support.
 
-    When it's a bound method of QobjEvo: bind the ``QobjEvo.matmul_data``
-    cython call directly as the derivative.
-    **This ignore the exact method used.**
+    When it's a the method ``QobjEvo.matmul_data``, it uses it directly as a
+    cython call.
 
     Parameters
     ----------

--- a/qutip/solver/integrator/explicit_rk.pxd
+++ b/qutip/solver/integrator/explicit_rk.pxd
@@ -1,6 +1,6 @@
 #cython: language_level=3
 from qutip.core.data cimport Data
-from qutip.core.cy.qobjevo cimport QobjEvo
+from qutip.solver.integrator._rhs cimport RHS
 
 cpdef enum Status:
     AT_FRONT = 2
@@ -12,7 +12,7 @@ cpdef enum Status:
     NOT_INITIATED = -4
 
 cdef class Explicit_RungeKutta:
-    cdef QobjEvo qevo
+    cdef RHS deriv
 
     # Ode state data, set in set_initial_value
     cdef list k

--- a/qutip/solver/integrator/explicit_rk.pyx
+++ b/qutip/solver/integrator/explicit_rk.pyx
@@ -101,7 +101,7 @@ cdef class Explicit_RungeKutta:
         ):
         # Function to integrate.
         if not isinstance(deriv, RHS):
-            derivative = RHS(deriv)
+            deriv = RHS(deriv)
         self.deriv = deriv
         # tolerances
         self.atol = atol

--- a/qutip/solver/integrator/explicit_rk.pyx
+++ b/qutip/solver/integrator/explicit_rk.pyx
@@ -53,7 +53,7 @@ cdef class Explicit_RungeKutta:
     ----------
     deriv : callable, RHS
         The system to integrate: ```dX = deriv(t, X)``, either as a callable
-        with signature (t, state) or a RHS objectself.
+        with signature (t, state) or a RHS object.
 
     butcher_tableau : dict
         The coefficients as butcher tableau:

--- a/qutip/solver/integrator/explicit_rk.pyx
+++ b/qutip/solver/integrator/explicit_rk.pyx
@@ -10,6 +10,7 @@ from qutip.core.data.mul cimport imul_data
 from qutip.core.data.tidyup import tidyup_csr
 from qutip.core.data.norm import frobenius_data
 from qutip.core.data.ode cimport cy_wrmn_error
+from qutip.solver.integrator._rhs cimport RHS
 from cpython.exc cimport PyErr_CheckSignals
 cimport cython
 import numpy as np
@@ -50,8 +51,9 @@ cdef class Explicit_RungeKutta:
 
     Parameters
     ----------
-    qevo : QobjEvo
-        The system to integrate: ```dX = qevo.matmul_data(t, X)``
+    deriv : callable, RHS
+        The system to integrate: ```dX = deriv(t, X)``, either as a callable
+        with signature (t, state) or a RHS objectself.
 
     butcher_tableau : dict
         The coefficients as butcher tableau:
@@ -87,7 +89,7 @@ cdef class Explicit_RungeKutta:
     """
     def __init__(
             self,
-            QobjEvo qevo,
+            object deriv,
             dict butcher_tableau,
             double rtol=1e-6,
             double atol=1e-8,
@@ -98,7 +100,9 @@ cdef class Explicit_RungeKutta:
             bint interpolate=True,
         ):
         # Function to integrate.
-        self.qevo = qevo
+        if not isinstance(deriv, RHS):
+            derivative = RHS(deriv)
+        self.deriv = deriv
         # tolerances
         self.atol = atol
         self.rtol = rtol
@@ -192,7 +196,7 @@ cdef class Explicit_RungeKutta:
         Helper for pickle to serialize the object
         """
         return (self.__class__, (
-            self.qevo, self.butcher_tableau,
+            self.deriv, self.butcher_tableau,
             self.rtol, self.atol, self.max_numsteps, self.first_step,
             self.min_step, self.max_step, self.interpolate,
         ))
@@ -218,7 +222,7 @@ cdef class Explicit_RungeKutta:
         if self.first_same_as_last:
             self._k_fsal = self._y.copy()
             self._k_fsal = imul_data(<Data> self._k_fsal, 0)
-            self._k_fsal = self.qevo.matmul_data(t, y0, <Data> self._k_fsal)
+            self._k_fsal = self.deriv.apply(t, y0, <Data> self._k_fsal)
 
         if not self.first_step:
             self._dt_safe = self._estimate_first_step(t, self._y)
@@ -237,7 +241,7 @@ cdef class Explicit_RungeKutta:
             self.k[0] = copy_to(self._k_fsal, self.k[0])
         else:
             self.k[0] = imul_data(<Data> self.k[0], 0)
-            self.k[0] = self.qevo.matmul_data(t, y0, <Data> self.k[0])
+            self.k[0] = self.deriv.apply(t, y0, <Data> self.k[0])
 
         # Ok approximation for linear system. But not in a general case.
         if norm <= self.atol:
@@ -256,7 +260,7 @@ cdef class Explicit_RungeKutta:
         # below dt1 / 100 is an arbitrary small fraction of dt1:
         self._y_temp = iadd_data(self._y_temp, <Data> self.k[0], dt1 / 100)
         self.k[1] = imul_data(<Data> self.k[1], 0)
-        self.k[1] = self.qevo.matmul_data(t1, self._y_temp, <Data> self.k[1])
+        self.k[1] = self.deriv.apply(t1, self._y_temp, <Data> self.k[1])
         tmp_norm = frobenius_data(<Data> self.k[1])
         if tmp_norm >= (self.atol * 1e-6):
             dt2 = ((tol * factorial * norm**self.order)**(1 / (self.order+1))
@@ -362,14 +366,14 @@ cdef class Explicit_RungeKutta:
             self.k[0] = copy_to(self._k_fsal, self.k[0])
         else:
             self.k[0] = imul_data(<Data> self.k[0], 0.)
-            self.k[0] = self.qevo.matmul_data(self._t_prev, self._y_prev,
+            self.k[0] = self.deriv.apply(self._t_prev, self._y_prev,
                                               <Data> self.k[0])
 
         for i in range(1, self.rk_step):
             self.k[i] = imul_data(<Data> self.k[i], 0.)
             self._y_temp = copy_to(self._y_prev, self._y_temp)
             self._y_temp = self._accumulate(self._y_temp, self.a[i,:], dt, i)
-            self.k[i] = self.qevo.matmul_data(self._t_prev + self.c[i]*dt,
+            self.k[i] = self.deriv.apply(self._t_prev + self.c[i]*dt,
                                               self._y_temp, <Data> self.k[i])
 
         # Compute the state
@@ -402,7 +406,7 @@ cdef class Explicit_RungeKutta:
             self.k[i] = imul_data(<Data> self.k[i], 0.)
             self._y_temp = copy_to(self._y_prev, self._y_temp)
             self._y_temp = self._accumulate(self._y_temp, self.a[i,:], dt, i)
-            self.k[i] = self.qevo.matmul_data(self._t_prev + self.c[i]*dt,
+            self.k[i] = self.deriv.apply(self._t_prev + self.c[i]*dt,
                                               self._y_temp, <Data> self.k[i])
 
     cdef Data _interpolate_step(self, double t, Data out):

--- a/qutip/solver/integrator/integrator.py
+++ b/qutip/solver/integrator/integrator.py
@@ -31,7 +31,7 @@ class Integrator:
     ----------
     derivative: callable | QobjEvo
         Function to integrate.
-        Note that specific integrator may require other input as controlled by
+        Note that specific integrators may require other input types. These types are specified by
         the ``RHS_format`` attribute.
 
     options: dict
@@ -43,16 +43,16 @@ class Integrator:
         The name of the integrator.
 
     RHS_format : {"callable", "matrix", "solver"}
-        Which format the ODE integrator rhs is used by the integration method.
-        - "callable": The integrator expect a function with signature
+        Which format the ODE integrator expects for its RHS:
+        - "callable": The integrator expects a function with the signature
           ``rhs(t, Data) -> Data``.
-          Some cython integrator use ``RHS`` object for cython binding.
+          Some cython integrators use the RHS object for cython binding.
           "callable" is the default for most ODE methods.
-        - "matrix": The integrator take a constant matrix as a ``Data`` object
-          as the rhs and will solve the equation ``dX/dt = RHS @ X``.
-        - "solver": The integrator take the Solver instance that created it and
-          build the RHS itself. These are limited to integration method that
-          mixes the physics of the problem and the numerics.
+        - "matrix": The integrator takes a constant matrix as a ``Data`` object
+          as the RHS and will solve the equation ``dX/dt = RHS @ X``.
+        - "solver": The integrator takes the Solver instance that created it and
+          builds the RHS itself. Typically used only by integration methods that
+          mix the system physics and the integrator numerics.
 
     integrator_options : dict
         A dictionary of options used by the integrator and their default
@@ -64,7 +64,7 @@ class Integrator:
     integrator_options = {}
     _options = None
     # How the rhs is passed to the integrator.
-    # "Solver", "matrix", or "callable".
+    # "solver", "matrix", or "callable".
     RHS_format = "callable"
     # The name of the integrator
     name = None

--- a/qutip/solver/integrator/integrator.py
+++ b/qutip/solver/integrator/integrator.py
@@ -2,6 +2,7 @@
 import numpy as np
 from collections.abc import Iterator, Callable
 from qutip.core import QobjEvo
+from ._rhs import RHS
 from qutip.core.data import Data
 
 __all__ = ['Integrator', 'IntegratorException']
@@ -44,7 +45,8 @@ class Integrator:
     RHS_format : {"callable", "matrix", "Solver"}
         Which format the ODE integrator rhs is used by the integration method.
         - "callable": The integrator expect a function with signature
-          ``rhs(t, Data) -> Data``, ``rhs(t, Data, out=Data)``.
+          ``rhs(t, Data) -> Data``.
+          Some cython integrator use ``RHS`` object for cython binding.
           "callable" is the default for most ODE methods.
         - "matrix": The integrator take a constant matrix as a ``Data`` object
           as the rhs and will solve the equation ``dX/dt = RHS @ X``.

--- a/qutip/solver/integrator/integrator.py
+++ b/qutip/solver/integrator/integrator.py
@@ -1,5 +1,8 @@
 """ `Integrator`: ODE solver wrapper to use in qutip's Solver """
 import numpy as np
+from collections.abc import Iterator, Callable
+from qutip.core import QobjEvo
+from qutip.core.data import Data
 
 __all__ = ['Integrator', 'IntegratorException']
 
@@ -25,8 +28,10 @@ class Integrator:
 
     Parameters
     ----------
-    system: qutip.QobjEvo
-        Quantum system in which states evolve.
+    derivative: callable | QobjEvo
+        Function to integrate.
+        Note that specific integrator may require other input as controlled by
+        the ``RHS_format`` attribute.
 
     options: dict
         Options for the integrator.
@@ -36,19 +41,16 @@ class Integrator:
     name : str
         The name of the integrator.
 
-    supports_blackbox : bool
-        If True, then the integrator calls only ``system.matmul``,
-        ``system.matmul_data``, ``system.expect``, ``system.expect_data`` and
-        ``isconstant``, ``isoper`` or ``issuper``. This allows the solver using
-        the integrator to modify the system in creative ways. In particular,
-        the solver may modify the system depending on *both* the time ``t``
-        *and* the current ``state`` the system is being applied to.
-
-        If the integrator calls any other methods, set to False.
-
-    supports_time_dependent : bool
-        If True, then the integrator supports time dependent systems. If False,
-        ``supports_blackbox`` should usually be ``False`` too.
+    RHS_format : {"callable", "matrix", "Solver"}
+        Which format the ODE integrator rhs is used by the integration method.
+        - "callable": The integrator expect a function with signature
+          ``rhs(t, Data) -> Data``, ``rhs(t, Data, out=Data)``.
+          "callable" is the default for most ODE methods.
+        - "matrix": The integrator take a constant matrix as a ``Data`` object
+          as the rhs and will solve the equation ``dX/dt = RHS @ X``.
+        - "solver": The integrator take the Solver instance that created it and
+          build the RHS itself. These are limited to integration method that
+          mixes the physics of the problem and the numerics.
 
     integrator_options : dict
         A dictionary of options used by the integrator and their default
@@ -59,16 +61,21 @@ class Integrator:
     # Dict of used options and their default values
     integrator_options = {}
     _options = None
-    # Can evolve time dependent system
-    support_time_dependant = None
-    # Whether the integrator used the system QobjEvo as a blackbox
-    supports_blackbox = None
+    # How the rhs is passed to the integrator.
+    # "Solver", "matrix", or "callable".
+    RHS_format = "callable"
     # The name of the integrator
     name = None
     method = ""
 
-    def __init__(self, system, options):
-        self.system = system
+    def __init__(
+        self,
+        derivative: Callable[[float, Data], Data] | QobjEvo | RHS,
+        options: dict
+    ):
+        if not callable(derivative):
+            raise TypeError("The derivative must be a callable.")
+        self.derivative = derivative
         self._is_set = False  # get_state can be used and return a valid state.
         self._back = (np.inf, None)
         self._options = self.integrator_options.copy()
@@ -82,7 +89,7 @@ class Integrator:
         """
         raise NotImplementedError
 
-    def set_state(self, t, state0):
+    def set_state(self, t: float, state: Data):
         """
         Set the state of the ODE solver.
 
@@ -99,7 +106,9 @@ class Integrator:
         """
         raise NotImplementedError
 
-    def integrate(self, t, copy=True):
+    def integrate(
+        self, t: float, copy: bool = True
+    ) -> tuple[float, Data]:
         """
         Evolve to t.
 
@@ -121,7 +130,7 @@ class Integrator:
         """
         raise NotImplementedError
 
-    def mcstep(self, t, copy=True):
+    def mcstep(self, t: float, copy: bool = True) -> tuple[float, Data]:
         """
         Evolve toward the time ``t``.
 
@@ -167,7 +176,7 @@ class Integrator:
             )
         return self.integrate(t, copy)
 
-    def get_state(self, copy=True):
+    def get_state(self, copy: bool = True) -> tuple[float, Data]:
         """
         Obtain the state of the solver as a pair (t, state).
 
@@ -183,7 +192,7 @@ class Integrator:
         """
         raise NotImplementedError
 
-    def run(self, tlist):
+    def run(self, tlist: list[float]) -> Iterator[tuple[float, Data]]:
         """
         Integrate the system yielding the state for each times in tlist.
 
@@ -200,7 +209,9 @@ class Integrator:
         for t in tlist[1:]:
             yield self.integrate(t, False)
 
-    def reset(self, hard=False):
+        #TODO: why cut tlist[0] here, not in solver?
+
+    def reset(self, hard: bool = False):
         """Reset internal state of the ODE solver."""
         if self._is_set:
             state = self.get_state()
@@ -219,16 +230,17 @@ class Integrator:
         args : dict
             New arguments
         """
+        raise Exception("Remove this method")
         self.system.arguments(args)
         self.reset()
 
     @property
-    def options(self):
+    def options(self) -> dict:
         # Options should be overwritten by each integrators.
         return self._options
 
     @options.setter
-    def options(self, new_options):
+    def options(self, new_options: dict):
         # This does not apply the new options.
         self._options = {
             **self._options,

--- a/qutip/solver/integrator/integrator.py
+++ b/qutip/solver/integrator/integrator.py
@@ -32,7 +32,7 @@ class Integrator:
     derivative: callable | QobjEvo
         Function to integrate.
         Note that specific integrators may require other input types. These types are specified by
-        the ``RHS_format`` attribute.
+        the ``rhs_format`` attribute.
 
     options: dict
         Options for the integrator.
@@ -42,7 +42,7 @@ class Integrator:
     name : str
         The name of the integrator.
 
-    RHS_format : {"callable", "matrix", "solver"}
+    rhs_format : {"callable", "matrix", "solver"}
         Which format the ODE integrator expects for its RHS:
         - "callable": The integrator expects a function with the signature
           ``rhs(t, Data) -> Data``.
@@ -65,7 +65,7 @@ class Integrator:
     _options = None
     # How the rhs is passed to the integrator.
     # "solver", "matrix", or "callable".
-    RHS_format = "callable"
+    rhs_format = "callable"
     # The name of the integrator
     name = None
     method = ""
@@ -221,20 +221,6 @@ class Integrator:
             self._prepare()
         if self._is_set:
             self.set_state(*state)
-
-    def arguments(self, args):
-        """
-        Change the argument of the system.
-        Reset the ODE solver to ensure numerical validity.
-
-        Parameters
-        ----------
-        args : dict
-            New arguments
-        """
-        raise Exception("Remove this method")
-        self.system.arguments(args)
-        self.reset()
 
     @property
     def options(self) -> dict:

--- a/qutip/solver/integrator/integrator.py
+++ b/qutip/solver/integrator/integrator.py
@@ -42,7 +42,7 @@ class Integrator:
     name : str
         The name of the integrator.
 
-    RHS_format : {"callable", "matrix", "Solver"}
+    RHS_format : {"callable", "matrix", "solver"}
         Which format the ODE integrator rhs is used by the integration method.
         - "callable": The integrator expect a function with signature
           ``rhs(t, Data) -> Data``.

--- a/qutip/solver/integrator/krylov.py
+++ b/qutip/solver/integrator/krylov.py
@@ -26,11 +26,14 @@ class IntegratorKrylov(Integrator):
         'sub_system_tol': 1e-7,
         'algorithm': 'auto',
     }
-    method = 'krylov'
+    RHS_format = "matrix"
 
-    def _prepare(self):
-        if not self.system.isconstant:
-            raise ValueError("Krylov method only supports constant systems.")
+    def __init__(self, rhs: _data.Data, options: dict):
+        self.rhs = rhs
+        self._is_set = False
+        self._back = (np.inf, None)
+        self._options = self.integrator_options.copy()
+        self.options = options
 
         if self.options["krylov_dim"] <= 0:
             raise ValueError("The option 'krylov_dim', must be an integer "
@@ -38,7 +41,7 @@ class IntegratorKrylov(Integrator):
 
         self._max_step = -np.inf
         self._krylov_dim = self.options["krylov_dim"]
-        self._hermitian = (1j*self.system(0)).isherm
+        self._hermitian = _data.isherm(self.rhs * 1j)
 
         if self.options['algorithm'] == 'auto':
             if self._hermitian:
@@ -93,7 +96,7 @@ class IntegratorKrylov(Integrator):
             The basis vectors of the Krylov subspace.
         """
         krylov_dim = self._krylov_dim
-        H = (1j * self.system(0)).data
+        H = (1j * self.rhs)
         p0 = _data.inner(psi, psi)  # purity
         sp0 = np.sqrt(p0)
 
@@ -175,7 +178,7 @@ class IntegratorKrylov(Integrator):
             The basis vectors of the Krylov subspace.
         """
         krylov_dim = self._krylov_dim
-        H = (1j * self.system(0)).data
+        H = (1j * self.rhs)
         p0 = _data.inner(psi, psi)  # purity
         sp0 = np.sqrt(p0)
 
@@ -248,7 +251,7 @@ class IntegratorKrylov(Integrator):
             )
         return min(dt, self.options["max_step"])
 
-    def set_state(self, t, state0):
+    def set_state(self, t: float, state0: _data.Data):
         self._t_0 = t
 
         krylov_tridiag, krylov_basis = self._algorithm(state0)
@@ -257,7 +260,7 @@ class IntegratorKrylov(Integrator):
 
         if (
             krylov_tridiag.shape[0] < self._krylov_dim
-            or krylov_tridiag.shape == self.system.shape
+            or krylov_tridiag.shape == self.rhs.shape
         ):
             # happy_breakdown
             self._max_step = np.inf
@@ -269,10 +272,10 @@ class IntegratorKrylov(Integrator):
         ):
             self._max_step = self._compute_max_step(krylov_tridiag)
 
-    def get_state(self, copy=True):
+    def get_state(self, copy=True) -> tuple[float, Data]:
         return self._t_0, self._compute_psi(0, *self._krylov_state)
 
-    def integrate(self, t, copy=True):
+    def integrate(self, t: float, copy: bool = True) -> tuple[float, Data]:
         step = 0
         while t > self._t_0 + self._max_step:
             # The approximation in only valid in the range t_0, t_0 + max step
@@ -292,7 +295,7 @@ class IntegratorKrylov(Integrator):
         return t, self._compute_psi(delta_t, *self._krylov_state)
 
     @property
-    def options(self):
+    def options(self) -> dict:
         """
         Supported options by krylov method:
 
@@ -329,7 +332,7 @@ class IntegratorKrylov(Integrator):
         return self._options
 
     @options.setter
-    def options(self, new_options):
+    def options(self, new_options: dict):
         Integrator.options.fset(self, new_options)
 
 

--- a/qutip/solver/integrator/krylov.py
+++ b/qutip/solver/integrator/krylov.py
@@ -43,17 +43,18 @@ class IntegratorKrylov(Integrator):
         self._krylov_dim = self.options["krylov_dim"]
         self._hermitian = _data.isherm(self.rhs * 1j)
 
+    def _algorithm(self, psi):
         if self.options['algorithm'] == 'auto':
             if self._hermitian:
-                self._algorithm = self._lanczos_full_reorth_algorithm
+                _algorithm = self._lanczos_full_reorth_algorithm
             else:
-                self._algorithm = self._arnoldi_algorithm
+                _algorithm = self._arnoldi_algorithm
         elif self.options['algorithm'] == 'arnoldi':
-            self._algorithm = self._arnoldi_algorithm
+            _algorithm = self._arnoldi_algorithm
         elif self.options['algorithm'] == 'lanczos_fro':
-            self._algorithm = self._lanczos_full_reorth_algorithm
+            _algorithm = self._lanczos_full_reorth_algorithm
         elif self.options['algorithm'] == 'lanczos':
-            self._algorithm = self._lanczos_algorithm
+            _algorithm = self._lanczos_algorithm
         else:
             raise ValueError("The requested algorithm "
                              f"{self.options['algorithm']} "
@@ -61,11 +62,12 @@ class IntegratorKrylov(Integrator):
                              "Possible options are: \'lanczos\', "
                              "\'lanczos_fro\', \'arnoldi\'.")
 
-        if not self._hermitian and self._algorithm != self._arnoldi_algorithm:
+        if not self._hermitian and _algorithm != self._arnoldi_algorithm:
             # Arnoldi is the only algorithm for open systems in QuTiP atm
             raise ValueError(f"The requested Krylov algorithm "
                              f"{self.options['algorithm']} "
                              "is not supported for non-Hermitian systems.")
+        return _algorithm(psi)
 
     def _lanczos_algorithm(self, psi):
         return self._lanczos_core(psi, max_orthog_steps=2)

--- a/qutip/solver/integrator/krylov.py
+++ b/qutip/solver/integrator/krylov.py
@@ -272,10 +272,12 @@ class IntegratorKrylov(Integrator):
         ):
             self._max_step = self._compute_max_step(krylov_tridiag)
 
-    def get_state(self, copy=True) -> tuple[float, Data]:
+    def get_state(self, copy=True) -> tuple[float, _data.Data]:
         return self._t_0, self._compute_psi(0, *self._krylov_state)
 
-    def integrate(self, t: float, copy: bool = True) -> tuple[float, Data]:
+    def integrate(
+        self, t: float, copy: bool = True
+    ) -> tuple[float, _data.Data]:
         step = 0
         while t > self._t_0 + self._max_step:
             # The approximation in only valid in the range t_0, t_0 + max step

--- a/qutip/solver/integrator/krylov.py
+++ b/qutip/solver/integrator/krylov.py
@@ -26,8 +26,6 @@ class IntegratorKrylov(Integrator):
         'sub_system_tol': 1e-7,
         'algorithm': 'auto',
     }
-    support_time_dependant = False
-    supports_blackbox = False
     method = 'krylov'
 
     def _prepare(self):

--- a/qutip/solver/integrator/krylov.py
+++ b/qutip/solver/integrator/krylov.py
@@ -26,7 +26,7 @@ class IntegratorKrylov(Integrator):
         'sub_system_tol': 1e-7,
         'algorithm': 'auto',
     }
-    RHS_format = "matrix"
+    rhs_format = "matrix"
 
     def __init__(self, rhs: _data.Data, options: dict):
         self.rhs = rhs

--- a/qutip/solver/integrator/qutip_integrator.py
+++ b/qutip/solver/integrator/qutip_integrator.py
@@ -190,7 +190,7 @@ class IntegratorDiag(Integrator):
     Usable with ``method="diag"``
     """
     integrator_options = {"eigensolver_dtype": "dense"}
-    RHS_format = "matrix"
+    rhs_format = "matrix"
 
     def __init__(self, rhs: _data.Data, options: dict):
         self.rhs = rhs

--- a/qutip/solver/integrator/qutip_integrator.py
+++ b/qutip/solver/integrator/qutip_integrator.py
@@ -57,32 +57,31 @@ class IntegratorVern7(Integrator):
         'min_step': 0,
         'interpolate': True,
     }
-    support_time_dependant = True
-    supports_blackbox = True
-    method = 'vern7'
     tableau = vern7_coeff
 
     def _prepare(self):
         self._ode_solver = Explicit_RungeKutta(
-            self.system, self.tableau,
+            self.derivative, self.tableau,
             **self.options
         )
         self.name = self.method
 
-    def get_state(self, copy=True):
+    def get_state(self, copy: bool = True) -> tuple[float, _data.Data]:
         state = self._ode_solver.y
         return self._ode_solver.t, state.copy() if copy else state
 
-    def set_state(self, t, state):
+    def set_state(self, t: float, state: _data.Data):
         self._ode_solver.set_initial_value(state.copy(), t)
         self._is_set = True
 
-    def integrate(self, t, copy=True):
+    def integrate(
+        self, t: float, copy: bool = True
+    ) -> tuple[float, _data.Data]:
         self._ode_solver.integrate(t, step=False)
         self._check_failed_integration()
         return self.get_state(copy)
 
-    def mcstep(self, t, copy=True):
+    def mcstep(self, t: float, copy: bool = True) -> tuple[float, _data.Data]:
         self._ode_solver.integrate(t, step=True)
         self._check_failed_integration()
         return self.get_state(copy)
@@ -93,7 +92,7 @@ class IntegratorVern7(Integrator):
         raise IntegratorException(self._ode_solver.status_message())
 
     @property
-    def options(self):
+    def options(self) -> dict:
         """
         Supported options by verner method:
 
@@ -123,7 +122,7 @@ class IntegratorVern7(Integrator):
         return self._options
 
     @options.setter
-    def options(self, new_options):
+    def options(self, new_options: dict):
         Integrator.options.fset(self, new_options)
 
 
@@ -151,7 +150,6 @@ class IntegratorVern9(IntegratorVern7):
         'min_step': 0,
         'interpolate': True,
     }
-    method = 'vern9'
     tableau = vern9_coeff
 
 
@@ -180,7 +178,6 @@ class IntegratorTsit5(IntegratorVern7):
         'min_step': 0,
         'interpolate': True,
     }
-    method = 'tsit5'
     tableau = tsit5_coeff
 
 
@@ -193,26 +190,25 @@ class IntegratorDiag(Integrator):
     Usable with ``method="diag"``
     """
     integrator_options = {"eigensolver_dtype": "dense"}
-    support_time_dependant = False
-    supports_blackbox = False
-    method = 'diag'
+    RHS_format = "matrix"
 
-    def __init__(self, system, options):
-        if not system.isconstant:
-            raise ValueError("Hamiltonian system must be constant to use "
-                             "diagonalized method")
-        super().__init__(system, options)
+    def __init__(self, rhs: _data.Data, options: dict):
+        self.rhs = rhs
+        self._is_set = False
+        self._options = self.integrator_options.copy()
+        self.options = options
 
-    def _prepare(self):
         self._dt = 0.
         self._expH = None
-        H0 = self.system(0).to(self.options["eigensolver_dtype"])
-        self.diag, self.U = _data.eigs(H0.data, False)
+        H0 = _data.to(self.options["eigensolver_dtype"], self.rhs)
+        self.diag, self.U = _data.eigs(H0, False)
         self.diag = self.diag.reshape((-1, 1))
         self.Uinv = _data.inv(self.U)
         self.name = "qutip diagonalized"
 
-    def integrate(self, t, copy=True):
+    def integrate(
+        self, t: float, copy: bool = True
+    ) -> tuple[float, _data.Data]:
         dt = t - self._t
         if dt == 0:
             return self.get_state()
@@ -223,21 +219,21 @@ class IntegratorDiag(Integrator):
         self._t = t
         return self.get_state(copy)
 
-    def mcstep(self, t, copy=True):
+    def mcstep(self, t: float, copy: bool = True) -> tuple[float, _data.Data]:
         return self.integrate(t, copy=copy)
 
-    def get_state(self, copy=True):
+    def get_state(self, copy: bool = True) -> tuple[float, _data.Data]:
         return self._t, _data.matmul(
             self.U, _data.dense.fast_from_numpy(self._y)
         )
 
-    def set_state(self, t, state0):
+    def set_state(self, t: float, state0: _data.Data):
         self._t = t
         self._y = _data.matmul(self.Uinv, state0).to_array()
         self._is_set = True
 
     @property
-    def options(self):
+    def options(self) -> dict:
         """
         Supported options by "diag" method:
 
@@ -249,7 +245,7 @@ class IntegratorDiag(Integrator):
         return self._options
 
     @options.setter
-    def options(self, new_options):
+    def options(self, new_options: dict):
         Integrator.options.fset(self, new_options)
 
 

--- a/qutip/solver/integrator/scipy_integrator.py
+++ b/qutip/solver/integrator/scipy_integrator.py
@@ -34,8 +34,6 @@ class IntegratorScipyAdams(Integrator):
         'max_step': 0,
         'min_step': 0,
     }
-    support_time_dependant = True
-    supports_blackbox = True
     method = 'adams'
 
     class _zvode(zvode):
@@ -54,23 +52,25 @@ class IntegratorScipyAdams(Integrator):
         """
         self._ode_solver = ode(self._mul_np_vec)
         self._ode_solver.set_integrator('zvode')
+        self._ode_solver.set_f_params(self)
         self._ode_solver._integrator = self._zvode(
             method=self.method,
             **self.options,
         )
         self.name = "scipy zvode " + self.method
 
-    def _mul_np_vec(self, t, vec):
+    @staticmethod
+    def _mul_np_vec(t, vec, self):
         """
         Interface between scipy which use numpy and the driver, which use data.
         """
         state = _data.dense.fast_from_numpy(vec)
-        column_unstack_dense(state, self._size, inplace=True)
-        out = self.system.matmul_data(t, state)
-        column_stack_dense(out, inplace=True)
+        state = column_unstack_dense(state, self._size, inplace=True)
+        out = _data.to(_data.Dense, self.derivative(t, state))
+        out = column_stack_dense(out, inplace=out.fortran)
         return out.as_ndarray().ravel()
 
-    def set_state(self, t, state0):
+    def set_state(self, t: float, state0: _data.Data):
         self._is_set = True
         self._back = t
         self._front = t
@@ -80,7 +80,7 @@ class IntegratorScipyAdams(Integrator):
             state0 = _data.column_stack(state0)
         self._ode_solver.set_initial_value(state0.to_array().ravel(), t)
 
-    def get_state(self, copy=True):
+    def get_state(self, copy: bool = True) -> tuple[float, _data.Data]:
         if not self._is_set:
             raise IntegratorException("The state is not initialted")
         self._check_failed_integration()
@@ -104,13 +104,15 @@ class IntegratorScipyAdams(Integrator):
             if integrator.handle != integrator.__class__.active_global_handle:
                 integrator.reset(len(self._ode_solver._y), False)
 
-    def integrate(self, t, copy=True):
+    def integrate(
+        self, t: float, copy: bool = True
+    ) -> tuple[float, _data.Data]:
         self._check_handle()
         if t != self._ode_solver.t:
             self._ode_solver.integrate(t)
         return self.get_state(copy)
 
-    def mcstep(self, t, copy=True):
+    def mcstep(self, t: float, copy: bool = True) -> tuple[float, _data.Data]:
         # When working with mcstep, we use the dense output feature:
         # a range in which the state at any time can be computed with
         # minimal work. We keep track of the range with _back and _front.
@@ -159,7 +161,7 @@ class IntegratorScipyAdams(Integrator):
         )
 
     @property
-    def options(self):
+    def options(self) -> dict:
         """
         Supported options by zvode integrator:
 
@@ -189,7 +191,7 @@ class IntegratorScipyAdams(Integrator):
         return self._options
 
     @options.setter
-    def options(self, new_options):
+    def options(self, new_options: dict):
         Integrator.options.fset(self, new_options)
 
 
@@ -233,9 +235,6 @@ class IntegratorScipyDop853(Integrator):
         'dfactor': 0.3,
         'beta': 0.0,
     }
-    support_time_dependant = True
-    supports_blackbox = True
-    method = 'dop853'
 
     def _prepare(self):
         """
@@ -245,24 +244,28 @@ class IntegratorScipyDop853(Integrator):
         # scipy 1.17 does not convert automatically anymore
         self.options["nsteps"] = int(self.options["nsteps"])
         self._ode_solver.set_integrator('dop853', **self.options)
+        self._ode_solver.set_f_params(self)
         self.name = "scipy ode dop853"
 
-    def _mul_np_vec(self, t, vec):
+    @staticmethod
+    def _mul_np_vec(t, vec, self):
         """
         Interface between scipy which use numpy and the driver, which use data.
         """
         state = _data.dense.fast_from_numpy(vec.view(np.complex128))
         column_unstack_dense(state, self._size, inplace=True)
-        out = self.system.matmul_data(t, state)
-        column_stack_dense(out, inplace=True)
+        out = _data.to(_data.Dense, self.derivative(t, state))
+        out = column_stack_dense(out, inplace=out.fortran)
         return out.as_ndarray().ravel().view(np.float64)
 
-    def integrate(self, t, copy=True):
+    def integrate(
+        self, t: float, copy: bool = True
+    ) -> tuple[float, _data.Data]:
         if t != self._ode_solver.t:
             self._ode_solver.integrate(t)
         return self.get_state(copy)
 
-    def mcstep(self, t, copy=True):
+    def mcstep(self, t: float, copy: bool = True) -> tuple[float, _data.Data]:
         if self._ode_solver.t <= t:
             # Scipy's DOP853 does not have a step function.
             # It has a safe step length, but can be 0 if unknown.
@@ -278,7 +281,7 @@ class IntegratorScipyDop853(Integrator):
             self._ode_solver._integrator.work[6] *= -1
         return self.get_state(copy)
 
-    def get_state(self, copy=True):
+    def get_state(self, copy: bool = True) -> tuple[float, _data.Data]:
         if not self._is_set:
             raise IntegratorException("The state is not initialted")
         self._check_failed_integration()
@@ -296,7 +299,7 @@ class IntegratorScipyDop853(Integrator):
             )
         return t, state
 
-    def set_state(self, t, state0):
+    def set_state(self, t: float, state0: _data.Data):
         self._is_set = True
         self._mat_state = state0.shape[1] > 1
         self._size = state0.shape[0]
@@ -323,7 +326,7 @@ class IntegratorScipyDop853(Integrator):
         )
 
     @property
-    def options(self):
+    def options(self) -> dict:
         """
         Supported options by dop853 integrator:
 
@@ -353,7 +356,7 @@ class IntegratorScipyDop853(Integrator):
         return self._options
 
     @options.setter
-    def options(self, new_options):
+    def options(self, new_options: dict):
         Integrator.options.fset(self, new_options)
 
 
@@ -375,9 +378,6 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
         'max_step': 0.0,
         'min_step': 0.0,
     }
-    support_time_dependant = True
-    supports_blackbox = True
-    method = 'lsoda'
 
     def _prepare(self):
         """
@@ -385,6 +385,7 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
         """
         self._ode_solver = ode(self._mul_np_vec)
         self._ode_solver.set_integrator('lsoda', **self.options)
+        self._ode_solver.set_f_params(self)
         self.name = "scipy lsoda"
 
     def _check_handle(self):
@@ -397,16 +398,20 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
             if integrator.handle != integrator.__class__.active_global_handle:
                 integrator.reset(len(self._ode_solver._y), False)
 
-    def integrate(self, t, copy=True):
+    def integrate(
+        self, t: float, copy: bool = True
+    ) -> tuple[float, _data.Data]:
         self._check_handle()
-        return super().integrate(t, copy)
+        out = super().integrate(t, copy)
+        self._front = self._ode_solver._integrator.rwork[12]
+        return out
 
-    def set_state(self, t, state0):
+    def set_state(self, t: float, state0: _data.Data):
         self._front = t
         super().set_state(t, state0)
         self._back = self.get_state()
 
-    def mcstep(self, t, copy=True):
+    def mcstep(self, t: float, copy: bool = True) -> tuple[float, _data.Data]:
         # This solver support dense output:
         # a range in which the state at any time can be computed with
         # minimal work. We keep track of the range with _back[0] and _front.
@@ -488,7 +493,7 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
         )
 
     @property
-    def options(self):
+    def options(self) -> dict:
         """
         Supported options by lsoda integrator:
 
@@ -521,7 +526,7 @@ class IntegratorScipylsoda(IntegratorScipyDop853):
         return self._options
 
     @options.setter
-    def options(self, new_options):
+    def options(self, new_options: dict):
         Integrator.options.fset(self, new_options)
 
 

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -795,7 +795,7 @@ class MCSolver(MultiTrajSolver):
                     "only support constant systems."
                 )
             integrator_instance = integrator(rhs(0).data, self.options)
-        elif integrator.RHS_format == "Solver":
+        elif integrator.RHS_format == "solver":
             integrator_instance = integrator(self, self.options)
         else:
             raise ValueError("Integrator entry point not supported.")

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -786,16 +786,16 @@ class MCSolver(MultiTrajSolver):
         else:
             raise ValueError("Integrator method not supported.")
         rhs = self.rhs()
-        if integrator.RHS_format == "callable":
+        if integrator.rhs_format == "callable":
             integrator_instance = integrator(rhs.matmul_data, self.options)
-        elif integrator.RHS_format == "matrix":
+        elif integrator.rhs_format == "matrix":
             if not rhs.isconstant:
                 raise TypeError(
                     f"The integration method {method} "
                     "only support constant systems."
                 )
             integrator_instance = integrator(rhs(0).data, self.options)
-        elif integrator.RHS_format == "solver":
+        elif integrator.rhs_format == "solver":
             integrator_instance = integrator(self, self.options)
         else:
             raise ValueError("Integrator entry point not supported.")

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -785,7 +785,20 @@ class MCSolver(MultiTrajSolver):
             integrator = method
         else:
             raise ValueError("Integrator method not supported.")
-        integrator_instance = integrator(self.rhs(), self.options)
+        rhs = self.rhs()
+        if integrator.RHS_format == "callable":
+            integrator_instance = integrator(rhs.matmul_data, self.options)
+        elif integrator.RHS_format == "matrix":
+            if not rhs.isconstant:
+                raise TypeError(
+                    f"The integration method {method} "
+                    "only support constant systems."
+                )
+            integrator_instance = integrator(rhs(0).data, self.options)
+        elif integrator.RHS_format == "Solver":
+            integrator_instance = integrator(self, self.options)
+        else:
+            raise ValueError("Integrator entry point not supported.")
         mc_integrator = self._mc_integrator_class(
             integrator_instance, self.rhs, self.options
         )

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -377,7 +377,7 @@ class MultiTrajSolver(Solver):
         """Update the args, for the `rhs` and `c_ops` and other operators."""
         if args:
             self.rhs.arguments(args)
-            self._integrator.arguments(args)
+            self._integrator.reset()
 
     def _get_generator(self, seed):
         """

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -286,18 +286,18 @@ class Solver:
             integrator = method
         else:
             raise ValueError("Integrator method not supported.")
-        if integrator.RHS_format == "callable":
+        if integrator.rhs_format == "callable":
             integrator_instance = integrator(
                 self.rhs.matmul_data, self.options
             )
-        elif integrator.RHS_format == "matrix":
+        elif integrator.rhs_format == "matrix":
             if not self.rhs.isconstant:
                 raise TypeError(
                     f"The integration method {method} "
                     "only support constant systems."
                 )
             integrator_instance = integrator(self.rhs(0).data, self.options)
-        elif integrator.RHS_format == "solver":
+        elif integrator.rhs_format == "solver":
             integrator_instance = integrator(self, self.options)
         else:
             raise ValueError("Integrator entry point not supported.")

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -286,7 +286,22 @@ class Solver:
             integrator = method
         else:
             raise ValueError("Integrator method not supported.")
-        integrator_instance = integrator(self.rhs, self.options)
+        if integrator.RHS_format == "callable":
+            integrator_instance = integrator(
+                self.rhs.matmul_data, self.options
+            )
+        elif integrator.RHS_format == "matrix":
+            if not self.rhs.isconstant:
+                raise TypeError(
+                    f"The integration method {method} "
+                    "only support constant systems."
+                )
+            integrator_instance = integrator(self.rhs(0).data, self.options)
+        elif integrator.RHS_format == "Solver":
+            integrator_instance = integrator(self, self.options)
+        else:
+            raise ValueError("Integrator entry point not supported.")
+
         self._init_integrator_time = time() - _time_start
         return integrator_instance
 
@@ -439,7 +454,7 @@ class Solver:
         """Update the args, for the `rhs` and other operators."""
         if args:
             self.rhs.arguments(args)
-            self._integrator.arguments(args)
+            self._integrator.reset()
 
     @classmethod
     def avail_integrators(cls):

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -297,7 +297,7 @@ class Solver:
                     "only support constant systems."
                 )
             integrator_instance = integrator(self.rhs(0).data, self.options)
-        elif integrator.RHS_format == "Solver":
+        elif integrator.RHS_format == "solver":
             integrator_instance = integrator(self, self.options)
         else:
             raise ValueError("Integrator entry point not supported.")

--- a/qutip/solver/stochastic.py
+++ b/qutip/solver/stochastic.py
@@ -1035,6 +1035,21 @@ class StochasticSolver(MultiTrajSolver):
             return _DataFeedback(default, open=cls._open)
         return _QobjFeedback(default, open=cls._open)
 
+    def _get_integrator(self):
+        """ Return the initialted integrator. """
+        _time_start = time()
+        method = self._options["method"]
+        if method in self.avail_integrators():
+            integrator = self.avail_integrators()[method]
+        elif issubclass(method, Integrator):
+            integrator = method
+        else:
+            raise ValueError("Integrator method not supported.")
+        integrator_instance = integrator(self.rhs, self.options)
+
+        self._init_integrator_time = time() - _time_start
+        return integrator_instance
+
 
 class SMESolver(StochasticSolver):
     r"""

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -52,7 +52,7 @@ class TestIntegratorCallable:
     @pytest.fixture(params=[
         method
         for method, integrator in Solver.avail_integrators().items()
-        if integrator.RHS_format == "callable"
+        if integrator.rhs_format == "callable"
     ])
     def method(self, request):
         # Callable are the general method that should all be registered with
@@ -155,9 +155,9 @@ class TestIntegratorMCstep():
 
     def test_mc_integration(self, mc_method):
         integrator = MCSolver.avail_integrators()[mc_method]
-        if integrator.RHS_format == "callable":
+        if integrator.rhs_format == "callable":
             evol = integrator(self.system.matmul_data, {})
-        elif integrator.RHS_format == "matrix":
+        elif integrator.rhs_format == "matrix":
             evol = integrator(self.system(0).data, {})
         else:
             pytest.skip()
@@ -185,9 +185,9 @@ class TestIntegratorMCstep():
     def test_mc_integration_mixed(self, start, mc_method):
         system = qutip.QobjEvo(qutip.qeye(1))
         integrator = MCSolver.avail_integrators()[mc_method]
-        if integrator.RHS_format == "callable":
+        if integrator.rhs_format == "callable":
             evol = integrator(system.matmul_data, {})
-        elif integrator.RHS_format == "matrix":
+        elif integrator.rhs_format == "matrix":
             evol = integrator(system(0).data, {})
         else:
             pytest.skip()

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -17,39 +17,47 @@ from qutip.core.coefficient import WARN_MISSING_MODULE
 WARN_MISSING_MODULE[0] = 0
 
 
-def derivative_1(t, state, out=None):
-    x = state.to_array()
-    der = np.array([
-        [1, t],
-        [x[1, 0] * -0.1, t**2],
-        [-0.1j * t * x[2, 0], t**3],
-    ])
-    der = _data.Dense(der)
-    if out is not None:
-        out += der
-        der = out
-    return der
-
-def analytical_1(t, x0):
-    x0 = x0.to_array()
-    out = np.array([
-        [x0[0, 0] + t, x0[0, 1] + t**2/2],
-        [np.exp(t * -0.1) * x0[1, 0] , x0[1, 1] + t**3/3],
-        [np.exp(-0.1j * t**2/2) * x0[2, 0], x0[2, 1] + t**4/4],
-    ])
-    return out
-
-mat = qutip.rand_herm(3, density=0.75) * -1j
-
-derivative_2 = qutip.QobjEvo(mat).matmul_data
-
-def analytical_2(t, x0):
-    return ((t * mat).expm() @ qutip.Qobj(x0)).full()
-
-derivative_3 = RHS(derivative_1, inplace=True)
-
-
 class TestIntegratorCallable:
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        def derivative_1(t, state, out=None):
+            x = state.to_array()
+            der = np.array([
+                [1, t],
+                [x[1, 0] * -0.1, t**2],
+                [-0.1j * t * x[2, 0], t**3],
+            ])
+            der = _data.Dense(der)
+            if out is not None:
+                out += der
+                der = out
+            return der
+
+        def analytical_1(t, x0):
+            x0 = x0.to_array()
+            out = np.array([
+                [x0[0, 0] + t, x0[0, 1] + t**2/2],
+                [np.exp(t * -0.1) * x0[1, 0] , x0[1, 1] + t**3/3],
+                [np.exp(-0.1j * t**2/2) * x0[2, 0], x0[2, 1] + t**4/4],
+            ])
+            return out
+
+        mat = qutip.rand_herm(3, density=0.75) * -1j
+
+        derivative_2 = qutip.QobjEvo(mat).matmul_data
+
+        def analytical_2(t, x0):
+            return ((t * mat).expm() @ qutip.Qobj(x0)).full()
+
+        derivative_3 = RHS(derivative_1, inplace=True)
+
+        self.tests_cases = {
+            "function": (derivative_1, analytical_1),
+            "QobjEvo": (derivative_2, analytical_2),
+            "RHS": (derivative_3, analytical_1),
+        }
+
     @pytest.fixture(params=[
         method
         for method, integrator in Solver.avail_integrators().items()
@@ -77,12 +85,9 @@ class TestIntegratorCallable:
         assert t_in == t_target
         assert_allclose(analytical(t_in, state0), state.to_array(), atol=5e-5)
 
-    @pytest.mark.parametrize(["derivative", "analytical"], [
-        (derivative_1, analytical_1),
-        (derivative_2, analytical_2),
-        (derivative_3, analytical_1),
-    ], ids=["function", "QobjEvo", "RHS"])
-    def test_integration_func(self, derivative, analytical, method):
+    @pytest.mark.parametrize("case", ["function", "QobjEvo", "RHS"])
+    def test_integration_func(self, case, method):
+        derivative, analytical = self.tests_cases[case]
         integrator = Solver.avail_integrators()[method]
         integrator_instance = integrator(derivative, {})
         state0 = _data.Dense(np.array([

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -3,7 +3,11 @@ from qutip.solver.mesolve import MESolver
 from qutip.solver.mcsolve import MCSolver
 from qutip.solver.solver_base import Solver
 from qutip.solver.integrator import *
+from qutip.solver.integrator._rhs import RHS
 import qutip
+import qutip.core.data as _data
+
+import functools
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -13,48 +17,150 @@ from qutip.core.coefficient import WARN_MISSING_MODULE
 WARN_MISSING_MODULE[0] = 0
 
 
-class TestIntegratorCte():
-    _analytical_se = lambda _, t: np.cos(t * np.pi)
-    se_system = qutip.QobjEvo(-1j * qutip.sigmax() * np.pi)
-    _analytical_me = lambda _, t: 1 - np.exp(-t)
-    me_system = qutip.liouvillian(qutip.QobjEvo(qutip.qeye(2)),
-                                  c_ops=[qutip.destroy(2)])
-    kopt = {"krylov_dim": 3}
+def derivative_1(t, state, out=None):
+    x = state.to_array()
+    der = np.array([
+        [1, t],
+        [x[1, 0] * -0.1, t**2],
+        [-0.1j * t * x[2, 0], t**3],
+    ])
+    der = _data.Dense(der)
+    if out is not None:
+        der += out
+    return der
 
-    @pytest.fixture(params=list(SESolver.avail_integrators().keys()))
-    def se_method(self, request):
+def analytical_1(t, x0):
+    x0 = x0.to_array()
+    out = np.array([
+        [x0[0, 0] + t, x0[0, 1] + t**2/2],
+        [np.exp(t * -0.1) * x0[1, 0] , x0[1, 1] + t**3/3],
+        [np.exp(-0.1j * t**2/2) * x0[2, 0], x0[2, 1] + t**4/4],
+    ])
+    return out
+
+mat = qutip.rand_herm(3, density=0.75) * -1j
+
+derivative_2 = qutip.QobjEvo(mat).matmul_data
+
+def analytical_2(t, x0):
+    return ((t * mat).expm() @ qutip.Qobj(x0)).full()
+
+derivative_3 = RHS(derivative_1, inplace=True)
+
+
+class TestIntegratorCallable:
+    @pytest.fixture(params=[
+        method
+        for method, integrator in Solver.avail_integrators().items()
+        if integrator.RHS_format == "callable"
+    ])
+    def method(self, request):
+        # Callable are the general method that should all be registered with
+        # the general Solver
         return request.param
 
-    @pytest.fixture(params=list(MESolver.avail_integrators().keys()))
-    def me_method(self, request):
+    def _check_integrator(self, integrator_instance, state0, analytical):
+        integrator_instance.set_state(0, state0)
+        tlist = np.linspace(0, 2, 21)
+        for (t, state), t_in in zip(integrator_instance.run(tlist), tlist[1:]):
+            assert t == t_in
+            assert_allclose(analytical(t, state0), state.to_array(), atol=5e-5)
+            assert state.shape == state0.shape
+        t, state = integrator_instance.integrate(3)
+        assert t == 3.
+        assert_allclose(analytical(t, state0), state.to_array(), atol=5e-5)
+
+        t_front, state = integrator_instance.mcstep(5)
+        t_target = (3 + t_front) / 2
+        t_in, state = integrator_instance.mcstep(t_target)
+        assert t_in == t_target
+        assert_allclose(analytical(t_in, state0), state.to_array(), atol=5e-5)
+
+    # When the derivative is C ordered, the messa
+    # @pytest.mark.filterwarnings("ignore:cannot stack columns")
+
+    @pytest.mark.parametrize(['derivative', "analytical"], [
+        (derivative_1, analytical_1),
+        (derivative_2, analytical_2),
+        (derivative_3, analytical_1),
+    ], ids=["function", "QobjEvo", "RHS"])
+    def test_integration_func(self, derivative, analytical, method):
+        integrator = Solver.avail_integrators()[method]
+        integrator_instance = integrator(derivative, {})
+        state0 = _data.Dense(np.array([
+            [1, 1j],
+            [1., 0.25 + 0.75j],
+            [0.5 - 0.5j, 0.],
+        ]))
+        self._check_integrator(integrator_instance, state0, analytical)
+
+
+class TestIntegratorMatrix:
+    hermitian = qutip.rand_herm(10).data
+    non_hermitian = (
+        qutip.rand_stochastic(10, density=0.4) +
+        qutip.rand_stochastic(10, density=0.4) *1j
+    ).data
+
+    @pytest.fixture(params=[
+        (IntegratorKrylov, {"krylov_dim": 5}),
+        (IntegratorDiag, {}),
+    ], ids=["krylov", "diag"])
+    def integrator(self, request):
+        # Matrix could be limited to hermitian only and not registered with
+        # all solver.
         return request.param
 
-    # TODO: Change when the MCSolver is added
+    @staticmethod
+    def analytical(matrix, t, state0):
+        return ((qutip.Qobj(matrix) * t).expm() @ qutip.Qobj(state0)).full()
+
+    def _check_integrator(self, integrator_instance, state0, analytical):
+        integrator_instance.set_state(0, state0)
+        tlist = np.linspace(0, 2, 21)
+        for (t, state), t_in in zip(integrator_instance.run(tlist), tlist[1:]):
+            assert t == t_in
+            assert_allclose(analytical(t, state0), state.to_array(), atol=2e-5)
+            assert state.shape == state0.shape
+        t, state = integrator_instance.integrate(3)
+        assert t == 3.
+        assert_allclose(analytical(t, state0), state.to_array(), atol=2e-5)
+
+    def test_integration_hermitian(self, integrator):
+        integrator, options = integrator
+        integrator_instance = integrator(self.hermitian, options)
+        state0 = qutip.rand_ket(10).data
+        self._check_integrator(
+            integrator_instance, state0,
+            functools.partial(self.analytical, self.hermitian)
+        )
+
+    def test_integration_non_hermitian(self, integrator):
+        integrator, options = integrator
+        integrator_instance = integrator(self.non_hermitian, options)
+        state0 = qutip.rand_ket(10).data
+        self._check_integrator(
+            integrator_instance, state0,
+            functools.partial(self.analytical, self.non_hermitian)
+        )
+
+
+class TestIntegratorMCstep():
+    analytical = lambda _, t: np.cos(t * np.pi)
+    system = qutip.QobjEvo(-1j * qutip.sigmax() * np.pi)
+
     @pytest.fixture(params=list(MCSolver.avail_integrators().keys()))
     def mc_method(self, request):
         return request.param
 
-    def test_se_integration(self, se_method):
-        evol = SESolver.avail_integrators()[se_method](self.se_system, self.kopt)
-        state0 = qutip.basis(2, 0).data
-        evol.set_state(0, state0)
-        for t, state in evol.run(np.linspace(0, 2, 21)):
-            assert_allclose(self._analytical_se(t),
-                            state.to_array()[0, 0], atol=2e-5)
-            assert state.shape == (2, 1)
-
-    def test_me_integration(self, me_method):
-        evol = MESolver.avail_integrators()[me_method](self.me_system, self.kopt)
-        state0 = qutip.operator_to_vector(qutip.fock_dm(2,1)).data
-        evol.set_state(0, state0)
-        for t in np.linspace(0, 2, 21):
-            t_, state = evol.integrate(t)
-            assert t_ == t
-            assert_allclose(self._analytical_me(t),
-                            state.to_array()[0, 0], atol=2e-5)
-
     def test_mc_integration(self, mc_method):
-        evol = MCSolver.avail_integrators()[mc_method](self.se_system, {})
+        integrator = MCSolver.avail_integrators()[mc_method]
+        if integrator.RHS_format == "callable":
+            evol = integrator(self.system.matmul_data, {})
+        elif integrator.RHS_format == "matrix":
+            evol = integrator(self.system(0).data, {})
+        else:
+            pytest.skip()
         state = qutip.basis(2,0).data
         evol.set_state(0, state)
         t = 0
@@ -65,12 +171,12 @@ class TestIntegratorCte():
                 t, state = evol.mcstep(t_target)
                 assert t <= t_target
                 assert t > t_old
-                assert_allclose(self._analytical_se(t),
+                assert_allclose(self.analytical(t),
                                 state.to_array()[0, 0], atol=2e-5)
                 t_back = (t + t_old) / 2
                 t_got, bstate = evol.mcstep(t_back)
                 assert t_back == t_got
-                assert_allclose(self._analytical_se(t),
+                assert_allclose(self.analytical(t),
                                 state.to_array()[0, 0], atol=2e-5)
                 t, state = evol.mcstep(t)
 
@@ -78,7 +184,13 @@ class TestIntegratorCte():
     @pytest.mark.parametrize('start', [1, -1])
     def test_mc_integration_mixed(self, start, mc_method):
         system = qutip.QobjEvo(qutip.qeye(1))
-        evol = Solver.avail_integrators()[mc_method](system, {})
+        integrator = MCSolver.avail_integrators()[mc_method]
+        if integrator.RHS_format == "callable":
+            evol = integrator(system.matmul_data, {})
+        elif integrator.RHS_format == "matrix":
+            evol = integrator(system(0).data, {})
+        else:
+            pytest.skip()
 
         state = qutip.basis(1,0).data
         evol.set_state(start, state)
@@ -95,37 +207,6 @@ class TestIntegratorCte():
         )
 
 
-class TestIntegrator(TestIntegratorCte):
-    _analytical_se = lambda _, t: np.cos(t**2/2 * np.pi)
-    se_system = qutip.QobjEvo([-1j * qutip.sigmax() * np.pi, "t"])
-    _analytical_me = lambda _, t: 1 - np.exp(-(t**3) / 3)
-    me_system = qutip.liouvillian(
-        qutip.QobjEvo(qutip.qeye(2)),
-        c_ops=[qutip.QobjEvo([qutip.destroy(2), 't'])]
-    )
-
-    @pytest.fixture(
-        params=[key for key, integrator in SESolver.avail_integrators().items()
-                if integrator.support_time_dependant]
-    )
-    def se_method(self, request):
-        return request.param
-
-    @pytest.fixture(
-        params=[key for key, integrator in MESolver.avail_integrators().items()
-                if integrator.support_time_dependant]
-    )
-    def me_method(self, request):
-        return request.param
-
-    @pytest.fixture(
-        params=[key for key, integrator in MCSolver.avail_integrators().items()
-                if integrator.support_time_dependant]
-    )
-    def mc_method(self, request):
-        return request.param
-
-
 @pytest.mark.parametrize('sizes', [(1, 100), (10, 10), (100, 0)],
                      ids=["large", "multiple subspaces", "diagonal"])
 def test_krylov(sizes):
@@ -135,9 +216,9 @@ def test_krylov(sizes):
     H = qutip.qeye(N)
     if M:
         H = H & (qutip.num(M) + qutip.create(M) + qutip.destroy(M))
-    H = qutip.QobjEvo(-1j * H)
-    integrator = IntegratorKrylov(H, {"krylov_dim": 30})
-    ref_integrator = IntegratorDiag(H, {})
+    H = -1j * H
+    integrator = IntegratorKrylov(H.data, {"krylov_dim": 30})
+    ref_integrator = IntegratorDiag(H.data, {})
     psi = qutip.basis(100, 95).data
     integrator.set_state(0, psi)
     ref_integrator.set_state(0, psi)
@@ -155,11 +236,11 @@ def test_concurent_usage(integrator):
     opt = {'atol':1e-10, 'rtol':1e-7}
 
     sys1 = qutip.QobjEvo(0.5 * qutip.qeye(1))
-    inter1 = integrator(sys1, opt)
+    inter1 = integrator(sys1.matmul_data, opt)
     inter1.set_state(0, qutip.basis(1,0).data)
 
     sys2 = qutip.QobjEvo(-0.5 * qutip.qeye(1))
-    inter2 = integrator(sys2, opt)
+    inter2 = integrator(sys2.matmul_data, opt)
     inter2.set_state(0, qutip.basis(1,0).data)
 
     for t in np.linspace(0,1,6):
@@ -178,7 +259,7 @@ def test_pickling_rk_methods(integrator):
     opt = {'atol':1e-10, 'rtol':1e-7}
 
     sys = qutip.QobjEvo(0.5 * qutip.qeye(1))
-    inter = integrator(sys, opt)
+    inter = integrator(sys.matmul_data, opt)
     inter.set_state(0, qutip.basis(1,0).data)
 
     import pickle
@@ -202,7 +283,7 @@ def test_rk_options(integrator):
         'atol':1e-10, 'rtol':1e-7, 'interpolate':False, 'first_step':0.5
     }
 
-    sys = qutip.QobjEvo(qutip.qeye(1))
+    sys = qutip.QobjEvo(qutip.qeye(1)).matmul_data
     inter = integrator(sys, opt)
     inter.set_state(0, qutip.basis(1,0).data)
 

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -55,13 +55,13 @@ class TestIntegratorCallable:
         if integrator.rhs_format == "callable"
     ])
     def method(self, request):
-        # Callable are the general method that should all be registered with
-        # the general Solver
+        # The callables returned are the general method registered with
+        # the base Solver class.
         return request.param
 
     def _check_integrator(self, integrator_instance, state0, analytical):
-        integrator_instance.set_state(0, state0)
         tlist = np.linspace(0, 2, 21)
+        integrator_instance.set_state(tlist[0], state0)
         for (t, state), t_in in zip(integrator_instance.run(tlist), tlist[1:]):
             assert t == t_in
             assert_allclose(analytical(t, state0), state.to_array(), atol=5e-5)
@@ -79,7 +79,7 @@ class TestIntegratorCallable:
     # When the derivative is C ordered, the messa
     # @pytest.mark.filterwarnings("ignore:cannot stack columns")
 
-    @pytest.mark.parametrize(['derivative', "analytical"], [
+    @pytest.mark.parametrize(["derivative", "analytical"], [
         (derivative_1, analytical_1),
         (derivative_2, analytical_2),
         (derivative_3, analytical_1),

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -26,7 +26,8 @@ def derivative_1(t, state, out=None):
     ])
     der = _data.Dense(der)
     if out is not None:
-        der += out
+        out += der
+        der = out
     return der
 
 def analytical_1(t, x0):
@@ -75,9 +76,6 @@ class TestIntegratorCallable:
         t_in, state = integrator_instance.mcstep(t_target)
         assert t_in == t_target
         assert_allclose(analytical(t_in, state0), state.to_array(), atol=5e-5)
-
-    # When the derivative is C ordered, the messa
-    # @pytest.mark.filterwarnings("ignore:cannot stack columns")
 
     @pytest.mark.parametrize(['derivative', "analytical"], [
         (derivative_1, analytical_1),

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -15,7 +15,7 @@ WARN_MISSING_MODULE[0] = 0
 
 all_ode_method = [
     method for method, integrator in MESolver.avail_integrators().items()
-    if integrator.support_time_dependant
+    if integrator.RHS_format == "callable"
 ]
 
 def fidelitycheck(out1, out2, rho0vec):

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -15,7 +15,7 @@ WARN_MISSING_MODULE[0] = 0
 
 all_ode_method = [
     method for method, integrator in MESolver.avail_integrators().items()
-    if integrator.RHS_format == "callable"
+    if integrator.rhs_format == "callable"
 ]
 
 def fidelitycheck(out1, out2, rho0vec):

--- a/qutip/tests/solver/test_sesolve.py
+++ b/qutip/tests/solver/test_sesolve.py
@@ -13,7 +13,7 @@ WARN_MISSING_MODULE[0] = 0
 
 all_ode_method = [
     method for method, integrator in SESolver.avail_integrators().items()
-    if integrator.support_time_dependant
+    if integrator.RHS_format == "callable"
 ]
 
 def _analytic(t, alpha):

--- a/qutip/tests/solver/test_sesolve.py
+++ b/qutip/tests/solver/test_sesolve.py
@@ -13,7 +13,7 @@ WARN_MISSING_MODULE[0] = 0
 
 all_ode_method = [
     method for method, integrator in SESolver.avail_integrators().items()
-    if integrator.RHS_format == "callable"
+    if integrator.rhs_format == "callable"
 ]
 
 def _analytic(t, alpha):


### PR DESCRIPTION
**Description**
Change integrator to accept other format that QobjEvo.
Remove the  `support_time_dependant`, `supports_blackbox` flags for a `RHS_format` value.
This `RHS_format` indicate the format of the RHS: arbitrary function, constant matrix or the solver itself.

Now most integrator can take any callable with the right signature as the derivative. `krylov`, `diag` take a matrix directly.

I also added an internal documentation section for the integrators.

- Made change to the memory management: avoided integrator to keep a one of it's method as an attribute. This create a reference loop and stop easy de-allocation. Should help with #2819, but does not fully solve the issue.

- Added types hint for public facing Integrator method.

- Removed the `method` attribute, it's explicitly passed in `add_integrator` so redundant.

This is the first of a set of PR adding internal documentation for the solvers.

**AI Tools Usage Disclosure**
Gemini: review + Rephrased the documentation `.rst`.
