### PR TITLE
Upgrade minimal SciPy, Cython, NumPy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
             python-version: "3.12"
             numpy-build: ">=2.1.0,<2.2.0"
             numpy-requirement: ">=1.26,<1.27"
-            scipy-requirement: ">=1.15,<1.16"
+            scipy-requirement: ">=1.13,<1.14"
             pypi: 1
             oldmpl: 1
             coveralls: 1
@@ -78,8 +78,8 @@ jobs:
           - case-name: Oldest officially supported
             os: ubuntu-latest
             python-version: "3.11"
-            numpy-build: ">=1.26.4,<1.27.0"
-            numpy-requirement: ">=1.26.4,<1.27.0"
+            numpy-build: ">=1.23.2,<1.24.0"
+            numpy-requirement: ">=1.23.2,<1.24.0"
             scipy-requirement: ">=1.13,<1.14"
             semidefinite: 1
             oldcython: 1
@@ -190,7 +190,7 @@ jobs:
             conda install --channel conda-forge "openmpi>=5.0" mpi4py
           fi
           if [[ "${{ matrix.oldcython }}" ]]; then
-            python -m pip install cython==0.29.36 filelock matplotlib==3.6
+            python -m pip install cython==3.0.8 filelock matplotlib==3.6
           else
             python -m pip install cython filelock
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,8 +78,8 @@ jobs:
           - case-name: Oldest officially supported
             os: ubuntu-latest
             python-version: "3.11"
-            numpy-build: ">=1.23.5,<1.24.0"
-            numpy-requirement: ">=1.23.5,<1.24.0"
+            numpy-build: ">=1.26.4,<1.27.0"
+            numpy-requirement: ">=1.26.4,<1.27.0"
             scipy-requirement: ">=1.13,<1.14"
             semidefinite: 1
             oldcython: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,7 +190,7 @@ jobs:
             conda install --channel conda-forge "openmpi>=5.0" mpi4py
           fi
           if [[ "${{ matrix.oldcython }}" ]]; then
-            python -m pip install cython==3.0.8 filelock matplotlib==3.6
+            python -m pip install cython==0.29.36 filelock matplotlib==3.6
           else
             python -m pip install cython filelock
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         condaforge: [1]
         numpy-build: [""]
         numpy-requirement: [""]
-        scipy-requirement: [">=1.15"]
+        scipy-requirement: [">=1.13"]
         coverage-requirement: ["==6.5"]
         pytest-extra-options: ["-W ignore:Matrix:scipy.linalg._misc.LinAlgWarning"]
         # Extra special cases.  In these, the new variable defined should always
@@ -80,7 +80,7 @@ jobs:
             python-version: "3.11"
             numpy-build: ">=1.23.5,<1.24.0"
             numpy-requirement: ">=1.23.5,<1.24.0"
-            scipy-requirement: ">=1.15,<1.16"
+            scipy-requirement: ">=1.13,<1.14"
             semidefinite: 1
             oldcython: 1
             oldmpl: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         condaforge: [1]
         numpy-build: [""]
         numpy-requirement: [""]
-        scipy-requirement: [">=1.9"]
+        scipy-requirement: [">=1.15"]
         coverage-requirement: ["==6.5"]
         pytest-extra-options: ["-W ignore:Matrix:scipy.linalg._misc.LinAlgWarning"]
         # Extra special cases.  In these, the new variable defined should always
@@ -69,7 +69,7 @@ jobs:
             python-version: "3.12"
             numpy-build: ">=2.1.0,<2.2.0"
             numpy-requirement: ">=1.26,<1.27"
-            scipy-requirement: ">=1.11,<1.12"
+            scipy-requirement: ">=1.15,<1.16"
             pypi: 1
             oldmpl: 1
             coveralls: 1
@@ -78,9 +78,9 @@ jobs:
           - case-name: Oldest officially supported
             os: ubuntu-latest
             python-version: "3.11"
-            numpy-build: ">=1.22.0,<1.23.0"
-            numpy-requirement: ">=1.22.0,<1.23.0"
-            scipy-requirement: ">=1.9,<1.10"
+            numpy-build: ">=1.23.5,<1.24.0"
+            numpy-requirement: ">=1.23.5,<1.24.0"
+            scipy-requirement: ">=1.15,<1.16"
             semidefinite: 1
             oldcython: 1
             oldmpl: 1

