### PR TITLE
Add qutip.berry: Berry curvature, Chern numbers and Zak phases

### DIFF
--- a/doc/changes/2972.feature
+++ b/doc/changes/2972.feature
@@ -1,0 +1,5 @@
+Added `qutip.berry`, restoring and modernizing the Berry curvature and
+Chern number toolkit removed in QuTiP 5.0: a Fukui-Hatsugai-Suzuki
+single-band formulation with exactly integral Chern numbers, the
+multi-band determinant (Wilson loop) formulation, and a one-dimensional
+Wilson loop for Berry/Zak phases along a closed path.

--- a/qutip/__init__.py
+++ b/qutip/__init__.py
@@ -47,6 +47,7 @@ from .wigner import *
 from .random_objects import *
 from .simdiag import *
 from .entropy import *
+from .berry import *
 from .partial_transpose import *
 from .continuous_variables import *
 from .distributions import *

--- a/qutip/berry.py
+++ b/qutip/berry.py
@@ -1,0 +1,203 @@
+"""
+Geometric phases and topological invariants on discretized parameter grids.
+
+This module restores and modernizes ``qutip.topology.berry_curvature``
+(removed in QuTiP 5.0) and extends it with:
+
+- a Fukui--Hatsugai--Suzuki (FHS) U(1) formulation for a single band, in
+  which the Chern number is exactly integral for any grid size,
+- the multi-band determinant (Wilson loop) formulation of the original
+  implementation, valid when bands do not mix,
+- a one-dimensional Wilson loop for Berry/Zak phases along a closed path,
+- periodic-grid support: dimensions flagged in ``periodic`` are closed,
+  with the link crossing the grid boundary included (needed, e.g., for
+  the azimuthal direction of a spherical grid).
+
+References
+----------
+T. Fukui, Y. Hatsugai and H. Suzuki,
+"Chern Numbers in Discretized Brillouin Zone: Efficient Method of
+Computing (Spin) Hall Conductances",
+J. Phys. Soc. Jpn. 74, 1674 (2005).
+"""
+
+import numpy as np
+
+__all__ = ["berry_phase", "berry_curvature", "chern_number"]
+
+
+def _to_grid(eigfs):
+    """Normalize ``eigfs`` to a complex ndarray.
+
+    Accepts an ndarray in one of the layouts below, or a nested list of
+    Qobj kets (anything exposing a ``full()`` method) in the same layout.
+    """
+    if isinstance(eigfs, np.ndarray):
+        return np.asarray(eigfs, dtype=complex)
+
+    def convert(x):
+        if hasattr(x, "full"):
+            return np.asarray(x.full(), dtype=complex).reshape(-1)
+        if isinstance(x, (list, tuple)):
+            return [convert(e) for e in x]
+        return np.asarray(x, dtype=complex).reshape(-1)
+
+    return np.asarray(convert(eigfs), dtype=complex)
+
+
+def _check_2d_grid(grid):
+    if grid.ndim == 3:
+        grid = grid[:, :, None, :]
+    if grid.ndim != 4:
+        raise ValueError(
+            "eigfs must be a 4d array (n0, n1, nocc, hilbert) or a 3d "
+            "array (n0, n1, hilbert); got shape {}".format(grid.shape)
+        )
+    return grid
+
+
+def berry_curvature(eigfs, periodic=(False, False)):
+    """Computes the discretized Berry curvature on a two-dimensional grid of
+    parameters.
+
+    Parameters
+    ----------
+    eigfs : ndarray or nested list of Qobj
+        - a 4d array of shape ``(n0, n1, nocc, hilbert)`` holding the
+          eigenstates, where the first two indices run over the discrete
+          values of the two parameters, the third indexes the occupied
+          bands, and the fourth spans the Hilbert space; or
+        - a 3d array of shape ``(n0, n1, hilbert)`` for a single band.
+
+    periodic : tuple of bool, default (False, False)
+        Flags whether each grid dimension is closed.  For a closed
+        dimension the link crossing the grid boundary (index ``n - 1`` to
+        index 0) is included and the returned curvature has ``n``
+        plaquettes along that dimension; otherwise it has ``n - 1``.
+
+    Returns
+    -------
+    b_curv : ndarray
+        A two dimensional array of the discretized Berry curvature
+        (plaquette flux) of shape ``(m0, m1)``, where ``m = n`` for a
+        periodic dimension and ``m = n - 1`` otherwise.
+
+    Notes
+    -----
+    For a single band the plaquette flux is assembled from the
+    phase-field link variables in the Fukui--Hatsugai--Suzuki (FHS)
+    formulation: each flux is wrapped into :math:`(-\\pi, \\pi]`, which
+    makes the summed Chern number exactly integral on any grid size.
+
+    For multiple bands the determinant of the Wilson loop around each
+    plaquette is used, as in the original ``qutip.topology``
+    implementation.  This is valid when the bands do not mix; the summed
+    Chern number then converges to an integer as the grid is refined.
+    """
+    grid = _check_2d_grid(_to_grid(eigfs))
+    n0, n1, nocc, _ = grid.shape
+    per0, per1 = bool(periodic[0]), bool(periodic[1])
+    m0 = n0 if per0 else n0 - 1
+    m1 = n1 if per1 else n1 - 1
+    b_curv = np.zeros((m0, m1), dtype=float)
+
+    if nocc == 1:
+        psi = grid[:, :, 0, :]
+        if per0:
+            th0 = np.angle(
+                np.einsum("ijh,ijh->ij", psi.conj(), np.roll(psi, -1, axis=0))
+            )
+        else:
+            th0 = np.angle(np.einsum("ijh,ijh->ij", psi[:-1].conj(), psi[1:]))
+        if per1:
+            th1 = np.angle(
+                np.einsum("ijh,ijh->ij", psi.conj(), np.roll(psi, -1, axis=1))
+            )
+        else:
+            th1 = np.angle(np.einsum("ijh,ijh->ij", psi[:, :-1].conj(), psi[:, 1:]))
+        for i in range(m0):
+            for j in range(m1):
+                flux = (
+                    th0[i, j]
+                    + th1[(i + 1) % n0, j]
+                    - th0[i, (j + 1) % n1]
+                    - th1[i, j]
+                )
+                # wrap the plaquette phase into (-pi, pi]
+                b_curv[i, j] = (flux + np.pi) % (2 * np.pi) - np.pi
+        return b_curv
+
+    edges = [((0, 0), (1, 0)), ((1, 0), (1, 1)), ((1, 1), (0, 1)), ((0, 1), (0, 0))]
+    for i in range(m0):
+        for j in range(m1):
+            rect_prd = np.eye(nocc, dtype=complex)
+            for (di0, dj0), (di1, dj1) in edges:
+                s = np.einsum(
+                    "kh,lh->kl",
+                    grid[(i + di0) % n0, (j + dj0) % n1].conj(),
+                    grid[(i + di1) % n0, (j + dj1) % n1],
+                )
+                rect_prd = rect_prd @ s
+            b_curv[i, j] = np.angle(np.linalg.det(rect_prd))
+    return b_curv
+
+
+def chern_number(eigfs, periodic=(False, False)):
+    """Sums the discretized Berry curvature over the grid to give the
+    (first) Chern number.
+
+    Parameters
+    ----------
+    eigfs : ndarray or nested list of Qobj
+        Eigenstates on a two-dimensional grid, as for
+        :func:`berry_curvature`.
+
+    periodic : tuple of bool, default (False, False)
+        Flags whether each grid dimension is closed; see
+        :func:`berry_curvature`.
+
+    Returns
+    -------
+    chern : float
+        The summed Berry curvature divided by :math:`2\\pi`.  With the
+        single-band FHS formulation this is exactly integral up to
+        floating point roundoff; with the multi-band determinant
+        formulation it converges to an integer as the grid is refined.
+    """
+    return np.sum(berry_curvature(eigfs, periodic=periodic)) / (2 * np.pi)
+
+
+def berry_phase(eigfs):
+    """Computes the Berry (Zak) phase accumulated along a closed
+    one-dimensional path.
+
+    Parameters
+    ----------
+    eigfs : ndarray or nested list of Qobj
+        - a 3d array of shape ``(n, nocc, hilbert)`` holding the
+          eigenstates along the discrete values of the parameter; or
+        - a 2d array of shape ``(n, hilbert)`` for a single band.
+
+        The path is closed: eigenstate at index ``n`` is identified with
+        the one at index 0.
+
+    Returns
+    -------
+    phase : float
+        The gauge-invariant phase in :math:`(-\\pi, \\pi]`, given by the
+        determinant of the Wilson loop around the path.
+    """
+    grid = _to_grid(eigfs)
+    if grid.ndim == 2:
+        grid = grid[:, None, :]
+    if grid.ndim != 3:
+        raise ValueError(
+            "eigfs must be a 3d array (n, nocc, hilbert) or a 2d array "
+            "(n, hilbert); got shape {}".format(grid.shape)
+        )
+    n, nocc, _ = grid.shape
+    w = np.eye(nocc, dtype=complex)
+    for i in range(n):
+        s = np.einsum("kh,lh->kl", grid[i].conj(), grid[(i + 1) % n])
+        w = w @ s
+    return np.angle(np.linalg.det(w))

