### PR TITLE
Fixing building wheels failure for Windows

### DIFF
--- a/doc/changes/2983.bugfix
+++ b/doc/changes/2983.bugfix
@@ -1,0 +1,1 @@
+Fix building wheels error for Windows: enforce activating Visual Studio Environment in order to the MSVC compiler to be detected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ full = [
 # When building wheels on Windows, we have to force the Visual Studio environment
 # to be activated. Otherwise, meson would pick the first C++ compiler on PATH,
 # which is usually Strawberry Perl's MinGW g++ (instead of the
-# expected MSVC which expected by CPython used in cibuildwheel)
+# expected MSVC)
 setup = ["--vsenv"]
 
 [tool.cibuildwheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,13 @@ full = [
   "qutip[graphics,runtime_compilation,semidefinite,tests,ipython,extras]",
 ]
 
+[tool.meson-python.args]
+# When building wheels on Windows, we have to force the Visual Studio environment
+# to be activated. Otherwise, meson would pick the first C++ compiler on PATH,
+# which is usually Strawberry Perl's MinGW g++ (instead of the
+# expected MSVC which expected by CPython used in cibuildwheel)
+setup = ["--vsenv"]
+
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux_2_28"
 build-frontend = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ full = [
 
 [tool.meson-python.args]
 # Force activation of the Visual Studio environment on Windows (ignored on other platforms);
-# Otherwise, meson would pick the first C++ compiler on PATH, which is often Strawberry Perl's MinGW g++, but MSVC is expected by qutip. This setting will be used for both wheels and source builds.
+# Otherwise, meson would pick the first C++ compiler on PATH, which is often Strawberry Perl's MinGW g++, but MSVC is expected by qutip.
+# This setting will be used for both wheels and source builds.
 setup = ["--vsenv"]
 
 [tool.cibuildwheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,8 @@ full = [
 ]
 
 [tool.meson-python.args]
-# When building wheels on Windows, we have to force the Visual Studio environment
-# to be activated. Otherwise, meson would pick the first C++ compiler on PATH,
-# which is usually Strawberry Perl's MinGW g++ (instead of the
-# expected MSVC)
+# Force activation of the Visual Studio environment on Windows (ignored on other platforms);
+# Otherwise, meson would pick the first C++ compiler on PATH, which is often Strawberry Perl's MinGW g++, but MSVC is expected by qutip. This setting will be used for both wheels and source builds.
 setup = ["--vsenv"]
 
 [tool.cibuildwheel]


### PR DESCRIPTION
**Description**

After merging #2945, I did a dry run to test building all the wheels. 

The first job to fail was for the latest Windows (see the error below; link to the [CI job](https://github.com/qutip/qutip/actions/runs/32333793593/job/96320338380)). Most likely, jobs for Windows 11 would have failed too, since it depends on the same toolchain. 


Turned out that on GitHub's runner with the latest Windows, meson would happen to first find the _MinGW-w64 g++_ compiler, which happens to be the first on the `PATH` if the Visual Studio environment is not activated. We force it to be active for Windows to be able to pick up _MSVC_, something that we expect in general (e.g., in tests it's reflected via using `ilammy/msvc-dev-cmd@v1` for Windows runners, in string compilation functionality the expectation is captured implicitly via compiler flags handling etc. But we missed setting up this expectation explicitly for builds.)

Tested building wheels on this branch; now builds are successful: link to the [workflow](https://github.com/veronikakurth/qutip/actions/runs/32336538154). 

**Error** 
```
FAILED: [code=1] qutip/_distributions.cp311-win_amd64.pyd.p/meson-generated__distributions.pyx.cpp.obj 

 "C:\Strawberry\c\bin\ccache.exe" "c++" "-Iqutip\_distributions.cp311-win_amd64.pyd.p" "-Iqutip" "-I..\qutip" "-I..\qutip\core\data" "-IC:\Users\runneradmin\AppData\Local\Temp\build-env-xz78c614\Lib\site-packages\numpy\_core\include" "-IC:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.11.9\tools\Include" "-fvisibility=hidden" "-fvisibility-inlines-hidden" "-fdiagnostics-color=always" "-DNDEBUG" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-std=c++17" "-O3" "-funroll-loops" "-Wno-unused-but-set-variable" "-Wno-unused-function" "-Wno-conversion" "-Wno-misleading-indentation" "-Wno-unused-but-set-variable" "-Wno-unused-function" "-Wno-conversion" "-Wno-misleading-indentation" "-Wno-psabi" "-DMS_WIN64=" -MD -MQ qutip/_distributions.cp311-win_amd64.pyd.p/meson-generated__distributions.pyx.cpp.obj -MF "qutip\_distributions.cp311-win_amd64.pyd.p\meson-generated__distributions.pyx.cpp.obj.d" -o qutip/_distributions.cp311-win_amd64.pyd.p/meson-generated__distributions.pyx.cpp.obj "-c" qutip/_distributions.cp311-win_amd64.pyd.p/_distributions.pyx.cpp

 qutip/_distributions.cp311-win_amd64.pyd.p/_distributions.pyx.cpp: In function 'PyArrayObject* __pyx_f_5qutip_14_distributions_psi_n_single_fock_multiple_position_complex(int, PyArrayObject*, int)':

 qutip/_distributions.cp311-win_amd64.pyd.p/_distributions.pyx.cpp:4939:73: error: 'M_PI' was not declared in this scope

 4939 |   __pyx_v_pi_025 = __Pyx_c_pow_double(__pyx_t_double_complex_from_parts(M_PI, 0), __pyx_t_double_complex_from_parts(-0.25, 0));

      |                                                                         ^~~~

 qutip/_distributions.cp311-win_amd64.pyd.p/_distributions.pyx.cpp:2553:55: note: in definition of macro '__Pyx_c_pow_double'

 2553 |         #define __Pyx_c_pow_double(a, b)  (::std::pow(a, b))

      |                                                       ^

 [41/129] Compiling Cython source D:/a/qutip/qutip/qutip/solver/sode/_sode.pyx

 [42/129] Compiling Cython source D:/a/qutip/qutip/qutip/solver/sode/ssystem.pyx

 [43/129] Compiling Cython source D:/a/qutip/qutip/qutip/core/data/matmul.pyx

 [44/129] Compiling C++ object qutip/_brtools.cp311-win_amd64.pyd.p/meson-generated__brtools.pyx.cpp.obj

 [45/129] Compiling C++ object qutip/_brtensor.cp311-win_amd64.pyd.p/meson-generated__brtensor.pyx.cpp.obj

 ninja: build stopped: subcommand failed.

 INFO: autodetecting backend as ninja

 INFO: calculating backend command to run: C:\ProgramData\Chocolatey\bin\ninja.exe

 

 ERROR Backend subprocess exited when trying to invoke build_wheel

 Error: cibuildwheel: Command ['C:\\Users\\runneradmin\\AppData\\Local\\Temp\\cibw-run-k6xa3uff\\cp311-win_amd64\\build\\venv\\Scripts\\python.EXE', '-m', 'build', 'D:\\a\\qutip\\qutip', '--wheel', '--outdir=C:\\Users\\runneradmin\\AppData\\Local\\Temp\\cibw-run-k6xa3uff\\cp311-win_amd64\\built_wheel'] failed with code 1.

```



**Related issues or PRs**
Please mention the related issues or PRs here. If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id, e.g. fix #1184

**AI Tools Usage Disclosure**
- [x] AI tools were used, as described below:
  - `Claude, Opus 5`: for troubleshooting and detecting the error's source & understanding the way meson checks for C++ compilers. Wrote a comment in `pyproject.toml` myself. 