--- a/doc/changes/2951.misc
+++ b/doc/changes/2951.misc
@@ -1,1 +1,2 @@
 Raise the minimum supported SciPy version to 1.13, and the minimum NumPy version to 1.23.2, and fixes Cython to 3.0.8 as the minimal version since newer versions of SciPy require 3.x versions of Cython.
+Removes dead version-based branching for lower SciPy versions.

--- a/doc/changes/2951.misc
+++ b/doc/changes/2951.misc
@@ -1,1 +1,1 @@
-Raise the minimum supported SciPy version to 1.13, and the minimum NumPy version to 1.25.2.
+Raise the minimum supported SciPy version to 1.13, and the minimum NumPy version to 1.23.2, and fixes Cython to 3.0.8 as the minimal version since newer versions of SciPy require 3.x versions of Cython.

--- a/doc/changes/2951.misc
+++ b/doc/changes/2951.misc
@@ -1,1 +1,1 @@
-Raise the minimum supported SciPy version to 1.13, and the minimum NumPy version to 1.22.4 as required by SciPy 1.13.
+Raise the minimum supported SciPy version to 1.13, and the minimum NumPy version to 1.25.2.

--- a/doc/changes/2951.misc
+++ b/doc/changes/2951.misc
@@ -1,2 +1,2 @@
-Raise the minimum supported SciPy version to 1.13, and the minimum NumPy version to 1.23.2, and fixes Cython to 3.0.8 as the minimal version since newer versions of SciPy require 3.x versions of Cython.
+Raise the minimum supported SciPy version to 1.13, and the minimum NumPy version to 1.23.2, and fixes Cython to 3.0.0 as the minimal version for build. Runtime dependencies still support Cython 0.29.x.
 Removes dead version-based branching for lower SciPy versions.

--- a/doc/changes/2951.misc
+++ b/doc/changes/2951.misc
@@ -1,0 +1,1 @@
+Raise the minimum supported SciPy version to 1.13, and the minimum NumPy version to 1.22.4 as required by SciPy 1.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "wheel",
     "cython>=0.29.20",
     "numpy>=2.0.0",
-    "scipy>=1.9",
+    "scipy>=1.15",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -44,8 +44,8 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "numpy>=1.23.2",
-    "scipy>=1.9.2,!=1.16.0,!=1.17.0",
+    "numpy>=1.23.5",
+    "scipy>=1.15,!=1.16.0,!=1.17.0",
     "packaging",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "wheel",
     "cython>=0.29.20",
     "numpy>=2.0.0",
-    "scipy>=1.15",
+    "scipy>=1.13",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -44,8 +44,8 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "numpy>=1.23.5",
-    "scipy>=1.15,!=1.16.0,!=1.17.0",
+    "numpy>=1.22.4",
+    "scipy>=1.13,!=1.16.0,!=1.17.0",
     "packaging",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "numpy>=1.22.4",
+    "numpy>=1.23.5",
     "scipy>=1.13,!=1.16.0,!=1.17.0",
     "packaging",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=77.0.3",
     "packaging",
     "wheel",
-    "cython>=0.29.20",
+    "cython>=3.0.8,<3.1.0",
     "numpy>=2.0.0",
     "scipy>=1.13",
 ]
@@ -44,7 +44,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "numpy>=1.25.2",
+    "numpy>=1.23.2",
     "scipy>=1.13,!=1.16.0,!=1.17.0",
     "packaging",
 ]
@@ -59,7 +59,7 @@ Funding = "https://github.com/sponsors/qutip"
 
 [project.optional-dependencies]
 graphics = ["matplotlib>=3.6"]
-runtime_compilation = ["cython>=0.29.34", "filelock", "setuptools"]
+runtime_compilation = ["cython>=3.0.8,<3.1.0", "filelock", "setuptools"]
 semidefinite = ["cvxpy>=1.3", "cvxopt"]
 tests = ["pytest>=7.2", "pytest-rerunfailures"]
 ipython = ["ipython"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=77.0.3",
     "packaging",
     "wheel",
-    "cython>=3.0.8,<3.1.0",
+    "cython>=3.0.0",
     "numpy>=2.0.0",
     "scipy>=1.13",
 ]
@@ -59,7 +59,7 @@ Funding = "https://github.com/sponsors/qutip"
 
 [project.optional-dependencies]
 graphics = ["matplotlib>=3.6"]
-runtime_compilation = ["cython>=3.0.8,<3.1.0", "filelock", "setuptools"]
+runtime_compilation = ["cython>=0.29.34", "filelock", "setuptools"]
 semidefinite = ["cvxpy>=1.3", "cvxopt"]
 tests = ["pytest>=7.2", "pytest-rerunfailures"]
 ipython = ["ipython"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "numpy>=1.23.5",
+    "numpy>=1.25.2",
     "scipy>=1.13,!=1.16.0,!=1.17.0",
     "packaging",
 ]

