### PR TITLE
Fixed mcsolve trajectory allocation for unnormalized mixed states

### DIFF
--- a/doc/changes/2927.bugfix
+++ b/doc/changes/2927.bugfix
@@ -1,0 +1,1 @@
+Normalize mixed-state eigenvalue weights in ``mcsolve`` so that unnormalized density matrices correctly allocate the requested number of trajectories.

--- a/doc/changes/2927.bugfix
+++ b/doc/changes/2927.bugfix
@@ -1,1 +1,1 @@
-Normalize mixed-state eigenvalue weights in ``mcsolve`` so that unnormalized density matrices correctly allocate the requested number of trajectories.
+Use normalized mixed-state weights for trajectory allocation in ``mcsolve`` so that unnormalized density matrices correctly allocate the requested number of trajectories while preserving the original state trace.

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -10,6 +10,7 @@ from time import time
 from typing import Any
 import warnings
 
+from .. import settings
 from ..core import QobjEvo, spre, spost, Qobj, unstack_columns, qzero_like
 from ..typing import QobjEvoLike, EopsLike
 from .multitraj import MultiTrajSolver, _MultiTrajRHS, _InitialConditions
@@ -655,7 +656,6 @@ class MCSolver(MultiTrajSolver):
         # We process the arguments and pass on to other functions depending on
         # whether "improved sampling" is turned on, and whether the initial
         # state is mixed.
-        allocation_state = None
         if isinstance(state, (list, tuple)):
             is_mixed = True
         else:  # state is Qobj, either pure state or dm
@@ -669,19 +669,22 @@ class MCSolver(MultiTrajSolver):
                 # format, i.e., into eigenstates and eigenvalues
                 eigenvalues, eigenstates = state.eigenstates()
 
-                # Preserve the original eigenvalues for result averaging.
-                state = [
-                    (psi, p)
-                    for psi, p in zip(eigenstates, eigenvalues)
-                    if p > 0
-                ]
+                state = [(psi, p) for psi, p
+                         in zip(eigenstates, eigenvalues) if p > 0]
 
-                # Normalized weights are used only for trajectory allocation.
+                # We allow the initial density matrix to be unnormalized.
+                # Since super()._run_mixed expects `state` to be normalized
+                # we must generate the "numbers of trajectories per state"
+                # list here manually, based on the normalized state
                 total_weight = sum(p for _, p in state)
-                allocation_state = [
-                    (psi, p / total_weight)
-                    for psi, p in state
-                ]
+                if abs(total_weight - 1) > settings.core["atol"]:
+                    normalized_state = [
+                        (psi, p / total_weight)
+                        for psi, p in state
+                    ]
+                    ntraj = _InitialConditions._minimum_roundoff_ensemble(
+                        normalized_state, ntraj or len(state)
+                    )
         if is_mixed and target_tol is not None:
             warnings.warn('Monte Carlo simulations with mixed initial '
                           'state do not support target tolerance')
@@ -692,9 +695,6 @@ class MCSolver(MultiTrajSolver):
                 ntraj = len(state)
             else:
                 ntraj = 1
-
-        if allocation_state is not None:
-            ntraj = _InitialConditions(allocation_state, ntraj).ntraj
 
         if not self.options["improved_sampling"]:
             if is_mixed:

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -655,6 +655,7 @@ class MCSolver(MultiTrajSolver):
         # We process the arguments and pass on to other functions depending on
         # whether "improved sampling" is turned on, and whether the initial
         # state is mixed.
+        allocation_state = None
         if isinstance(state, (list, tuple)):
             is_mixed = True
         else:  # state is Qobj, either pure state or dm
@@ -667,14 +668,20 @@ class MCSolver(MultiTrajSolver):
                 # Mixed state given as density matrix. Decompose into list
                 # format, i.e., into eigenstates and eigenvalues
                 eigenvalues, eigenstates = state.eigenstates()
