### PR TITLE
doc: repoint stale API references and dead links

### DIFF
--- a/doc/changes/2997.doc
+++ b/doc/changes/2997.doc
@@ -1,0 +1,1 @@
+Fix four cross-references that named modules removed or renamed in v5: ``qutip.operators.sigmaz``, ``qutip.propagator.propagator``, ``qutip.stochastic.smesolve``, and the misspelled ``qutip.core.data.csr.zeroes``.

--- a/doc/changes/2997.doc
+++ b/doc/changes/2997.doc
@@ -1,1 +1,1 @@
-Fix four cross-references that named modules removed or renamed in v5: ``qutip.operators.sigmaz``, ``qutip.propagator.propagator``, ``qutip.stochastic.smesolve``, and the misspelled ``qutip.core.data.csr.zeroes``.
+Fix four cross-references that named modules removed or renamed in v5 (``qutip.operators.sigmaz``, ``qutip.propagator.propagator``, ``qutip.stochastic.smesolve``, and the misspelled ``qutip.core.data.csr.zeroes``), and four dead documentation links.

--- a/doc/development/ideas/quantum-error-mitigation.rst
+++ b/doc/development/ideas/quantum-error-mitigation.rst
@@ -21,7 +21,7 @@ framework for quantum circuits (`qutip.qip.circuit`). There are also possible
 applications such as error mitigation techniques ([1]_, [2]_, [3]_).
 
 The tutorial notebooks can be found in the Quantum information processing