--- a/qutip/settings.py
+++ b/qutip/settings.py
@@ -254,17 +254,9 @@ class Settings:
         Whether `eigh` call is reliable.
         Some implementation of blas have some issues on some OS.
         """
-        from packaging import version as pac_version
-        import scipy
-        is_old_scipy = (
-            pac_version.parse(scipy.__version__) < pac_version.parse("1.5")
-        )
         return (
             # macOS OpenBLAS eigh is unstable, see #1288
-            (_blas_info() == "OPENBLAS" and platform.system() == 'Darwin')
-            # The combination of scipy<1.5 and MKL causes wrong results when
-            # calling eigh for big matrices.  See #1495, #1491 and #1498.
-            or (is_old_scipy and (_blas_info() == 'INTEL MKL'))
+            _blas_info() == "OPENBLAS" and platform.system() == 'Darwin'
         )
 
     @property

--- a/qutip/tests/solver/test_steadystate.py
+++ b/qutip/tests/solver/test_steadystate.py
@@ -3,7 +3,6 @@ import scipy
 import pytest
 import qutip
 import warnings
-from packaging import version as pac_version
 from qutip.solver.steadystate import _permute_rcm, _permute_wbm
 import qutip.core.data as _data
 
@@ -41,10 +40,7 @@ def test_qubit(method, kwargs, dtype):
     sz = qutip.sigmaz().to(dtype)
     sm = qutip.destroy(2, dtype=dtype)
 
-    if (
-        pac_version.parse(scipy.__version__) >= pac_version.parse("1.12")
-        and "tol" in kwargs
-    ):
+    if "tol" in kwargs:
         # From scipy 1.12, the tol keyword is renamed to rtol
         kwargs["rtol"] = kwargs.pop("tol")
 
@@ -109,10 +105,7 @@ def test_exact_solution_for_simple_methods(method, kwargs):
 def test_ho(method, kwargs):
     # thermal steadystate of an oscillator: compare numerics with analytical
     # formula
-    if (
-        pac_version.parse(scipy.__version__) >= pac_version.parse("1.12")
-        and "tol" in kwargs
-    ):
+    if "tol" in kwargs:
         # From scipy 1.12, the tol keyword is renamed to rtol
         kwargs["rtol"] = kwargs.pop("tol")
 
@@ -153,10 +146,7 @@ def test_ho(method, kwargs):
     pytest.param('iterative-bicgstab', {"atol": 1e-10, "tol": 1e-10}, id="iterative-bicgstab"),
 ])
 def test_driven_cavity(method, kwargs):
-    if (
-        pac_version.parse(scipy.__version__) >= pac_version.parse("1.12")
-        and "tol" in kwargs
-    ):
+    if "tol" in kwargs:
         # From scipy 1.12, the tol keyword is renamed to rtol
         kwargs["rtol"] = kwargs.pop("tol")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython>=0.29.20
-numpy>=1.22
-scipy>=1.8
+numpy>=1.23.5
+scipy>=1.15
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython>=0.29.20
-numpy>=1.23.5
-scipy>=1.15
+numpy>=1.22.4
+scipy>=1.13
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython>=0.29.20
-numpy>=1.22.4
+numpy>=1.25.2
 scipy>=1.13
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython>=0.29.20
-numpy>=1.23.2
+numpy>=1.25.2
 scipy>=1.13
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython>=0.29.20
-numpy>=1.25.2
+numpy>=1.23.2
 scipy>=1.13
 packaging


### PR DESCRIPTION
**Checklist**
- [x] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](https://qutip.readthedocs.io/en/stable/development/contributing.html#changelog-generation) for more information).

**Description**
Upgrade the minimal SciPy version: not only does it help us to be aligned with SPEC 0 (at least in the sense of runtime deps), but we may also use certain parts of the `scipy.sparse` API previously not available (`diags_array`, `random_array`, etc). Actually, this upgrade is mostly feature-driven since during #2938 we noticed that certain useful features from scipy.sparse API are lacking when trying to be compatible with much lower versions of SciPy. 

**AI Tools Usage Disclosure**

- Claude Sonnet: finding matching combinations of SciPy 1.15 and Python/NumPy versions; detecting & removing parts of the codebase doing version-based branching, which is not relevant anymore.
