### PR TITLE
docs: harden contributors plot against GitHub API 403s

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -37,11 +37,16 @@ Developers
     LOGO_TRANSPARENCY = 0.5
 
     # load the list of contributors from qutip/qutip repo
-    url_object = urllib.request.urlopen(LINK_CONTRIBUTORS)
-    list_contributors = json.loads(url_object.read())
-    qutip_contributors = [element["login"] for element in list_contributors]
-    qutip_contributors = [s.lower() for s in qutip_contributors]
-    text = " ".join(qutip_contributors)
+    # GitHub anonymous API rate limits can 403 on shared RTD IPs; catch so
+    # fail_on_warning docs builds do not flake.
+    try:
+        url_object = urllib.request.urlopen(LINK_CONTRIBUTORS)
+        list_contributors = json.loads(url_object.read())
+        qutip_contributors = [element["login"] for element in list_contributors]
+        qutip_contributors = [s.lower() for s in qutip_contributors]
+        text = " ".join(qutip_contributors)
+    except Exception:
+        text = "qutip developers and contributors"
 
     # load the QuTiP logo
     img = PIL.Image.open(urllib.request.urlopen(LINK_LOGO))


### PR DESCRIPTION
## What
Catch GitHub API failures when building the contributors spiral so RTD does not flake under anonymous rate limits (`fail_on_warning`).

## Why
Shared RTD IPs can get HTTP 403; that was failing docs checks on unrelated PRs (see #2940).

This replaces #2946, which I had to close after an accidental rewrite of fork history. Same branch, same change.

## Test
Simulated API failure → fallback text path; plot still renders under `MPLBACKEND=Agg`.

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.