--- a/qutip/tests/test_berry.py
+++ b/qutip/tests/test_berry.py
@@ -1,0 +1,133 @@
+import numpy as np
+import pytest
+
+import qutip.berry as berry
+from qutip import Qobj, sigmax, sigmay, sigmaz
+
+
+def _monopole_eigfs(n0=40, n1=40, winding=1, excited=False):
+    """Ground/excited eigenstates of H = B.sigma on the unit sphere, with
+    B a winding-n hedgehog.  Ground state has Chern number -n, excited +n.
+    """
+    thetas = np.linspace(0, np.pi, n0)
+    phis = np.linspace(0, 2 * np.pi, n1, endpoint=False)
+    eigfs = np.zeros((n0, n1, 2), dtype=complex)
+    for i, th in enumerate(thetas):
+        for j, ph in enumerate(phis):
+            B = np.array(
+                [
+                    np.sin(th) * np.cos(winding * ph),
+                    np.sin(th) * np.sin(winding * ph),
+                    np.cos(th),
+                ]
+            )
+            H = B[0] * sigmax().full() + B[1] * sigmay().full() + B[2] * sigmaz().full()
+            _, ekets = Qobj(H).eigenstates()
+            eigfs[i, j] = ekets[1 if excited else 0].full().reshape(-1)
+    return eigfs
+
+
+def _ssh_eigfs(n=100, v=1.0, w=2.0):
+    """Lower-band eigenstates of the SSH model on a k-mesh around the BZ."""
+    ks = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    eigfs = np.zeros((n, 2), dtype=complex)
+    for i, k in enumerate(ks):
+        H = (v + w * np.cos(k)) * sigmax().full() + w * np.sin(k) * sigmay().full()
+        _, ekets = Qobj(H).eigenstates()
+        eigfs[i] = ekets[0].full().reshape(-1)
+    return eigfs
+
+
+def test_monopole_ground_state_chern_minus_one():
+    """S^2 monopole: ground state of H = B.sigma carries C = -1."""
+    C = berry.chern_number(
+        _monopole_eigfs(n0=30, n1=30), periodic=(False, True)
+    )
+    assert np.isclose(C, -1.0, atol=1e-9)
+
+
+def test_monopole_excited_state_chern_plus_one():
+    """Excited state of the same model carries C = +1."""
+    C = berry.chern_number(
+        _monopole_eigfs(n0=30, n1=30, excited=True), periodic=(False, True)
+    )
+    assert np.isclose(C, 1.0, atol=1e-9)
+
+
+def test_ssh_zak_phase():
+    """SSH: lower-band Zak phase is pi in the topological phase (v < w)
+    and 0 in the trivial phase (v > w)."""
+    topo = berry.berry_phase(_ssh_eigfs(n=100, v=1.0, w=2.0))
+    assert np.isclose(abs(topo), np.pi, atol=1e-9)
+    triv = berry.berry_phase(_ssh_eigfs(n=100, v=2.0, w=1.0))
+    assert np.isclose(abs(triv), 0.0, atol=1e-9)
+
+
+def test_three_sector_chern_sum_zero():
+    """Two +1 sectors and one -2 sector: the Chern numbers sum to zero."""
+    C1 = berry.chern_number(
+        _monopole_eigfs(n0=30, n1=30, excited=True), periodic=(False, True)
+    )
+    C2 = berry.chern_number(
+        _monopole_eigfs(n0=30, n1=30, excited=True), periodic=(False, True)
+    )
+    C3 = berry.chern_number(
+        _monopole_eigfs(n0=30, n1=30, winding=2), periodic=(False, True)
+    )
+    assert np.isclose(C1, 1.0, atol=1e-9)
+    assert np.isclose(C2, 1.0, atol=1e-9)
+    assert np.isclose(C3, -2.0, atol=1e-9)
+    assert np.isclose(C1 + C2 + C3, 0.0, atol=1e-9)
+
+
+def test_multiband_determinant_formulation():
+    """Block-diagonal 6-level system (two monopoles + one winding-2
+    monopole, scaled apart): the determinant formulation over all six
+    bands sums to zero Chern number (bands come in +- pairs)."""
+    n0, n1 = 30, 30
+    thetas = np.linspace(0, np.pi, n0)
+    phis = np.linspace(0, 2 * np.pi, n1, endpoint=False)
+    eigfs = np.zeros((n0, n1, 6, 6), dtype=complex)
+    for i, th in enumerate(thetas):
+        for j, ph in enumerate(phis):
+            H = np.zeros((6, 6), dtype=complex)
+            for idx, (winding, scale) in enumerate([(1, 1.0), (1, 2.0), (2, 3.0)]):
+                B = np.array(
+                    [
+                        np.sin(th) * np.cos(winding * ph),
+                        np.sin(th) * np.sin(winding * ph),
+                        np.cos(th),
+                    ]
+                )
+                block = (
+                    B[0] * sigmax().full()
+                    + B[1] * sigmay().full()
+                    + B[2] * sigmaz().full()
+                )
+                H[2 * idx : 2 * idx + 2, 2 * idx : 2 * idx + 2] = scale * block
+            _, ekets = Qobj(H).eigenstates()
+            for b in range(6):
+                eigfs[i, j, b] = ekets[b].full().reshape(-1)
+    C = berry.chern_number(eigfs, periodic=(False, True))
+    # determinant formulation converges as the grid is refined; total over
+    # all bands of a time-reversal-free block system is near zero
+    assert abs(C) < 0.5
+
+
+def test_qobj_input_berry_phase():
+    """The 1d phase accepts a plain list of Qobj kets."""
+    n = 60
+    ks = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    kets = []
+    for k in ks:
+        H = (1.0 + 2.0 * np.cos(k)) * sigmax() + 2.0 * np.sin(k) * sigmay()
+        kets.append(H.eigenstates()[1][0])
+    phase = berry.berry_phase(kets)
+    assert np.isclose(abs(phase), np.pi, atol=1e-9)
+
+
+def test_bad_shapes_raise():
+    with pytest.raises(ValueError):
+        berry.berry_curvature(np.zeros((3, 3, 3, 3, 3), dtype=complex))
+    with pytest.raises(ValueError):
+        berry.berry_phase(np.zeros((3, 3, 3, 3), dtype=complex))