-section of https://qutip.org/qutip-tutorials/index-v5.html. A
+section of https://qutip.org/qutip-tutorials/. A
 recent presentation on the FOSDEM conference may help you get an overview
 (https://fosdem.org/2020/schedule/event/quantum_qutip/). See also the Github
 Project page for a collection of related issues and ongoing Pull Requests.

--- a/doc/frontmatter.rst
+++ b/doc/frontmatter.rst
@@ -171,9 +171,9 @@ Several libraries rely on QuTiP for quantum physics or quantum information proce
 
 :scQubits: `scQubits <https://scqubits.readthedocs.io/en/latest/>`_ is a Python library which provides a convenient way to simulate superconducting qubits by providing an interface to QuTiP
 
-:SimulaQron: `SimulaQron <https://softwarequtech.github.io/SimulaQron/html/index.html>`_ is a distributed simulation of the end nodes in a quantum internet with the specific goal to explore application development
+:SimulaQron: `SimulaQron <https://github.com/SoftwareQuTech/SimulaQron>`_ is a distributed simulation of the end nodes in a quantum internet with the specific goal to explore application development
 
-:QInfer: `QInfer <http://qinfer.org/>`_ is a library for working with sequential Monte Carlo methods for parameter estimation in quantum information
+:QInfer: `QInfer <https://github.com/QInfer/python-qinfer>`_ is a library for working with sequential Monte Carlo methods for parameter estimation in quantum information
 
 :QPtomographer: `QPtomographer <https://qptomographer.readthedocs.io/en/latest/>`_ derive quantum error bars for quantum processes in terms of the diamond norm to a reference quantum channel
 

--- a/doc/guide/dynamics/dynamics-stochastic.rst
+++ b/doc/guide/dynamics/dynamics-stochastic.rst
@@ -75,7 +75,7 @@ Stochastic Master Equation
 
 .. Stochastic Master equation
 
-When the initial state of the system is a density matrix :math:`\rho`, the stochastic master equation solver :func:`qutip.stochastic.smesolve` must be used.
+When the initial state of the system is a density matrix :math:`\rho`, the stochastic master equation solver :func:`qutip.solver.stochastic.smesolve` must be used.
 The stochastic master equation is given by (see section 4.4, [Wis09]_)
 
 .. math::

--- a/doc/guide/guide-measurement.rst
+++ b/doc/guide/guide-measurement.rst
@@ -136,7 +136,7 @@ We can also choose what to measure by specifying a *list of projection operators
 example, we could select the projection operators :math:`\ket{0} \bra{0}` and
 :math:`\ket{1} \bra{1}` which measure the state in the :math:`\ket{0}, \ket{1}`
 basis. Note that these projection operators are simply the projectors determined by
-the eigenstates of the :func:`~qutip.operators.sigmaz` operator.
+the eigenstates of the :func:`~qutip.core.operators.sigmaz` operator.
 
 .. testcode::
 

--- a/doc/guide/guide-visualization.rst
+++ b/doc/guide/guide-visualization.rst
@@ -355,7 +355,7 @@ where :math:`N` is the number of states of the system (that is, :math:`\rho` is 
 
 where :math:`\chi_{mn} = \sum_{ij} b_{im}b_{jn}^*` and :math:`A_i = \sum_{m} b_{im}B_{m}`. Here, matrix :math:`\chi` is the transformation matrix we are after, since it describes how much :math:`B_m \rho_{\rm in} B_n^\dagger` contributes to :math:`\rho_{\rm out}`.
 
-In a numerical simulation of a quantum process we usually do not have access to the quantum map in the form Eq. :eq:`qpt-quantum-map`. Instead, what we usually can do is to calculate the propagator :math:`U` for the density matrix in superoperator form, using for example the QuTiP function :func:`qutip.propagator.propagator`. We can then write
+In a numerical simulation of a quantum process we usually do not have access to the quantum map in the form Eq. :eq:`qpt-quantum-map`. Instead, what we usually can do is to calculate the propagator :math:`U` for the density matrix in superoperator form, using for example the QuTiP function :func:`qutip.solver.propagator.propagator`. We can then write
 
 .. math::
 

--- a/doc/internals/data-layer/types.rst
+++ b/doc/internals/data-layer/types.rst
@@ -35,7 +35,7 @@ an array should follow this type within C or Cython code.
 SciPy's :obj:`~scipy.sparse.csr_matrix`, but it also provides fast-path
 initialisation from Python or C using the type's
 :meth:`~qutip.core.data.CSR.copy` method, or the low-level constructors
-:obj:`~qutip.core.data.csr.empty`, :obj:`~qutip.core.data.csr.zeroes`,
+:obj:`~qutip.core.data.csr.empty`, :obj:`~qutip.core.data.csr.zeros`,
 :obj:`~qutip.core.data.csr.identity`, and
 :obj:`~qutip.core.data.csr.copy_structure`.
 

--- a/doc/internals/index.rst
+++ b/doc/internals/index.rst
@@ -10,7 +10,7 @@ that is what you are looking for, please refer to the :ref:`guide` or the large
 collection of `example notebooks`_.
 
 .. _GitHub repository qutip/qutip: https://github.com/qutip/qutip
-.. _user guide: http://qutip.org/docs/latest/
+.. _user guide: https://qutip.readthedocs.io/en/latest/guide/guide.html
 .. _example notebooks: http://qutip.org/tutorials.html
 
 .. toctree::


### PR DESCRIPTION
Four Sphinx cross-references in the docs name module paths that no longer exist, so they render as plain literals rather than links. Related to #1898 — @Ericgig invited "fix error, improve wording, fix broken links" there, and these are the mechanical half of "documentation matches the actual existing code".

| Reference | Where | Reality |
| --- | --- | --- |
| `~qutip.operators.sigmaz` | `doc/guide/guide-measurement.rst` | `qutip/operators.py` was removed in v5; `sigmaz` is in `qutip/core/operators.py` |
| `qutip.propagator.propagator` | `doc/guide/guide-visualization.rst` | now `qutip/solver/propagator.py` |
| `qutip.stochastic.smesolve` | `doc/guide/dynamics/dynamics-stochastic.rst` | now `qutip/solver/stochastic.py` |
| `~qutip.core.data.csr.zeroes` | `doc/internals/data-layer/types.rst` | the function is `zeros` (`csr.pyx`: `cpdef CSR zeros`) |

The `smesolve` one is a straggler: three other references in the docs already use `qutip.solver.stochastic.smesolve`, so this file was missed when the rest were updated. The `zeroes` one is a plain spelling slip.

## How these were found

I resolved every `:func:`/`:class:`/`:meth:`/`:obj:` target in `doc/` against the names actually defined in the source tree (parsing the `.py` and `.pyx` files rather than importing, so the check runs against the working tree without a build). These four are the only remaining references whose leading module segment does not exist.

Deliberately untouched: `qutip.Qobj`, `qutip.QobjEvo` and `qutip.Dispatcher` are classes rather than modules, and the 44 `qutip.data.*` references resolve through the `from .core import *` re-export — my checker flags all of those, and all of them are fine.

I have not built the docs locally, so I have not confirmed how Sphinx currently renders each one; the claim here is only that the targets do not exist in the source and the replacements do.

I will add the `doc/changes/<PR>.doc` towncrier fragment once this has a number, following #2988 and #2969.

Disclosure: written with Claude Code, and the commit carries `Assisted-by: Claude Code (Opus 5)`.

## Second commit: four dead links

I also checked every external URL in `doc/` (288 unique). Four are genuinely unreachable rather than bot-blocked:

| Link | Where | Now |
| --- | --- | --- |
| `qutip.org/docs/latest/` (404) | `doc/internals/index.rst`, the `user guide` target | the current guide on readthedocs |
| `qutip.org/qutip-tutorials/index-v5.html` (404) | `doc/development/ideas/quantum-error-mitigation.rst` | the tutorials index, which resolves |
| SimulaQron's `github.io` docs page (404) | `doc/frontmatter.rst` | its repository |
| `qinfer.org` (domain no longer resolves) | `doc/frontmatter.rst` | the QInfer repository |

Every replacement was probed and returns 200.

Deliberately **not** touched: `sciencedirect.com`, `pubs.acs.org`, `doi.org`, `mpich.org` and a StackOverflow answer all return 403 to scripted requests but load fine in a browser. That is bot protection, not rot, and "fixing" them would be wrong.

Happy to split this into a separate PR if you would rather keep the API-reference fixes and the link fixes apart.
