### PR TITLE
Update Install instructions + few minor changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build wheels, optionally deploy to PyPI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,8 @@
 #     Tests / ubuntu-latest, python-3.9, defaults
 # or similar.
 name: Tests
+permissions:
+  contents: read
 
 on:
     [push, pull_request]

--- a/.github/workflows/tests_env.yml
+++ b/.github/workflows/tests_env.yml
@@ -35,12 +35,7 @@ jobs:
 
       - name: Install QuTiP and dependencies
         run: |
-          # Install the extra requirement
-          python -m pip install meson-python meson ninja # build
-          python -m pip install setuptools  # runtime string-coefficient compilation
-          python -m pip install pytest pytest-rerunfailures  # tests
-          python -m pip install numpy scipy cython filelock
-          python -m pip install . -v --no-build-isolation
+          python -m pip install .[runtime_compilation] --group tests -v
 
       - name: Pre-install development dependencies
         if: ${{ matrix.repo == 'qutip-qoc' }}

--- a/.github/workflows/tests_env.yml
+++ b/.github/workflows/tests_env.yml
@@ -1,4 +1,6 @@
 name: Test family projects
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/doc/changes/2994.doc
+++ b/doc/changes/2994.doc
@@ -1,0 +1,1 @@
+Update installation instructions in the documentation.

--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -13,8 +13,8 @@ The exact details of environment set-up, build process and testing vary by repos
 
 #. Consider creating an issue on the GitHub page of the relevant repository, describing the change you think should be made and why, so we can discuss details with you and make sure it is appropriate.
 #. (If this is your first contribution.) Make a fork of the relevant repository on GitHub and clone it to your local computer.  Also add our copy as a remote (``git remote add qutip https://github.com/qutip/<repo>``)
-#. Begin on the ``master`` branch (``git checkout master``), and pull in changes from the main QuTiP repository to make sure you have an up-to-date copy (``git pull qutip master``).
-#. Switch to a new ``git`` branch (``git checkout -b <branch-name>``).
+#. Begin on the ``master`` branch (``git switch master``), and pull in changes from the main QuTiP repository to make sure you have an up-to-date copy (``git pull qutip master``).
+#. Switch to a new ``git`` branch (``git switch -c <branch-name>``).
 #. Make the changes you want to make, then create some commits with short, descriptive names (``git add <files>`` then ``git commit``).
 #. Follow the build process for this repository to build the final result so you can check your changes work sensibly.
 #. Run the tests for the repository (if it has them).
@@ -22,7 +22,7 @@ The exact details of environment set-up, build process and testing vary by repos
 #. Go to the GitHub website for the repository you are contributing to, click on the "Pull Requests" tab, click the "New Pull Request" button, and follow the instructions there.
 
 Once the pull request is created, some members of the QuTiP admin team will review the code to make sure it is suitable for inclusion in the library, to check the programming, and to ensure everything meets our standards.
-For some repositories, several automated tests will run whenever you create or modify a pull request; in general these will be the same tests you can run locally, and all tests are required to pass online before your changes are merged.
+For some repositories, several automated tests will run whenever you create or modify a pull request; in general these will be the same tests you can run locally, and all tests are required to pass in the CI before your changes are merged.
 There may be some feedback and possibly some requested changes.
 You can add more commits to address these, and push them to the relevant branch of your fork to update the pull request.
 
@@ -42,11 +42,13 @@ Building
 Building the core library from source is typically a bit more difficult than simply installing the package for regular use.
 You will most likely want to do this in a clean Python environment so that you do not compromise a working installation of a release version, for example by starting from ::
 
+.. code-block:: bash
+
    conda create -n qutip-dev python
 
 :ref:`Complete instructions for the build <install>` are elsewhere in this guide, however beware that you will need to follow the :ref:`installation from source <build-meson>`, not the general installation.
