### PR TITLE
Test out silencing promo notices from conda-pipy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,9 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           channels: ${{ matrix.condaforge == 1 && 'conda-forge' || 'defaults' }}
-
+      - name: Silence conda-pypi promo notice
+        if: matrix.os != 'windows-11-arm'
+        run: conda config --set plugins.conda_pypi_pip_warning false || true
       - name: Install pip
         if: matrix.os != 'windows-11-arm'
         shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,9 +140,9 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           channels: ${{ matrix.condaforge == 1 && 'conda-forge' || 'defaults' }}
-      - name: Silence conda-pypi promo notice
+      - name: Remove conda-pypi
         if: matrix.os != 'windows-11-arm'
-        run: conda config --set plugins.conda_pypi_pip_warning false || true
+        run: conda remove -n base conda-pypi -y || true
       - name: Install pip
         if: matrix.os != 'windows-11-arm'
         shell: bash -l {0}


### PR DESCRIPTION
**Checklist**

- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](https://qutip.readthedocs.io/en/stable/development/contributing.html#changelog-generation) for more information).


**Description**
Fixing a very minor thing, but slightly annoying behaviour: conda's promotion attempts for beta features of conda-pipy result in warnings in our GitHub Actions. If we don't silence them, we get a lot of false positives in the summary of the workflow and may miss real warnings requiring our attention.

<img width="1350" height="690" alt="image" src="https://github.com/user-attachments/assets/dc03bd0e-6355-47c3-a4ae-71db3bdf3fc0" />

The config is supposed to mute only the conda-pypi warnings and leave other possible conda warnings intact.
UPD: Doesn't work yet. 

**AI Tools Usage Disclosure**
  - `Claude Opus`: to find a combination of flags for conda's config to silence warnings from conda-pipy. 
