### PR TITLE
qutip-qoc use dev qutip-jax

### DIFF
--- a/.github/workflows/tests_env.yml
+++ b/.github/workflows/tests_env.yml
@@ -43,30 +43,29 @@ jobs:
       - name: Pre-install development dependencies
         if: ${{ matrix.repo == 'qutip-qoc' }}
         run: |
-          python -m pip install jax[cpu]
           cd ..
           git clone https://github.com/qutip/qutip-jax.git
           cd qutip-jax
-          if [[ $inputs.version == "release" ]]; then
+          if [[ ${{ inputs.version }} == "release" ]]; then
             # Checkout the latest tag as the latest release
             git fetch --tags
             git checkout $(git describe --tags "$(git rev-list --tags --max-count=1)")
           fi
-          python -m pip install .
+          python -m pip install . --no-build-isolation
 
       - name: Install QuTiP family package
         run: |
           cd ..
           git clone https://github.com/qutip/${{ matrix.repo }}.git
           cd ${{ matrix.repo }}
-          if [[ $inputs.version == "release" ]]; then
+          if [[ ${{ inputs.version }} == "release" ]]; then
             # Checkout the latest tag as the latest release
             git fetch --tags
             git checkout $(git describe --tags "$(git rev-list --tags --max-count=1)")
           elif [[ "${{ inputs.version }}" ]]; then
             git checkout ${{ inputs.version }}
           fi
-          python -m pip install .[full] --no-build-isolation
+          python -m pip install .[full] --no-build-isolation --upgrade-strategy only-if-needed
 
 
       - name: Print python environment

--- a/.github/workflows/tests_env.yml
+++ b/.github/workflows/tests_env.yml
@@ -37,10 +37,25 @@ jobs:
           python -m pip install pytest pytest-rerunfailures  # tests
           python -m pip install numpy scipy cython filelock
           python -m pip install -e . -v --no-build-isolation
-      - name: Install QuTiP family package
-        run: |
           # jax cannot be installed from requirement (cpu vs gpu issue)
           python -m pip install jax[cpu]
+
+      - name: Pre-install development dependencies
+        if: ${{ matrix.repo == 'qutip-qoc' }}
+        run: |
+          python -m pip install jax[cpu]
+          cd ..
+          git clone https://github.com/qutip/qutip-jax.git
+          cd qutip-jax
+          if [[ $inputs.version == "release" ]]; then
+            # Checkout the latest tag as the latest release
+            git fetch --tags
+            git checkout $(git describe --tags "$(git rev-list --tags --max-count=1)")
+          fi
+          python -m pip install .
+
+      - name: Install QuTiP family package
+        run: |
           cd ..
           git clone https://github.com/qutip/${{ matrix.repo }}.git
           cd ${{ matrix.repo }}
@@ -51,10 +66,13 @@ jobs:
           elif [[ "${{ inputs.version }}" ]]; then
             git checkout ${{ inputs.version }}
           fi
-          python -m pip install .[full]
+          python -m pip install .[full] --no-build-isolation
+
+
       - name: Print python environment
         run: |
           pip list
+
       - name: Run test
         run: |
           cd ../${{ matrix.repo }}

--- a/.github/workflows/tests_env.yml
+++ b/.github/workflows/tests_env.yml
@@ -46,7 +46,7 @@ jobs:
           cd ..
           git clone https://github.com/qutip/qutip-jax.git
           cd qutip-jax
-          if [[ ${{ inputs.version }} == "release" ]]; then
+          if [[ "${{ inputs.version }}" == "release" ]]; then
             # Checkout the latest tag as the latest release
             git fetch --tags
             git checkout $(git describe --tags "$(git rev-list --tags --max-count=1)")
@@ -58,7 +58,7 @@ jobs:
           cd ..
           git clone https://github.com/qutip/${{ matrix.repo }}.git
           cd ${{ matrix.repo }}
-          if [[ ${{ inputs.version }} == "release" ]]; then
+          if [[ "${{ inputs.version }}" == "release" ]]; then
             # Checkout the latest tag as the latest release
             git fetch --tags
             git checkout $(git describe --tags "$(git rev-list --tags --max-count=1)")


### PR DESCRIPTION
**Description**
In family tests, the development version of the family packages are installed, but their dependencies are always the release version. So you have:
- qutip: branch / PR version
- qutip-qoc: dev version
- qutip-jax: released version

So any changes in qutip that need an update in qutip-jax will break tests of qutip-qoc until we do a release.

This update the script to use the dev version of qutip-jax for qutip-qoc.

**Related issues or PRs**
#2916 qutip/qutip-jax#102

**AI Tools Usage Disclosure**
  - Gemini to update action script.
