### PR TITLE
qfunc using log space

### DIFF
--- a/qutip/tests/test_wigner.py
+++ b/qutip/tests/test_wigner.py
@@ -232,59 +232,31 @@ class TestHusimiQ:
         np.testing.assert_allclose(naive, qutip.QFunc(xs, ys, g)(state))
 
     def test_large_size(self):
-        xs = np.linspace(0, 30, 31)
-        arr = np.zeros(200, dtype=complex)
-        arr[155] = 1.
-        arr[165] = 1j
-        arr[175] = -1j
-        state = qutip.Qobj(arr)
+        xs = [-20, -15, -10, 10, 15, 20]
+        for x, y in itertools.product(xs, repeat=2):
+            state = qutip.coherent(600, alpha=(x + 1j * y) / 2**0.5)
 
-        qfunc_150 = qutip.qfunc(state, xs, xs, cutoff=150)
-        qfunc_160 = qutip.qfunc(state, xs, xs, cutoff=160)
-        qfunc_170 = qutip.qfunc(state, xs, xs, cutoff=170)
+            func_out = qutip.qfunc(state, [x], [y])[0, 0]
+            cls_out = qutip.QFunc([x], [y])(state)[0, 0]
 
-        QFunc_150 = qutip.QFunc(xs, xs, cutoff=150)
-        QFunc_160 = qutip.QFunc(xs, xs, cutoff=160)
-        QFunc_170 = qutip.QFunc(xs, xs, cutoff=170)
+            msg = f"failed as {x=}, {y=}"
 
-        np.testing.assert_allclose(qfunc_150, qfunc_160, rtol=1e-6)
-        np.testing.assert_allclose(qfunc_170, qfunc_160, rtol=1e-6)
-
-        np.testing.assert_allclose(QFunc_150(state), qfunc_150, rtol=1e-13)
-        np.testing.assert_allclose(QFunc_160(state), qfunc_160, rtol=1e-13)
-        np.testing.assert_allclose(QFunc_170(state), qfunc_170, rtol=1e-13)
+            assert func_out == pytest.approx(0.5 / np.pi, abs=1e-13), msg
+            assert cls_out == pytest.approx(0.5 / np.pi, abs=1e-13), msg
 
     def test_QFunc_large_size_step(self):
-        xs = np.linspace(0, 30, 31)
-        arr = np.zeros(200, dtype=complex)
-        arr[155] = 1.
-        arr[165] = 1j
-        state = qutip.Qobj(arr)
+        xs = np.linspace(0, 20, 21)
 
-        QFinst = qutip.QFunc(xs, xs, cutoff=160)
-        one_step = QFinst(qutip.Qobj(arr))
+        QFinst = qutip.QFunc(xs, [0])
+        step1 = QFinst(qutip.coherent(50, alpha=4/2**0.5))
+        assert step1[0, 4] == pytest.approx(0.5 / np.pi, abs=1e-13)
 
-        QFinst = qutip.QFunc(xs, xs, cutoff=160)
-        # Internal buffer computed up to the size of the first state
-        QFinst(qutip.Qobj(arr[::150]))
-        # Expand the buffer to full size
-        pre_data = QFinst(qutip.Qobj(arr))
-        np.testing.assert_allclose(one_step, pre_data, rtol=1e-13)
+        step2 = QFinst(qutip.coherent(100, alpha=7/2**0.5))
+        assert step2[0, 7] == pytest.approx(0.5 / np.pi, abs=1e-13)
 
