### PR TITLE
Fix typo in plot_energy_levels docstring: h_lables -> h_labels

### DIFF
--- a/doc/changes/2969.doc
+++ b/doc/changes/2969.doc
@@ -1,0 +1,1 @@
+Fix a typo in the ``plot_energy_levels`` docstring: the argument is ``h_labels``, not ``h_lables``.

--- a/qutip/visualization.py
+++ b/qutip/visualization.py
@@ -1065,7 +1065,7 @@ def plot_energy_levels(H_list, h_labels=None, energy_levels=None, N=0, *,
         H_list : List of Qobj
             A list of Hamiltonians.
 
-        h_lables : List of string, optional
+        h_labels : List of string, optional
             A list of xticklabels for each Hamiltonian
 
         energy_levels : List of string, optional


### PR DESCRIPTION
**Description**

`plot_energy_levels` documents `h_lables`, the parameter is `h_labels`. Two letters swapped, so the parameter shows up as undocumented and `h_lables` as one that does not exist.

**Related issues or PRs**

None.

**AI Tools Usage Disclosure**
- [ ] No AI tools were used for this contribution.
- [x] AI tools were used, as described below:
  - `Claude Opus: wrote the checker that compares numpydoc Parameters against the real signature, and drafted this description. I read the docstring and the signature myself before changing anything.`

---

Not in this PR, in case it is useful: the same checker flags about 18 more places across the package where the documented name differs from the parameter. Most of them are one pattern, the docstring says `state` while the signature says `rho` or `psi` -- for example `concurrence(rho)`, `wigner(psi, ...)`, `update_psi(self, psi)`. A few others look deliberate rather than wrong, like `Qobj.proj` documenting `Q` for the object itself.

That is a different kind of change from a typo, so I left it out. I can send it as one PR or split by module, whichever you prefer.