-                state = []
-                total_weight = 0
-                for psi, p in zip(eigenstates, eigenvalues):
-                    if p > 0:
-                        state.append((psi, p))
-                        total_weight += p
-                state = [(psi, p / total_weight) for psi, p in state]
 
+                # Preserve the original eigenvalues for result averaging.
+                state = [
+                    (psi, p)
+                    for psi, p in zip(eigenstates, eigenvalues)
+                    if p > 0
+                ]
+
+                # Normalized weights are used only for trajectory allocation.
+                total_weight = sum(p for _, p in state)
+                allocation_state = [
+                    (psi, p / total_weight)
+                    for psi, p in state
+                ]
         if is_mixed and target_tol is not None:
             warnings.warn('Monte Carlo simulations with mixed initial '
                           'state do not support target tolerance')
@@ -685,6 +692,9 @@ class MCSolver(MultiTrajSolver):
                 ntraj = len(state)
             else:
                 ntraj = 1
+
+        if allocation_state is not None:
+            ntraj = _InitialConditions(allocation_state, ntraj).ntraj
 
         if not self.options["improved_sampling"]:
             if is_mixed:

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -667,8 +667,13 @@ class MCSolver(MultiTrajSolver):
                 # Mixed state given as density matrix. Decompose into list
                 # format, i.e., into eigenstates and eigenvalues
                 eigenvalues, eigenstates = state.eigenstates()
