### PR TITLE
mesolve: additional `isherm` test case for propagators

### DIFF
--- a/doc/changes/2987.misc
+++ b/doc/changes/2987.misc
@@ -1,0 +1,1 @@
+Extra test for testing the correctness of the ``isherm`` attribute for the case when the state is a propagator.

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -1049,6 +1049,7 @@ def test_mesolve_does_not_cache_isherm_for_propagator():
 
     assert propagator._isherm is None
     assert not qutip.data.isherm(propagator.data)
+    assert propagator.isherm is False
 
 
 def test_mesolve_caches_isherm_for_time_dependent_standard_rhs():

--- a/qutip/tests/solver/test_mesolve.py
+++ b/qutip/tests/solver/test_mesolve.py
@@ -1036,6 +1036,21 @@ def test_mesolve_does_not_cache_isherm_for_time_dependent_rhs():
     assert result.final_state.isherm is False
 
 
+def test_mesolve_does_not_cache_isherm_for_propagator():
+    """Propagator evolved by mesolve must not inherit the fast path for isherm. """
+
+    propagator = mesolve(
+            qutip.num(2),
+            qutip.qeye([[2], [2]]),
+            [0, 1],
+            c_ops=[qutip.destroy(2)],
+            options={"progress_bar": None},
+        ).final_state
+
+    assert propagator._isherm is None
+    assert not qutip.data.isherm(propagator.data)
+
+
 def test_mesolve_caches_isherm_for_time_dependent_standard_rhs():
     """Hamiltonian and collapse-operator construction is known to be safe."""
     rho0 = qutip.ket2dm(qutip.basis(2, 1))


### PR DESCRIPTION
**Description**
Adding an extra test case as a follow-up to Eric's [code improvement suggestion](https://github.com/qutip/qutip/pull/2940#discussion_r3796820923) in #2940.

We should test that the final state is non-Hermitian in case the evolved state is a propagator. 

**Related issues or PRs**
#2940

**AI Tools Usage Disclosure**
- [x] No AI tools were used for this contribution.