### PR TITLE
Restore accidentally deleted changelog items

### DIFF
--- a/doc/changes/2196.doc
+++ b/doc/changes/2196.doc
@@ -1,0 +1,1 @@
+Add integrator developer documentation

--- a/doc/changes/2196.feature
+++ b/doc/changes/2196.feature
@@ -1,0 +1,1 @@
+Allows QuTiP's integrator to support callable derivative instead of only QobjEvo.


### PR DESCRIPTION
**Description**
Restoring the accidentally deleted towncrier items during `5.3.1` release. Those have not been released yet; hence, they have to stay in `master`. 

**AI Tools Usage Disclosure**
- [x] No AI tools were used for this contribution.