-You will need all the *build* and *tests* "optional" requirements for the package.
-The build requirements can be found in the |pyproject.toml|_ file, and the testing requirements are in the ``tests`` key of the ``project.optional-dependencies`` section of |pyproject.toml|_.
+You will need all the *build* and *tests* dependencies for the project.
+The build requirements can be found in the |pyproject.toml|_ file, and the testing requirements are in the ``tests`` key of the ``project.group-dependency`` section of |pyproject.toml|_.
 You will also need the requirements for any optional features you want to test as well.
 
 .. |pyproject.toml| replace:: ``pyproject.toml`` file
@@ -54,18 +56,20 @@ You will also need the requirements for any optional features you want to test a
 
 Refer to the main instructions for the most up-to-date version, however as of version 5.4 the requirements can be installed into a conda environment with ::
 
-   conda install meson-python ninja numpy scipy cython setuptools filelock pytest pytest-rerunfailures
-
-Note that ``qutip`` should *not* be installed with ``conda install``.
+   conda install meson-python ninja numpy scipy cython pytest pytest-rerunfailures
 
 .. note::
    If you prefer, you can also use ``pip`` to install all the dependencies.
    We typically recommend ``conda`` when doing main-library development because it is easier to switch low-level packages around like BLAS implementations, but if you don't require this, feel free to use ``pip``.
 
+Note that ``qutip`` should *not* be listed in ``conda install`` or ``pip install``.
+
 You will need to make sure you have a functioning C++ compiler to build QuTiP.
 If you are on Linux or Mac, this is likely already done for you, however if you are on Windows, refer to the :ref:`Windows installation <install-on-windows>` section of the installation guide.
 
 The command to build QuTiP in editable mode is ::
+
+.. code-block:: bash
 
    pip install --no-build-isolation --editable .
 
@@ -78,8 +82,8 @@ Generally the low-level linear algebra routines that QuTiP uses are written in t
 
 .. warning::
 
-   The ``--no-build-isolation`` flag is required, not merely an optimisation.
-   Without it, ``pip`` builds inside a temporary virtual environment which it then deletes, leaving the build directory pointing at header files that no longer exist.
+   The ``--no-build-isolation`` flag is required.
+   Without it, ``pip`` will build inside a temporary virtual environment which it then deletes, leaving the build directory pointing at header files that no longer exist.
    The install itself will appear to succeed, but the next time anything needs recompiling you will get an unhelpful ``ImportError`` about the rebuild having failed.
 
 .. note::
@@ -89,7 +93,7 @@ Generally the low-level linear algebra routines that QuTiP uses are written in t
     These coincide with the versions employed for testing in continuous integration.
 
     In the event of a feature requiring a version upgrade of python or a dependency, it will be considered appropriately in the pull request.
-    In any case, python and dependency upgrades will only happen in mayor or minor versions of QuTiP, not in a patch.
+    In any case, python and dependency upgrades will only happen in mayor or minor versions of QuTiP, not in the patch releases.
 
 .. _NEP29: https://numpy.org/neps/nep-0029-deprecation_policy.html
 
@@ -99,12 +103,16 @@ Build options
 
 You can pass build options are passed through ``pip`` using ``--config-settings`` (``-C`` for short) ::
 
+.. code-block:: bash
+
    pip install --no-build-isolation -Csetup-args=-Didxint_64=true --editable .
 
 Here ``idxint_64`` selects 64-bit integers for the internal sparse-matrix memory indices.
 All the available build options are declared in the ``meson.options`` file in the repository root.
 
 Also you can build C extension without installing QuTiP, which is useful when you only want to check that your changes compile ::
+
+.. code-block:: bash
 
    meson setup build
    meson compile -C build
@@ -157,6 +165,8 @@ Testing
 We use ``pytest`` as our test runner.
 The base way to run every test is ::
 
+.. code-block:: bash
+
    pytest /path/to/repo/qutip/tests
 
 This will take around 10 to 30 minutes, depending on your computer and how many of the optional requirements you have installed.
@@ -204,14 +214,18 @@ Building the documentation can be a little finnicky on occasion.
 You likely will want to keep a separate Python environment to build the documentation in, because some of the dependencies can have tight requirements that may conflict with your favourite tools for Python development.
 We recommend creating an empty ``conda`` environment containing only Python with ::
 
