### PR TITLE
Fix: AttributeError in Bloch.render with matplotlib widget mode

### DIFF
--- a/doc/changes/2914.bugfix
+++ b/doc/changes/2914.bugfix
@@ -1,0 +1,1 @@
+Fixed an AttributeError in Bloch.render() while using the interactive ipympl matplotlib backend.

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -785,7 +785,7 @@ class Bloch:
             self.fig.canvas.draw()
 
     def plot_back(self):
-        # back half of sphere=
+        # back half of sphere
         u = np.linspace(0, np.pi, 25)
         v = np.linspace(0, np.pi, 25)
         w = np.linspace(-np.pi / 2, np.pi / 2, 25)

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -782,7 +782,12 @@ class Bloch:
         self.plot_annotations()
         # Trigger an update of the Bloch sphere if it is already shown:
         if getattr(self.fig.canvas, "manager", None) is not None:
-            self.fig.canvas.draw()
+            try:
+                self.fig.canvas.draw()
+            except AttributeError as e:
+                # Catching matplotlib WebAgg backend initialization quirk in newer versions
+                if "refresh_all" not in str(e):
+                    raise
 
     def plot_back(self):
         # back half of sphere

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -782,12 +782,7 @@ class Bloch:
         self.plot_annotations()
         # Trigger an update of the Bloch sphere if it is already shown:
         if getattr(self.fig.canvas, "manager", None) is not None:
-            try:
-                self.fig.canvas.draw()
-            except AttributeError as e:
-                # Catching matplotlib WebAgg backend initialization quirk in newer versions
-                if "refresh_all" not in str(e):
-                    raise
+            self.fig.canvas.draw_idle()
 
     def plot_back(self):
         # back half of sphere

--- a/qutip/bloch.py
+++ b/qutip/bloch.py
@@ -781,10 +781,11 @@ class Bloch:
         self.plot_axes_labels()
         self.plot_annotations()
         # Trigger an update of the Bloch sphere if it is already shown:
-        self.fig.canvas.draw()
+        if getattr(self.fig.canvas, "manager", None) is not None:
+            self.fig.canvas.draw()
 
     def plot_back(self):
-        # back half of sphere
+        # back half of sphere=
         u = np.linspace(0, np.pi, 25)
         v = np.linspace(0, np.pi, 25)
         w = np.linspace(-np.pi / 2, np.pi / 2, 25)


### PR DESCRIPTION
Fixes #2914

## Description
This PR fixes an issue where using `%matplotlib widget` (the `ipympl` backend) causes an `AttributeError` when instantiating a `Bloch()` sphere.

The root cause is a timing mismatch. During IPython's rendering hook, the figure evaluates before the UI manager is fully attached to the canvas. Because `self.fig.canvas.manager` is `None`, calling `draw()` forces a `refresh_all()` on a non-existent manager, which crashes the output.

To fix this, I added a defensive attribute check in `Bloch.render()` right before triggering the canvas draw. This ensures the UI manager is actually present before it attempts an update.

## AI Tools Usage Disclosure
- [x] I used AI tools during the development of this PR.

**Details of use:** I used Gemini 3.1 Pro Extended as a learning aid to help me explore the QuTiP codebase and trace the `ipympl` rendering lifecycle to understand the root cause. I have fully read, tested, and understood the resulting fix. The final implementation is my own, and I take full accountability for this contribution as per the project guidelines.

## Checklist
- [x] I have read the Contributing Guidelines from the file` CONTRIBUTING.md`.
- [x] I have performed a self-review of my own code.
- [x] I have verified the fix locally using the `ipympl` backend.