-        QFinst = qutip.QFunc(xs, xs, cutoff=160)
-        QFinst(qutip.Qobj(arr[::158]))
-        pre_cutoff = QFinst(qutip.Qobj(arr))
-        np.testing.assert_allclose(one_step, pre_cutoff, rtol=1e-13)
-
-        QFinst = qutip.QFunc(xs, xs, cutoff=160)
-        QFinst(qutip.Qobj(arr[::163]))
-        post_cutoff = QFinst(qutip.Qobj(arr))
-        np.testing.assert_allclose(one_step, post_cutoff, rtol=1e-13)
-
-        QFinst = qutip.QFunc(xs, xs, cutoff=160)
-        QFinst(qutip.Qobj(arr[::168]))
-        post_data = QFinst(qutip.Qobj(arr))
-        np.testing.assert_allclose(one_step, post_data, rtol=1e-13)
+        step3 = QFinst(qutip.coherent(200, alpha=14/2**0.5))
+        assert step3[0, 14] == pytest.approx(0.5 / np.pi, abs=1e-13)
+        assert step1[0, 14] != pytest.approx(0.5 / np.pi, abs=1e-13)
 
 
 def test_wigner_bell1_su2parity():
@@ -647,6 +619,7 @@ def test_wigner_clenshaw_sp_iter_dm():
         Wdiff = abs(W - Wclen)
         assert_equal(np.sum(abs(Wdiff)) < 1e-7, True)
 