-   conda create -n qutip-doc python=3.8
+.. code-block:: bash
+
+   conda create -n qutip-doc python=3.13
 
 and install all further dependencies with ``pip``.
-There is a ``requirements.txt`` file in the repository root that fixes all package versions exactly into a known-good configuration for a completely empty environment, using ::
+There is a ``doc/requirements.txt`` file in the repository root that fixes all package versions exactly into a known-good configuration for a completely empty environment, using ::
 
-   pip install -r requirements.txt
+.. code-block:: bash
 
-This known-good configuration was intended for Python 3.8, though in principle it is possible that other Python versions will work.
+   pip install -r doc/requirements.txt
+
+This known-good configuration was intended for Python 3.13, though in principle it is possible that other Python versions will work.
 
 .. note::
 
@@ -221,15 +235,19 @@ The documentation build includes running many components of the main QuTiP libra
 You therefore need to have a version of QuTiP available in the same Python environment.
 If you are only interested in updating the users' guide, you can use a release version of QuTiP, for example by running ``pip install qutip``.
 If you are also modifying the main library, you need to make your development version accessible in this environment.
-See the `above section on building QuTiP <contributing-qutip_>`_ for more details, though the ``requirements.txt`` file will have already installed all the build requirements, so you should be able to simply run ::
+See the `above section on building QuTiP <contributing-qutip_>`_ for more details, though the ``doc/requirements.txt`` file will have already installed all the build requirements, so you should be able to simply run ::
 
-   python setup.py develop
+.. code-block:: bash
+
+   python install .
 
 in the main library repository.
 
 The documentation is built by running the ``make`` command.
 There are several targets to build, but the most useful will be ``html`` to build the webpage documentation, ``latexpdf`` to build the PDF documentation (you will also need a full ``pdflatex`` installation), and ``clean`` to remove all built files.
 The most important command you will want to run is ::
+
+.. code-block:: bash
 
    make html
 

--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -44,7 +44,7 @@ You will most likely want to do this in a clean Python environment so that you d
 
    conda create -n qutip-dev python
 
-:ref:`Complete instructions for the build <install>` are elsewhere in this guide, however beware that you will need to follow the :ref:`installation from source using setuptools section <build-setuptools>`, not the general installation.
+:ref:`Complete instructions for the build <install>` are elsewhere in this guide, however beware that you will need to follow the :ref:`installation from source <build-meson>`, not the general installation.
 You will need all the *build* and *tests* "optional" requirements for the package.
 The build requirements can be found in the |pyproject.toml|_ file, and the testing requirements are in the ``tests`` key of the ``project.optional-dependencies`` section of |pyproject.toml|_.
 You will also need the requirements for any optional features you want to test as well.
@@ -54,13 +54,13 @@ You will also need the requirements for any optional features you want to test a
 
 Refer to the main instructions for the most up-to-date version, however as of version 5.4 the requirements can be installed into a conda environment with ::
 
-   conda install meson-python meson ninja numpy scipy cython setuptools filelock pytest pytest-rerunfailures
+   conda install meson-python ninja numpy scipy cython setuptools filelock pytest pytest-rerunfailures
 
 Note that ``qutip`` should *not* be installed with ``conda install``.
 
 .. note::
    If you prefer, you can also use ``pip`` to install all the dependencies.
-   We typically recommend ``conda`` when doing main-library development because it is easier to switch low-level packages around like BLAS implementations, but if this doesn't mean anything to you, feel free to use ``pip``.
+   We typically recommend ``conda`` when doing main-library development because it is easier to switch low-level packages around like BLAS implementations, but if you don't require this, feel free to use ``pip``.
 
 You will need to make sure you have a functioning C++ compiler to build QuTiP.
 If you are on Linux or Mac, this is likely already done for you, however if you are on Windows, refer to the :ref:`Windows installation <install-on-windows>` section of the installation guide.