-                state = [(psi, p) for psi, p
-                         in zip(eigenstates, eigenvalues) if p > 0]
+                state = []
+                total_weight = 0
+                for psi, p in zip(eigenstates, eigenvalues):
+                    if p > 0:
+                        state.append((psi, p))
+                        total_weight += p
+                state = [(psi, p / total_weight) for psi, p in state]
 
         if is_mixed and target_tol is not None:
             warnings.warn('Monte Carlo simulations with mixed initial '

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -439,7 +439,8 @@ class _InitialConditions:
             raise ValueError('Each initial state must be use for at least '
                              'one trajectory')
 
-    def _minimum_roundoff_ensemble(self, state_list, ntraj_total):
+    @classmethod
+    def _minimum_roundoff_ensemble(cls, state_list, ntraj_total):
         """
         Calculate a list ntraj from the given total number, under contraints
         explained above. Algorithm based on https://stackoverflow.com/a/792490

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -658,9 +658,23 @@ def test_mixed_equals_merged(improved_sampling, p):
     )
 
 
-def test_mcsolve_unnormalized_mixed_state():
+@pytest.mark.parametrize(
+    "weight_0, weight_1, expected_trace",
+    [
+        (0.5, 0.25, 0.75),
+        (0.75, 0.5, 1.25),
+    ],
+)
+def test_mcsolve_unnormalized_mixed_state(
+    weight_0, weight_1, expected_trace
+):
     ntraj = 10
-    initial_state = 0.5 * qutip.fock_dm(2, 0) + 0.25 * qutip.fock_dm(2, 1)
+
+    # Test density matrices with traces below and above one.
+    initial_state = (
+        weight_0 * qutip.fock_dm(2, 0)
+        + weight_1 * qutip.fock_dm(2, 1)
+    )
 
     result = mcsolve(
         qutip.sigmaz(),
@@ -671,8 +685,10 @@ def test_mcsolve_unnormalized_mixed_state():
         options={"progress_bar": False},
         seeds=1234,
     )
-
-    assert initial_state.tr() == 0.75
     assert result.num_trajectories == ntraj
     assert sum(result.ntraj_per_initial_state) == ntraj
+    assert all(
+        state.tr() == pytest.approx(expected_trace)
+        for state in result.states
+    )
     

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -656,3 +656,23 @@ def test_mixed_equals_merged(improved_sampling, p):
         sum(merged_result.runs_weights + merged_result.deterministic_weights)
         == pytest.approx(1.)
     )
+
+
+def test_mcsolve_unnormalized_mixed_state():
+    ntraj = 10
+    initial_state = 0.5 * qutip.fock_dm(2, 0) + 0.25 * qutip.fock_dm(2, 1)
+
+    result = mcsolve(
+        qutip.sigmaz(),
+        initial_state,
+        np.linspace(0, 1, 100),
+        [qutip.sigmam()],
+        ntraj=ntraj,
+        options={"progress_bar": False},
+        seeds=1234,
+    )
+
+    assert initial_state.tr() == 0.75
+    assert result.num_trajectories == ntraj
+    assert sum(result.ntraj_per_initial_state) == ntraj
+    

--- a/qutip/tests/solver/test_mcsolve.py
+++ b/qutip/tests/solver/test_mcsolve.py
@@ -683,7 +683,6 @@ def test_mcsolve_unnormalized_mixed_state(
         [qutip.sigmam()],
         ntraj=ntraj,
         options={"progress_bar": False},
-        seeds=1234,
     )
     assert result.num_trajectories == ntraj
     assert sum(result.ntraj_per_initial_state) == ntraj
@@ -691,4 +690,3 @@ def test_mcsolve_unnormalized_mixed_state(
         state.tr() == pytest.approx(expected_trace)
         for state in result.states
     )
-    

--- a/qutip/tests/solver/test_nm_mcsolve.py
+++ b/qutip/tests/solver/test_nm_mcsolve.py
@@ -793,3 +793,39 @@ def test_mixed_equals_merged(improved_sampling, p):
         sum(merged_result.runs_weights + merged_result.deterministic_weights)
         == pytest.approx(1.)
     )
+
+
+@pytest.mark.parametrize(
+    "weight_0, weight_1, expected_trace",
+    [
+        (0.5, 0.25, 0.75),
+        (0.75, 0.5, 1.25),
+    ],
+)
+
+
+def test_nmmcsolve_unnormalized_mixed_state(
+    weight_0, weight_1, expected_trace
+):
+    ntraj = 10
+
+    # Test density matrices with traces below and above one.
+    initial_state = (
+        weight_0 * qutip.fock_dm(2, 0)
+        + weight_1 * qutip.fock_dm(2, 1)
+    )
+
+    result = nm_mcsolve(
+        qutip.sigmaz(),
+        initial_state,
+        np.linspace(0, 1, 100),
+        [(qutip.sigmam(), 1.0)],
+        ntraj=ntraj,
+        options={"progress_bar": False},
+    )
+    assert result.num_trajectories == ntraj
+    assert sum(result.ntraj_per_initial_state) == ntraj
+    assert all(
+        state.tr() == pytest.approx(expected_trace)
+        for state in result.states
+    )


### PR DESCRIPTION
## Description

Fixes #2880.

`mcsolve` accepts the initial state as a `Qobj`. When the initial state is a mixed density matrix, `MCSolver.run` decomposes it into eigenstates and eigenvalues. This creates a list of pure-state components in the form `(psi, p)`.

The mixed-state trajectory code assumes that these weights sum to one. If the input density matrix is not normalized, the total weight can be smaller or larger than one. This can make `_minimum_roundoff_ensemble` allocate a different number of trajectories from the requested `ntraj`. The solver still creates seeds for the requested number of trajectories, which can later cause an `IndexError`.

This PR keeps the original eigenvalue weights for calculating the result states, but uses normalized weights for trajectory allocation. This makes sure the requested number of trajectories is allocated while keeping the original trace in the output states.

For direct ensemble input through `MCSolver.run`, where the user passes a list of `(state, weight)` pairs, the existing assumption that the weights sum to one is unchanged.

## Tests
Added a parameterized test for unnormalized mixed density matrices with traces below and above one.
The test checks that:
- `mcsolve` completes without an error.
- The requested number of trajectories is allocated.
- The total number of trajectories across the initial states matches `ntraj`.
- The states in `result.states` keep the trace of the original input state.

Tested with:
```bash
python -m pytest qutip/tests/solver/test_mcsolve.py
```

## AI Tools Usage Disclosure
OpenAI ChatGPT/Codex: Used to better understand the issue, improve the PR description, and provide suggestions/autocomplete in VS Code. I reviewed and implemented all the final changes.