### PR TITLE
fix(heom): always initialize final_ado_state/ado_states on HEOMResult

### DIFF
--- a/doc/changes/2933.bugfix
+++ b/doc/changes/2933.bugfix
@@ -1,0 +1,1 @@
+Accessing `HEOMResult.final_ado_state` no longer raises an `AttributeError` when `store_ados` is not set; the attribute is now always initialized and returns `None` when ADOs were not stored.

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -391,9 +391,12 @@ class HEOMResult(Result):
         super()._post_init()
 
         self.store_ados = self.options["store_ados"]
-        if self.store_ados:
-            self._final_ado_state = None
-            self.ado_states = []
+        # Always initialize these attributes so that accessing them does not
+        # raise an AttributeError when store_ados is False (result objects
+        # expose all attributes even when the corresponding data is not
+        # stored, e.g. Result.states when store_states is False).
+        self._final_ado_state = None
+        self.ado_states = []
 
     def _e_op_func(self, e_op):
         """ Convert an e_op into a function ``f(t, ado_state)``. """

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -391,10 +391,6 @@ class HEOMResult(Result):
         super()._post_init()
 
         self.store_ados = self.options["store_ados"]
-        # Always initialize these attributes so that accessing them does not
-        # raise an AttributeError when store_ados is False (result objects
-        # expose all attributes even when the corresponding data is not
-        # stored, e.g. Result.states when store_states is False).
         self._final_ado_state = None
         self.ado_states = []
 

--- a/qutip/tests/solver/heom/test_bofin_solvers.py
+++ b/qutip/tests/solver/heom/test_bofin_solvers.py
@@ -1792,10 +1792,13 @@ class TestHEOMResult:
         return rho, ado_soln
 
     def test_create_ado_states_attribute(self):
+        # The attributes exist even when store_ados is False (result objects
+        # expose all attributes regardless of what is stored), so accessing
+        # final_ado_state never raises an AttributeError.
         options = fill_options()
         result = HEOMResult(e_ops=[], options=options)
-        assert not hasattr(result, "final_ado_state")
-        assert not hasattr(result, "ado_states")
+        assert result.final_ado_state is None
+        assert result.ado_states == []
         assert result.store_ados is False
 
         options = fill_options(store_ados=True)
@@ -1803,6 +1806,22 @@ class TestHEOMResult:
         assert result.final_ado_state is None
         assert result.ado_states == []
         assert result.store_ados is True
+
+    def test_final_ado_state_none_when_ados_not_stored(self):
+        # Accessing final_ado_state on a populated result with
+        # store_ados=False returns None rather than raising AttributeError.
+        options = fill_options()
+        result = HEOMResult(e_ops=[], options=options)
+
+        ados = self.mk_ados([2, 3], max_depth=2)
+        rho, ado_soln = self.mk_rho_and_soln(ados, [[2], [2]])
+        ado_state = HierarchyADOsState(rho, ados, ado_soln)
+
+        result.add(0.1, ado_state)
+
+        assert result.final_state is rho
+        assert result.final_ado_state is None
+        assert result.ado_states == []
 
     @pytest.mark.parametrize(['e_op_type'], [
         pytest.param("qobj", id="qobj"),

--- a/qutip/tests/solver/heom/test_bofin_solvers.py
+++ b/qutip/tests/solver/heom/test_bofin_solvers.py
@@ -1792,9 +1792,6 @@ class TestHEOMResult:
         return rho, ado_soln
 
     def test_create_ado_states_attribute(self):
-        # The attributes exist even when store_ados is False (result objects
-        # expose all attributes regardless of what is stored), so accessing
-        # final_ado_state never raises an AttributeError.
         options = fill_options()
         result = HEOMResult(e_ops=[], options=options)
         assert result.final_ado_state is None
@@ -1808,8 +1805,6 @@ class TestHEOMResult:
         assert result.store_ados is True
 
     def test_final_ado_state_none_when_ados_not_stored(self):
-        # Accessing final_ado_state on a populated result with
-        # store_ados=False returns None rather than raising AttributeError.
         options = fill_options()
         result = HEOMResult(e_ops=[], options=options)
 


### PR DESCRIPTION
Follow-up to #2931. As @pmenczel noted there, qutip result objects expose all attributes even when the corresponding data is not stored (e.g. `Result.states` is `[]` when `store_states=False`), but `HEOMResult` only created `_final_ado_state` and `ado_states` when `store_ados=True`. Accessing `result.final_ado_state` with `store_ados=False` therefore raised `AttributeError` instead of returning `None`.

This removes the guard in `_post_init` so both attributes always exist, updates `test_create_ado_states_attribute` to the always-present convention (it previously asserted the attributes were absent), and adds a regression test covering the populated-result case.

Ran `qutip/tests/solver/heom/test_bofin_solvers.py` locally against a source build: 128 passed. Both updated tests fail on current `master` without the fix.

**AI Tools Usage Disclosure**

Claude (Anthropic), Claude Code: used to implement the change suggested in the #2931 review, update the affected tests, and run the HEOM test suite against a source build. Reviewed before submission.
