### PR TITLE
docs: link mesolve/mcsolve docstrings to their user guide sections

### DIFF
--- a/doc/changes/2929.doc
+++ b/doc/changes/2929.doc
@@ -1,0 +1,1 @@
+Link mesolve and mcsolve docstrings to their user guide sections.

--- a/qutip/solver/mcsolve.py
+++ b/qutip/solver/mcsolve.py
@@ -39,6 +39,9 @@ def mcsolve(
     given Hamiltonian and sets of collapse operators. Options for the
     underlying ODE solver are given by the Options class.
 
+    See the guide on the :ref:`monte` for a discussion of the method and
+    its conventions.
+
     Parameters
     ----------
     H : :class:`.Qobj`, :class:`.QobjEvo`, ``list``, callable.

--- a/qutip/solver/mesolve.py
+++ b/qutip/solver/mesolve.py
@@ -52,6 +52,9 @@ def mesolve(
     This allows the solution of master equations that are not in standard
     Lindblad form.
 
+    See the guide on the :ref:`master` for a derivation of the equations
+    solved here and a discussion of the conventions used.
+
     **Time-dependent operators**
 
     For time-dependent problems, ``H`` and ``c_ops`` can be a :obj:`.QobjEvo`
@@ -129,7 +132,7 @@ def mesolve(
         - | matrix_form : bool
           | Use matrix-form Lindblad solver instead of superoperator form.
             The matrix-form solver can be faster for denser systems.
-            Default: False.
+            Default: False. See :ref:`master-matrix-form` for details.
 
         Other options could be supported depending on the integration method,
         see `Integrator <./classes.html#classes-ode>`_.


### PR DESCRIPTION
**Description**
Adds :ref: links from the mesolve and mcsolve docstrings back to
their user guide sections, so the API docs don't skip the physics
and conventions explained there. Scoped to these two solvers per
the issue thread; can extend to the rest in follow-ups.

**Related issues or PRs**
Contributes to #2854

**AI Tools Usage Disclosure**
Claude: used to find the guide labels and draft the docstring text.