### PR TITLE
Use a two-sided FFT in spectrum_correlation_fft

### DIFF
--- a/doc/changes/1537.bugfix
+++ b/doc/changes/1537.bugfix
@@ -1,0 +1,1 @@
+Fix ``spectrum_correlation_fft`` to symmetrise the correlation function to negative times before taking the FFT, so that the resulting spectrum converges to the correct two-sided Fourier transform (gh-1537).

--- a/qutip/solver/spectrum.py
+++ b/qutip/solver/spectrum.py
@@ -96,10 +96,16 @@ def spectrum_correlation_fft(tlist, y, inverse=False):
     """
     tlist = np.asarray(tlist)
     N = tlist.shape[0]
+    if N < 2:
+        raise ValueError('tlist must have at least 2 points for FFT.')
     dt = tlist[1] - tlist[0]
     if not np.allclose(np.diff(tlist), dt * np.ones(N - 1, dtype=float)):
         raise ValueError('tlist must be equally spaced for FFT.')
     y = np.asarray(y)
+    if y.shape[0] != N:
+        raise ValueError(
+            f'y length ({y.shape[0]}) must match tlist length ({N}).'
+        )
     # Symmetrise the correlation function to negative times, using
     # C(-t) = C(t)^*.  The samples then cover the interval [-tmax, tmax].
     tmax = tlist[-1]
@@ -116,10 +122,7 @@ def spectrum_correlation_fft(tlist, y, inverse=False):
     else:
         F *= dt * np.exp(1j * w * tmax)
     # re-order frequencies from most negative to most positive (centre on 0)
-    idx = np.array([], dtype='int')
-    idx = np.append(idx, np.where(w < 0.0))
-    idx = np.append(idx, np.where(w >= 0.0))
-    return w[idx], np.real(F[idx])
+    return np.fft.fftshift(w), np.fft.fftshift(F).real
 
 
 def _spectrum_es(L, wlist, a_op, b_op):

--- a/qutip/solver/spectrum.py
+++ b/qutip/solver/spectrum.py
@@ -60,16 +60,29 @@ def spectrum(H, wlist, c_ops, a_op, b_op, solver="es"):
 
 
 def spectrum_correlation_fft(tlist, y, inverse=False):
-    """
+    r"""
     Calculate the power spectrum corresponding to a two-time correlation
     function using FFT.
+
+    The correlation function is assumed to be given for times :math:`t \ge 0`
+    and to satisfy :math:`C(-t) = C(t)^*`, as is the case for the
+    autocorrelation of Hermitian operators in a stationary state.  Before
+    taking the FFT, the correlation function is symmetrised to negative times
+    according to :math:`C(-t) = C(t)^*`, so that the returned spectrum is the
+    Fourier transform of the full (two-sided) correlation function:
+
+    .. math::
+
+        S(\omega) = \int_{-\infty}^{\infty} C(t) e^{-i\omega t} dt.
 
     Parameters
     ----------
     tlist : array_like
-        list/array of times :math:`t` which the correlation function is given.
+        list/array of equally spaced times :math:`t \ge 0` at which the
+        correlation function is given.
     y : array_like
-        list/array of correlations corresponding to time delays :math:`t`.
+        list/array of correlations corresponding to the time delays in
+        `tlist`.
     inverse: bool, default: False
         boolean parameter for using a positive exponent in the Fourier
         Transform instead. Default is False.
@@ -86,14 +99,27 @@ def spectrum_correlation_fft(tlist, y, inverse=False):
     dt = tlist[1] - tlist[0]
     if not np.allclose(np.diff(tlist), dt * np.ones(N - 1, dtype=float)):
         raise ValueError('tlist must be equally spaced for FFT.')
-    F = (N * scipy.fftpack.ifft(y)) if inverse else scipy.fftpack.fft(y)
-    # calculate the frequencies for the components in F
-    f = scipy.fftpack.fftfreq(N, dt)
+    y = np.asarray(y)
+    # Symmetrise the correlation function to negative times, using
+    # C(-t) = C(t)^*.  The samples then cover the interval [-tmax, tmax].
+    tmax = tlist[-1]
+    y_sym = np.concatenate([np.conj(y[:0:-1]), y])
+    N_sym = y_sym.shape[0]
+    F = (N_sym * scipy.fftpack.ifft(y_sym)
+         if inverse else scipy.fftpack.fft(y_sym))
+    # calculate the angular frequencies for the components in F
+    w = 2 * np.pi * scipy.fftpack.fftfreq(N_sym, dt)
+    # The FFT assumes the first sample is at t=0, but the symmetrised
+    # correlation starts at -tmax, so shift the phases of the transform.
+    if inverse:
+        F *= dt * np.exp(-1j * w * tmax)
+    else:
+        F *= dt * np.exp(1j * w * tmax)
     # re-order frequencies from most negative to most positive (centre on 0)
     idx = np.array([], dtype='int')
-    idx = np.append(idx, np.where(f < 0.0))
-    idx = np.append(idx, np.where(f >= 0.0))
-    return 2 * np.pi * f[idx], 2 * dt * np.real(F[idx])
+    idx = np.append(idx, np.where(w < 0.0))
+    idx = np.append(idx, np.where(w >= 0.0))
+    return w[idx], np.real(F[idx])
 
 
 def _spectrum_es(L, wlist, a_op, b_op):

--- a/qutip/tests/solver/test_correlation.py
+++ b/qutip/tests/solver/test_correlation.py
@@ -88,6 +88,22 @@ def test_spectrum_solver_equivalence_to_es(spectrum):
     np.testing.assert_allclose(base, test, atol=1e-3)
 
 
+def test_spectrum_correlation_fft_lorentzian():
+    """
+    Regression test for gh-1537: the spectrum of an exponentially decaying
+    correlation function should be a Lorentzian.
+    """
+    times = np.linspace(0, 100, 2500)
+    correlation = np.exp(-times)
+    frequencies, spectrum = qutip.spectrum_correlation_fft(times, correlation)
+    # Only compare where the spectrum is well above the FFT discretisation
+    # floor at large frequencies.
+    valid = np.abs(frequencies) < 10
+    expected = 2 / (1 + frequencies[valid]**2)
+    np.testing.assert_allclose(spectrum[valid], expected,
+                               atol=1e-3, rtol=1e-2)
+
+
 def _trapz_2d(z, xy):
     """2D trapezium-method integration assuming a square grid."""
     dx = xy[1] - xy[0]


### PR DESCRIPTION
This addresses gh-1537: spectrum_correlation_fft only transformed the correlation function over positive times, then multiplied by two to make up for the missing negative-time part. That approximation breaks down unless the correlation function is exactly periodic on the sampling grid, which is never the case for decaying correlations, so the result was noticeably off (e.g. an exponentially decaying correlation gives a spectrum with a systematic error of about half a percent and a wrong high-frequency tail instead of a Lorentzian).

Since the function implicitly assumes C(-t) = C(t)* anyway, it now symmetrises the input to negative times before taking the FFT, using the same phase-shifted transform as in qutip.core.environment._fft. The input convention is documented in the docstring. I also added a regression test comparing the spectrum of exp(-t) to the analytic Lorentzian.

I checked that the new test fails on the old implementation and that the existing spectrum solver equivalence tests still pass.