### PR TITLE
WIP: backward compatible PoC of qutip's compatibility with SciPy 1.18 & ILP64

### DIFF
--- a/qutip/core/_brtools.pyx
+++ b/qutip/core/_brtools.pyx
@@ -13,6 +13,7 @@ from qutip.core.cy.coefficient cimport Coefficient
 from qutip.core.data cimport Data, Dense, idxint
 import qutip.core.data as _data
 from qutip.core import Qobj
+include "_blas_int.pxi"
 from scipy.linalg cimport cython_blas as blas
 
 
@@ -131,7 +132,8 @@ cdef Dense matmul_var_Dense(Dense left, Dense right,
         raise ValueError("Only implemented for square operators")
     cdef Dense out, a, b
     cdef double complex alpha = 1., beta = 0.
-    cdef int tleft, tright, size = left.shape[0]
+    cdef int tleft, tright
+    cdef blas_int size = left.shape[0]
 
     # Since fortran to C equivalent to transpose, fix the codes to fortran
     tleft = transleft ^ (not left.fortran)

--- a/qutip/core/data/_blas_int.pxi.in
+++ b/qutip/core/data/_blas_int.pxi.in
@@ -1,0 +1,11 @@
+# Generated from _blas_int.pxi.in by meson. Do not edit the generated file.
+#
+# Defines `blas_int`: the integer type SciPy's cython_blas / cython_lapack
+# expect. It is `int` for a normal (LP64) SciPy, and `int64_t` for a SciPy
+# built against an ILP64 BLAS. SciPy < 1.18 does not export the name, so we
+# fall back to plain `int`, which is what those versions always used.
+#
+# See qutip/meson.build for the compile-time probe that picks a branch, and
+# https://github.com/scipy/scipy/pull/25025 for the upstream reference
+# implementation of this pattern.
+@BLAS_INT_DEF@

--- a/qutip/core/data/_local_matmul.pyx
+++ b/qutip/core/data/_local_matmul.pyx
@@ -9,6 +9,7 @@ from qutip.core.data.add cimport iadd_dense
 from qutip.core.data.data_iterator cimport Data_iterator, _make_iter
 import numpy as np
 cimport cython
+include "_blas_int.pxi"
 from scipy.linalg.cython_blas cimport zaxpy
 
 cdef extern from "<complex>" namespace "std" nogil:
@@ -22,7 +23,7 @@ __all__ = [
 ]
 
 
-cdef int ONE = 1
+cdef blas_int ONE = 1
 cdef double NaN = np.nan
 
 
@@ -363,7 +364,7 @@ cpdef void n_mode_kernel(
     out_row_stride = 1 if out.fortran else out.shape[1]
     out_col_stride = 1 if not out.fortran else out.shape[0]
 
-    cdef int chunk_len = meta.pass_through_step
+    cdef blas_int chunk_len = meta.pass_through_step
     if not state.fortran and not out.fortran:
         chunk_len *= state.shape[1]
 

--- a/qutip/core/data/add.pyx
+++ b/qutip/core/data/add.pyx
@@ -4,6 +4,7 @@
 cimport cython
 import numpy as np
 cimport numpy as cnp
+include "_blas_int.pxi"
 from scipy.linalg cimport cython_blas as blas
 from qutip.settings import settings
 
@@ -26,7 +27,7 @@ __all__ = [
 ]
 
 
-cdef int _ONE=1
+cdef blas_int _ONE=1
 
 
 cdef int _check_shape(Data left, Data right) except -1 nogil:
@@ -172,14 +173,14 @@ cpdef CSR add_csr(CSR left, CSR right, double complex scale=1):
 
 
 cdef void add_dense_eq_order_inplace(Dense left, Dense right, double complex scale):
-    cdef int size = left.shape[0] * left.shape[1]
+    cdef blas_int size = left.shape[0] * left.shape[1]
     with nogil:
         blas.zaxpy(&size, &scale, right.data, &_ONE, left.data, &_ONE)
 
 
 cdef Dense _add_dense_eq_order(Dense left, Dense right, double complex scale):
     cdef Dense out = left.copy()
-    cdef int size = left.shape[0] * left.shape[1]
+    cdef blas_int size = left.shape[0] * left.shape[1]
     with nogil:
         blas.zaxpy(&size, &scale, right.data, &_ONE, out.data, &_ONE)
     return out
@@ -192,7 +193,7 @@ cpdef Dense add_dense(Dense left, Dense right, double complex scale=1):
     cdef Dense out = left.copy()
     cdef size_t nrows=left.shape[0], ncols=left.shape[1], idx
     # We always iterate through `left` and `out` in memory-layout order.
-    cdef int dim1, dim2
+    cdef blas_int dim1, dim2
     dim1, dim2 = (nrows, ncols) if left.fortran else (ncols, nrows)
     with nogil:
         for idx in range(dim2):
@@ -204,8 +205,8 @@ cpdef Dense iadd_dense(Dense left, Dense right, double complex scale=1):
     _check_shape(left, right)
     if scale == 0:
         return left
-    cdef int size = left.shape[0] * left.shape[1]
-    cdef int dim1, dim2
+    cdef blas_int size = left.shape[0] * left.shape[1]
+    cdef blas_int dim1, dim2
     cdef size_t nrows=left.shape[0], ncols=left.shape[1], idx
     dim1, dim2 = (nrows, ncols) if left.fortran else (ncols, nrows)
     with nogil:
@@ -241,7 +242,7 @@ cpdef Dia add_dia(Dia left, Dia right, double complex scale=1):
     cdef double complex *ptr_right
     cdef bint sorted=True
     cdef Dia out = dia.empty(left.shape[0], left.shape[1], left.num_diag + right.num_diag)
-    cdef int length, size=left.shape[1]
+    cdef blas_int length, size=left.shape[1]
 
     ptr_out = out.data
     ptr_left = left.data

--- a/qutip/core/data/csr.pyx
+++ b/qutip/core/data/csr.pyx
@@ -41,6 +41,19 @@ from qutip.core.data.adjoint cimport adjoint_csr, transpose_csr, conj_csr
 from qutip.core.data.trace cimport trace_csr
 from qutip.core.data.tidyup cimport tidyup_csr
 from .base import idxint_dtype
+
+# NumPy 2's ``copy=False`` means "never copy" and raises if a dtype conversion
+# is needed, where NumPy 1's meant "copy only if needed". SciPy's index arrays
+# are always int32, so on an ``idxint_64`` build converting them to idxint
+# genuinely requires a copy. Fall back to copy-if-needed in exactly that case.
+_NUMPY_2 = np.lib.NumpyVersion(np.__version__) >= '2.0.0b1'
+
+
+cdef object _array_idxint(object arg, object copy):
+    if _NUMPY_2 and copy is False and np.asarray(arg).dtype != idxint_dtype:
+        copy = None
+    return np.array(arg, dtype=idxint_dtype, copy=copy, order='C')
+
 from qutip.settings import settings
 
 cnp.import_array()
@@ -116,8 +129,8 @@ cdef class CSR(base.Data):
             # np2 accept None which act as np1's False
             copy = builtins.bool(copy)
         data = np.array(arg[0], dtype=np.complex128, copy=copy, order='C')
-        col_index = np.array(arg[1], dtype=idxint_dtype, copy=copy, order='C')
-        row_index = np.array(arg[2], dtype=idxint_dtype, copy=copy, order='C')
+        col_index = _array_idxint(arg[1], copy)
+        row_index = _array_idxint(arg[2], copy)
 
         if data.ndim != 1 or col_index.ndim != 1 or row_index.ndim != 1:
             raise TypeError("data, col_index, row_index must all be 1D arrays")

--- a/qutip/core/data/dia.pyx
+++ b/qutip/core/data/dia.pyx
@@ -32,6 +32,7 @@ else:
     scipy_data_matrix_init = scipy_data_matrix.__init__
 
 from scipy.sparse import dia_array as scipy_dia_array
+include "_blas_int.pxi"
 from scipy.linalg cimport cython_blas as blas
 
 from qutip.core.data cimport base, Dense, CSR
@@ -39,6 +40,19 @@ from qutip.core.data.adjoint import adjoint_dia, transpose_dia, conj_dia
 from qutip.core.data.trace import trace_dia
 from qutip.core.data.tidyup import tidyup_dia
 from .base import idxint_dtype
+
+# NumPy 2's ``copy=False`` means "never copy" and raises if a dtype conversion
+# is needed, where NumPy 1's meant "copy only if needed". SciPy's index arrays
+# are always int32, so on an ``idxint_64`` build converting them to idxint
+# genuinely requires a copy. Fall back to copy-if-needed in exactly that case.
+_NUMPY_2 = np.lib.NumpyVersion(np.__version__) >= '2.0.0b1'
+
+
+cdef object _array_idxint(object arg, object copy):
+    if _NUMPY_2 and copy is False and np.asarray(arg).dtype != idxint_dtype:
+        copy = None
+    return np.array(arg, dtype=idxint_dtype, copy=copy, order='C')
+
 from qutip.settings import settings
 
 cnp.import_array()
@@ -100,7 +114,7 @@ cdef class Dia(base.Data):
             # np2 accept None which act as np1's False
             copy = builtins.bool(copy)
         data = np.array(arg[0], dtype=np.complex128, copy=copy, order='C')
-        offsets = np.array(arg[1], dtype=idxint_dtype, copy=copy, order='C')
+        offsets = _array_idxint(arg[1], copy)
 
         self.num_diag = offsets.shape[0]
         self._max_diag = self.num_diag
@@ -385,7 +399,7 @@ cpdef Dia clean_dia(Dia matrix, bint inplace=False):
     cdef base.idxint diag=0, new_diag=0, start, end, col
     cdef double complex zONE=1.
     cdef bint has_duplicate
-    cdef int length=out.shape[1], ONE=1
+    cdef blas_int length=out.shape[1], ONE=1
 
     if out.num_diag == 0:
         return out

--- a/qutip/core/data/matmul.pyx
+++ b/qutip/core/data/matmul.pyx
@@ -15,6 +15,7 @@ from cpython cimport mem
 
 import numpy as np
 cimport numpy as cnp
+include "_blas_int.pxi"
 from scipy.linalg cimport cython_blas as blas
 
 from qutip.core.data.base import idxint_dtype
@@ -293,7 +294,7 @@ cpdef Dense matmul_dense(Dense left, Dense right, double complex scale=1, Dense 
     cdef double complex *a
     cdef double complex *b
     cdef char transa, transb
-    cdef int m, n, k=left.shape[1], lda, ldb
+    cdef blas_int m, n, k=left.shape[1], lda, ldb
     if right.shape[1] == 1:
         # Matrix Vector product
         a, b = left.data, right.data
@@ -361,7 +362,7 @@ cpdef Dia matmul_dia(Dia left, Dia right, double complex scale=1):
     cdef idxint col, row, ii, num_diag_out, offset
     cdef idxint start_left, end_left, start_out, end_out, start, end, off_out
     cdef idxint start_right, end_right
-    cdef int ONE=1, ZERO=0, num_elem
+    cdef blas_int ONE=1, ZERO=0, num_elem
 
     out = dia.empty(
         left.shape[0], right.shape[1],
@@ -689,7 +690,7 @@ cpdef Dense matmul_dag_dense(
         )
     cdef Dense a, b, out_add=None
     cdef double complex alpha = 1., out_scale = 0.
-    cdef int m, n, k = left.shape[1], lda, ldb, ldc
+    cdef blas_int m, n, k = left.shape[1], lda, ldb, ldc
     cdef char left_code, right_code
 
     if not right.fortran:

--- a/qutip/core/data/mul.pyx
+++ b/qutip/core/data/mul.pyx
@@ -2,6 +2,7 @@
 #cython: boundscheck=False, wrapround=False, initializedcheck=False
 
 from qutip.core.data cimport idxint, csr, CSR, dense, Dense, Data, Dia, dia
+include "_blas_int.pxi"
 from scipy.linalg.cython_blas cimport zscal
 
 __all__ = [
@@ -13,8 +14,8 @@ __all__ = [
 
 cpdef CSR imul_csr(CSR matrix, double complex value):
     """Multiply this CSR `matrix` by a complex scalar `value`."""
-    cdef idxint l = csr.nnz(matrix)
-    cdef int ONE=1
+    cdef blas_int l = <blas_int> csr.nnz(matrix)
+    cdef blas_int ONE=1
     zscal(&l, &value, matrix.data, &ONE)
     return matrix
 
@@ -41,8 +42,8 @@ cpdef CSR neg_csr(CSR matrix):
 
 cpdef Dia imul_dia(Dia matrix, double complex value):
     """Multiply this Dia `matrix` by a complex scalar `value`."""
-    cdef idxint l = matrix.num_diag * matrix.shape[1]
-    cdef int ONE=1
+    cdef blas_int l = <blas_int> (matrix.num_diag * matrix.shape[1])
+    cdef blas_int ONE=1
     zscal(&l, &value, matrix.data, &ONE)
     return matrix
 
@@ -73,8 +74,8 @@ cpdef Dia neg_dia(Dia matrix):
 cpdef Dense imul_dense(Dense matrix, double complex value):
     """Multiply this Dense `matrix` by a complex scalar `value`."""
     cdef size_t ptr
-    cdef int ONE=1
-    cdef idxint l = matrix.shape[0]*matrix.shape[1]
+    cdef blas_int ONE=1
+    cdef blas_int l = <blas_int> (matrix.shape[0]*matrix.shape[1])
     zscal(&l, &value, matrix.data, &ONE)
     return matrix
 

--- a/qutip/core/data/norm.pyx
+++ b/qutip/core/data/norm.pyx
@@ -5,6 +5,7 @@ from libc cimport math
 
 from cpython cimport mem
 
+include "_blas_int.pxi"
 from scipy.linalg cimport cython_blas as blas
 import scipy
 import numpy as np
@@ -34,7 +35,7 @@ cdef double abssq(double complex x) nogil:
 __all__ = []
 
 cpdef double one_csr(CSR matrix) except -1:
-    cdef int n=matrix.shape[1], inc=1
+    cdef blas_int n=matrix.shape[1], inc=1
     cdef size_t ptr
     cdef double *col = <double *> PyMem_Calloc(matrix.shape[1], sizeof(double))
     try:
@@ -90,7 +91,7 @@ cpdef double max_csr(CSR matrix) nogil:
 cpdef double frobenius_csr(CSR matrix) nogil:
     # The Frobenius norm is effectively the same as the L2 norm when
     # considering the non-zero elements as a vector.
-    cdef int n=csr.nnz(matrix), inc=1
+    cdef blas_int n=csr.nnz(matrix), inc=1
     return blas.dznrm2(&n, &matrix.data[0], &inc)
 
 cpdef double l2_csr(CSR matrix) except -1 nogil:
@@ -125,8 +126,8 @@ cpdef double max_dense(Dense matrix) nogil:
     return math.sqrt(total)
 
 cpdef double frobenius_dense(Dense matrix) nogil:
-    cdef int n = matrix.shape[0] * matrix.shape[1]
-    cdef int inc = 1
+    cdef blas_int n = matrix.shape[0] * matrix.shape[1]
+    cdef blas_int inc = 1
     return blas.dznrm2(&n, matrix.data, &inc)
 
 cpdef double l2_dense(Dense matrix) except -1 nogil:

--- a/qutip/core/data/reshape.pyx
+++ b/qutip/core/data/reshape.pyx
@@ -2,6 +2,7 @@
 #cython: boundscheck=False, wraparound=False, initializedcheck=False, cdivision=True
 
 from libc.string cimport memcpy, memset
+include "_blas_int.pxi"
 from scipy.linalg cimport cython_blas as blas
 cimport cython
 
@@ -102,11 +103,13 @@ cpdef Dense column_stack_dense(Dense matrix, bint inplace=False):
         warnings.warn("cannot stack columns inplace for C-ordered matrix")
     out = dense.zeros(matrix.shape[0] * matrix.shape[1], 1)
     cdef idxint col
-    cdef int ONE=1
+    cdef blas_int ONE=1
+    cdef blas_int nrows = <blas_int> matrix.shape[0]
+    cdef blas_int ncols = <blas_int> matrix.shape[1]
     for col in range(matrix.shape[1]):
         blas.zcopy(
-            &matrix.shape[0],
-            &matrix.data[col], &matrix.shape[1],
+            &nrows,
+            &matrix.data[col], &ncols,
             &out.data[col * matrix.shape[0]], &ONE
         )
     return out

--- a/qutip/core/data/tidyup.pyx
+++ b/qutip/core/data/tidyup.pyx
@@ -4,6 +4,7 @@
 from libc.math cimport fabs
 
 cimport numpy as cnp
+include "_blas_int.pxi"
 from scipy.linalg cimport cython_blas as blas
 
 from qutip.core.data cimport csr, dense, CSR, Dense, dia, Dia, base
@@ -58,10 +59,11 @@ cpdef Dense tidyup_dense(Dense matrix, double tol, bint inplace=True):
 
 cpdef Dia tidyup_dia(Dia matrix, double tol, bint inplace=True):
     cdef Dia out = matrix if inplace else matrix.copy()
-    cdef base.idxint diag=0, new_diag=0, ONE=1, start, end, col
+    cdef base.idxint diag=0, new_diag=0, start, end, col
+    cdef blas_int ONE=1
     cdef bint re, im, has_data
     cdef double complex value
-    cdef int length
+    cdef blas_int length
 
     while diag < out.num_diag:
         start = max(0, out.offsets[diag])

--- a/qutip/meson.build
+++ b/qutip/meson.build
@@ -21,6 +21,32 @@ qutip_dep = declare_dependency(
   include_directories: include_directories('core/data'),
 )
 
+# ---- SciPy BLAS integer width ----
+# SciPy >= 1.18 exports `blas_int` from cython_blas / cython_lapack: it is C
+# `int` for a normal build and `int64_t` for one against an ILP64 BLAS. Probe
+# for the name and generate core/data/_blas_int.pxi accordingly, so our .pyx
+# files can `include "_blas_int.pxi"` and declare BLAS arguments as blas_int.
+# Pattern from scipy/scipy#25025.
+cy = meson.get_compiler('cython')
+_blas_int_conf = configuration_data()
+if cy.compiles('from scipy.linalg.cython_blas cimport blas_int',
+               name: 'scipy cython_blas exports blas_int')
+  _blas_int_conf.set('BLAS_INT_DEF',
+                     'from scipy.linalg.cython_blas cimport blas_int')
+else
+  # SciPy < 1.18: always LP64.
+  _blas_int_conf.set('BLAS_INT_DEF', 'ctypedef int blas_int')
+endif
+
+blas_int_pxi = configure_file(
+  input: 'core/data/_blas_int.pxi.in',
+  output: '_blas_int.pxi',
+  configuration: _blas_int_conf,
+)
+
+# `include "_blas_int.pxi"` resolves against the Cython include path.
+add_project_arguments('-I' + meson.current_build_dir(), language: 'cython')
+
 # ---- extension modules ----
 cy_modules = {
   '.':                 ['_distributions'],
@@ -43,7 +69,7 @@ foreach reldir, names : cy_modules
   foreach name : names
     py3.extension_module(
       name,
-      reldir / name + '.pyx',
+      [reldir / name + '.pyx', blas_int_pxi],
       dependencies: [qutip_dep],
       install: true,
       subdir: 'qutip' / reldir,
@@ -56,6 +82,7 @@ py3.extension_module(
   'matmul',
   [
     'core/data/matmul.pyx',
+    blas_int_pxi,
     'core/data/src/matmul_csr_vector.cpp',
     'core/data/src/matmul_csr_dense.cpp',
     'core/data/src/matmul_diag_vector.cpp',


### PR DESCRIPTION
**Checklist**
Thank you for contributing to QuTiP! Please make sure you have finished the following tasks before opening the PR.

- [ ] Please read [Contributing to QuTiP Development](https://qutip.readthedocs.io/en/stable/development/contributing.html)
- [ ] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
- [ ] Please add tests to cover your changes if applicable.
- [ ] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-tutorials). Feel free to ask if you are not sure.
- [ ] Include the changelog in a file named: `doc/changes/<PR number>.<type>` 'type' can be one of the following: feature, bugfix, doc, removal, misc, or deprecation (see [here](https://qutip.readthedocs.io/en/stable/development/contributing.html#changelog-generation) for more information).

Delete this checklist after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.

**Description**

Now that we have an adaptation of qutip to Meson's build system (thanks, Mayank!), we could try out the "recipes" for downstream libraries to introduce support for ILP64 BLAS/LAPACK (referring to this "canonical example" by SciPy: https://github.com/scipy/scipy/pull/25025).
It is a work in progress (hence a draft for now) for the sake of having a proof of concept that qutip could be built with 64-bit indices for sparse matrices and usage of ILP64 BLAS.

It is subject to discussion, of course. We don't have to hurry to bring it to the next version, but it would be nice to challenge the compatibility attempt to see the benefits/disadvantages it could give. 

The current tests in CI would be insufficient to cover the changes; those have to be extended too. For now, I'm going to share the results of building QuTiP locally with compilation of SciPy with BLAS from source.

**Related issues or PRs**
Please mention the related issues or PRs here. If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id, e.g. fix #1184

**AI Tools Usage Disclosure**
- [x] AI tools were used, as described below:

Already did this work locally in the past on adopting the `blas_int` type in Cython (before moving to meson; in that case', but this time I used `Claude/Opus 5` to do all the adaptations. The next refinements will be human-made and reviewed, so this disclosure will be adapted again as the PR progresses (if it does - there might also be reasons not to proceed with adaptations; this will be decided in the public discussion).