### PR TITLE
BUG: allow tuples for outer dimensions

### DIFF
--- a/doc/changes/2955.bugfix
+++ b/doc/changes/2955.bugfix
@@ -1,1 +1,1 @@
-Restore pre-maturely dropped support of tuples for specifying outer dimensions. List stays a prefer data structure for this; raise a warning about deprecation of tuple support in future versions of QuTiP.
+Restore unintentionally dropped support of tuples for specifying outer dimensions. List stays a prefer data structure for this, but tuples are allowed.

--- a/doc/changes/2955.bugfix
+++ b/doc/changes/2955.bugfix
@@ -1,0 +1,1 @@
+Restore pre-maturely dropped support of tuples for specifying outer dimensions. List stays a prefer data structure for this; raise a warning about deprecation of tuple support in future versions of QuTiP.

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 import numpy as np
 import numbers
-import warnings
 from operator import getitem
 from functools import partial
 from typing import Any, Literal
@@ -952,12 +951,6 @@ class Dimensions(metaclass=MetaDims):
     @classmethod
     def _process_args(cls, *args, **kwargs):
         if len(args) == 1 and isinstance(args[0], (list, tuple)):
-            if isinstance(args[0], tuple):
-                warnings.warn(
-                    f"{args[0]} tuple is passed as outer dimensions. \n"
-                    "Passing tuples meaning outer dimensions will be deprecated in future QuTiP releases. \n"
-                    "Please use a list instead."
-                )
             # from list representation
             if len(args[0]) != 2:
                 raise ValueError(f"Format dims not understood {args[0]}.")

--- a/qutip/core/dimensions.py
+++ b/qutip/core/dimensions.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 import numpy as np
 import numbers
+import warnings
 from operator import getitem
 from functools import partial
 from typing import Any, Literal
@@ -950,7 +951,13 @@ class SuperSpace(Space):
 class Dimensions(metaclass=MetaDims):
     @classmethod
     def _process_args(cls, *args, **kwargs):
-        if len(args) == 1 and isinstance(args[0], list):
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            if isinstance(args[0], tuple):
+                warnings.warn(
+                    f"{args[0]} tuple is passed as outer dimensions. \n"
+                    "Passing tuples meaning outer dimensions will be deprecated in future QuTiP releases. \n"
+                    "Please use a list instead."
+                )
             # from list representation
             if len(args[0]) != 2:
                 raise ValueError(f"Format dims not understood {args[0]}.")


### PR DESCRIPTION
**Checklist**
- [x] See what else should be reverted in `Dimensions` to pre-5.3 release (without breaking the direct sum feature)

**Description**
Aligns the behaviour of the `Dimensions` class with pre-5.3 versions, where it was possible to pass a tuple for outer dimensions of a quantum object.

**Related issues or PRs**

#2915 

**AI Tools Usage Disclosure**
- [x] No AI tools were used for this contribution.