--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -93,7 +93,7 @@ Generally the low-level linear algebra routines that QuTiP uses are written in t
     These coincide with the versions employed for testing in continuous integration.
 
     In the event of a feature requiring a version upgrade of python or a dependency, it will be considered appropriately in the pull request.
-    In any case, python and dependency upgrades will only happen in mayor or minor versions of QuTiP, not in the patch releases.
+    In any case, python and dependency upgrades will only happen in major or minor versions of QuTiP, not in the patch releases.
 
 .. _NEP29: https://numpy.org/neps/nep-0029-deprecation_policy.html
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -11,7 +11,7 @@ Installation
 Quick Start
 ===========
 
-From QuTiP version 4.6 onwards, you should be able to get a working version of QuTiP with the standard
+You can get a working version of QuTiP with the standard
 
 .. code-block:: bash
 
@@ -33,15 +33,15 @@ The following packages are currently required:
 
 .. cssclass:: table-striped
 
-+----------------+--------------+-----------------------------------------------------+
-| Package        | Version      | Details                                             |
-+================+==============+=====================================================+
-| **Python**     | 3.9+         | 3.6+ for version 4.7                                |
-+----------------+--------------+-----------------------------------------------------+
-| **NumPy**      | 1.22+ <2.0   | 1.16+ for version 4.7                               |
-+----------------+--------------+-----------------------------------------------------+
-| **SciPy**      | 1.8+         | 1.0+ for version 4.7                                |
-+----------------+--------------+-----------------------------------------------------+
++----------------+--------------+
+| Package        | Version      |
++================+==============+
+| **Python**     | 3.11+        |
++----------------+--------------+
+| **NumPy**      | 1.23.2+      |
++----------------+--------------+
+| **SciPy**      | 1.13+        |
++----------------+--------------+
 
 
 In addition, there are several optional packages that provide additional functionality:
@@ -51,19 +51,16 @@ In addition, there are several optional packages that provide additional functio
 +--------------------------+--------------+-----------------------------------------------------+
 | Package                  | Version      | Details                                             |
 +==========================+==============+=====================================================+
-| ``matplotlib``           | 1.2.1+       | Needed for all visualisation tasks.                 |
+| ``matplotlib``           | 3.6+         | Needed for all visualisation tasks.                 |
 +--------------------------+--------------+-----------------------------------------------------+
-| ``cython``               | 0.29.20+     | Needed for compiling some time-dependent            |
-| ``setuptools``           |              | Hamiltonians. Cython needs a working C++ compiler.  |
+| ``cython``               | 0.29.34+     | Needed for compiling some time-dependent            |
+| ``setuptools``           |              | Hamiltonians. Cython will require a C++ compiler.   |
 | ``filelock``             |              |                                                     |
 +--------------------------+--------------+-----------------------------------------------------+
 | ``cvxpy``                | 1.0+         | Needed to calculate diamond norms.                  |
 +--------------------------+--------------+-----------------------------------------------------+
-| ``pytest``,              | 5.3+         | For running the test suite.                         |
+| ``pytest``,              | 7.2+         | For running the test suite.                         |
 | ``pytest-rerunfailures`` |              |                                                     |
-+--------------------------+--------------+-----------------------------------------------------+
-| LaTeX                    | TeXLive 2009+| Needed if using LaTeX in matplotlib figures, or for |
-|                          |              | nice circuit drawings in IPython.                   |
 +--------------------------+--------------+-----------------------------------------------------+
 | ``loky``, ``mpi4py``     |              | Extra parallel map back-ends.                       |
 +--------------------------+--------------+-----------------------------------------------------+
@@ -73,21 +70,29 @@ In addition, there are several optional packages that provide additional functio
 In addition, there are several additional packages that are not dependencies, but may give you a better programming experience.
 `IPython <https://ipython.org/>`_ provides an improved text-based Python interpreter that is far more full-featured that the default interpreter, and runs in a terminal.
 If you prefer a more graphical set-up, `Jupyter <https://jupyter.org/>`_ provides a notebook-style interface to mix code and mathematical notes together.
