### PR TITLE
Fix docstring parameter names that do not match the signature

### DIFF
--- a/doc/changes/2988.doc
+++ b/doc/changes/2988.doc
@@ -1,0 +1,1 @@
+Fix 17 docstrings that name a parameter the signature does not have.

--- a/qutip/animation.py
+++ b/qutip/animation.py
@@ -601,7 +601,7 @@ def anim_schmidt(kets, theme='light', splitting=None,
 
     Parameters
     ----------
-    ket : :class:`.Result` or list of :class:`.Qobj`
+    kets : :class:`.Result` or list of :class:`.Qobj`
         Pure states for animation.
 
     theme : str {'light', 'dark'}, default: 'light'

--- a/qutip/core/gates.py
+++ b/qutip/core/gates.py
@@ -601,8 +601,6 @@ def molmer_sorensen(theta: float, *, dtype: LayerType = None) -> Qobj:
     ----------
     theta: float
         The duration of the interaction pulse.
-    target: int
-        The indices of the target qubits.
     dtype : str or type, [keyword only] [optional]
         Storage representation. Any data-layer known to `qutip.data.to` is
         accepted.

--- a/qutip/core/qobj.py
+++ b/qutip/core/qobj.py
@@ -840,11 +840,6 @@ class Qobj:
     def proj(self) -> Qobj:
         """Form the projector from a given ket or bra vector.
 
-        Parameters
-        ----------
-        Q : :class:`.Qobj`
-            Input bra or ket vector
-
         Returns
         -------
         P : :class:`.Qobj`

--- a/qutip/distributions.py
+++ b/qutip/distributions.py
@@ -309,7 +309,7 @@ class TwoModeQuadratureCorrelation(Distribution):
 
         Parameters
         ----------
-        state : Qobj
+        psi : Qobj
             A wavefunction from which the distribution is generated.
 
         """
@@ -339,7 +339,7 @@ class TwoModeQuadratureCorrelation(Distribution):
 
         Parameters
         ----------
-        state : Qobj
+        rho : Qobj
             A density matrix from which the distribution is generated.
 
         """
@@ -506,7 +506,7 @@ class HarmonicOscillatorProbabilityFunction(Distribution):
 
         Parameters
         ----------
-        state : Qobj
+        rho : Qobj
             A density matrix from which the distribution is generated.
 
         """

--- a/qutip/entropy.py
+++ b/qutip/entropy.py
@@ -81,7 +81,7 @@ def concurrence(rho):
 
     Parameters
     ----------
-    state : qobj
+    rho : qobj
         Ket, bra, or density matrix for a two-qubit state.
 
     Returns

--- a/qutip/measurement.py
+++ b/qutip/measurement.py
@@ -92,7 +92,7 @@ def _measurement_statistics_povm_dm(density_mat, ops, tol=None):
 
     Parameters
     ----------
-    state : :class:`.Qobj` (density matrix)
+    density_mat : :class:`.Qobj` (density matrix)
         The density matrix specifying the state to measure.
 
     ops : iterable of :class:`.Qobj`

--- a/qutip/random_objects.py
+++ b/qutip/random_objects.py
@@ -707,7 +707,7 @@ def rand_super(
         the new Qobj are set to this list.  This can produce either `oper` or
         `super` depending on the passed `dimensions`.
 
-    superrop : str, default: "super"
+    superrep : str, default: "super"
         Representation of the super operator
 
     seed : int, SeedSequence, Generator, optional
@@ -773,7 +773,7 @@ def rand_super_bcsz(
         Seed to create the random number generator or a pre prepared
         generator. When none is suplied, a default generator is used.
 
-    superrop : str, default: "super"
+    superrep : str, default: "super"
         representation of the
 
     dtype : type or str, optional

--- a/qutip/solver/heom/bofin_solvers.py
+++ b/qutip/solver/heom/bofin_solvers.py
@@ -369,7 +369,7 @@ class HierarchyADOsState:
 
         Parameters
         ----------
-        idx : int or label
+        idx_or_label : int or label
             The index of the ADO to extract. If an ADO label, e.g.
             ``(0, 1, 0, ...)`` is supplied instead, then the ADO
             is extracted by label instead.

--- a/qutip/solver/integrator/integrator.py
+++ b/qutip/solver/integrator/integrator.py
@@ -100,7 +100,7 @@ class Integrator:
         t : float
             Initial time
 
-        state0 : qutip.Data
+        state : qutip.Data
             Initial state.
 
         .. note:

--- a/qutip/solver/multitraj.py
+++ b/qutip/solver/multitraj.py
@@ -98,7 +98,7 @@ class MultiTrajSolver(Solver):
 
         Parameters
         ----------
-        state : :obj:`.Qobj`
+        state0 : :obj:`.Qobj`
             Initial state of the evolution.
 
         t0 : double

--- a/qutip/solver/solver_base.py
+++ b/qutip/solver/solver_base.py
@@ -482,7 +482,7 @@ class Solver:
         integrator : Integrator
             The ODE solver to register.
 
-        keys : list of str
+        key : list of str
             Values of the method options that refer to this integrator.
         """
         if not issubclass(integrator, Integrator):

--- a/qutip/wigner.py
+++ b/qutip/wigner.py
@@ -179,7 +179,7 @@ def wigner(psi, xvec, yvec=None, method='clenshaw', g=sqrt(2),
     Parameters
     ----------
 
-    state : qobj
+    psi : qobj
         A state vector or density matrix.
 
     xvec : array_like
@@ -978,7 +978,7 @@ def spin_q_function(rho, theta, phi):
 
     Parameters
     ----------
-    state : qobj
+    rho : qobj
         A state vector or density matrix for a spin-j quantum system.
     theta : array_like
         Polar (colatitude) angle at which to calculate the Husimi-Q function.
@@ -1085,7 +1085,7 @@ def spin_wigner(rho, theta, phi):
 
     Parameters
     ----------
-    state : qobj
+    rho : qobj
         A state vector or density matrix for a spin-j quantum system.
     theta : array_like
         Polar (colatitude) angle at which to calculate the W function.


### PR DESCRIPTION
**Description**

17 docstrings name a parameter the signature does not have.

Most are a rename that never reached the docs: `concurrence` documents `state` while the signature is `rho`, `wigner` documents `state` for `psi`, `set_state` documents `state0` for `state`, `start` the other way round. Two are typos, `superrop` for `superrep` in `rand_super` and `rand_super_bcsz`, and `keys` for `key` in `add_integrator`. Two are leftovers: `molmer_sorensen` documents a `target` argument that is not in the signature at all, and `Qobj.proj` documents `Q` but takes only `self`, so both blocks are dropped rather than renamed.

Found with a docstring checker I maintain, then opened each of the 17 against its signature by hand. Nothing here changes behaviour.

There is an 18th hit in `MCSolver.StateFeedback` that I left out, because it looks like a code bug rather than a docs one and needs a maintainer decision. Filing it separately.

**Related issues or PRs**

None.

**AI Tools Usage Disclosure**
- [x] AI tools were used, as described below:
  - `Claude (Anthropic): drafting the patch and this description. The mismatches came from a static checker, and I read all 17 sites against their signatures before including them.`
