### PR TITLE
Fix `bures_dist` returning `nan` for identical density matrices

### DIFF
--- a/doc/changes/2985.bugfix
+++ b/doc/changes/2985.bugfix
@@ -1,0 +1,1 @@
+Fixed ``bures_dist`` returning ``nan`` for identical density matrices.

--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -345,7 +345,7 @@ def bures_dist(A, B):
         B = B.proj()
     if A._dims != B._dims:
         raise TypeError('A and B do not have same dimensions.')
-    dist = np.sqrt(2 * (1 - fidelity(A, B)))
+    dist = np.sqrt(2 * np.maximum(0, 1 - fidelity(A, B)))
     return dist
 
 

--- a/qutip/core/metrics.py
+++ b/qutip/core/metrics.py
@@ -345,7 +345,9 @@ def bures_dist(A, B):
         B = B.proj()
     if A._dims != B._dims:
         raise TypeError('A and B do not have same dimensions.')
-    dist = np.sqrt(2 * np.maximum(0, 1 - fidelity(A, B)))
+    if A == B:
+        return 0
+    dist = np.sqrt(2 * np.maximum(0, 1 - np.real(fidelity(A, B))))
     return dist
 
 

--- a/qutip/tests/core/test_metrics.py
+++ b/qutip/tests/core/test_metrics.py
@@ -195,11 +195,19 @@ class Test_hellinger_dist:
         assert hellinger_dist(rho_sim, sigma) == pytest.approx(dist, abs=tol)
 
 
-
 class Test_bures_dist:
-    def test_state_with_itself(self):
-        state = rand_dm(3, seed=465)
-        assert bures_dist(state, state) == pytest.approx(0, abs=1e-6)
+    def test_state_with_itself(self, state):
+        dist = bures_dist(state, state)
+        assert np.isfinite(dist)
+        assert dist == pytest.approx(0, abs=1e-12)
+
+    def test_state_with_itself_pure_and_mixed_edges(self):
+        psi = basis(2, 0)
+        rho = qeye(2) / 2
+        assert np.isfinite(bures_dist(psi, psi))
+        assert bures_dist(psi, psi) == pytest.approx(0, abs=1e-12)
+        assert np.isfinite(bures_dist(rho, rho))
+        assert bures_dist(rho, rho) == pytest.approx(0, abs=1e-12)
 
 
 class Test_average_gate_fidelity:

--- a/qutip/tests/core/test_metrics.py
+++ b/qutip/tests/core/test_metrics.py
@@ -194,10 +194,14 @@ class Test_hellinger_dist:
         assert hellinger_dist(rho, sigma) + tol > dist
         assert hellinger_dist(rho_sim, sigma) == pytest.approx(dist, abs=tol)
 
+
+
 class Test_bures_dist:
     def test_state_with_itself(self):
         state = rand_dm(3, seed=465)
         assert bures_dist(state, state) == pytest.approx(0, abs=1e-6)
+
+
 class Test_average_gate_fidelity:
     def test_identity(self, dimension):
         id = qeye(dimension)

--- a/qutip/tests/core/test_metrics.py
+++ b/qutip/tests/core/test_metrics.py
@@ -194,7 +194,10 @@ class Test_hellinger_dist:
         assert hellinger_dist(rho, sigma) + tol > dist
         assert hellinger_dist(rho_sim, sigma) == pytest.approx(dist, abs=tol)
 
-
+class Test_bures_dist:
+    def test_state_with_itself(self):
+        state = rand_dm(3, seed=465)
+        assert bures_dist(state, state) == pytest.approx(0, abs=1e-6)
 class Test_average_gate_fidelity:
     def test_identity(self, dimension):
         id = qeye(dimension)


### PR DESCRIPTION
**Description**
`bures_dist` returned `nan` when called with the same density matrix because floating-point roundoff could make the fidelity slightly greater than 1.
Consequently, the argument to the square root became negative.
This change clamps the square-root argument to zero when it is slightly negative, preventing `nan` and returning the mathematically correct distance of zero. A regression test was added for identical density matrices.

**Related issues or PRs**
Fixes #2985 

**Tests**
- `python -m pytest qutip/tests/core/test_metrics.py -q`
- `git diff --check`

**AI Tools Usage Disclosure**
- [ ] No AI tools were used for this contribution.
- [x] AI tools were used, as described below:
  - `I used Github Copilot and gemini-flash to understand the issue, and existing implementation. Also, to understand and troubleshoot the development environment, and review the code and test changes`