-Alternatively, `Spyder <https://www.spyder-ide.org/>`_ is a free integrated development environment for Python, with several nice features for debugging code.
 QuTiP will detect if it is being used within one of these richer environments, and various outputs will have enhanced formatting.
 
-.. _install-with-conda:
 
-Installing with conda
-=====================
+.. _building-conda-environment:
 
-If you already have your conda environment set up, and have the ``conda-forge`` channel available, then you can install QuTiP using:
+New conda environments
+----------------------
+
+The default Anaconda environment has all the Python packages needed for running QuTiP installed already.
+If you have only installed Miniconda, or you want a completely clean virtual environment to install QuTiP in, the ``conda`` package manager provides a convenient way to do this.
+
+To create a conda environment for QuTiP called ``qutip-env``:
 
 .. code-block:: bash
 
-   conda install qutip
+   conda create -n qutip-env python
 
-This will install the minimum set of dependences, but none of the optional packages.
+You activate the new environment by running
+
+.. code-block:: bash
+
+   conda activate qutip-env
+
 
 .. _adding-conda-forge:
 
@@ -101,30 +106,21 @@ The following command adds this channel with lowest priority, so conda will stil
 
    conda config --append channels conda-forge
 
-If you want to change the order of your channels later, you can edit your ``.condarc`` (user home folder) file manually, but it is recommended to keep ``defaults`` as the highest priority.
+It is recommended to keep ``defaults`` channel as the highest priority, but if you want to change the order of your channels later you can edit your ``.condarc`` (user home folder) file manually.
 
 
-.. _building-conda-environment:
+.. _install-with-conda:
 
-New conda environments
-----------------------
+Installing with conda
+=====================
 
-The default Anaconda environment has all the Python packages needed for running QuTiP installed already, so you will only need to add the ``conda-forge`` channel and then install the package.
-If you have only installed Miniconda, or you want a completely clean virtual environment to install QuTiP in, the ``conda`` package manager provides a convenient way to do this.
-
-To create a conda environment for QuTiP called ``qutip-env``:
+If you already have your conda environment set up, and have the ``conda-forge`` channel available, then you can install QuTiP using:
 
 .. code-block:: bash
 
-   conda create -n qutip-env python qutip
+   conda install qutip
 
-This will automatically install all the necessary packages, and none of the optional packages.
-You activate the new environment by running
-
-.. code-block:: bash
-
-   conda activate qutip-env
-
+This will install the minimum set of dependences, but none of the optional packages.
 You can also install any more optional packages you want with ``conda install``, for example ``matplotlib``, ``ipython`` or ``jupyter``.
 
 
@@ -136,14 +132,14 @@ Installing from Source
 Official releases of QuTiP are available from the download section on `the project's web pages <https://qutip.org/download.html>`_, and the latest source code is available in `our GitHub repository <https://github.com/qutip/qutip>`_.
 In general we recommend users to use the latest stable release of QuTiP, but if you are interested in helping us out with development or wish to submit bug fixes, then use the latest development version from the GitHub repository.
 
-You can install from source by using the `Python-recommended PEP 517 procedure <build-pep517_>`_, or if you want more control or to have a development version, you can use the `low-level build procedure with setuptools <build-setuptools_>`_.
+You can install from source by using the `Python-recommended PEP 517 procedure <build-pep517_>`_, or if you want more control or to have a development version, you can use the `low-level build procedure with meson <build-meson>`_.
 
 .. _build-pep517:
 
 PEP 517 Source Builds
 ---------------------
 
-The easiest way to build QuTiP from source is to use a PEP-517-compatible builder such as the ``build`` package available on ``pip``.
+The easiest way to build QuTiP from source is to use a PEP-517-compatible builder such as the ``build`` package available on ``pip`` to build the wheel.
 These will automatically install all build dependencies for you, and the ``pip`` installation step afterwards will install the minimum runtime dependencies.
 You can do this by doing (for example)
 
