### PR TITLE
Fix minor typos in direct_sum_sparse documentation

### DIFF
--- a/doc/changes/2947.doc
+++ b/doc/changes/2947.doc
@@ -1,0 +1,1 @@
+Minor typo correction in `direct_sum_sparse`'s docstring explaining the list/tuple syntax for dimensions.

--- a/qutip/core/direct_sum.py
+++ b/qutip/core/direct_sum.py
@@ -299,8 +299,8 @@ def direct_sum_sparse(qobjs, sum_dimensions, dtype=None):
       :math:`n_1` up to :math:`n_k`, is represented by the list
       :code:`[n1, n2, ..., nk]`.
     * The direct sum of Hilbert spaces, which have the list representations
-      :code:`l1` up to :code:`[lk]`, is represented by the tuple
-      :code:`[l1, l2, ..., lk]`. Sum dimensions may be nested.
+      :code:`l1` up to :code:`lk`, is represented by the tuple
+      :code:`(l1, l2, ..., lk)`. Sum dimensions may be nested.
     * For example, the direct sum of a 2D space and a 3D space has the list
       representation :code:`([2], [3])`.
     * As another example, the direct sum of a 2D space, and the product of two


### PR DESCRIPTION
I noticed typos in the docstring explaining the list/tuple syntax for dimensions.

**AI Tools Usage Disclosure**
- [X] No AI tools were used for this contribution.