### PR DESCRIPTION
## Summary

Implements the proposal in #2972: restores and modernizes the geometric-phase toolkit removed from QuTiP in 5.0 (qutip.topology.berry_curvature), as a new top-level module qutip.berry.

## What is included

- berry_curvature(eigfs, periodic=(False, False)) -- discretized Berry curvature (plaquette flux) on a 2D parameter grid, with
  - a **Fukui-Hatsugai-Suzuki (FHS) single-band formulation** (J. Phys. Soc. Jpn. 74, 1674): each plaquette flux is wrapped into (-pi, pi], so the summed Chern number is **exactly integral on any grid size**;
  - the **multi-band determinant (Wilson loop) formulation** of the original implementation, valid when bands do not mix;
  - per-dimension periodicity flags (needed e.g. for the azimuthal direction of a spherical grid).
- chern_number(eigfs, periodic=...) -- summed flux / 2pi.
- berry_phase(eigfs) -- 1D closed-loop Wilson loop (Zak/Berry phase).
- Input accepts numpy arrays or nested lists of Qobj kets.

## Tests (7 new, all passing)

- S^2 monopole (H = B.sigma, hedgehog B): ground state C = -1, excited C = +1, winding-2 ground state C = -2 -- all to 1e-9.
- Three-sector sum rule: (+1) + (+1) + (-2) = 0.
- SSH chain Zak phase: pi in the topological phase, 0 in the trivial phase.
- Multi-band determinant formulation on a 6-level block-diagonal system (total C ~ 0).
- Qobj list input for berry_phase.
- Shape validation raises ValueError.

## Notes

- The 1D loop is always closed (a Zak loop is a closed path by definition); for 2D grids the closure is opt-in via periodic so that, e.g., the polar direction of a spherical grid stays open.
- No band-mixing handling yet in the multi-band path (same limitation as the original implementation); a non-Abelian projector formulation is a natural follow-up.

Closes #2972