@@ -156,43 +152,43 @@ You can do this by doing (for example)
 The first command installs the reference PEP-517 build tool, the second effects the build and the third uses ``pip`` to install the built package.
 You will need to replace ``<path to qutip>`` with the actual path to the QuTiP source code.
 The string ``<version>`` will depend on the version of QuTiP, the version of Python and your operating system.
-It will look something like ``4.6.0-cp39-cp39-manylinux1_x86_64``, but there should only be one ``.whl`` file in the ``dist/`` directory, which will be the correct one.
+It will look something like ``5.4.0-cp314-cp314-manylinux_2_28_x86_64``, but there should only be one ``.whl`` file in the ``dist/`` directory, which will be the correct one.
 
 
-.. _build-setuptools:
+.. _build-meson:
 
-Direct Setuptools Source Builds
--------------------------------
+Direct Source Builds
+--------------------
 
 This is the method to have the greatest amount of control over the installation, but it the most error-prone and not recommended unless you know what you are doing.
 You first need to have all the runtime dependencies installed.
 The most up-to-date requirements will be listed in ``pyproject.toml`` file, in the ``build-system.requires`` key.
-As of the 5.0.0 release, the build requirements can be installed with
+
+The build requirements can be installed with
 
 .. code-block:: bash
 
-   pip install setuptools wheel packaging cython 'numpy<2.0.0' scipy
+    pip install meson-python ninja cython numpy scipy
 
-or similar with ``conda`` if you prefer.
-You will also need to have a functional C++ compiler installed on your system.
+You will also need to have a functional C++ compiler installed on your system for Cython.
 This is likely already done for you if you are on Linux or macOS, but see the `section on Windows installations <install-on-windows_>`_ if that is your operating system.
 
 To install QuTiP from the source code run:
 
 .. code-block:: bash
 
-   pip install .
+   pip install . --no-build-isolation
 
 If you wish to contribute to the QuTiP project, then you will want to create your own fork of `the QuTiP git repository <https://github.com/qutip/qutip>`_, clone this to a local folder, and install it into your Python environment using:
 
 .. code-block:: bash
 
-   python setup.py develop
+   pip install -e . --no-build-isolation
 
-When you do ``import qutip`` in this environment, you will then load the code from your local fork, enabling you to edit the Python files and have the changes immediately available when you restart your Python interpreter, without needing to rebuild the package.
-Note that if you change any Cython files, you will need to rerun the build command.
+When you do ``import qutip``, you will then load the code from your local fork, enabling you to edit any file in the qutip source code and have the changes immediately available when you restart your Python interpreter, without needing to rebuild the package.
+Note that if you add a new Cython file (extension module), you will need to rerun the build command.
 
-You should not need to use ``sudo`` (or other superuser privileges) to install into a personal virtual environment; if it feels like you need it, there is a good chance that you are installing into the system Python environment instead.
+**Note:** You should not need to use ``sudo`` (or other superuser privileges) to install into a personal virtual environment; if it feels like you need it, there is a good chance that you are installing into the system Python environment instead.
 
 
 .. _install-on-windows:
@@ -203,21 +199,32 @@ Installation on Windows
 As with other operating systems, the easiest method is to use ``pip install qutip``, or use the ``conda`` procedure described above.
 If you want to build from source or use runtime compilation with Cython, you will need to have a working C++ compiler.
 
-You can `download the Visual Studio IDE from Microsoft <https://visualstudio.microsoft.com/downloads/>`_, which has a free Community edition containing a sufficient C++ compiler.
-This is the recommended compiler toolchain on Windows.
-When installing, be sure to select the following components:
+On Windows, the recommended compiler is the Microsoft Visual C++ compiler (MSVC), distributed with Visual Studio IDE and the standalone Visual Studio Build Tools.
 
-- Windows "X" SDK (where "X" stands for your version: 7/8/8.1/10)
-- Visual Studio C++ build tools
+You can `download Visual Studio IDE from Microsoft <https://visualstudio.microsoft.com/downloads/>_`. The free Community edition provides everything required to compile QuTiP.
+When running the Visual Studio Installer, select the:
 