+
 @pytest.mark.parametrize(['spin'], [
     pytest.param(1/2, id="spin-one-half"),
     pytest.param(3, id="spin-three"),
@@ -670,6 +643,7 @@ def test_spin_q_function(spin, pure):
         state = qutip.spin_coherent(spin, theta_prime, phi_prime)
         direct_Q = abs(state.dag() * rho * state)
         assert_almost_equal(Q.flat[k], direct_Q, decimal=9)
+
 
 @pytest.mark.parametrize(['spin'], [
     pytest.param(1/2, id="spin-one-half"),
@@ -719,6 +693,7 @@ def test_spin_wigner_normalized(spin, pure):
         trapezoid(W * np.sin(THETA) * np.sqrt(d / (4*np.pi)), theta), phi
     )
     assert_almost_equal(norm, 1, decimal=4)
+
 
 @pytest.mark.parametrize(['spin'], [
     pytest.param(1 / 2, id="spin-one-half"),

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -685,6 +685,7 @@ class _QFuncCoherentGrid:
 
         lngrid = scipy.special.xlogy(1, self.grid)
         zeros_loc = self.grid == 0
+        lngrid[zeros_loc] = 0
         for i, n in list(enumerate(ns))[start:]:
             part = (
                 lngrid * n

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -677,7 +677,7 @@ class _QFuncCoherentGrid:
         out *= self.prefactor
         return out
 
-    def __call__(self, first: int, last: int = None, cutoff: int = 170):
+    def __call__(self, first: int, last: int = None):
         """
         Get a 3D array of shape ``(yvec.size, xvec.size, last - first)`` of the
         coherent-state vectors for all the Fock states in the range ``first``
@@ -686,6 +686,28 @@ class _QFuncCoherentGrid:
         ``numpy.meshgrid``), and the last runs over the selected range of
         Fock-space dimensions.
         """
+
+        out = np.empty(self.grid.shape + (last - first,), dtype=np.complex128)
+        ns = np.arange(first, last)
+        start = 0
+        if first == 0:
+            out[:, :, 0] = self.prefactor.copy()
+            start = 1
+
+        # n_factors = - 0.5 * scipy.special.gammaln(ns + 1)
+        lngrid = scipy.special.xlogy(1, self.grid)
+        zeros_loc = self.grid == 0
+        for i, n in list(enumerate(ns))[start:]:
+            part = (
+                lngrid * n
+                -0.5 * scipy.special.gammaln(n + 1)
+                -0.5 * np.abs(self.grid)**2
+            )
+            part[zeros_loc] = -np.inf
+            out[:, :, i] = np.exp(part)
+
+        return out
+
         ns = np.arange(first, last).reshape(1, 1, -1)
         out = np.empty(self.grid.shape + (ns.size,), dtype=np.complex128)
         cutoff_loc = cutoff - first
@@ -737,10 +759,6 @@ class QFunc:
         :obj:`.qfunc` with ``precompute_memory=None`` instead to force using
         the slower, more memory-efficient algorithm.
 
-    cutoff : int, default: 170
-        Size at which to switch from using scipy.special.factorial to
-        Stirling's approximation. From 171, scipy.special.factorial return inf.
-
     Examples
     --------
     Initialise the class for a square set of coordinates, with some states we
@@ -768,7 +786,6 @@ class QFunc:
         yvec,
         g: float = np.sqrt(2),
         memory: float = 1024,
-        cutoff: int=170
     ):
         self._g = g
         self._coherent_grid = _QFuncCoherentGrid(xvec, yvec, g)
@@ -778,7 +795,6 @@ class QFunc:
         self._max_size = int(self._memory_mb // self._size_mb)
         self._current_size = 0
         self._cache = None
-        self._cutoff = cutoff
 
     def _alphas(self, size: int):
         r"""
@@ -795,15 +811,10 @@ class QFunc:
                 f" but only {self._memory_mb} MB is allowed."
             )
         if self._cache is None:
-            self._cache = self._coherent_grid(
-                self._current_size, size, self._cutoff
-            )
+            self._cache = self._coherent_grid(self._current_size, size)
         else:
             self._cache = np.dstack(
-                [
-                    self._cache,
-                    self._coherent_grid(self._current_size, size, self._cutoff)
-                ]
+                [self._cache, self._coherent_grid(self._current_size, size)]
             )
         self._current_size = size
         return self._cache
@@ -840,31 +851,26 @@ def _qfunc_iterative_single(
     vector: np.ndarray,
     alpha_grid: _QFuncCoherentGrid,
     g: float,
-    cutoff: int = 170,
 ):
     r"""
     Get the Q function (without the :math:`\pi` scaling factor) of a single
     state vector, using the iterative algorithm which recomputes the powers of
     the coherent-state matrix.
     """
-    size = min(cutoff, vector.shape[0])
-    ns = np.arange(size)
-    out = np.polyval(
-        (0.5 * g * vector[:size] / np.sqrt(scipy.special.factorial(ns)))[::-1],
-        alpha_grid.grid,
-    )
-    if vector.shape[0] > cutoff:
-        # scipy.special.factorial reach inf at 171
-        # So we use an approximation for large number.
-        e_sqrt = np.e**(0.5)
-        pi = np.pi
-        idx = np.arange(cutoff, vector.shape[0])
-        coeffs = vector[idx] * 0.5 * g * ((2*idx + 1/3) * pi)**(-0.25)
-        grid = alpha_grid.grid[:, :, None] * e_sqrt * idx[None, None, :]**-0.5
-        out += np.sum(grid**idx[None, None, :] * coeffs[None, None, :], axis=2)
+    out = vector[0]
+
+    # Nonzero without the first terms
+    ns = np.nonzero(vector[1:])[0] + 1
+    n_factors = np.log(vector[ns]) - 0.5 * scipy.special.gammaln(ns + 1)
+    lngrid = scipy.special.xlogy(1, alpha_grid.grid)
+    zeros_loc = alpha_grid.grid == 0
+    for i, n in enumerate(ns):
+        part = lngrid * n + n_factors[i]
+        part[zeros_loc] = -np.inf
+        out += np.exp(part)
 
     out *= alpha_grid.prefactor
-    return np.abs(out)**2
+    return np.abs(out * 0.5 * g)**2
 
 
 def qfunc(
@@ -873,7 +879,6 @@ def qfunc(
     yvec,
     g: float = sqrt(2),
     precompute_memory: float = 1024,
-    cutoff: int = 170
 ):
     r"""
     Husimi-Q function of a given state vector or density matrix at phase-space
@@ -901,10 +906,6 @@ def qfunc(
         smaller, intermediaries being necessary, but is a good approximation.
         If you want to use the same iterative algorithm for density matrices
         that is used for single kets, set ``precompute_memory=None``.
-
-    cutoff : int, default: 170
-        Size at which to switch from using scipy.special.factorial to
-        Stirling's approximation. From 171, scipy.special.factorial return inf.
 
     Returns
     -------
@@ -938,7 +939,7 @@ def qfunc(
     alpha_grid = _QFuncCoherentGrid(xvec, yvec, g)
     if state.isket:
         out = _qfunc_iterative_single(
-            state.full().ravel(), alpha_grid, g, cutoff
+            state.full().ravel(), alpha_grid, g
         )
         out /= np.pi
         return out
@@ -947,10 +948,10 @@ def qfunc(
     values, vectors = eigh(state.full())
     vectors = vectors.T
     out = values[0] * _qfunc_iterative_single(
-        vectors[0], alpha_grid, g, cutoff
+        vectors[0], alpha_grid, g
     )
     for value, vector in zip(values[1:], vectors[1:]):
-        out += value * _qfunc_iterative_single(vector, alpha_grid, g, cutoff)
+        out += value * _qfunc_iterative_single(vector, alpha_grid, g)
     out /= np.pi
     return out
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -675,24 +675,20 @@ class _QFuncCoherentGrid:
         ``numpy.meshgrid``), and the last runs over the selected range of
         Fock-space dimensions.
         """
-
-        out = np.empty(self.grid.shape + (last - first,), dtype=np.complex128)
         ns = np.arange(first, last)
-        start = 0
-        if first == 0:
-            out[:, :, 0] = self.prefactor
-            start = 1
+        out = np.empty(self.grid.shape + (ns.size,), dtype=np.complex128)
 
         lngrid = scipy.special.xlogy(1, self.grid)
         zeros_loc = self.grid == 0
         lngrid[zeros_loc] = 0
-        for i, n in list(enumerate(ns))[start:]:
+        prefact = -0.5 * np.abs(self.grid)**2
+        for i, n in enumerate(ns):
             part = (
                 lngrid * n
                 -0.5 * scipy.special.gammaln(n + 1)
-                -0.5 * np.abs(self.grid)**2
+                + prefact
             )
-            part[zeros_loc] = -np.inf
+            part[zeros_loc] = 0 if n == 0 else -np.inf
             out[:, :, i] = np.exp(part)
 
         return out
@@ -823,18 +819,18 @@ def _qfunc_iterative_single(
     state vector, using the iterative algorithm which recomputes the powers of
     the coherent-state matrix.
     """
-    out = vector[0] * alpha_grid.prefactor
-
-    # Nonzero without the first terms
-    ns = np.nonzero(vector[1:])[0] + 1
-    n_factors = np.log(vector[ns]) - 0.5 * scipy.special.gammaln(ns + 1)
+    out = 0
+    ns = np.nonzero(vector)[0]
+    # Using xlogy(n, alpha_grid.grid) would avoid special case at `0`
+    # But the log in the loop is quite slow
     lngrid = scipy.special.xlogy(1, alpha_grid.grid)
     zeros_loc = alpha_grid.grid == 0
+    lngrid[zeros_loc] = 0
     prefact = -0.5 * np.abs(alpha_grid.grid)**2
-    for i, n in enumerate(ns):
-        part = lngrid * n + n_factors[i] + prefact
-        part[zeros_loc] = -np.inf
-        out += np.exp(part)
+    for n in ns:
+        part = lngrid * n - 0.5 * scipy.special.gammaln(n + 1) + prefact
+        part[zeros_loc] = 0 if n == 0 else -np.inf
+        out += np.exp(part) * vector[n]
 
     return np.abs(out * 0.5 * g)**2
 

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -666,17 +666,6 @@ class _QFuncCoherentGrid:
         self.grid.imag = -y
         self.prefactor = np.exp(-0.5 * (x * x + y * y)).astype(np.complex128)
 
-    def _start(self, first: int):
-        """
-        Get the coherent state matrix corresponding to the first needed Fock
-        state.
-        """
-        if first == 0:
-            return self.prefactor.copy()
-        out = np.power(self.grid, first)
-        out *= self.prefactor
-        return out
-
     def __call__(self, first: int, last: int = None):
         """
         Get a 3D array of shape ``(yvec.size, xvec.size, last - first)`` of the
@@ -691,10 +680,9 @@ class _QFuncCoherentGrid:
         ns = np.arange(first, last)
         start = 0
         if first == 0:
-            out[:, :, 0] = self.prefactor.copy()
+            out[:, :, 0] = self.prefactor
             start = 1
 
-        # n_factors = - 0.5 * scipy.special.gammaln(ns + 1)
         lngrid = scipy.special.xlogy(1, self.grid)
         zeros_loc = self.grid == 0
         for i, n in list(enumerate(ns))[start:]:
@@ -706,29 +694,6 @@ class _QFuncCoherentGrid:
             part[zeros_loc] = -np.inf
             out[:, :, i] = np.exp(part)
 
-        return out
-
-        ns = np.arange(first, last).reshape(1, 1, -1)
-        out = np.empty(self.grid.shape + (ns.size,), dtype=np.complex128)
-        cutoff_loc = cutoff - first
-
-        if cutoff_loc >= 0:
-            # Compute the out grid from first to cutoff [exclusive]
-            out[:, :, 0] = self._start(ns[0, 0, 0])
-            end = min(ns.size, cutoff_loc)
-            for i in range(1, end):
-                out[:, :, i] = out[:, :, i-1] * self.grid
-            out[:, :, :end] /= np.sqrt(scipy.special.factorial(ns[:, :, :end]))
-
-        if ns.size >= cutoff_loc:
-            # Compute the out grid from cutoff to last
-            e_sqrt = np.e**0.5
-            start = max(cutoff_loc, 0)
-            idx = ns[:, :, start:]
-            out[:, :, start:] = (
-                (self.grid[:, :, None] * e_sqrt * idx**-0.5) ** idx
-                * ((2 * idx + 1./3.) * np.pi)**-0.25 * self.prefactor[:, :, None]
-            )
         return out
 
 
@@ -857,19 +822,19 @@ def _qfunc_iterative_single(
     state vector, using the iterative algorithm which recomputes the powers of
     the coherent-state matrix.
     """
-    out = vector[0]
+    out = vector[0] * alpha_grid.prefactor
 
     # Nonzero without the first terms
     ns = np.nonzero(vector[1:])[0] + 1
     n_factors = np.log(vector[ns]) - 0.5 * scipy.special.gammaln(ns + 1)
     lngrid = scipy.special.xlogy(1, alpha_grid.grid)
     zeros_loc = alpha_grid.grid == 0
+    prefact = -0.5 * np.abs(alpha_grid.grid)**2
     for i, n in enumerate(ns):
-        part = lngrid * n + n_factors[i]
+        part = lngrid * n + n_factors[i] + prefact
         part[zeros_loc] = -np.inf
         out += np.exp(part)
 
-    out *= alpha_grid.prefactor
     return np.abs(out * 0.5 * g)**2
 
 


### PR DESCRIPTION
**Description**
Better version of https://github.com/qutip/qutip/issues/2932.
`qfunc` uses larges numbers that cancel each other, but independently diverge:

    ~ exp(-x**2) x**n / sqrt(n!)

The first to break was the factorial function, so in #2932, I used an approximation for it at large number.
That approximation is not perfect, from when we start using it (n=170) it's precise to under 1e-6.
But it's bad at small values, so I needed to use different code for small and larges values.

I rewrote it to do the computation in log scale: less branching, no approximation: `gammaln` is valid to machine precision, good with even larger state, no `cutoff` parameter only useful for tests.
It's speed is of a similar order of magnitude.


**AI Tools Usage Disclosure**
- [x] AI tools were used, as described below:
  - Gemini: Discussion to find error and comments.