-You can then follow the `installation from source <install-from-source_>`_ section as normal.
+- Desktop development with C++ workload
 
-.. important::
+and ensure that the following components are installed:
 
-   In order to prevent issues with the ``PATH`` environment variable not containing the compiler and associated libraries, it is recommended to use the developer command prompt in the Visual Studio installation folder instead of the built-in command prompt.
+- MSVC C++ build tools for x64/x86
+- a recent Windows SDK, such as the Windows 10 SDK or Windows 11 SDK
 
-The Community edition of Visual Studio takes around 10GB of disk space.
-If this is prohibitive for you, it is also possible to install `only the build tools and necessary SDKs <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_ instead, which should save about 2GB of space.
+If you do not need the full Visual Studio IDE, you can instead install the
+Visual Studio Build Tools <https://visualstudio.microsoft.com/visual-cpp-build-tools/>_.
+In the Build Tools installer, select the same Desktop development with C++
+workload. This installs the MSVC compiler, Windows SDK and associated build
+tools without installing the complete Visual Studio IDE.
+
+You can verify that the compiler is available by running::
+
+.. code-block::
+
+   cl
+
+If MSVC is configured correctly, this should print the Microsoft C++ compiler version and usage information.
+You can then follow the installation from source <install-from-source_>_ section as normal.
 
 
 .. _install-verify:
@@ -227,11 +234,10 @@ Verifying the Installation
 
 QuTiP includes a collection of built-in test scripts to verify that an installation was successful.
 To run the suite of tests scripts you must also have the ``pytest`` testing library.
-After installing QuTiP, leave the installation directory and call:
 
 .. code-block:: bash
 
-   python -c "import qutip.testing; qutip.testing.run()"
+   pytest .
 
 This will take between 10 and 30 minutes, depending on your computer.
 At the end, the testing report should report a success; it is normal for some tests to be skipped, and for some to be marked "xfail" in yellow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "scipy>=1.13,!=1.16.0,!=1.17.0",
     "packaging",
 ]
+# While updating the dependencies also update installation.rst
 
 # URLs for your project
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,12 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: Microsoft :: Windows",
 ]
+# While updating the dependencies also update installation.rst
 dependencies = [
     "numpy>=1.23.2",
     "scipy>=1.13,!=1.16.0,!=1.17.0",
     "packaging",
 ]
-# While updating the dependencies also update installation.rst
 
 # URLs for your project
 [project.urls]
@@ -60,7 +60,6 @@ Funding = "https://github.com/sponsors/qutip"
 graphics = ["matplotlib>=3.6"]
 runtime_compilation = ["cython>=0.29.34", "filelock", "setuptools"]
 semidefinite = ["cvxpy>=1.3", "cvxopt"]
-tests = ["pytest>=7.2", "pytest-rerunfailures"]
 ipython = ["ipython"]
 extras = [
   "loky",
@@ -69,8 +68,11 @@ extras = [
 ]
 mpi = ["mpi4py"]
 full = [
-  "qutip[graphics,runtime_compilation,semidefinite,tests,ipython,extras]",
+  "qutip[graphics,runtime_compilation,semidefinite,ipython,extras]",
 ]
+
+[dependency-groups]
+tests = ["pytest>=7.2", "pytest-rerunfailures"]
 
 [tool.meson-python.args]
 # Force activation of the Visual Studio environment on Windows (ignored on other platforms);


### PR DESCRIPTION
**Description**
- Update the installation instructions.
- Update contributing instructions.
- Add explicit read only permission for github actions.
- Move tests ( a dev dependency) from optional dependency to group dependency as per PEP 735. This is because pytest is not meant to be used as an optional feature by an user downloading qutip wheels.

Note: While merging don't squash merge this PR. As each change and commit is independent of the other.

**Related issues or PRs**
Fix #2984 

**AI Tools Usage Disclosure**
- [x] No AI tools were used for this contribution.